### PR TITLE
Fixup deleted join entities

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -150,12 +150,23 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             _logger.DetectChangesStarting(stateManager.Context);
 
-            foreach (var entry in stateManager.ToListForState(
-                added: true, modified: true, deleted: true, unchanged: true, returnDeletedSharedIdentity: false))
+            foreach (var entry in stateManager.ToList()) // Might be too big, but usually _all_ entities are using Snapshot tracking
             {
-                if (entry.EntityState != EntityState.Detached)
+                switch (entry.EntityState)
                 {
-                    LocalDetectChanges(entry);
+                    case EntityState.Detached:
+                        break;
+                    case EntityState.Deleted:
+                        if (entry.SharedIdentityEntry != null)
+                        {
+                            continue;
+                        }
+
+                        LocalDetectChanges(entry);
+                        break;
+                    default:
+                        LocalDetectChanges(entry);
+                        break;
                 }
             }
 

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -762,13 +762,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 SetNavigation(dependentEntry, foreignKey.DependentToPrincipal, entry, fromQuery);
                             }
 
-                            foreach (var skipNavigation in foreignKey.GetReferencingSkipNavigations())
+                            if (dependentEntry.EntityState != EntityState.Deleted
+                                && dependentEntry.EntityState != EntityState.Detached)
                             {
-                                var otherEntry = stateManager.FindPrincipal(dependentEntry, skipNavigation.Inverse.ForeignKey);
-                                if (otherEntry != null)
+                                foreach (var skipNavigation in foreignKey.GetReferencingSkipNavigations())
                                 {
-                                    AddToCollection(otherEntry, skipNavigation.Inverse, entry, fromQuery);
-                                    AddToCollection(entry, skipNavigation, otherEntry, fromQuery);
+                                    var otherEntry = stateManager.FindPrincipal(dependentEntry, skipNavigation.Inverse.ForeignKey);
+                                    if (otherEntry != null)
+                                    {
+                                        AddToCollection(otherEntry, skipNavigation.Inverse, entry, fromQuery);
+                                        AddToCollection(entry, skipNavigation, otherEntry, fromQuery);
+                                    }
                                 }
                             }
                         }
@@ -1309,7 +1313,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         break;
                     case EntityState.Unchanged:
                     case EntityState.Modified:
-                        dependentEntry.SetEntityState(EntityState.Deleted);
+                        dependentEntry.SetEntityState(dependentEntry.SharedIdentityEntry != null ? EntityState.Detached : EntityState.Deleted);
                         DeleteFixup(dependentEntry);
                         break;
                 }

--- a/src/EFCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
+++ b/src/EFCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
@@ -62,18 +62,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 return value;
             }
 
-            public void RemoveFromCollection(IPropertyBase propertyBase, object removedEntity)
+            public void RemoveFromCollection(INavigationBase navigation, object removedEntity)
             {
-                var index = propertyBase.GetRelationshipIndex();
+                var index = navigation.GetRelationshipIndex();
                 if (index != -1)
                 {
                     ((HashSet<object>)_values[index]!)?.Remove(removedEntity);
                 }
             }
 
-            public void AddToCollection(IPropertyBase propertyBase, object addedEntity)
+            public void AddToCollection(INavigationBase navigation, object addedEntity)
             {
-                var index = propertyBase.GetRelationshipIndex();
+                var index = navigation.GetRelationshipIndex();
                 if (index != -1)
                 {
                     var snapshot = GetOrCreateCollection(index);
@@ -82,9 +82,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
             }
 
-            public void AddRangeToCollection(IPropertyBase propertyBase, IEnumerable<object> addedEntities)
+            public void AddRangeToCollection(INavigationBase navigation, IEnumerable<object> addedEntities)
             {
-                var index = propertyBase.GetRelationshipIndex();
+                var index = navigation.GetRelationshipIndex();
                 if (index != -1)
                 {
                     var snapshot = GetOrCreateCollection(index);

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -44,7 +44,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private Dictionary<IKey, IIdentityMap>? _identityMaps;
         private bool _needsUnsubscribe;
         private IChangeDetector? _changeDetector;
-        private bool _changeDetectorInitialized;
 
         private readonly IDiagnosticsLogger<DbLoggerCategory.ChangeTracking> _changeTrackingLogger;
         private readonly IInternalEntityEntrySubscriber _internalEntityEntrySubscriber;
@@ -82,7 +81,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             UpdateLogger = dependencies.UpdateLogger;
             _changeTrackingLogger = dependencies.ChangeTrackingLogger;
-            _changeDetectorInitialized = false;
         }
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -200,17 +198,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public IChangeDetector? ChangeDetector
+        public IChangeDetector ChangeDetector
         {
             get
             {
-                if (!_changeDetectorInitialized)
+                if (_changeDetector == null)
                 {
-                    _changeDetector = Context.ChangeTracker.AutoDetectChangesEnabled
-                        && !((IRuntimeModel)Context.Model).SkipDetectChanges
-                            ? Context.GetDependencies().ChangeDetector
-                            : null;
-                    _changeDetectorInitialized = true;
+                    _changeDetector = Context.GetDependencies().ChangeDetector;
                 }
 
                 return _changeDetector;
@@ -1052,7 +1046,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         continue;
                     }
 
-                    ChangeDetector?.DetectChanges(dependent);
+                    ChangeDetector.DetectChanges(dependent);
 
                     if (dependent.EntityState != EntityState.Deleted
                         && dependent.EntityState != EntityState.Detached

--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -107,6 +107,30 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IKey? FindKey(IReadOnlyProperty property) => FindKey(new[] { property });
 
         /// <summary>
+        ///     Returns the closest entity type that is a parent of both given entity types. If one of the given entities is
+        ///     a parent of the other, that parent is returned. Returns <see langword="null" /> if the two entity types aren't
+        ///     in the same hierarchy.
+        /// </summary>
+        /// <param name="otherEntityType"> Another entity type.</param>
+        /// <returns>
+        ///     The closest common parent of this entity type and <paramref name="otherEntityType" />,
+        ///     or <see langword="null" /> if they have not common parent.
+        /// </returns>
+        IEntityType? FindClosestCommonParent(IEntityType otherEntityType)
+            => (IEntityType?)((IReadOnlyEntityType)this).FindClosestCommonParent(otherEntityType);
+
+        /// <summary>
+        ///     Gets the least derived type between the specified two.
+        /// </summary>
+        /// <param name="otherEntityType"> The other entity type to compare with. </param>
+        /// <returns>
+        ///     The least derived type between the specified two.
+        ///     If the given entity types are not related, then <see langword="null" /> is returned.
+        /// </returns>
+        IEntityType? LeastDerivedType(IEntityType otherEntityType)
+            => (IEntityType?)((IReadOnlyEntityType)this).LeastDerivedType(otherEntityType);
+
+        /// <summary>
         ///     Gets primary key for this entity type. Returns <see langword="null" /> if no primary key is defined.
         /// </summary>
         /// <returns> The primary key, or <see langword="null" /> if none is defined. </returns>

--- a/src/EFCore/Metadata/IReadOnlyEntityType.cs
+++ b/src/EFCore/Metadata/IReadOnlyEntityType.cs
@@ -217,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     a parent of the other, that parent is returned. Returns <see langword="null" /> if the two entity types aren't
         ///     in the same hierarchy.
         /// </summary>
-        /// <param name="otherEntityType"> Another entity type.</param>
+        /// <param name="otherEntityType"> Another entity type. </param>
         /// <returns>
         ///     The closest common parent of this entity type and <paramref name="otherEntityType" />,
         ///     or <see langword="null" /> if they have not common parent.
@@ -225,6 +225,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IReadOnlyEntityType? FindClosestCommonParent(IReadOnlyEntityType otherEntityType)
         {
             Check.NotNull(otherEntityType, nameof(otherEntityType));
+
+            var leastDerived = LeastDerivedType(otherEntityType);
+            if (leastDerived != null)
+            {
+                return leastDerived;
+            }
 
             return GetAllBaseTypesInclusiveAscending()
                 .FirstOrDefault(i => otherEntityType.GetAllBaseTypesInclusiveAscending().Any(j => j == i));

--- a/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -830,6 +830,92 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public void Can_replace_identifying_FK_entity_with_many_to_many()
+        {
+            using var testDatabase = SqlServerTestStore.CreateInitialized(DatabaseName);
+            var options = Fixture.CreateOptions(testDatabase);
+
+            using (var context = new SomeDbContext(options))
+            {
+                context.Database.EnsureCreatedResiliently();
+
+                context.Add(new EntityA()
+                {
+                    EntityB = new EntityB()
+                    {
+                        EntitiesC = { new EntityC() },
+                    }
+                });
+
+                context.SaveChanges();
+            }
+
+            var expectedCId = 0;
+            using (var context = new SomeDbContext(options))
+            {
+                var entityA = context.EntitiesA.Include(x => x.EntityB).ThenInclude(x => x.EntitiesC).OrderBy(x => x.Id).First();
+
+                entityA.EntityB = new EntityB()
+                {
+                    EntitiesC = { new EntityC() }
+                };
+
+                context.ChangeTracker.DetectChanges();
+
+                context.SaveChanges();
+
+                expectedCId = entityA.EntityB.EntitiesC.Single().Id;
+            }
+
+            using (var context = new SomeDbContext(options))
+            {
+                var entityA = context.EntitiesA.Include(x => x.EntityB).ThenInclude(x => x.EntitiesC).OrderBy(x => x.Id).First();
+
+                Assert.Equal(expectedCId, entityA.EntityB.EntitiesC.Single().Id);
+            }
+        }
+
+        private class EntityA
+        {
+            public int Id { get; set; }
+            public virtual EntityB EntityB { get; set; }
+        }
+
+        private class EntityB
+        {
+            public int Id { get; set; }
+            public virtual EntityA EntityA { get; set; }
+            public virtual ICollection<EntityC> EntitiesC { get; } = new List<EntityC>();
+        }
+
+        private class EntityC
+        {
+            public int Id { get; set; }
+            public virtual ICollection<EntityB> EntitiesB { get; } = new List<EntityB>();
+        }
+
+        private class SomeDbContext : DbContext
+        {
+            public SomeDbContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<EntityA> EntitiesA { get; set; }
+            public DbSet<EntityB> EntitiesB { get; set; }
+            public DbSet<EntityC> EntitiesC { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder
+                    .Entity<EntityA>()
+                    .HasOne(e => e.EntityB)
+                    .WithOne(e => e.EntityA)
+                    .HasForeignKey<EntityB>(e => e.Id);
+            }
+        }
+
+        [ConditionalFact]
         public void Adding_an_item_to_a_collection_marks_it_as_modified()
         {
             using var testDatabase = SqlServerTestStore.CreateInitialized(DatabaseName);

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -860,8 +860,6 @@ namespace Microsoft.EntityFrameworkCore
                     EntitiesC = { new EntityC() }
                 };
 
-                context.ChangeTracker.DetectChanges();
-
                 context.SaveChanges();
 
                 expectedCId = entityA.EntityB.EntitiesC.Single().Id;

--- a/test/EFCore.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Tests/ApiConsistencyTest.cs
@@ -86,7 +86,10 @@ namespace Microsoft.EntityFrameworkCore
                 typeof(InternalEntityEntry).GetMethod(nameof(InternalEntityEntry.HasDefaultValue)),
                 typeof(DiagnosticsLogger<>).GetMethod("DispatchEventData", AnyInstance),
                 typeof(DiagnosticsLogger<>).GetMethod("ShouldLog", AnyInstance),
-                typeof(DiagnosticsLogger<>).GetMethod("NeedsEventData", AnyInstance)
+                typeof(DiagnosticsLogger<>).GetMethod("NeedsEventData", AnyInstance),
+                typeof(ChangeDetector).GetMethod("DetectValueChange"),
+                typeof(ChangeDetector).GetMethod("DetectNavigationChange"),
+                typeof(StateManager).GetMethod("get_ChangeDetector")
             };
 
             public override HashSet<MethodInfo> NotAnnotatedMethods { get; } = new()
@@ -119,8 +122,6 @@ namespace Microsoft.EntityFrameworkCore
                 typeof(IConventionAnnotatable).GetMethod(nameof(IConventionAnnotatable.SetOrRemoveAnnotation)),
                 typeof(IConventionModelBuilder).GetMethod(nameof(IConventionModelBuilder.HasNoEntityType)),
                 typeof(IReadOnlyEntityType).GetMethod(nameof(IReadOnlyEntityType.GetConcreteDerivedTypesInclusive)),
-                typeof(IReadOnlyEntityType).GetMethod(nameof(IReadOnlyEntityType.FindClosestCommonParent)),
-                typeof(IReadOnlyEntityType).GetMethod(nameof(IReadOnlyEntityType.LeastDerivedType)),
                 typeof(IMutableEntityType).GetMethod(nameof(IMutableEntityType.AddData)),
                 typeof(IReadOnlyNavigationBase).GetMethod("get_DeclaringEntityType"),
                 typeof(IReadOnlyNavigationBase).GetMethod("get_TargetEntityType"),

--- a/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -791,7 +791,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var fixer = CreateNavigationFixer(contextServices);
 
             entry1.SetEntityState(EntityState.Added);
-            entry1.SetEntityState(EntityState.Added);
+            entry2.SetEntityState(EntityState.Added);
             entry3.SetEntityState(EntityState.Added);
 
             Assert.Same(entity2, entity1.AlternateProduct);

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -1778,7 +1778,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 typeof(Parent).ShortDisplayName() + "." + nameof(Parent.Child2) + "#" + nameof(Child),
                 dependent2Entry.Metadata.DisplayName());
             Assert.Equal(
-                entityState == EntityState.Added ? null : (EntityState?)EntityState.Deleted,
+                entityState == EntityState.Added ? null : EntityState.Deleted,
                 dependent2Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
             Assert.Same(subDependent1, dependent1.SubChild);
@@ -2078,7 +2078,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 typeof(Parent).ShortDisplayName() + "." + nameof(Parent.ChildCollection1) + "#" + nameof(Child),
                 newDependentEntry1.Metadata.DisplayName());
             Assert.Equal(
-                entityState == EntityState.Added ? null : (EntityState?)EntityState.Deleted,
+                entityState == EntityState.Added ? null : EntityState.Deleted,
                 newDependentEntry1.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
             Assert.Equal(principal.Id, newDependentEntry2.Property("ParentId").CurrentValue);
@@ -2087,7 +2087,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 typeof(Parent).ShortDisplayName() + "." + nameof(Parent.ChildCollection2) + "#" + nameof(Child),
                 newDependentEntry2.Metadata.DisplayName());
             Assert.Equal(
-                entityState == EntityState.Added ? null : (EntityState?)EntityState.Deleted,
+                entityState == EntityState.Added ? null : EntityState.Deleted,
                 newDependentEntry2.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
             Assert.Contains(dependent1.SubChildCollection, e => ReferenceEquals(e, subDependent1));
@@ -3680,19 +3680,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             principal2.Child1 = dependent1;
             principal1.Child2 = dependent2;
 
-            if (entityState != EntityState.Added)
-            {
-                Assert.Equal(
-                    CoreStrings.KeyReadOnly("ParentId", "Parent.Child2#Child"),
-                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
-                return;
-            }
-
             context.ChangeTracker.DetectChanges();
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(6, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 6 : 10, context.ChangeTracker.Entries().Count());
             Assert.Null(principal1.Child1);
             Assert.Same(dependent2, principal1.Child2);
             Assert.Same(dependent1, principal2.Child1);
@@ -3709,7 +3701,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 typeof(Parent).ShortDisplayName() + "." + nameof(Parent.Child2) + "#" + nameof(Child),
                 dependent1Entry.Metadata.DisplayName());
             Assert.Equal(
-                entityState == EntityState.Added ? null : (EntityState?)EntityState.Deleted,
+                entityState == EntityState.Added ? null : EntityState.Deleted,
                 dependent1Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
             var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
@@ -3719,7 +3711,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 typeof(Parent).ShortDisplayName() + "." + nameof(Parent.Child1) + "#" + nameof(Child),
                 dependent2Entry.Metadata.DisplayName());
             Assert.Equal(
-                entityState == EntityState.Added ? null : (EntityState?)EntityState.Deleted,
+                entityState == EntityState.Added ? null : EntityState.Deleted,
                 dependent1Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
             Assert.Same(subDependent1, dependent1.SubChild);
@@ -3758,7 +3750,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             Assert.True(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(6, context.ChangeTracker.Entries().Count());
+            Assert.Equal(entityState == EntityState.Added ? 6 : 10, context.ChangeTracker.Entries().Count());
 
             context.ChangeTracker.AcceptAllChanges();
 


### PR DESCRIPTION
Fixes #24123

**Description**
- Navigation fixup is erroneously performed using a deleted entity when there is also an added entity with the same key value.
- Navigation fixup is not performed on many-to-many skip navigations when just the join entity is removed

**Customer Impact**
- The first issue causes **data corruption** that can go undetected as expected changes are not persisted to the database.
- The second issue is less severe and just causes the client state to go out-of sync with the database after `SaveChanges`

**How found**
- Customer

**Test coverage**
- Added regression tests for the scenario.

**Regression?**
- No

**Risk**
- Medium. This potentially affects many shared-identity and many-to-many scenarios
