### PR TITLE
List shared-identity entries for STETs

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -2018,12 +2018,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
                             var sourceValue = sourceEntry.GetCurrentValue(sourceProperty);
                             var targetValue = entry.GetCurrentValue(targetProperty);
-                            var comparer = targetProperty.GetValueComparer()
-                                ?? sourceProperty.GetValueComparer();
+                            var comparer = targetProperty.GetValueComparer();
 
                             var modelValuesChanged
                                 = sourceProperty.ClrType.UnwrapNullableType() == targetProperty.ClrType.UnwrapNullableType()
-                                && comparer?.Equals(sourceValue, targetValue) == false;
+                                && comparer.Equals(sourceValue, targetValue) == false;
 
                             if (!modelValuesChanged)
                             {

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -1877,23 +1877,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             private static bool CompareIdentifiers(IReadOnlyList<ValueComparer> valueComparers, object[] left, object[] right)
             {
-                if (valueComparers != null)
+                // Ignoring size check on all for perf as they should be same unless bug in code.
+                for (var i = 0; i < left.Length; i++)
                 {
-                    // Ignoring size check on all for perf as they should be same unless bug in code.
-                    for (var i = 0; i < left.Length; i++)
+                    if (!valueComparers[i].Equals(left[i], right[i]))
                     {
-                        if (valueComparers[i] != null
-                            ? !valueComparers[i].Equals(left[i], right[i])
-                            : !Equals(left[i], right[i]))
-                        {
-                            return false;
-                        }
+                        return false;
                     }
-
-                    return true;
                 }
 
-                return StructuralComparisons.StructuralEqualityComparer.Equals(left, right);
+                return true;
             }
 
             private sealed class CollectionShaperFindingExpressionVisitor : ExpressionVisitor

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -423,7 +423,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             _sharedColumnModifications ??= new List<IColumnModification>();
 
             if (UseCurrentValueParameter
-                && !StructuralComparisons.StructuralEqualityComparer.Equals(Value, modification.Value))
+                && !modification.Property.GetValueComparer().Equals(Value, modification.Value))
             {
                 if (_sensitiveLoggingEnabled)
                 {
@@ -447,7 +447,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             }
 
             if (UseOriginalValueParameter
-                && !StructuralComparisons.StructuralEqualityComparer.Equals(OriginalValue, modification.OriginalValue))
+                && !modification.Property.GetValueComparer().Equals(OriginalValue, modification.OriginalValue))
             {
                 if (Entry.EntityState == EntityState.Modified
                     && modification.Entry.EntityState == EntityState.Added

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -208,21 +208,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     var current = entry[property];
                     var original = entry.GetOriginalValue(property);
 
-                    var comparer = property.GetValueComparer();
-
-                    if (comparer == null)
-                    {
-                        if (!Equals(current, original))
-                        {
-                            SetPropertyModified();
-                        }
-                    }
-                    else if (!comparer.Equals(current, original))
-                    {
-                        SetPropertyModified();
-                    }
-
-                    void SetPropertyModified()
+                    if (!property.GetValueComparer().Equals(current, original))
                     {
                         if (entry.EntityState == EntityState.Deleted)
                         {

--- a/src/EFCore/ChangeTracking/Internal/EntityGraphAttacher.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityGraphAttacher.cs
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     ? (isGenerated ? storeGenTargetState : targetState)
                     : EntityState.Added, // Key can only be not-set if it is store-generated
                 acceptChanges: true,
-                forceStateWhenUnknownKey: force ? (EntityState?)targetState : null);
+                forceStateWhenUnknownKey: force ? targetState : null);
 
             return true;
         }

--- a/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
@@ -178,10 +178,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual int GetCountForState(
-            bool added = false,
-            bool modified = false,
-            bool deleted = false,
-            bool unchanged = false)
+            bool added, bool modified, bool deleted, bool unchanged, bool countDeletedSharedIdentity)
         {
             var count = 0;
 
@@ -200,7 +197,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             if (deleted
                 && _deletedReferenceMap != null)
             {
-                count += _deletedReferenceMap.Count;
+                count += countDeletedSharedIdentity
+                    ? _deletedReferenceMap.Count
+                    : _deletedReferenceMap.Count(p => p.Value.SharedIdentityEntry == null);
             }
 
             if (unchanged
@@ -213,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 foreach (var map in _sharedTypeReferenceMap)
                 {
-                    count += map.Value.GetCountForState(added, modified, deleted, unchanged);
+                    count += map.Value.GetCountForState(added, modified, deleted, unchanged, countDeletedSharedIdentity);
                 }
             }
 
@@ -227,10 +226,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IEnumerable<InternalEntityEntry> GetEntriesForState(
-            bool added = false,
-            bool modified = false,
-            bool deleted = false,
-            bool unchanged = false)
+            bool added, bool modified, bool deleted, bool unchanged, bool returnDeletedSharedIdentity)
         {
             // Perf sensitive
 
@@ -298,7 +294,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             return GetEntriesForState(
                 added, modified, deleted, unchanged,
                 hasSharedTypes,
-                returnAdded, returnModified, returnDeleted, returnUnchanged);
+                returnAdded, returnModified, returnDeleted, returnUnchanged,
+                returnDeletedSharedIdentity);
         }
 
         private IEnumerable<InternalEntityEntry> GetEntriesForState(
@@ -310,7 +307,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             bool returnAdded,
             bool returnModified,
             bool returnDeleted,
-            bool returnUnchanged)
+            bool returnUnchanged,
+            bool returnSharedIdentity)
         {
             if (returnAdded)
             {
@@ -332,7 +330,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 foreach (var entry in _deletedReferenceMap!.Values)
                 {
-                    yield return entry;
+                    if (entry.SharedIdentityEntry == null
+                        || returnSharedIdentity)
+                    {
+                        yield return entry;
+                    }
                 }
             }
 
@@ -348,13 +350,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 foreach (var subMap in _sharedTypeReferenceMap!.Values)
                 {
-                    foreach (var entry in subMap.GetEntriesForState(added, modified, deleted, unchanged))
+                    foreach (var entry in subMap.GetEntriesForState(added, modified, deleted, unchanged, returnSharedIdentity))
                     {
-                        if ((entry.SharedIdentityEntry == null
-                            || entry.EntityState != EntityState.Deleted))
-                        {
-                            yield return entry;
-                        }
+                        yield return entry;
                     }
                 }
             }

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -149,7 +149,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             bool added = false,
             bool modified = false,
             bool deleted = false,
-            bool unchanged = false);
+            bool unchanged = false,
+            bool returnSharedIdentity = false);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -161,7 +162,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             bool added = false,
             bool modified = false,
             bool deleted = false,
-            bool unchanged = false);
+            bool unchanged = false,
+            bool returnSharedIdentity = false);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1391,13 +1391,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         private static Func<object?, object?, bool> ValuesEqualFunc(IProperty property)
-        {
-            var comparer = property.GetValueComparer();
-
-            return comparer != null
-                ? (Func<object?, object?, bool>)((l, r) => comparer.Equals(l, r))
-                : (l, r) => Equals(l, r);
-        }
+            => property.GetValueComparer().Equals;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/OriginalValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/OriginalValues.cs
@@ -104,11 +104,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             private static object? SnapshotValue(IProperty property, object? value)
-            {
-                var comparer = property.GetValueComparer();
-
-                return comparer == null ? value : comparer.Snapshot(value);
-            }
+                => property.GetValueComparer().Snapshot(value);
 
             public bool IsEmpty
                 => _values == null;

--- a/src/EFCore/ChangeTracking/Internal/SidecarValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/SidecarValues.cs
@@ -50,11 +50,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             private static object? SnapshotValue(IProperty property, object? value)
-            {
-                var comparer = property.GetValueComparer();
-
-                return comparer == null ? value : comparer.Snapshot(value);
-            }
+                => property.GetValueComparer().Snapshot(value);
 
             public bool IsEmpty
                 => _values == null;

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -415,7 +415,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     ? throwOnTypeMismatch
                         ? throw new InvalidOperationException(
                             CoreStrings.TrackingTypeMismatch(entry.EntityType.DisplayName(), entityType.DisplayName()))
-                        : (InternalEntityEntry?)null
+                        : null
                     : entry
                 : null;
 
@@ -496,8 +496,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             bool added = false,
             bool modified = false,
             bool deleted = false,
-            bool unchanged = false)
-            => _entityReferenceMap.GetCountForState(added, modified, deleted, unchanged);
+            bool unchanged = false,
+            bool countDeletedSharedIdentity = false)
+            => _entityReferenceMap.GetCountForState(added, modified, deleted, unchanged, countDeletedSharedIdentity);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -506,7 +507,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual int Count
-            => GetCountForState(added: true, modified: true, deleted: true, unchanged: true);
+            => GetCountForState(added: true, modified: true, deleted: true, unchanged: true, countDeletedSharedIdentity: true);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -518,8 +519,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             bool added = false,
             bool modified = false,
             bool deleted = false,
-            bool unchanged = false)
-            => _entityReferenceMap.GetEntriesForState(added, modified, deleted, unchanged);
+            bool unchanged = false,
+            bool returnDeletedSharedIdentity = false)
+            => _entityReferenceMap.GetEntriesForState(added, modified, deleted, unchanged, returnDeletedSharedIdentity);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -528,7 +530,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IEnumerable<InternalEntityEntry> Entries
-            => GetEntriesForState(added: true, modified: true, deleted: true, unchanged: true);
+            => GetEntriesForState(added: true, modified: true, deleted: true, unchanged: true, returnDeletedSharedIdentity: true);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/StateManagerExtensions.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManagerExtensions.cs
@@ -24,12 +24,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             bool added = false,
             bool modified = false,
             bool deleted = false,
-            bool unchanged = false)
+            bool unchanged = false,
+            bool returnDeletedSharedIdentity = false)
         {
             var list = new List<InternalEntityEntry>(
-                stateManager.GetCountForState(added, modified, deleted, unchanged));
+                stateManager.GetCountForState(added, modified, deleted, unchanged, returnDeletedSharedIdentity));
 
-            foreach (var entry in stateManager.GetEntriesForState(added, modified, deleted, unchanged))
+            foreach (var entry in stateManager.GetEntriesForState(added, modified, deleted, unchanged, returnDeletedSharedIdentity))
             {
                 list.Add(entry);
             }
@@ -45,6 +46,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public static IReadOnlyList<InternalEntityEntry> ToList(
             this IStateManager stateManager)
-            => stateManager.ToListForState(added: true, modified: true, deleted: true, unchanged: true);
+            => stateManager.ToListForState(added: true, modified: true, deleted: true, unchanged: true, returnDeletedSharedIdentity: true);
     }
 }

--- a/src/EFCore/Extensions/PropertyBaseExtensions.cs
+++ b/src/EFCore/Extensions/PropertyBaseExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     when throwing exceptions about keys, indexes, etc. that use the properties.
         /// </summary>
         /// <param name="properties"> The properties to format. </param>
-        /// <param name="includeTypes"> If true, then type names are included in the string. The default is <see langword="false" />.</param>
+        /// <param name="includeTypes"> If true, then type names are included in the string. The default is <see langword="false" />. </param>
         /// <returns> The string representation. </returns>
         public static string Format(this IEnumerable<IReadOnlyPropertyBase> properties, bool includeTypes = false)
             => "{"

--- a/src/EFCore/Metadata/IReadOnlyIndex.cs
+++ b/src/EFCore/Metadata/IReadOnlyIndex.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     ", ",
                     Properties.Select(
                         p => singleLine
-                            ? p.DeclaringEntityType.DisplayName() + "." + p.Name
+                            ? p.DeclaringEntityType.DisplayName(omitSharedType: true) + "." + p.Name
                             : p.Name));
 
             builder.Append(" " + Name ?? "<unnamed>");

--- a/src/EFCore/Metadata/IReadOnlyKey.cs
+++ b/src/EFCore/Metadata/IReadOnlyKey.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             builder.AppendJoin(
                 ", ", Properties.Select(
                     p => singleLine
-                        ? p.DeclaringEntityType.DisplayName() + "." + p.Name
+                        ? p.DeclaringEntityType.DisplayName(omitSharedType: true) + "." + p.Name
                         : p.Name));
 
             if (IsPrimaryKey())

--- a/src/EFCore/Metadata/IReadOnlyTypeBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyTypeBase.cs
@@ -64,6 +64,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <returns> The display name. </returns>
         [DebuggerStepThrough]
         string DisplayName()
+            => DisplayName(omitSharedType: false);
+
+        /// <summary>
+        ///     Gets the friendly display name for the given <see cref="IReadOnlyTypeBase" />.
+        /// </summary>
+        /// <param name="omitSharedType">
+        ///     A value indicating whether the name of the type for shared type entity types should be omitted from the returned value.
+        /// </param>
+        /// <returns> The display name. </returns>
+        [DebuggerStepThrough]
+        string DisplayName(bool omitSharedType)
         {
             if (!HasSharedClrType)
             {
@@ -97,8 +108,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             }
 
             return shortName == Name
-                       ? shortName + " (" + ClrType.ShortDisplayName() + ")"
-                       : shortName;
+                ? shortName + " (" + ClrType.ShortDisplayName() + ")"
+                : shortName;
         }
 
         /// <summary>

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -5798,7 +5798,7 @@ namespace RootNamespace
                 Activator.CreateInstance(factoryType),
                 new object[] { builder });
 
-            var services = TestHelpers.CreateContextServices();
+            var services = TestHelpers.CreateContextServices(new ServiceCollection().AddEntityFrameworkSqlServerNetTopologySuite());
 
             var processor = new SnapshotModelProcessor(new TestOperationReporter(), services.GetService<IModelRuntimeInitializer>());
             return processor.Process(builder.Model);

--- a/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
@@ -808,10 +808,10 @@ namespace Microsoft.EntityFrameworkCore
 
                     Assert.All(
                         context.ChangeTracker.Entries<Dictionary<string, object>>(), e => Assert.Equal(
-                            ((int)e.Entity["CompositeId1"] == key1
-                                && (string)e.Entity["CompositeId2"] == key2
-                                && (DateTime)e.Entity["CompositeId3"] == key3)
-                            || (int)e.Entity["RootId"] == id
+                            ((int)e.Entity["CompositeKeySkipSharedKey1"] == key1
+                                && (string)e.Entity["CompositeKeySkipSharedKey2"] == key2
+                                && (DateTime)e.Entity["CompositeKeySkipSharedKey3"] == key3)
+                            || (int)e.Entity["RootSkipSharedId"] == id
                                 ? EntityState.Deleted
                                 : EntityState.Unchanged, e.State));
 
@@ -828,10 +828,10 @@ namespace Microsoft.EntityFrameworkCore
 
                     Assert.DoesNotContain(
                         context.ChangeTracker.Entries<Dictionary<string, object>>(),
-                        e => ((int)e.Entity["CompositeId1"] == key1
-                                && (string)e.Entity["CompositeId2"] == key2
-                                && (DateTime)e.Entity["CompositeId3"] == key3)
-                            || (int)e.Entity["RootId"] == id);
+                        e => ((int)e.Entity["CompositeKeySkipSharedKey1"] == key1
+                                && (string)e.Entity["CompositeKeySkipSharedKey2"] == key2
+                                && (DateTime)e.Entity["CompositeKeySkipSharedKey3"] == key3)
+                            || (int)e.Entity["RootSkipSharedId"] == id);
                 },
                 context =>
                 {
@@ -842,10 +842,10 @@ namespace Microsoft.EntityFrameworkCore
 
                     Assert.DoesNotContain(
                         context.ChangeTracker.Entries<Dictionary<string, object>>(),
-                        e => ((int)e.Entity["CompositeId1"] == key1
-                                && (string)e.Entity["CompositeId2"] == key2
-                                && (DateTime)e.Entity["CompositeId3"] == key3)
-                            || (int)e.Entity["RootId"] == id);
+                        e => ((int)e.Entity["CompositeKeySkipSharedKey1"] == key1
+                                && (string)e.Entity["CompositeKeySkipSharedKey2"] == key2
+                                && (DateTime)e.Entity["CompositeKeySkipSharedKey3"] == key3)
+                            || (int)e.Entity["RootSkipSharedId"] == id);
                 });
 
             void ValidateNavigations(
@@ -4869,7 +4869,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        protected void VerifyRelationshipSnapshots(DbContext context, IEnumerable<object> entities)
+        protected static void VerifyRelationshipSnapshots(DbContext context, IEnumerable<object> entities)
         {
             var detectChanges = context.ChangeTracker.AutoDetectChangesEnabled;
             try

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
@@ -258,25 +258,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l => l.HasOne(x => x.Two).WithMany(e => e.JoinThreeFull));
 
             // Nav:2 Payload:No Join:Shared Extra:Self-ref
-            // TODO: Remove UsingEntity
             modelBuilder.Entity<EntityTwo>()
                 .HasMany(e => e.SelfSkipSharedLeft)
-                .WithMany(e => e.SelfSkipSharedRight)
-                .UsingEntity<Dictionary<string, object>>(
-                    "JoinTwoSelfShared",
-                    l => l.HasOne<EntityTwo>().WithMany().HasForeignKey("LeftId"),
-                    r => r.HasOne<EntityTwo>().WithMany().HasForeignKey("RightId"));
+                .WithMany(e => e.SelfSkipSharedRight);
 
             // Nav:2 Payload:No Join:Shared Extra:CompositeKey
-            // TODO: Remove UsingEntity
             modelBuilder.Entity<EntityTwo>()
                 .HasMany(e => e.CompositeKeySkipShared)
-                .WithMany(e => e.TwoSkipShared)
-                .UsingEntity<Dictionary<string, object>>(
-                    "JoinTwoToCompositeKeyShared",
-                    r => r.HasOne<EntityCompositeKey>().WithMany().HasForeignKey("CompositeId1", "CompositeId2", "CompositeId3"),
-                    l => l.HasOne<EntityTwo>().WithMany().HasForeignKey("TwoId"))
-                .HasKey("TwoId", "CompositeId1", "CompositeId2", "CompositeId3");
+                .WithMany(e => e.TwoSkipShared);
 
             // Nav:6 Payload:No Join:Concrete Extra:CompositeKey
             modelBuilder.Entity<EntityThree>()
@@ -293,23 +282,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                     r => r.HasOne(x => x.Three).WithMany(x => x.JoinCompositeKeyFull).IsRequired());
 
             // Nav:2 Payload:No Join:Shared Extra:Inheritance
-            // TODO: Remove UsingEntity
-            modelBuilder.Entity<EntityThree>().HasMany(e => e.RootSkipShared).WithMany(e => e.ThreeSkipShared)
-                .UsingEntity<Dictionary<string, object>>(
-                    "EntityRootEntityThree",
-                    r => r.HasOne<EntityRoot>().WithMany().HasForeignKey("EntityRootId"),
-                    l => l.HasOne<EntityThree>().WithMany().HasForeignKey("EntityThreeId"));
+            modelBuilder.Entity<EntityThree>()
+                .HasMany(e => e.RootSkipShared)
+                .WithMany(e => e.ThreeSkipShared);
 
             // Nav:2 Payload:No Join:Shared Extra:Inheritance,CompositeKey
-            // TODO: Remove UsingEntity
             modelBuilder.Entity<EntityCompositeKey>()
                 .HasMany(e => e.RootSkipShared)
-                .WithMany(e => e.CompositeKeySkipShared)
-                .UsingEntity<Dictionary<string, object>>(
-                    "JoinCompositeKeyToRootShared",
-                    r => r.HasOne<EntityRoot>().WithMany().HasForeignKey("RootId"),
-                    l => l.HasOne<EntityCompositeKey>().WithMany().HasForeignKey("CompositeId1", "CompositeId2", "CompositeId3"))
-                .HasKey("CompositeId1", "CompositeId2", "CompositeId3", "RootId");
+                .WithMany(e => e.CompositeKeySkipShared);
 
             // Nav:6 Payload:No Join:Concrete Extra:Inheritance,CompositeKey
             modelBuilder.Entity<EntityCompositeKey>()

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyData.cs
@@ -43,10 +43,10 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
             context.Set<Dictionary<string, object>>("EntityOneEntityTwo").AddRange(CreateEntityOneEntityTwos(context));
             context.Set<Dictionary<string, object>>("JoinOneToThreePayloadFullShared")
                 .AddRange(CreateJoinOneToThreePayloadFullShareds(context));
-            context.Set<Dictionary<string, object>>("JoinTwoSelfShared").AddRange(CreateJoinTwoSelfShareds(context));
-            context.Set<Dictionary<string, object>>("JoinTwoToCompositeKeyShared").AddRange(CreateJoinTwoToCompositeKeyShareds(context));
+            context.Set<Dictionary<string, object>>("EntityTwoEntityTwo").AddRange(CreateJoinTwoSelfShareds(context));
+            context.Set<Dictionary<string, object>>("EntityCompositeKeyEntityTwo").AddRange(CreateJoinTwoToCompositeKeyShareds(context));
             context.Set<Dictionary<string, object>>("EntityRootEntityThree").AddRange(CreateEntityRootEntityThrees(context));
-            context.Set<Dictionary<string, object>>("JoinCompositeKeyToRootShared").AddRange(CreateJoinCompositeKeyToRootShareds(context));
+            context.Set<Dictionary<string, object>>("EntityCompositeKeyEntityRoot").AddRange(CreateJoinCompositeKeyToRootShareds(context));
         }
 
         public IQueryable<TEntity> Set<TEntity>()
@@ -1064,10 +1064,10 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
             EntityTwo left,
             EntityTwo right)
             => CreateInstance(
-                context?.Set<Dictionary<string, object>>("JoinTwoSelfShared"), (e, p) =>
+                context?.Set<Dictionary<string, object>>("EntityTwoEntityTwo"), (e, p) =>
                 {
-                    e["LeftId"] = context?.Entry(left).Property(e => e.Id).CurrentValue ?? left.Id;
-                    e["RightId"] = context?.Entry(right).Property(e => e.Id).CurrentValue ?? right.Id;
+                    e["SelfSkipSharedLeftId"] = context?.Entry(left).Property(e => e.Id).CurrentValue ?? left.Id;
+                    e["SelfSkipSharedRightId"] = context?.Entry(right).Property(e => e.Id).CurrentValue ?? right.Id;
                 });
 
         private Dictionary<string, object>[] CreateJoinTwoToCompositeKeyShareds(ManyToManyContext context)
@@ -1116,12 +1116,12 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
             EntityTwo two,
             EntityCompositeKey composite)
             => CreateInstance(
-                context?.Set<Dictionary<string, object>>("JoinTwoToCompositeKeyShared"), (e, p) =>
+                context?.Set<Dictionary<string, object>>("EntityCompositeKeyEntityTwo"), (e, p) =>
                 {
-                    e["TwoId"] = context?.Entry(two).Property(e => e.Id).CurrentValue ?? two.Id;
-                    e["CompositeId1"] = context?.Entry(composite).Property(e => e.Key1).CurrentValue ?? composite.Key1;
-                    e["CompositeId2"] = composite.Key2;
-                    e["CompositeId3"] = composite.Key3;
+                    e["TwoSkipSharedId"] = context?.Entry(two).Property(e => e.Id).CurrentValue ?? two.Id;
+                    e["CompositeKeySkipSharedKey1"] = context?.Entry(composite).Property(e => e.Key1).CurrentValue ?? composite.Key1;
+                    e["CompositeKeySkipSharedKey2"] = composite.Key2;
+                    e["CompositeKeySkipSharedKey3"] = composite.Key3;
                 });
 
         private Dictionary<string, object>[] CreateEntityRootEntityThrees(ManyToManyContext context)
@@ -1165,8 +1165,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
             => CreateInstance(
                 context?.Set<Dictionary<string, object>>("EntityRootEntityThree"), (e, p) =>
                 {
-                    e["EntityThreeId"] = context?.Entry(three).Property(e => e.Id).CurrentValue ?? three.Id;
-                    e["EntityRootId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
+                    e["ThreeSkipSharedId"] = context?.Entry(three).Property(e => e.Id).CurrentValue ?? three.Id;
+                    e["RootSkipSharedId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
                 });
 
         private Dictionary<string, object>[] CreateJoinCompositeKeyToRootShareds(ManyToManyContext context)
@@ -1214,19 +1214,19 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
             };
 
         private static ICollection<TEntity> CreateCollection<TEntity>(bool proxy)
-            => proxy ? (ICollection<TEntity>)new ObservableCollection<TEntity>() : new List<TEntity>();
+            => proxy ? new ObservableCollection<TEntity>() : new List<TEntity>();
 
         private static Dictionary<string, object> CreateJoinCompositeKeyToRootShared(
             ManyToManyContext context,
             EntityRoot root,
             EntityCompositeKey composite)
             => CreateInstance(
-                context?.Set<Dictionary<string, object>>("JoinCompositeKeyToRootShared"), (e, p) =>
+                context?.Set<Dictionary<string, object>>("EntityCompositeKeyEntityRoot"), (e, p) =>
                 {
-                    e["RootId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
-                    e["CompositeId1"] = context?.Entry(composite).Property(e => e.Key1).CurrentValue ?? composite.Key1;
-                    e["CompositeId2"] = composite.Key2;
-                    e["CompositeId3"] = composite.Key3;
+                    e["RootSkipSharedId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
+                    e["CompositeKeySkipSharedKey1"] = context?.Entry(composite).Property(e => e.Key1).CurrentValue ?? composite.Key1;
+                    e["CompositeKeySkipSharedKey2"] = composite.Key2;
+                    e["CompositeKeySkipSharedKey3"] = composite.Key3;
                 });
 
         private static TEntity CreateInstance<TEntity>(DbSet<TEntity> set, Action<TEntity, bool> configureEntity)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
@@ -130,9 +130,9 @@ WHERE (
 FROM [EntityTwos] AS [e]
 ORDER BY (
     SELECT COUNT_BIG(*)
-    FROM [JoinTwoSelfShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e0] ON [j].[LeftId] = [e0].[Id]
-    WHERE ([e].[Id] = [j].[RightId]) AND ([e0].[Name] IS NOT NULL AND ([e0].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    FROM [EntityTwoEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)
@@ -143,10 +143,10 @@ ORDER BY (
                 @"SELECT AVG(CAST([t].[Key1] AS float))
 FROM [EntityTwos] AS [e]
 INNER JOIN (
-    SELECT [e0].[Key1], [j].[TwoId]
-    FROM [JoinTwoToCompositeKeyShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[TwoId]");
+    SELECT [e1].[Key1], [e0].[TwoSkipSharedId]
+    FROM [EntityCompositeKeyEntityTwo] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[TwoSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_many_max(bool async)
@@ -171,10 +171,10 @@ INNER JOIN (
                 @"SELECT MIN([t].[Id])
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e0].[EntityThreeId]
+    SELECT [e1].[Id], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityRoots] AS [e1] ON [e0].[EntityRootId] = [e1].[Id]
-) AS [t] ON [e].[Id] = [t].[EntityThreeId]");
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[ThreeSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_many_sum(bool async)
@@ -185,10 +185,10 @@ INNER JOIN (
                 @"SELECT COALESCE(SUM([t].[Key1]), 0)
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e0].[Key1], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[RootId]");
+    SELECT [e1].[Key1], [e0].[RootSkipSharedId]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_subquery_average(bool async)
@@ -343,15 +343,15 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
             await base.Skip_navigation_of_type(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
-    WHERE [e0].[Discriminator] = N'EntityLeaf'
-) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
+    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
+    WHERE [e1].[Discriminator] = N'EntityLeaf'
+) AS [t] ON (([e].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -362,11 +362,11 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeI
                 @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId]
 FROM [EntityTwos] AS [e]
 INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
-    SELECT TOP(1) [e1].[Id]
-    FROM [JoinTwoSelfShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e1] ON [j].[RightId] = [e1].[Id]
-    WHERE [e0].[Id] = [j].[LeftId]
-    ORDER BY [e1].[Id])");
+    SELECT TOP(1) [e2].[Id]
+    FROM [EntityTwoEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[SelfSkipSharedRightId] = [e2].[Id]
+    WHERE [e0].[Id] = [e1].[SelfSkipSharedLeftId]
+    ORDER BY [e2].[Id])");
         }
 
         public override async Task Left_join_with_skip_navigation(bool async)
@@ -377,16 +377,16 @@ INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
                 @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN [EntityCompositeKeys] AS [e0] ON (
-    SELECT TOP(1) [e1].[Id]
-    FROM [JoinTwoToCompositeKeyShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e1] ON [j].[TwoId] = [e1].[Id]
-    WHERE (([e].[Key1] = [j].[CompositeId1]) AND ([e].[Key2] = [j].[CompositeId2])) AND ([e].[Key3] = [j].[CompositeId3])
-    ORDER BY [e1].[Id]) = (
     SELECT TOP(1) [e2].[Id]
-    FROM [JoinThreeToCompositeKeyFull] AS [j0]
-    INNER JOIN [EntityThrees] AS [e2] ON [j0].[ThreeId] = [e2].[Id]
-    WHERE (([e0].[Key1] = [j0].[CompositeId1]) AND ([e0].[Key2] = [j0].[CompositeId2])) AND ([e0].[Key3] = [j0].[CompositeId3])
-    ORDER BY [e2].[Id])
+    FROM [EntityCompositeKeyEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[TwoSkipSharedId] = [e2].[Id]
+    WHERE (([e].[Key1] = [e1].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [e1].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [e1].[CompositeKeySkipSharedKey3])
+    ORDER BY [e2].[Id]) = (
+    SELECT TOP(1) [e3].[Id]
+    FROM [JoinThreeToCompositeKeyFull] AS [j]
+    INNER JOIN [EntityThrees] AS [e3] ON [j].[ThreeId] = [e3].[Id]
+    WHERE (([e0].[Key1] = [j].[CompositeId1]) AND ([e0].[Key2] = [j].[CompositeId2])) AND ([e0].[Key3] = [j].[CompositeId3])
+    ORDER BY [e3].[Id])
 ORDER BY [e].[Key1], [e0].[Key1], [e].[Key2], [e0].[Key2]");
         }
 
@@ -398,10 +398,10 @@ ORDER BY [e].[Key1], [e0].[Key1], [e].[Key2], [e0].[Key2]");
                 @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityRootId]
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[RootSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityThrees] AS [e1] ON [e0].[EntityThreeId] = [e1].[Id]
-) AS [t] ON [e].[Id] = [t].[EntityRootId]");
+    INNER JOIN [EntityThrees] AS [e1] ON [e0].[ThreeSkipSharedId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]");
         }
 
         public override async Task Select_many_over_skip_navigation_where(bool async)
@@ -480,11 +480,11 @@ INNER JOIN (
                 @"SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen]
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[EntityThreeId]
+    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityRoots] AS [e1] ON [e0].[EntityRootId] = [e1].[Id]
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
     WHERE [e1].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
-) AS [t] ON [e].[Id] = [t].[EntityThreeId]");
+) AS [t] ON [e].[Id] = [t].[ThreeSkipSharedId]");
         }
 
         public override async Task Select_many_over_skip_navigation_cast(bool async)
@@ -525,7 +525,7 @@ ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
             await base.Select_skip_navigation_multiple(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
+                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3]
 FROM [EntityTwos] AS [e]
 LEFT JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[ThreeId], [j].[TwoId]
@@ -533,16 +533,16 @@ LEFT JOIN (
     INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
 LEFT JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[LeftId], [j0].[RightId]
-    FROM [JoinTwoSelfShared] AS [j0]
-    INNER JOIN [EntityTwos] AS [e1] ON [j0].[LeftId] = [e1].[Id]
-) AS [t0] ON [e].[Id] = [t0].[RightId]
+    SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[ExtraId], [e2].[Name], [e2].[ReferenceInverseId], [e1].[SelfSkipSharedLeftId], [e1].[SelfSkipSharedRightId]
+    FROM [EntityTwoEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[SelfSkipSharedLeftId] = [e2].[Id]
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedRightId]
 LEFT JOIN (
-    SELECT [e2].[Key1], [e2].[Key2], [e2].[Key3], [e2].[Name], [j1].[TwoId], [j1].[CompositeId1], [j1].[CompositeId2], [j1].[CompositeId3]
-    FROM [JoinTwoToCompositeKeyShared] AS [j1]
-    INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
-) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
+    SELECT [e4].[Key1], [e4].[Key2], [e4].[Key3], [e4].[Name], [e3].[TwoSkipSharedId], [e3].[CompositeKeySkipSharedKey1], [e3].[CompositeKeySkipSharedKey2], [e3].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityTwo] AS [e3]
+    INNER JOIN [EntityCompositeKeys] AS [e4] ON (([e3].[CompositeKeySkipSharedKey1] = [e4].[Key1]) AND ([e3].[CompositeKeySkipSharedKey2] = [e4].[Key2])) AND ([e3].[CompositeKeySkipSharedKey3] = [e4].[Key3])
+) AS [t1] ON [e].[Id] = [t1].[TwoSkipSharedId]
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t0].[Id], [t1].[TwoSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -569,14 +569,14 @@ ORDER BY [e].[Id]");
             await base.Include_skip_navigation(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
-) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
+    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
+) AS [t] ON (([e].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -692,18 +692,18 @@ ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
             await base.Filtered_include_skip_navigation_order_by_skip(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId]
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId]
 FROM [EntityTwos] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[LeftId], [t].[RightId]
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[SelfSkipSharedLeftId], [t].[SelfSkipSharedRightId]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[LeftId], [j].[RightId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoSelfShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[SelfSkipSharedLeftId], [e0].[SelfSkipSharedRightId], ROW_NUMBER() OVER(PARTITION BY [e0].[SelfSkipSharedLeftId] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityTwoEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedRightId] = [e1].[Id]
     ) AS [t]
     WHERE 2 < [t].[row]
-) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedLeftId]
+ORDER BY [e].[Id], [t0].[SelfSkipSharedLeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -711,18 +711,18 @@ ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
             await base.Filtered_include_skip_navigation_order_by_take(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoToCompositeKeyShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], ROW_NUMBER() OVER(PARTITION BY [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
     ) AS [t]
     WHERE [t].[row] <= 2
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -749,20 +749,20 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
             await base.Filtered_then_include_skip_navigation_where(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityRootId], [e0].[EntityThreeId], [t].[Id] AS [Id0], [t].[Name] AS [Name0], [t].[OneId], [t].[ThreeId]
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId], [t].[Id] AS [Id0], [t].[Name] AS [Name0], [t].[OneId], [t].[ThreeId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityThrees] AS [e1] ON [e0].[EntityThreeId] = [e1].[Id]
+    INNER JOIN [EntityThrees] AS [e1] ON [e0].[ThreeSkipSharedId] = [e1].[Id]
     LEFT JOIN (
         SELECT [e2].[Id], [e2].[Name], [j].[OneId], [j].[ThreeId]
         FROM [JoinOneToThreePayloadFullShared] AS [j]
         INNER JOIN [EntityOnes] AS [e2] ON [j].[OneId] = [e2].[Id]
         WHERE [e2].[Id] < 10
     ) AS [t] ON [e1].[Id] = [t].[ThreeId]
-) AS [t0] ON [e].[Id] = [t0].[EntityRootId]
-ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
+) AS [t0] ON [e].[Id] = [t0].[RootSkipSharedId]
+ORDER BY [e].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -770,23 +770,23 @@ ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[O
             await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
-    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[Id0], [t0].[CompositeId1] AS [CompositeId10], [t0].[CompositeId2] AS [CompositeId20], [t0].[CompositeId3] AS [CompositeId30]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+    SELECT [e1].[Key1], [e1].[Key2], [e1].[Key3], [e1].[Name], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[Id0], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
     LEFT JOIN (
         SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[Id0], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
         FROM (
-            SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[Id] AS [Id0], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
-            FROM [JoinThreeToCompositeKeyFull] AS [j0]
-            INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+            SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[Name], [e2].[ReferenceInverseId], [j].[Id] AS [Id0], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e2].[Id]) AS [row]
+            FROM [JoinThreeToCompositeKeyFull] AS [j]
+            INNER JOIN [EntityThrees] AS [e2] ON [j].[ThreeId] = [e2].[Id]
         ) AS [t]
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
-    ) AS [t0] ON (([e0].[Key1] = [t0].[CompositeId1]) AND ([e0].[Key2] = [t0].[CompositeId2])) AND ([e0].[Key3] = [t0].[CompositeId3])
-) AS [t1] ON [e].[Id] = [t1].[RootId]
-ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id]");
+    ) AS [t0] ON (([e1].[Key1] = [t0].[CompositeId1]) AND ([e1].[Key2] = [t0].[CompositeId2])) AND ([e1].[Key3] = [t0].[CompositeId3])
+) AS [t1] ON [e].[Id] = [t1].[RootSkipSharedId]
+ORDER BY [e].[Id], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -794,21 +794,21 @@ ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
             await base.Filtered_include_skip_navigation_where_then_include_skip_navigation(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
-    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name] AS [Name0], [t].[ReferenceInverseId], [t].[TwoId], [t].[CompositeId1] AS [CompositeId10], [t].[CompositeId2] AS [CompositeId20], [t].[CompositeId3] AS [CompositeId30]
+    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name] AS [Name0], [t].[ReferenceInverseId], [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
     FROM [JoinCompositeKeyToLeaf] AS [j]
     INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
     LEFT JOIN (
-        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[TwoId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3]
-        FROM [JoinTwoToCompositeKeyShared] AS [j0]
-        INNER JOIN [EntityTwos] AS [e1] ON [j0].[TwoId] = [e1].[Id]
-    ) AS [t] ON (([e0].[Key1] = [t].[CompositeId1]) AND ([e0].[Key2] = [t].[CompositeId2])) AND ([e0].[Key3] = [t].[CompositeId3])
+        SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[ExtraId], [e2].[Name], [e2].[ReferenceInverseId], [e1].[TwoSkipSharedId], [e1].[CompositeKeySkipSharedKey1], [e1].[CompositeKeySkipSharedKey2], [e1].[CompositeKeySkipSharedKey3]
+        FROM [EntityCompositeKeyEntityTwo] AS [e1]
+        INNER JOIN [EntityTwos] AS [e2] ON [e1].[TwoSkipSharedId] = [e2].[Id]
+    ) AS [t] ON (([e0].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e0].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e0].[Key3] = [t].[CompositeKeySkipSharedKey3])
     WHERE [e0].[Key1] < 5
 ) AS [t0] ON [e].[Id] = [t0].[LeafId]
 WHERE [e].[Discriminator] = N'EntityLeaf'
-ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
+ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -836,6 +836,7 @@ OUTER APPLY (
     ) AS [t0] ON [t].[Id] = [t0].[TwoId]
 ) AS [t1]
 ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0]");
+
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -984,10 +985,10 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
                 @"SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
-) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
+    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
+) AS [t] ON (([e].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t].[CompositeKeySkipSharedKey3])
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
         }
 
@@ -1159,15 +1160,15 @@ ORDER BY [e].[Id]",
                 @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id]
 FROM [EntityTwos] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[LeftId]
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[SelfSkipSharedLeftId]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[LeftId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoSelfShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[SelfSkipSharedLeftId], ROW_NUMBER() OVER(PARTITION BY [e0].[SelfSkipSharedLeftId] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityTwoEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedRightId] = [e1].[Id]
     ) AS [t]
     WHERE 2 < [t].[row]
-) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedLeftId]
+ORDER BY [e].[Id], [t0].[SelfSkipSharedLeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take_split(bool async)
@@ -1182,15 +1183,15 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
                 @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoToCompositeKeyShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], ROW_NUMBER() OVER(PARTITION BY [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
     ) AS [t]
     WHERE [t].[row] <= 2
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_split(bool async)
@@ -1225,29 +1226,29 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
 FROM [EntityRoots] AS [e]
 ORDER BY [e].[Id]",
                 //
-                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[EntityRootId], [t].[EntityThreeId]
+                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityRootId], [e0].[EntityThreeId]
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityThrees] AS [e1] ON [e0].[EntityThreeId] = [e1].[Id]
-) AS [t] ON [e].[Id] = [t].[EntityRootId]
-ORDER BY [e].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]",
+    INNER JOIN [EntityThrees] AS [e1] ON [e0].[ThreeSkipSharedId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]
+ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]",
                 //
-                @"SELECT [t0].[Id], [t0].[Name], [e].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]
+                @"SELECT [t0].[Id], [t0].[Name], [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e0].[EntityRootId], [e0].[EntityThreeId]
+    SELECT [e1].[Id], [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityThrees] AS [e1] ON [e0].[EntityThreeId] = [e1].[Id]
-) AS [t] ON [e].[Id] = [t].[EntityRootId]
+    INNER JOIN [EntityThrees] AS [e1] ON [e0].[ThreeSkipSharedId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]
 INNER JOIN (
     SELECT [e2].[Id], [e2].[Name], [j].[ThreeId]
     FROM [JoinOneToThreePayloadFullShared] AS [j]
     INNER JOIN [EntityOnes] AS [e2] ON [j].[OneId] = [e2].[Id]
     WHERE [e2].[Id] < 10
 ) AS [t0] ON [t].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]");
+ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take_split(bool async)
@@ -1259,32 +1260,32 @@ ORDER BY [e].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]");
 FROM [EntityRoots] AS [e]
 ORDER BY [e].[Id]",
                 //
-                @"SELECT [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]
+                @"SELECT [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [e].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[RootId]
-ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]",
+    SELECT [e1].[Key1], [e1].[Key2], [e1].[Key3], [e1].[Name], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]
+ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3]",
                 //
-                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[RootId]
+    SELECT [e1].[Key1], [e1].[Key2], [e1].[Key3], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]
 INNER JOIN (
     SELECT [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
     FROM (
-        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
-        FROM [JoinThreeToCompositeKeyFull] AS [j0]
-        INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+        SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[Name], [e2].[ReferenceInverseId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e2].[Id]) AS [row]
+        FROM [JoinThreeToCompositeKeyFull] AS [j]
+        INNER JOIN [EntityThrees] AS [e2] ON [j].[ThreeId] = [e2].[Id]
     ) AS [t1]
     WHERE (1 < [t1].[row]) AND ([t1].[row] <= 3)
 ) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_split(bool async)
@@ -1317,10 +1318,10 @@ INNER JOIN (
     WHERE [e0].[Key1] < 5
 ) AS [t] ON [e].[Id] = [t].[LeafId]
 INNER JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3]
-    FROM [JoinTwoToCompositeKeyShared] AS [j0]
-    INNER JOIN [EntityTwos] AS [e1] ON [j0].[TwoId] = [e1].[Id]
-) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
+    SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[ExtraId], [e2].[Name], [e2].[ReferenceInverseId], [e1].[CompositeKeySkipSharedKey1], [e1].[CompositeKeySkipSharedKey2], [e1].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[TwoSkipSharedId] = [e2].[Id]
+) AS [t0] ON (([t].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([t].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([t].[Key3] = [t0].[CompositeKeySkipSharedKey3])
 WHERE [e].[Discriminator] = N'EntityLeaf'
 ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -129,9 +129,9 @@ WHERE (
 FROM [EntityTwos] AS [e]
 ORDER BY (
     SELECT COUNT_BIG(*)
-    FROM [JoinTwoSelfShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e0] ON [j].[LeftId] = [e0].[Id]
-    WHERE ([e].[Id] = [j].[RightId]) AND ([e0].[Name] IS NOT NULL AND ([e0].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    FROM [EntityTwoEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)
@@ -142,10 +142,10 @@ ORDER BY (
                 @"SELECT AVG(CAST([t].[Key1] AS float))
 FROM [EntityTwos] AS [e]
 INNER JOIN (
-    SELECT [e0].[Key1], [j].[TwoId]
-    FROM [JoinTwoToCompositeKeyShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[TwoId]");
+    SELECT [e1].[Key1], [e0].[TwoSkipSharedId]
+    FROM [EntityCompositeKeyEntityTwo] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[TwoSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_many_max(bool async)
@@ -170,10 +170,10 @@ INNER JOIN (
                 @"SELECT MIN([t].[Id])
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e0].[EntityThreeId]
+    SELECT [e1].[Id], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityRoots] AS [e1] ON [e0].[EntityRootId] = [e1].[Id]
-) AS [t] ON [e].[Id] = [t].[EntityThreeId]");
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[ThreeSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_many_sum(bool async)
@@ -184,10 +184,10 @@ INNER JOIN (
                 @"SELECT COALESCE(SUM([t].[Key1]), 0)
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e0].[Key1], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[RootId]");
+    SELECT [e1].[Key1], [e0].[RootSkipSharedId]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_subquery_average(bool async)
@@ -342,15 +342,15 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
             await base.Skip_navigation_of_type(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
-    WHERE [e0].[Discriminator] = N'EntityLeaf'
-) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
+    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
+    WHERE [e1].[Discriminator] = N'EntityLeaf'
+) AS [t] ON (([e].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -361,11 +361,11 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeI
                 @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId]
 FROM [EntityTwos] AS [e]
 INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
-    SELECT TOP(1) [e1].[Id]
-    FROM [JoinTwoSelfShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e1] ON [j].[RightId] = [e1].[Id]
-    WHERE [e0].[Id] = [j].[LeftId]
-    ORDER BY [e1].[Id])");
+    SELECT TOP(1) [e2].[Id]
+    FROM [EntityTwoEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[SelfSkipSharedRightId] = [e2].[Id]
+    WHERE [e0].[Id] = [e1].[SelfSkipSharedLeftId]
+    ORDER BY [e2].[Id])");
         }
 
         public override async Task Left_join_with_skip_navigation(bool async)
@@ -376,16 +376,16 @@ INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
                 @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN [EntityCompositeKeys] AS [e0] ON (
-    SELECT TOP(1) [e1].[Id]
-    FROM [JoinTwoToCompositeKeyShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e1] ON [j].[TwoId] = [e1].[Id]
-    WHERE (([e].[Key1] = [j].[CompositeId1]) AND ([e].[Key2] = [j].[CompositeId2])) AND ([e].[Key3] = [j].[CompositeId3])
-    ORDER BY [e1].[Id]) = (
     SELECT TOP(1) [e2].[Id]
-    FROM [JoinThreeToCompositeKeyFull] AS [j0]
-    INNER JOIN [EntityThrees] AS [e2] ON [j0].[ThreeId] = [e2].[Id]
-    WHERE (([e0].[Key1] = [j0].[CompositeId1]) AND ([e0].[Key2] = [j0].[CompositeId2])) AND ([e0].[Key3] = [j0].[CompositeId3])
-    ORDER BY [e2].[Id])
+    FROM [EntityCompositeKeyEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[TwoSkipSharedId] = [e2].[Id]
+    WHERE (([e].[Key1] = [e1].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [e1].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [e1].[CompositeKeySkipSharedKey3])
+    ORDER BY [e2].[Id]) = (
+    SELECT TOP(1) [e3].[Id]
+    FROM [JoinThreeToCompositeKeyFull] AS [j]
+    INNER JOIN [EntityThrees] AS [e3] ON [j].[ThreeId] = [e3].[Id]
+    WHERE (([e0].[Key1] = [j].[CompositeId1]) AND ([e0].[Key2] = [j].[CompositeId2])) AND ([e0].[Key3] = [j].[CompositeId3])
+    ORDER BY [e3].[Id])
 ORDER BY [e].[Key1], [e0].[Key1], [e].[Key2], [e0].[Key2]");
         }
 
@@ -397,10 +397,10 @@ ORDER BY [e].[Key1], [e0].[Key1], [e].[Key2], [e0].[Key2]");
                 @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityRootId]
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[RootSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityThrees] AS [e1] ON [e0].[EntityThreeId] = [e1].[Id]
-) AS [t] ON [e].[Id] = [t].[EntityRootId]");
+    INNER JOIN [EntityThrees] AS [e1] ON [e0].[ThreeSkipSharedId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]");
         }
 
         public override async Task Select_many_over_skip_navigation_where(bool async)
@@ -479,11 +479,11 @@ INNER JOIN (
                 @"SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen]
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[EntityThreeId]
+    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityRoots] AS [e1] ON [e0].[EntityRootId] = [e1].[Id]
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
     WHERE [e1].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
-) AS [t] ON [e].[Id] = [t].[EntityThreeId]");
+) AS [t] ON [e].[Id] = [t].[ThreeSkipSharedId]");
         }
 
         public override async Task Select_many_over_skip_navigation_cast(bool async)
@@ -524,7 +524,7 @@ ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
             await base.Select_skip_navigation_multiple(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
+                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3]
 FROM [EntityTwos] AS [e]
 LEFT JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[ThreeId], [j].[TwoId]
@@ -532,16 +532,16 @@ LEFT JOIN (
     INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
 LEFT JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[LeftId], [j0].[RightId]
-    FROM [JoinTwoSelfShared] AS [j0]
-    INNER JOIN [EntityTwos] AS [e1] ON [j0].[LeftId] = [e1].[Id]
-) AS [t0] ON [e].[Id] = [t0].[RightId]
+    SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[ExtraId], [e2].[Name], [e2].[ReferenceInverseId], [e1].[SelfSkipSharedLeftId], [e1].[SelfSkipSharedRightId]
+    FROM [EntityTwoEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[SelfSkipSharedLeftId] = [e2].[Id]
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedRightId]
 LEFT JOIN (
-    SELECT [e2].[Key1], [e2].[Key2], [e2].[Key3], [e2].[Name], [j1].[TwoId], [j1].[CompositeId1], [j1].[CompositeId2], [j1].[CompositeId3]
-    FROM [JoinTwoToCompositeKeyShared] AS [j1]
-    INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
-) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
+    SELECT [e4].[Key1], [e4].[Key2], [e4].[Key3], [e4].[Name], [e3].[TwoSkipSharedId], [e3].[CompositeKeySkipSharedKey1], [e3].[CompositeKeySkipSharedKey2], [e3].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityTwo] AS [e3]
+    INNER JOIN [EntityCompositeKeys] AS [e4] ON (([e3].[CompositeKeySkipSharedKey1] = [e4].[Key1]) AND ([e3].[CompositeKeySkipSharedKey2] = [e4].[Key2])) AND ([e3].[CompositeKeySkipSharedKey3] = [e4].[Key3])
+) AS [t1] ON [e].[Id] = [t1].[TwoSkipSharedId]
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t0].[Id], [t1].[TwoSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -568,14 +568,14 @@ ORDER BY [e].[Id]");
             await base.Include_skip_navigation(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
-) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
+) AS [t] ON (([e].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -691,18 +691,18 @@ ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
             await base.Filtered_include_skip_navigation_order_by_skip(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId]
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId]
 FROM [EntityTwos] AS [e]
 LEFT JOIN (
-    SELECT [t].[LeftId], [t].[RightId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
+    SELECT [t].[SelfSkipSharedLeftId], [t].[SelfSkipSharedRightId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
     FROM (
-        SELECT [j].[LeftId], [j].[RightId], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoSelfShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+        SELECT [e0].[SelfSkipSharedLeftId], [e0].[SelfSkipSharedRightId], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [e0].[SelfSkipSharedLeftId] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityTwoEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedRightId] = [e1].[Id]
     ) AS [t]
     WHERE 2 < [t].[row]
-) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedLeftId]
+ORDER BY [e].[Id], [t0].[SelfSkipSharedLeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -710,18 +710,18 @@ ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
             await base.Filtered_include_skip_navigation_order_by_take(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[TwoId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
+    SELECT [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
     FROM (
-        SELECT [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoToCompositeKeyShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        SELECT [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
     ) AS [t]
     WHERE [t].[row] <= 2
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -748,20 +748,20 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
             await base.Filtered_then_include_skip_navigation_where(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
-    SELECT [e0].[EntityRootId], [e0].[EntityThreeId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [t].[OneId], [t].[ThreeId], [t].[Payload], [t].[Id] AS [Id0], [t].[Name] AS [Name0]
+    SELECT [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [t].[OneId], [t].[ThreeId], [t].[Payload], [t].[Id] AS [Id0], [t].[Name] AS [Name0]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityThrees] AS [e1] ON [e0].[EntityThreeId] = [e1].[Id]
+    INNER JOIN [EntityThrees] AS [e1] ON [e0].[ThreeSkipSharedId] = [e1].[Id]
     LEFT JOIN (
         SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e2].[Id], [e2].[Name]
         FROM [JoinOneToThreePayloadFullShared] AS [j]
         INNER JOIN [EntityOnes] AS [e2] ON [j].[OneId] = [e2].[Id]
         WHERE [e2].[Id] < 10
     ) AS [t] ON [e1].[Id] = [t].[ThreeId]
-) AS [t0] ON [e].[Id] = [t0].[EntityRootId]
-ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
+) AS [t0] ON [e].[Id] = [t0].[RootSkipSharedId]
+ORDER BY [e].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -769,23 +769,23 @@ ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[O
             await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [t0].[Id], [t0].[CompositeId1] AS [CompositeId10], [t0].[CompositeId2] AS [CompositeId20], [t0].[CompositeId3] AS [CompositeId30], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Key1], [e1].[Key2], [e1].[Key3], [e1].[Name], [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
     LEFT JOIN (
         SELECT [t].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[ThreeId], [t].[Id0], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
         FROM (
-            SELECT [j0].[Id], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [j0].[ThreeId], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
-            FROM [JoinThreeToCompositeKeyFull] AS [j0]
-            INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+            SELECT [j].[Id], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[ThreeId], [e2].[Id] AS [Id0], [e2].[CollectionInverseId], [e2].[Name], [e2].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e2].[Id]) AS [row]
+            FROM [JoinThreeToCompositeKeyFull] AS [j]
+            INNER JOIN [EntityThrees] AS [e2] ON [j].[ThreeId] = [e2].[Id]
         ) AS [t]
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
-    ) AS [t0] ON (([e0].[Key1] = [t0].[CompositeId1]) AND ([e0].[Key2] = [t0].[CompositeId2])) AND ([e0].[Key3] = [t0].[CompositeId3])
-) AS [t1] ON [e].[Id] = [t1].[RootId]
-ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id0]");
+    ) AS [t0] ON (([e1].[Key1] = [t0].[CompositeId1]) AND ([e1].[Key2] = [t0].[CompositeId2])) AND ([e1].[Key3] = [t0].[CompositeId3])
+) AS [t1] ON [e].[Id] = [t1].[RootSkipSharedId]
+ORDER BY [e].[Id], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Id0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -793,21 +793,21 @@ ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
             await base.Filtered_include_skip_navigation_where_then_include_skip_navigation(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId]
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [t].[TwoId], [t].[CompositeId1] AS [CompositeId10], [t].[CompositeId2] AS [CompositeId20], [t].[CompositeId3] AS [CompositeId30], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name] AS [Name0], [t].[ReferenceInverseId]
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name] AS [Name0], [t].[ReferenceInverseId]
     FROM [JoinCompositeKeyToLeaf] AS [j]
     INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
     LEFT JOIN (
-        SELECT [j0].[TwoId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId]
-        FROM [JoinTwoToCompositeKeyShared] AS [j0]
-        INNER JOIN [EntityTwos] AS [e1] ON [j0].[TwoId] = [e1].[Id]
-    ) AS [t] ON (([e0].[Key1] = [t].[CompositeId1]) AND ([e0].[Key2] = [t].[CompositeId2])) AND ([e0].[Key3] = [t].[CompositeId3])
+        SELECT [e1].[TwoSkipSharedId], [e1].[CompositeKeySkipSharedKey1], [e1].[CompositeKeySkipSharedKey2], [e1].[CompositeKeySkipSharedKey3], [e2].[Id], [e2].[CollectionInverseId], [e2].[ExtraId], [e2].[Name], [e2].[ReferenceInverseId]
+        FROM [EntityCompositeKeyEntityTwo] AS [e1]
+        INNER JOIN [EntityTwos] AS [e2] ON [e1].[TwoSkipSharedId] = [e2].[Id]
+    ) AS [t] ON (([e0].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e0].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e0].[Key3] = [t].[CompositeKeySkipSharedKey3])
     WHERE [e0].[Key1] < 5
 ) AS [t0] ON [e].[Id] = [t0].[LeafId]
 WHERE [e].[Discriminator] = N'EntityLeaf'
-ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
+ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -980,13 +980,13 @@ ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
                 //
-                @"SELECT [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [e].[Key1], [e].[Key2], [e].[Key3]
+                @"SELECT [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
-) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
+) AS [t] ON (([e].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t].[CompositeKeySkipSharedKey3])
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
         }
 
@@ -1155,18 +1155,18 @@ ORDER BY [e].[Id], [t].[Id]");
 FROM [EntityTwos] AS [e]
 ORDER BY [e].[Id]",
                 //
-                @"SELECT [t0].[LeftId], [t0].[RightId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id]
+                @"SELECT [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id]
 FROM [EntityTwos] AS [e]
 INNER JOIN (
-    SELECT [t].[LeftId], [t].[RightId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
+    SELECT [t].[SelfSkipSharedLeftId], [t].[SelfSkipSharedRightId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
     FROM (
-        SELECT [j].[LeftId], [j].[RightId], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoSelfShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+        SELECT [e0].[SelfSkipSharedLeftId], [e0].[SelfSkipSharedRightId], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [e0].[SelfSkipSharedLeftId] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityTwoEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedRightId] = [e1].[Id]
     ) AS [t]
     WHERE 2 < [t].[row]
-) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedLeftId]
+ORDER BY [e].[Id], [t0].[SelfSkipSharedLeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take_split(bool async)
@@ -1178,18 +1178,18 @@ ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
                 //
-                @"SELECT [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Key1], [e].[Key2], [e].[Key3]
+                @"SELECT [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [t].[TwoId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
+    SELECT [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
     FROM (
-        SELECT [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoToCompositeKeyShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        SELECT [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
     ) AS [t]
     WHERE [t].[row] <= 2
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_split(bool async)
@@ -1224,29 +1224,29 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
 FROM [EntityRoots] AS [e]
 ORDER BY [e].[Id]",
                 //
-                @"SELECT [t].[EntityRootId], [t].[EntityThreeId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id]
+                @"SELECT [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e0].[EntityRootId], [e0].[EntityThreeId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId]
+    SELECT [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityThrees] AS [e1] ON [e0].[EntityThreeId] = [e1].[Id]
-) AS [t] ON [e].[Id] = [t].[EntityRootId]
-ORDER BY [e].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]",
+    INNER JOIN [EntityThrees] AS [e1] ON [e0].[ThreeSkipSharedId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]
+ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]",
                 //
-                @"SELECT [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id], [t0].[Name], [e].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]
+                @"SELECT [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id], [t0].[Name], [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [e0].[EntityRootId], [e0].[EntityThreeId], [e1].[Id]
+    SELECT [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId], [e1].[Id]
     FROM [EntityRootEntityThree] AS [e0]
-    INNER JOIN [EntityThrees] AS [e1] ON [e0].[EntityThreeId] = [e1].[Id]
-) AS [t] ON [e].[Id] = [t].[EntityRootId]
+    INNER JOIN [EntityThrees] AS [e1] ON [e0].[ThreeSkipSharedId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]
 INNER JOIN (
     SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e2].[Id], [e2].[Name]
     FROM [JoinOneToThreePayloadFullShared] AS [j]
     INNER JOIN [EntityOnes] AS [e2] ON [j].[OneId] = [e2].[Id]
     WHERE [e2].[Id] < 10
 ) AS [t0] ON [t].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]");
+ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take_split(bool async)
@@ -1258,32 +1258,32 @@ ORDER BY [e].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]");
 FROM [EntityRoots] AS [e]
 ORDER BY [e].[Id]",
                 //
-                @"SELECT [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [e].[Id]
+                @"SELECT [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [e].[Id]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[RootId]
-ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]",
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Key1], [e1].[Key2], [e1].[Key3], [e1].[Name]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]
+ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3]",
                 //
-                @"SELECT [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]
+                @"SELECT [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Key1], [e0].[Key2], [e0].[Key3]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[RootId]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Key1], [e1].[Key2], [e1].[Key3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootSkipSharedId]
 INNER JOIN (
     SELECT [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId]
     FROM (
-        SELECT [j0].[Id], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [j0].[ThreeId], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
-        FROM [JoinThreeToCompositeKeyFull] AS [j0]
-        INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+        SELECT [j].[Id], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[ThreeId], [e2].[Id] AS [Id0], [e2].[CollectionInverseId], [e2].[Name], [e2].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e2].[Id]) AS [row]
+        FROM [JoinThreeToCompositeKeyFull] AS [j]
+        INNER JOIN [EntityThrees] AS [e2] ON [j].[ThreeId] = [e2].[Id]
     ) AS [t1]
     WHERE (1 < [t1].[row]) AND ([t1].[row] <= 3)
 ) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0]");
+ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_split(bool async)
@@ -1307,7 +1307,7 @@ INNER JOIN (
 WHERE [e].[Discriminator] = N'EntityLeaf'
 ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]",
                 //
-                @"SELECT [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]
+                @"SELECT [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]
 FROM [EntityRoots] AS [e]
 INNER JOIN (
     SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [e0].[Key1], [e0].[Key2], [e0].[Key3]
@@ -1316,10 +1316,10 @@ INNER JOIN (
     WHERE [e0].[Key1] < 5
 ) AS [t] ON [e].[Id] = [t].[LeafId]
 INNER JOIN (
-    SELECT [j0].[TwoId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId]
-    FROM [JoinTwoToCompositeKeyShared] AS [j0]
-    INNER JOIN [EntityTwos] AS [e1] ON [j0].[TwoId] = [e1].[Id]
-) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
+    SELECT [e1].[TwoSkipSharedId], [e1].[CompositeKeySkipSharedKey1], [e1].[CompositeKeySkipSharedKey2], [e1].[CompositeKeySkipSharedKey3], [e2].[Id], [e2].[CollectionInverseId], [e2].[ExtraId], [e2].[Name], [e2].[ReferenceInverseId]
+    FROM [EntityCompositeKeyEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[TwoSkipSharedId] = [e2].[Id]
+) AS [t0] ON (([t].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([t].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([t].[Key3] = [t0].[CompositeKeySkipSharedKey3])
 WHERE [e].[Discriminator] = N'EntityLeaf'
 ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
@@ -133,9 +133,9 @@ WHERE (
 FROM [EntityTwos] AS [e]
 ORDER BY (
     SELECT COUNT_BIG(*)
-    FROM [JoinTwoSelfShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e0] ON [j].[LeftId] = [e0].[Id]
-    WHERE ([e].[Id] = [j].[RightId]) AND ([e0].[Name] IS NOT NULL AND ([e0].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    FROM [EntityTwoEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)
@@ -146,10 +146,10 @@ ORDER BY (
                 @"SELECT AVG(CAST([t].[Key1] AS float))
 FROM [EntityTwos] AS [e]
 INNER JOIN (
-    SELECT [e0].[Key1], [j].[TwoId]
-    FROM [JoinTwoToCompositeKeyShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[TwoId]");
+    SELECT [e1].[Key1], [e0].[TwoSkipSharedId]
+    FROM [EntityCompositeKeyEntityTwo] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[TwoSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_many_max(bool async)
@@ -174,13 +174,13 @@ INNER JOIN (
                 @"SELECT MIN([t0].[Id])
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [e0].[EntityThreeId]
+    SELECT [t].[Id], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id]
         FROM [Roots] AS [r]
-    ) AS [t] ON [e0].[EntityRootId] = [t].[Id]
-) AS [t0] ON [e].[Id] = [t0].[EntityThreeId]");
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_many_sum(bool async)
@@ -191,10 +191,10 @@ INNER JOIN (
                 @"SELECT COALESCE(SUM([t].[Key1]), 0)
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e].[Key1], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
-) AS [t] ON [r].[Id] = [t].[RootId]");
+    SELECT [e0].[Key1], [e].[RootSkipSharedId]
+    FROM [EntityCompositeKeyEntityRoot] AS [e]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([e].[CompositeKeySkipSharedKey1] = [e0].[Key1]) AND ([e].[CompositeKeySkipSharedKey2] = [e0].[Key2])) AND ([e].[CompositeKeySkipSharedKey3] = [e0].[Key3])
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_subquery_average(bool async)
@@ -351,11 +351,11 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
             await base.Skip_navigation_of_type(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
@@ -364,10 +364,10 @@ LEFT JOIN (
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-    ) AS [t] ON [j].[RootId] = [t].[Id]
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] = N'EntityLeaf'
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -378,11 +378,11 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
                 @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId]
 FROM [EntityTwos] AS [e]
 INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
-    SELECT TOP(1) [e1].[Id]
-    FROM [JoinTwoSelfShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e1] ON [j].[RightId] = [e1].[Id]
-    WHERE [e0].[Id] = [j].[LeftId]
-    ORDER BY [e1].[Id])");
+    SELECT TOP(1) [e2].[Id]
+    FROM [EntityTwoEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[SelfSkipSharedRightId] = [e2].[Id]
+    WHERE [e0].[Id] = [e1].[SelfSkipSharedLeftId]
+    ORDER BY [e2].[Id])");
         }
 
         public override async Task Left_join_with_skip_navigation(bool async)
@@ -393,16 +393,16 @@ INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
                 @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN [EntityCompositeKeys] AS [e0] ON (
-    SELECT TOP(1) [e1].[Id]
-    FROM [JoinTwoToCompositeKeyShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e1] ON [j].[TwoId] = [e1].[Id]
-    WHERE (([e].[Key1] = [j].[CompositeId1]) AND ([e].[Key2] = [j].[CompositeId2])) AND ([e].[Key3] = [j].[CompositeId3])
-    ORDER BY [e1].[Id]) = (
     SELECT TOP(1) [e2].[Id]
-    FROM [JoinThreeToCompositeKeyFull] AS [j0]
-    INNER JOIN [EntityThrees] AS [e2] ON [j0].[ThreeId] = [e2].[Id]
-    WHERE (([e0].[Key1] = [j0].[CompositeId1]) AND ([e0].[Key2] = [j0].[CompositeId2])) AND ([e0].[Key3] = [j0].[CompositeId3])
-    ORDER BY [e2].[Id])
+    FROM [EntityCompositeKeyEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[TwoSkipSharedId] = [e2].[Id]
+    WHERE (([e].[Key1] = [e1].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [e1].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [e1].[CompositeKeySkipSharedKey3])
+    ORDER BY [e2].[Id]) = (
+    SELECT TOP(1) [e3].[Id]
+    FROM [JoinThreeToCompositeKeyFull] AS [j]
+    INNER JOIN [EntityThrees] AS [e3] ON [j].[ThreeId] = [e3].[Id]
+    WHERE (([e0].[Key1] = [j].[CompositeId1]) AND ([e0].[Key2] = [j].[CompositeId2])) AND ([e0].[Key3] = [j].[CompositeId3])
+    ORDER BY [e3].[Id])
 ORDER BY [e].[Key1], [e0].[Key1], [e].[Key2], [e0].[Key2]");
         }
 
@@ -414,10 +414,10 @@ ORDER BY [e].[Key1], [e0].[Key1], [e].[Key2], [e0].[Key2]");
                 @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[EntityRootId]
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId]
     FROM [EntityRootEntityThree] AS [e]
-    INNER JOIN [EntityThrees] AS [e0] ON [e].[EntityThreeId] = [e0].[Id]
-) AS [t] ON [r].[Id] = [t].[EntityRootId]");
+    INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]");
         }
 
         public override async Task Select_many_over_skip_navigation_where(bool async)
@@ -496,7 +496,7 @@ INNER JOIN (
                 @"SELECT [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator]
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[EntityThreeId]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
@@ -506,9 +506,9 @@ INNER JOIN (
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-    ) AS [t] ON [e0].[EntityRootId] = [t].[Id]
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
-) AS [t0] ON [e].[Id] = [t0].[EntityThreeId]");
+) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
         }
 
         public override async Task Select_many_over_skip_navigation_cast(bool async)
@@ -552,7 +552,7 @@ ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
             await base.Select_skip_navigation_multiple(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
+                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3]
 FROM [EntityTwos] AS [e]
 LEFT JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[ThreeId], [j].[TwoId]
@@ -560,16 +560,16 @@ LEFT JOIN (
     INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
 LEFT JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[LeftId], [j0].[RightId]
-    FROM [JoinTwoSelfShared] AS [j0]
-    INNER JOIN [EntityTwos] AS [e1] ON [j0].[LeftId] = [e1].[Id]
-) AS [t0] ON [e].[Id] = [t0].[RightId]
+    SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[ExtraId], [e2].[Name], [e2].[ReferenceInverseId], [e1].[SelfSkipSharedLeftId], [e1].[SelfSkipSharedRightId]
+    FROM [EntityTwoEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[SelfSkipSharedLeftId] = [e2].[Id]
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedRightId]
 LEFT JOIN (
-    SELECT [e2].[Key1], [e2].[Key2], [e2].[Key3], [e2].[Name], [j1].[TwoId], [j1].[CompositeId1], [j1].[CompositeId2], [j1].[CompositeId3]
-    FROM [JoinTwoToCompositeKeyShared] AS [j1]
-    INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
-) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
+    SELECT [e4].[Key1], [e4].[Key2], [e4].[Key3], [e4].[Name], [e3].[TwoSkipSharedId], [e3].[CompositeKeySkipSharedKey1], [e3].[CompositeKeySkipSharedKey2], [e3].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityTwo] AS [e3]
+    INNER JOIN [EntityCompositeKeys] AS [e4] ON (([e3].[CompositeKeySkipSharedKey1] = [e4].[Key1]) AND ([e3].[CompositeKeySkipSharedKey2] = [e4].[Key2])) AND ([e3].[CompositeKeySkipSharedKey3] = [e4].[Key3])
+) AS [t1] ON [e].[Id] = [t1].[TwoSkipSharedId]
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t0].[Id], [t1].[TwoSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -596,11 +596,11 @@ ORDER BY [e].[Id]");
             await base.Include_skip_navigation(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
@@ -609,9 +609,9 @@ LEFT JOIN (
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-    ) AS [t] ON [j].[RootId] = [t].[Id]
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]");
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -728,18 +728,18 @@ ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
             await base.Filtered_include_skip_navigation_order_by_skip(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId]
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId]
 FROM [EntityTwos] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[LeftId], [t].[RightId]
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[SelfSkipSharedLeftId], [t].[SelfSkipSharedRightId]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[LeftId], [j].[RightId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoSelfShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[SelfSkipSharedLeftId], [e0].[SelfSkipSharedRightId], ROW_NUMBER() OVER(PARTITION BY [e0].[SelfSkipSharedLeftId] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityTwoEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedRightId] = [e1].[Id]
     ) AS [t]
     WHERE 2 < [t].[row]
-) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedLeftId]
+ORDER BY [e].[Id], [t0].[SelfSkipSharedLeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -747,18 +747,18 @@ ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
             await base.Filtered_include_skip_navigation_order_by_take(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoToCompositeKeyShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], ROW_NUMBER() OVER(PARTITION BY [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
     ) AS [t]
     WHERE [t].[row] <= 2
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -788,22 +788,22 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
                 @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
-END AS [Discriminator], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
+END AS [Discriminator], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 LEFT JOIN (
-    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[EntityRootId], [e].[EntityThreeId], [t].[Id] AS [Id0], [t].[Name] AS [Name0], [t].[OneId], [t].[ThreeId]
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [t].[Id] AS [Id0], [t].[Name] AS [Name0], [t].[OneId], [t].[ThreeId]
     FROM [EntityRootEntityThree] AS [e]
-    INNER JOIN [EntityThrees] AS [e0] ON [e].[EntityThreeId] = [e0].[Id]
+    INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
     LEFT JOIN (
         SELECT [e1].[Id], [e1].[Name], [j].[OneId], [j].[ThreeId]
         FROM [JoinOneToThreePayloadFullShared] AS [j]
         INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
         WHERE [e1].[Id] < 10
     ) AS [t] ON [e0].[Id] = [t].[ThreeId]
-) AS [t0] ON [r].[Id] = [t0].[EntityRootId]
-ORDER BY [r].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
+) AS [t0] ON [r].[Id] = [t0].[RootSkipSharedId]
+ORDER BY [r].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -814,25 +814,25 @@ ORDER BY [r].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[O
                 @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
-END AS [Discriminator], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
+END AS [Discriminator], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 LEFT JOIN (
-    SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[Id0], [t0].[CompositeId1] AS [CompositeId10], [t0].[CompositeId2] AS [CompositeId20], [t0].[CompositeId3] AS [CompositeId30]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
+    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[Id0], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([e].[CompositeKeySkipSharedKey1] = [e0].[Key1]) AND ([e].[CompositeKeySkipSharedKey2] = [e0].[Key2])) AND ([e].[CompositeKeySkipSharedKey3] = [e0].[Key3])
     LEFT JOIN (
         SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[Id0], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
         FROM (
-            SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j0].[Id] AS [Id0], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-            FROM [JoinThreeToCompositeKeyFull] AS [j0]
-            INNER JOIN [EntityThrees] AS [e0] ON [j0].[ThreeId] = [e0].[Id]
+            SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j].[Id] AS [Id0], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
+            FROM [JoinThreeToCompositeKeyFull] AS [j]
+            INNER JOIN [EntityThrees] AS [e1] ON [j].[ThreeId] = [e1].[Id]
         ) AS [t]
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
-    ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-) AS [t1] ON [r].[Id] = [t1].[RootId]
-ORDER BY [r].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id]");
+    ) AS [t0] ON (([e0].[Key1] = [t0].[CompositeId1]) AND ([e0].[Key2] = [t0].[CompositeId2])) AND ([e0].[Key3] = [t0].[CompositeId3])
+) AS [t1] ON [r].[Id] = [t1].[RootSkipSharedId]
+ORDER BY [r].[Id], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -840,22 +840,22 @@ ORDER BY [r].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
             await base.Filtered_include_skip_navigation_where_then_include_skip_navigation(async);
 
             AssertSql(
-                @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]
+                @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [Roots] AS [r]
 INNER JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 INNER JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 LEFT JOIN (
-    SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name] AS [Name0], [t].[ReferenceInverseId], [t].[TwoId], [t].[CompositeId1] AS [CompositeId10], [t].[CompositeId2] AS [CompositeId20], [t].[CompositeId3] AS [CompositeId30]
+    SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name] AS [Name0], [t].[ReferenceInverseId], [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
     FROM [JoinCompositeKeyToLeaf] AS [j]
     INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
     LEFT JOIN (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j0].[TwoId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3]
-        FROM [JoinTwoToCompositeKeyShared] AS [j0]
-        INNER JOIN [EntityTwos] AS [e0] ON [j0].[TwoId] = [e0].[Id]
-    ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
+    ) AS [t] ON (([e].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t].[CompositeKeySkipSharedKey3])
     WHERE [e].[Key1] < 5
 ) AS [t0] ON [r].[Id] = [t0].[LeafId]
-ORDER BY [r].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
+ORDER BY [r].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -1034,8 +1034,8 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
                 @"SELECT [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
@@ -1044,8 +1044,8 @@ INNER JOIN (
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-    ) AS [t] ON [j].[RootId] = [t].[Id]
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
         }
 
@@ -1219,15 +1219,15 @@ ORDER BY [e].[Id]",
                 @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id]
 FROM [EntityTwos] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[LeftId]
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[SelfSkipSharedLeftId]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[LeftId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoSelfShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[SelfSkipSharedLeftId], ROW_NUMBER() OVER(PARTITION BY [e0].[SelfSkipSharedLeftId] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityTwoEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedRightId] = [e1].[Id]
     ) AS [t]
     WHERE 2 < [t].[row]
-) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedLeftId]
+ORDER BY [e].[Id], [t0].[SelfSkipSharedLeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take_split(bool async)
@@ -1242,15 +1242,15 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
                 @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoToCompositeKeyShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], ROW_NUMBER() OVER(PARTITION BY [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
     ) AS [t]
     WHERE [t].[row] <= 2
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_split(bool async)
@@ -1290,29 +1290,29 @@ LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 ORDER BY [r].[Id]",
                 //
-                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [r].[Id], [t].[EntityRootId], [t].[EntityThreeId]
+                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[EntityRootId], [e].[EntityThreeId]
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e]
-    INNER JOIN [EntityThrees] AS [e0] ON [e].[EntityThreeId] = [e0].[Id]
-) AS [t] ON [r].[Id] = [t].[EntityRootId]
-ORDER BY [r].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]",
+    INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]
+ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]",
                 //
-                @"SELECT [t0].[Id], [t0].[Name], [r].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]
+                @"SELECT [t0].[Id], [t0].[Name], [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e0].[Id], [e].[EntityRootId], [e].[EntityThreeId]
+    SELECT [e0].[Id], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e]
-    INNER JOIN [EntityThrees] AS [e0] ON [e].[EntityThreeId] = [e0].[Id]
-) AS [t] ON [r].[Id] = [t].[EntityRootId]
+    INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]
 INNER JOIN (
     SELECT [e1].[Id], [e1].[Name], [j].[ThreeId]
     FROM [JoinOneToThreePayloadFullShared] AS [j]
     INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
     WHERE [e1].[Id] < 10
 ) AS [t0] ON [t].[Id] = [t0].[ThreeId]
-ORDER BY [r].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]");
+ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take_split(bool async)
@@ -1329,32 +1329,32 @@ LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 ORDER BY [r].[Id]",
                 //
-                @"SELECT [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]
+                @"SELECT [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [r].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
-) AS [t] ON [r].[Id] = [t].[RootId]
-ORDER BY [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]",
+    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([e].[CompositeKeySkipSharedKey1] = [e0].[Key1]) AND ([e].[CompositeKeySkipSharedKey2] = [e0].[Key2])) AND ([e].[CompositeKeySkipSharedKey3] = [e0].[Key3])
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]
+ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3]",
                 //
-                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [r].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e].[Key1], [e].[Key2], [e].[Key3], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
-) AS [t] ON [r].[Id] = [t].[RootId]
+    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([e].[CompositeKeySkipSharedKey1] = [e0].[Key1]) AND ([e].[CompositeKeySkipSharedKey2] = [e0].[Key2])) AND ([e].[CompositeKeySkipSharedKey3] = [e0].[Key3])
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]
 INNER JOIN (
     SELECT [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
     FROM (
-        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinThreeToCompositeKeyFull] AS [j0]
-        INNER JOIN [EntityThrees] AS [e0] ON [j0].[ThreeId] = [e0].[Id]
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
+        FROM [JoinThreeToCompositeKeyFull] AS [j]
+        INNER JOIN [EntityThrees] AS [e1] ON [j].[ThreeId] = [e1].[Id]
     ) AS [t1]
     WHERE (1 < [t1].[row]) AND ([t1].[row] <= 3)
 ) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
-ORDER BY [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_split(bool async)
@@ -1391,10 +1391,10 @@ INNER JOIN (
     WHERE [e].[Key1] < 5
 ) AS [t] ON [r].[Id] = [t].[LeafId]
 INNER JOIN (
-    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3]
-    FROM [JoinTwoToCompositeKeyShared] AS [j0]
-    INNER JOIN [EntityTwos] AS [e0] ON [j0].[TwoId] = [e0].[Id]
-) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
+) AS [t0] ON (([t].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([t].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([t].[Key3] = [t0].[CompositeKeySkipSharedKey3])
 ORDER BY [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
@@ -132,9 +132,9 @@ WHERE (
 FROM [EntityTwos] AS [e]
 ORDER BY (
     SELECT COUNT_BIG(*)
-    FROM [JoinTwoSelfShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e0] ON [j].[LeftId] = [e0].[Id]
-    WHERE ([e].[Id] = [j].[RightId]) AND ([e0].[Name] IS NOT NULL AND ([e0].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    FROM [EntityTwoEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)
@@ -145,10 +145,10 @@ ORDER BY (
                 @"SELECT AVG(CAST([t].[Key1] AS float))
 FROM [EntityTwos] AS [e]
 INNER JOIN (
-    SELECT [e0].[Key1], [j].[TwoId]
-    FROM [JoinTwoToCompositeKeyShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
-) AS [t] ON [e].[Id] = [t].[TwoId]");
+    SELECT [e1].[Key1], [e0].[TwoSkipSharedId]
+    FROM [EntityCompositeKeyEntityTwo] AS [e0]
+    INNER JOIN [EntityCompositeKeys] AS [e1] ON (([e0].[CompositeKeySkipSharedKey1] = [e1].[Key1]) AND ([e0].[CompositeKeySkipSharedKey2] = [e1].[Key2])) AND ([e0].[CompositeKeySkipSharedKey3] = [e1].[Key3])
+) AS [t] ON [e].[Id] = [t].[TwoSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_many_max(bool async)
@@ -173,13 +173,13 @@ INNER JOIN (
                 @"SELECT MIN([t0].[Id])
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [e0].[EntityThreeId]
+    SELECT [t].[Id], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id]
         FROM [Roots] AS [r]
-    ) AS [t] ON [e0].[EntityRootId] = [t].[Id]
-) AS [t0] ON [e].[Id] = [t0].[EntityThreeId]");
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_many_sum(bool async)
@@ -190,10 +190,10 @@ INNER JOIN (
                 @"SELECT COALESCE(SUM([t].[Key1]), 0)
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e].[Key1], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
-) AS [t] ON [r].[Id] = [t].[RootId]");
+    SELECT [e0].[Key1], [e].[RootSkipSharedId]
+    FROM [EntityCompositeKeyEntityRoot] AS [e]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([e].[CompositeKeySkipSharedKey1] = [e0].[Key1]) AND ([e].[CompositeKeySkipSharedKey2] = [e0].[Key2])) AND ([e].[CompositeKeySkipSharedKey3] = [e0].[Key3])
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]");
         }
 
         public override async Task Skip_navigation_select_subquery_average(bool async)
@@ -350,11 +350,11 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
             await base.Skip_navigation_of_type(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
@@ -363,10 +363,10 @@ LEFT JOIN (
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-    ) AS [t] ON [j].[RootId] = [t].[Id]
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] = N'EntityLeaf'
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -377,11 +377,11 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
                 @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId]
 FROM [EntityTwos] AS [e]
 INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
-    SELECT TOP(1) [e1].[Id]
-    FROM [JoinTwoSelfShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e1] ON [j].[RightId] = [e1].[Id]
-    WHERE [e0].[Id] = [j].[LeftId]
-    ORDER BY [e1].[Id])");
+    SELECT TOP(1) [e2].[Id]
+    FROM [EntityTwoEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[SelfSkipSharedRightId] = [e2].[Id]
+    WHERE [e0].[Id] = [e1].[SelfSkipSharedLeftId]
+    ORDER BY [e2].[Id])");
         }
 
         public override async Task Left_join_with_skip_navigation(bool async)
@@ -392,16 +392,16 @@ INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
                 @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN [EntityCompositeKeys] AS [e0] ON (
-    SELECT TOP(1) [e1].[Id]
-    FROM [JoinTwoToCompositeKeyShared] AS [j]
-    INNER JOIN [EntityTwos] AS [e1] ON [j].[TwoId] = [e1].[Id]
-    WHERE (([e].[Key1] = [j].[CompositeId1]) AND ([e].[Key2] = [j].[CompositeId2])) AND ([e].[Key3] = [j].[CompositeId3])
-    ORDER BY [e1].[Id]) = (
     SELECT TOP(1) [e2].[Id]
-    FROM [JoinThreeToCompositeKeyFull] AS [j0]
-    INNER JOIN [EntityThrees] AS [e2] ON [j0].[ThreeId] = [e2].[Id]
-    WHERE (([e0].[Key1] = [j0].[CompositeId1]) AND ([e0].[Key2] = [j0].[CompositeId2])) AND ([e0].[Key3] = [j0].[CompositeId3])
-    ORDER BY [e2].[Id])
+    FROM [EntityCompositeKeyEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[TwoSkipSharedId] = [e2].[Id]
+    WHERE (([e].[Key1] = [e1].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [e1].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [e1].[CompositeKeySkipSharedKey3])
+    ORDER BY [e2].[Id]) = (
+    SELECT TOP(1) [e3].[Id]
+    FROM [JoinThreeToCompositeKeyFull] AS [j]
+    INNER JOIN [EntityThrees] AS [e3] ON [j].[ThreeId] = [e3].[Id]
+    WHERE (([e0].[Key1] = [j].[CompositeId1]) AND ([e0].[Key2] = [j].[CompositeId2])) AND ([e0].[Key3] = [j].[CompositeId3])
+    ORDER BY [e3].[Id])
 ORDER BY [e].[Key1], [e0].[Key1], [e].[Key2], [e0].[Key2]");
         }
 
@@ -413,10 +413,10 @@ ORDER BY [e].[Key1], [e0].[Key1], [e].[Key2], [e0].[Key2]");
                 @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[EntityRootId]
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId]
     FROM [EntityRootEntityThree] AS [e]
-    INNER JOIN [EntityThrees] AS [e0] ON [e].[EntityThreeId] = [e0].[Id]
-) AS [t] ON [r].[Id] = [t].[EntityRootId]");
+    INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]");
         }
 
         public override async Task Select_many_over_skip_navigation_where(bool async)
@@ -495,7 +495,7 @@ INNER JOIN (
                 @"SELECT [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator]
 FROM [EntityThrees] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[EntityThreeId]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[ThreeSkipSharedId]
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
@@ -505,9 +505,9 @@ INNER JOIN (
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-    ) AS [t] ON [e0].[EntityRootId] = [t].[Id]
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
-) AS [t0] ON [e].[Id] = [t0].[EntityThreeId]");
+) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
         }
 
         public override async Task Select_many_over_skip_navigation_cast(bool async)
@@ -551,7 +551,7 @@ ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
             await base.Select_skip_navigation_multiple(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
+                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3]
 FROM [EntityTwos] AS [e]
 LEFT JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[ThreeId], [j].[TwoId]
@@ -559,16 +559,16 @@ LEFT JOIN (
     INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
 LEFT JOIN (
-    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[LeftId], [j0].[RightId]
-    FROM [JoinTwoSelfShared] AS [j0]
-    INNER JOIN [EntityTwos] AS [e1] ON [j0].[LeftId] = [e1].[Id]
-) AS [t0] ON [e].[Id] = [t0].[RightId]
+    SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[ExtraId], [e2].[Name], [e2].[ReferenceInverseId], [e1].[SelfSkipSharedLeftId], [e1].[SelfSkipSharedRightId]
+    FROM [EntityTwoEntityTwo] AS [e1]
+    INNER JOIN [EntityTwos] AS [e2] ON [e1].[SelfSkipSharedLeftId] = [e2].[Id]
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedRightId]
 LEFT JOIN (
-    SELECT [e2].[Key1], [e2].[Key2], [e2].[Key3], [e2].[Name], [j1].[TwoId], [j1].[CompositeId1], [j1].[CompositeId2], [j1].[CompositeId3]
-    FROM [JoinTwoToCompositeKeyShared] AS [j1]
-    INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
-) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
+    SELECT [e4].[Key1], [e4].[Key2], [e4].[Key3], [e4].[Name], [e3].[TwoSkipSharedId], [e3].[CompositeKeySkipSharedKey1], [e3].[CompositeKeySkipSharedKey2], [e3].[CompositeKeySkipSharedKey3]
+    FROM [EntityCompositeKeyEntityTwo] AS [e3]
+    INNER JOIN [EntityCompositeKeys] AS [e4] ON (([e3].[CompositeKeySkipSharedKey1] = [e4].[Key1]) AND ([e3].[CompositeKeySkipSharedKey2] = [e4].[Key2])) AND ([e3].[CompositeKeySkipSharedKey3] = [e4].[Key3])
+) AS [t1] ON [e].[Id] = [t1].[TwoSkipSharedId]
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t0].[Id], [t1].[TwoSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -595,11 +595,11 @@ ORDER BY [e].[Id]");
             await base.Include_skip_navigation(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
@@ -608,9 +608,9 @@ LEFT JOIN (
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-    ) AS [t] ON [j].[RootId] = [t].[Id]
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]");
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -727,18 +727,18 @@ ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
             await base.Filtered_include_skip_navigation_order_by_skip(async);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId]
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[ExtraId], [e].[Name], [e].[ReferenceInverseId], [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId]
 FROM [EntityTwos] AS [e]
 LEFT JOIN (
-    SELECT [t].[LeftId], [t].[RightId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
+    SELECT [t].[SelfSkipSharedLeftId], [t].[SelfSkipSharedRightId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
     FROM (
-        SELECT [j].[LeftId], [j].[RightId], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoSelfShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+        SELECT [e0].[SelfSkipSharedLeftId], [e0].[SelfSkipSharedRightId], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [e0].[SelfSkipSharedLeftId] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityTwoEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedRightId] = [e1].[Id]
     ) AS [t]
     WHERE 2 < [t].[row]
-) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedLeftId]
+ORDER BY [e].[Id], [t0].[SelfSkipSharedLeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -746,18 +746,18 @@ ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
             await base.Filtered_include_skip_navigation_order_by_take(async);
 
             AssertSql(
-                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId]
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[TwoId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
+    SELECT [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
     FROM (
-        SELECT [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoToCompositeKeyShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        SELECT [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
     ) AS [t]
     WHERE [t].[row] <= 2
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -787,22 +787,22 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
                 @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
-END AS [Discriminator], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
+END AS [Discriminator], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 LEFT JOIN (
-    SELECT [e].[EntityRootId], [e].[EntityThreeId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [t].[OneId], [t].[ThreeId], [t].[Payload], [t].[Id] AS [Id0], [t].[Name] AS [Name0]
+    SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [t].[OneId], [t].[ThreeId], [t].[Payload], [t].[Id] AS [Id0], [t].[Name] AS [Name0]
     FROM [EntityRootEntityThree] AS [e]
-    INNER JOIN [EntityThrees] AS [e0] ON [e].[EntityThreeId] = [e0].[Id]
+    INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
     LEFT JOIN (
         SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e1].[Id], [e1].[Name]
         FROM [JoinOneToThreePayloadFullShared] AS [j]
         INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
         WHERE [e1].[Id] < 10
     ) AS [t] ON [e0].[Id] = [t].[ThreeId]
-) AS [t0] ON [r].[Id] = [t0].[EntityRootId]
-ORDER BY [r].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
+) AS [t0] ON [r].[Id] = [t0].[RootSkipSharedId]
+ORDER BY [r].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -813,25 +813,25 @@ ORDER BY [r].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[O
                 @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
-END AS [Discriminator], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
+END AS [Discriminator], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 LEFT JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[CompositeId1] AS [CompositeId10], [t0].[CompositeId2] AS [CompositeId20], [t0].[CompositeId3] AS [CompositeId30], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
+    SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId]
+    FROM [EntityCompositeKeyEntityRoot] AS [e]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([e].[CompositeKeySkipSharedKey1] = [e0].[Key1]) AND ([e].[CompositeKeySkipSharedKey2] = [e0].[Key2])) AND ([e].[CompositeKeySkipSharedKey3] = [e0].[Key3])
     LEFT JOIN (
         SELECT [t].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[ThreeId], [t].[Id0], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
         FROM (
-            SELECT [j0].[Id], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [j0].[ThreeId], [e0].[Id] AS [Id0], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-            FROM [JoinThreeToCompositeKeyFull] AS [j0]
-            INNER JOIN [EntityThrees] AS [e0] ON [j0].[ThreeId] = [e0].[Id]
+            SELECT [j].[Id], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[ThreeId], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
+            FROM [JoinThreeToCompositeKeyFull] AS [j]
+            INNER JOIN [EntityThrees] AS [e1] ON [j].[ThreeId] = [e1].[Id]
         ) AS [t]
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
-    ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-) AS [t1] ON [r].[Id] = [t1].[RootId]
-ORDER BY [r].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id0]");
+    ) AS [t0] ON (([e0].[Key1] = [t0].[CompositeId1]) AND ([e0].[Key2] = [t0].[CompositeId2])) AND ([e0].[Key3] = [t0].[CompositeId3])
+) AS [t1] ON [r].[Id] = [t1].[RootSkipSharedId]
+ORDER BY [r].[Id], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Id0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -839,22 +839,23 @@ ORDER BY [r].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
             await base.Filtered_include_skip_navigation_where_then_include_skip_navigation(async);
 
             AssertSql(
-                @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId]
+    @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId]
 FROM [Roots] AS [r]
 INNER JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 INNER JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 LEFT JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[TwoId], [t].[CompositeId1] AS [CompositeId10], [t].[CompositeId2] AS [CompositeId20], [t].[CompositeId3] AS [CompositeId30], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name] AS [Name0], [t].[ReferenceInverseId]
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name] AS [Name0], [t].[ReferenceInverseId]
     FROM [JoinCompositeKeyToLeaf] AS [j]
     INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
     LEFT JOIN (
-        SELECT [j0].[TwoId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId]
-        FROM [JoinTwoToCompositeKeyShared] AS [j0]
-        INNER JOIN [EntityTwos] AS [e0] ON [j0].[TwoId] = [e0].[Id]
-    ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
+        SELECT [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
+    ) AS [t] ON (([e].[Key1] = [t].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t].[CompositeKeySkipSharedKey3])
     WHERE [e].[Key1] < 5
 ) AS [t0] ON [r].[Id] = [t0].[LeafId]
-ORDER BY [r].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
+ORDER BY [r].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
+
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -1030,11 +1031,11 @@ ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
                 //
-                @"SELECT [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
+                @"SELECT [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+    FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
@@ -1043,8 +1044,8 @@ INNER JOIN (
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-    ) AS [t] ON [j].[RootId] = [t].[Id]
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+    ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
         }
 
@@ -1215,18 +1216,18 @@ ORDER BY [e].[Id], [t].[Id]");
 FROM [EntityTwos] AS [e]
 ORDER BY [e].[Id]",
                 //
-                @"SELECT [t0].[LeftId], [t0].[RightId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id]
+                @"SELECT [t0].[SelfSkipSharedLeftId], [t0].[SelfSkipSharedRightId], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id]
 FROM [EntityTwos] AS [e]
 INNER JOIN (
-    SELECT [t].[LeftId], [t].[RightId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
+    SELECT [t].[SelfSkipSharedLeftId], [t].[SelfSkipSharedRightId], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
     FROM (
-        SELECT [j].[LeftId], [j].[RightId], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoSelfShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+        SELECT [e0].[SelfSkipSharedLeftId], [e0].[SelfSkipSharedRightId], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [e0].[SelfSkipSharedLeftId] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityTwoEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedRightId] = [e1].[Id]
     ) AS [t]
     WHERE 2 < [t].[row]
-) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+) AS [t0] ON [e].[Id] = [t0].[SelfSkipSharedLeftId]
+ORDER BY [e].[Id], [t0].[SelfSkipSharedLeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take_split(bool async)
@@ -1238,18 +1239,18 @@ ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
                 //
-                @"SELECT [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Key1], [e].[Key2], [e].[Key3]
+                @"SELECT [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [t].[TwoId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
+    SELECT [t].[TwoSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId]
     FROM (
-        SELECT [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinTwoToCompositeKeyShared] AS [j]
-        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        SELECT [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3] ORDER BY [e1].[Id]) AS [row]
+        FROM [EntityCompositeKeyEntityTwo] AS [e0]
+        INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
     ) AS [t]
     WHERE [t].[row] <= 2
-) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([e].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([e].[Key3] = [t0].[CompositeKeySkipSharedKey3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_split(bool async)
@@ -1289,29 +1290,29 @@ LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 ORDER BY [r].[Id]",
                 //
-                @"SELECT [t].[EntityRootId], [t].[EntityThreeId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [r].[Id]
+                @"SELECT [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [r].[Id]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e].[EntityRootId], [e].[EntityThreeId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+    SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
     FROM [EntityRootEntityThree] AS [e]
-    INNER JOIN [EntityThrees] AS [e0] ON [e].[EntityThreeId] = [e0].[Id]
-) AS [t] ON [r].[Id] = [t].[EntityRootId]
-ORDER BY [r].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]",
+    INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]
+ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]",
                 //
-                @"SELECT [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id], [t0].[Name], [r].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]
+                @"SELECT [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id], [t0].[Name], [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [e].[EntityRootId], [e].[EntityThreeId], [e0].[Id]
+    SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id]
     FROM [EntityRootEntityThree] AS [e]
-    INNER JOIN [EntityThrees] AS [e0] ON [e].[EntityThreeId] = [e0].[Id]
-) AS [t] ON [r].[Id] = [t].[EntityRootId]
+    INNER JOIN [EntityThrees] AS [e0] ON [e].[ThreeSkipSharedId] = [e0].[Id]
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]
 INNER JOIN (
     SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e1].[Id], [e1].[Name]
     FROM [JoinOneToThreePayloadFullShared] AS [j]
     INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
     WHERE [e1].[Id] < 10
 ) AS [t0] ON [t].[Id] = [t0].[ThreeId]
-ORDER BY [r].[Id], [t].[EntityRootId], [t].[EntityThreeId], [t].[Id]");
+ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take_split(bool async)
@@ -1328,32 +1329,32 @@ LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
 ORDER BY [r].[Id]",
                 //
-                @"SELECT [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [r].[Id]
+                @"SELECT [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [r].[Id]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
-) AS [t] ON [r].[Id] = [t].[RootId]
-ORDER BY [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]",
+    SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
+    FROM [EntityCompositeKeyEntityRoot] AS [e]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([e].[CompositeKeySkipSharedKey1] = [e0].[Key1]) AND ([e].[CompositeKeySkipSharedKey2] = [e0].[Key2])) AND ([e].[CompositeKeySkipSharedKey3] = [e0].[Key3])
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]
+ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3]",
                 //
-                @"SELECT [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]
+                @"SELECT [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [r].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3]
 FROM [Roots] AS [r]
 INNER JOIN (
-    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e].[Key1], [e].[Key2], [e].[Key3]
-    FROM [JoinCompositeKeyToRootShared] AS [j]
-    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
-) AS [t] ON [r].[Id] = [t].[RootId]
+    SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3]
+    FROM [EntityCompositeKeyEntityRoot] AS [e]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([e].[CompositeKeySkipSharedKey1] = [e0].[Key1]) AND ([e].[CompositeKeySkipSharedKey2] = [e0].[Key2])) AND ([e].[CompositeKeySkipSharedKey3] = [e0].[Key3])
+) AS [t] ON [r].[Id] = [t].[RootSkipSharedId]
 INNER JOIN (
     SELECT [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId]
     FROM (
-        SELECT [j0].[Id], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [j0].[ThreeId], [e0].[Id] AS [Id0], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
-        FROM [JoinThreeToCompositeKeyFull] AS [j0]
-        INNER JOIN [EntityThrees] AS [e0] ON [j0].[ThreeId] = [e0].[Id]
+        SELECT [j].[Id], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[ThreeId], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
+        FROM [JoinThreeToCompositeKeyFull] AS [j]
+        INNER JOIN [EntityThrees] AS [e1] ON [j].[ThreeId] = [e1].[Id]
     ) AS [t1]
     WHERE (1 < [t1].[row]) AND ([t1].[row] <= 3)
 ) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
-ORDER BY [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0]");
+ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_split(bool async)
@@ -1379,7 +1380,7 @@ INNER JOIN (
 ) AS [t] ON [r].[Id] = [t].[LeafId]
 ORDER BY [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]",
                 //
-                @"SELECT [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]
+                @"SELECT [t0].[TwoSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name], [t0].[ReferenceInverseId], [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]
 FROM [Roots] AS [r]
 INNER JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
 INNER JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
@@ -1390,10 +1391,10 @@ INNER JOIN (
     WHERE [e].[Key1] < 5
 ) AS [t] ON [r].[Id] = [t].[LeafId]
 INNER JOIN (
-    SELECT [j0].[TwoId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId]
-    FROM [JoinTwoToCompositeKeyShared] AS [j0]
-    INNER JOIN [EntityTwos] AS [e0] ON [j0].[TwoId] = [e0].[Id]
-) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
+    SELECT [e0].[TwoSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[CollectionInverseId], [e1].[ExtraId], [e1].[Name], [e1].[ReferenceInverseId]
+    FROM [EntityCompositeKeyEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[TwoSkipSharedId] = [e1].[Id]
+) AS [t0] ON (([t].[Key1] = [t0].[CompositeKeySkipSharedKey1]) AND ([t].[Key2] = [t0].[CompositeKeySkipSharedKey2])) AND ([t].[Key3] = [t0].[CompositeKeySkipSharedKey3])
 ORDER BY [r].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]");
         }
 

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -49,6 +49,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Add(new DependentGN { Id = dependentKeyValue, PrincipalGN = new PrincipalGN { Id = principalKeyValue} }).Entity;
             Assert.Equal(EntityState.Added, context.Entry(added4).State);
             Assert.Equal(EntityState.Added, context.Entry(added4.PrincipalGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalTheory]
@@ -75,6 +77,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Add(new PrincipalGN { Id = principalKeyValue, DependentGN = new DependentGN { Id = dependentKeyValue} }).Entity;
             Assert.Equal(EntityState.Added, context.Entry(added4).State);
             Assert.Equal(EntityState.Added, context.Entry(added4.DependentGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]
@@ -97,6 +101,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Attach(new DependentGN { PrincipalGN = new PrincipalGN() }).Entity;
             Assert.Equal(EntityState.Added, context.Entry(added4).State);
             Assert.Equal(EntityState.Added, context.Entry(added4.PrincipalGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]
@@ -119,6 +125,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Attach(new DependentGN { PrincipalGN = new PrincipalGN { Id = 1 } }).Entity;
             Assert.Equal(EntityState.Added, context.Entry(added4).State);
             Assert.Equal(EntityState.Unchanged, context.Entry(added4.PrincipalGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]
@@ -141,6 +149,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Attach(new DependentGN { Id = 1, PrincipalGN = new PrincipalGN() }).Entity;
             Assert.Equal(EntityState.Unchanged, context.Entry(added4).State);
             Assert.Equal(EntityState.Added, context.Entry(added4.PrincipalGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]
@@ -163,6 +173,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Attach(new DependentGN { Id = 1, PrincipalGN = new PrincipalGN { Id = 1 } }).Entity;
             Assert.Equal(EntityState.Unchanged, context.Entry(added4).State);
             Assert.Equal(EntityState.Unchanged, context.Entry(added4.PrincipalGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]
@@ -185,6 +197,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Attach(new PrincipalGN { DependentGN = new DependentGN() }).Entity;
             Assert.Equal(EntityState.Added, context.Entry(added4).State);
             Assert.Equal(EntityState.Added, context.Entry(added4.DependentGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]
@@ -207,6 +221,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Attach(new PrincipalGN { Id = 1, DependentGN = new DependentGN() }).Entity;
             Assert.Equal(EntityState.Unchanged, context.Entry(added4).State);
             Assert.Equal(EntityState.Added, context.Entry(added4.DependentGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]
@@ -229,6 +245,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Attach(new PrincipalGN { DependentGN = new DependentGN { Id = 1 } }).Entity;
             Assert.Equal(EntityState.Added, context.Entry(added4).State);
             Assert.Equal(EntityState.Unchanged, context.Entry(added4.DependentGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]
@@ -251,6 +269,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var added4 = context.Attach(new PrincipalGN { Id = 1, DependentGN = new DependentGN { Id = 1 } }).Entity;
             Assert.Equal(EntityState.Unchanged, context.Entry(added4).State);
             Assert.Equal(EntityState.Unchanged, context.Entry(added4.DependentGN).State);
+
+            Assert.Equal(8, context.ChangeTracker.Entries().Count());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -927,7 +927,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 3 : 5, context.ChangeTracker.Entries().Count());
             Assert.Null(principal.Child1);
             Assert.Same(dependent2, principal.Child2);
             Assert.Equal(entityState, context.Entry(principal).State);
@@ -958,7 +958,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 3 : 5, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -1001,7 +1001,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 3 : 5, context.ChangeTracker.Entries().Count());
             Assert.Null(principal.Child2);
             Assert.Same(principal, dependent2.Parent);
             Assert.Same(dependent2, principal.Child1);
@@ -1034,7 +1034,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 3 : 5, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -1112,7 +1112,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 3 : 5, context.ChangeTracker.Entries().Count());
             Assert.Null(principal.ChildCollection1);
             Assert.Contains(principal.ChildCollection2, e => ReferenceEquals(e, dependent2));
             Assert.Equal(entityState, context.Entry(principal).State);
@@ -1141,7 +1141,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 3 : 5, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -1219,7 +1219,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 3 : 5, context.ChangeTracker.Entries().Count());
             Assert.Null(principal.ChildCollection2);
             Assert.Same(principal, dependent2.Parent);
             Assert.Contains(principal.ChildCollection1, e => ReferenceEquals(e, dependent2));
@@ -1250,7 +1250,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 3 : 5, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -1647,7 +1647,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(5, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 5 : 9, context.ChangeTracker.Entries().Count());
             Assert.Same(dependent1, principal.Child2);
             Assert.Same(dependent2, principal.Child1);
             Assert.Equal(entityState, context.Entry(principal).State);
@@ -1706,7 +1706,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(5, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 5 : 9, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -1754,7 +1754,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(5, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 5 : 9, context.ChangeTracker.Entries().Count());
             Assert.Same(principal, dependent1.Parent);
             Assert.Same(dependent1, principal.Child2);
             Assert.Same(principal, dependent2.Parent);
@@ -1817,7 +1817,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(5, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 5 : 9, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -1914,7 +1914,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(5, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 5 : 9, context.ChangeTracker.Entries().Count());
             Assert.Contains(principal.ChildCollection2, e => ReferenceEquals(e, dependent1));
             Assert.Contains(principal.ChildCollection1, e => ReferenceEquals(e, dependent2));
             Assert.Equal(entityState, context.Entry(principal).State);
@@ -1969,7 +1969,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(5, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 5 : 9, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -2065,7 +2065,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(5, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 5 : 9, context.ChangeTracker.Entries().Count());
             Assert.Same(principal, dependent1.Parent);
             Assert.Contains(principal.ChildCollection2, e => ReferenceEquals(e, dependent1));
             Assert.Same(principal, dependent2.Parent);
@@ -2124,7 +2124,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(5, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 5 : 9, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -3569,7 +3569,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(6, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 6 : 10, context.ChangeTracker.Entries().Count());
             Assert.Null(principal1.Child1);
             Assert.Same(dependent2, principal1.Child2);
             Assert.Same(dependent1, principal2.Child1);
@@ -3631,7 +3631,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(6, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 6 : 10, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 
@@ -3863,7 +3863,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             context.ChangeTracker.DetectChanges();
 
-            Assert.Equal(6, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 6 : 10, context.ChangeTracker.Entries().Count());
             Assert.Null(principal1.ChildCollection1);
             Assert.Contains(principal1.ChildCollection2, e => ReferenceEquals(e, dependent2));
             Assert.Contains(principal2.ChildCollection1, e => ReferenceEquals(e, dependent1));
@@ -3923,7 +3923,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(6, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 6 : 10, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -53,14 +53,16 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             bool added = false,
             bool modified = false,
             bool deleted = false,
-            bool unchanged = false)
+            bool unchanged = false,
+            bool returnSharedIdentity = false)
             => throw new NotImplementedException();
 
         public int GetCountForState(
             bool added = false,
             bool modified = false,
             bool deleted = false,
-            bool unchanged = false)
+            bool unchanged = false,
+            bool countSharedIdentity = false)
             => throw new NotImplementedException();
 
         public int ChangedCount { get; set; }


### PR DESCRIPTION
Remove null-checking code for `IProperty.GetValueComparer()`
Make `DebugString` terser for Indexes and keys on STETs
Remove extra `UsingEntity` in `ManyToManyQueryFixtureBase`

Fixes #23418