### PR TITLE
Query: Throw better error message when final result contains IGrouping

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -110,6 +110,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public virtual Expression Expand(Expression query)
         {
             var result = Visit(query);
+
+            if (result is GroupByNavigationExpansionExpression)
+            {
+                // This indicates that GroupBy was not condensed out of grouping operator.
+                throw new InvalidOperationException(CoreStrings.TranslationFailed(query.Print()));
+            }
+
             result = new PendingSelectorExpandingExpressionVisitor(this, _extensibilityHelper, applyIncludes: true).Visit(result);
             result = Reduce(result);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2752,6 +2752,34 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_as_final_operator(bool async)
+        {
+            return AssertTranslationFailed(() => AssertQuery(
+                async,
+                ss => ss.Set<Customer>().GroupBy(c => c.City)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_Where_with_grouping_result(bool async)
+        {
+            return AssertTranslationFailed(() => AssertQuery(
+                async,
+                ss => ss.Set<Customer>().GroupBy(c => c.City).Where(e => e.Key.StartsWith("s"))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_OrderBy_with_grouping_result(bool async)
+        {
+            return AssertTranslationFailed(() => AssertQuery(
+                async,
+                ss => ss.Set<Customer>().GroupBy(c => c.City).OrderBy(e => e.Key),
+                assertOrder: true));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_SelectMany(bool async)
         {
             return AssertTranslationFailed(() => AssertQuery(


### PR DESCRIPTION
Part 1 of #26046
