### PR TITLE
Fix to #26014 - Migrations/Temporal Tables: null value exception when executing Down migration to convert entity from temporal to normal

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -2242,11 +2242,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             foreach (var annotation in annotations)
             {
-                if (annotation.Value == null)
-                {
-                    continue;
-                }
-
                 // TODO: Give providers an opportunity to render these as provider-specific extension methods
                 builder
                     .AppendLine()

--- a/src/EFCore.Relational/Migrations/Operations/Builders/AlterOperationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/Operations/Builders/AlterOperationBuilder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public new virtual AlterOperationBuilder<TOperation> Annotation(
             string name,
-            object value)
+            object? value)
             => (AlterOperationBuilder<TOperation>)base.Annotation(name, value);
 
         /// <summary>
@@ -41,10 +41,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public virtual AlterOperationBuilder<TOperation> OldAnnotation(
             string name,
-            object value)
+            object? value)
         {
             Check.NotEmpty(name, nameof(name));
-            Check.NotNull(value, nameof(value));
 
             Operation.OldAnnotations.AddAnnotation(name, value);
 

--- a/src/EFCore.Relational/Migrations/Operations/Builders/OperationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/Operations/Builders/OperationBuilder.cs
@@ -41,10 +41,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public virtual OperationBuilder<TOperation> Annotation(
             string name,
-            object value)
+            object? value)
         {
             Check.NotEmpty(name, nameof(name));
-            Check.NotNull(value, nameof(value));
 
             Operation.AddAnnotation(name, value);
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -3625,6 +3625,46 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 });
         }
 
+        [ConditionalFact]
+        public void AlterTableOperation_annotation_set_to_null()
+        {
+            var oldTable = new CreateTableOperation
+            {
+                Name = "Customer",
+            };
+            oldTable.AddAnnotation("MyAnnotation1", "Bar");
+            oldTable.AddAnnotation("MyAnnotation2", null);
+
+            var alterTable = new AlterTableOperation
+            {
+                Name = "NewCustomer",
+                OldTable = oldTable
+            };
+
+            alterTable.AddAnnotation("MyAnnotation1", null);
+            alterTable.AddAnnotation("MyAnnotation2", "Foo");
+
+            Test(
+                alterTable,
+                "mb.AlterTable("
+                + _eol
+                + "    name: \"NewCustomer\")"
+                + _eol
+                + "    .Annotation(\"MyAnnotation1\", null)"
+                + _eol
+                + "    .Annotation(\"MyAnnotation2\", \"Foo\")"
+                + _eol
+                + "    .OldAnnotation(\"MyAnnotation1\", \"Bar\")"
+                + _eol
+                + "    .OldAnnotation(\"MyAnnotation2\", null);",
+                operation =>
+                {
+                    Assert.Equal("NewCustomer", operation.Name);
+                    Assert.Null(operation.GetAnnotation("MyAnnotation1").Value);
+                    Assert.Equal("Foo", operation.GetAnnotation("MyAnnotation2").Value);
+                });
+        }
+
         private void Test<T>(T operation, string expectedCode, Action<T> assert)
             where T : MigrationOperation
         {


### PR DESCRIPTION
Problem was that we perform a null check on old and new annotation, but null is a valid value for annotation. We should allow this and also mark the annotation value as nullable object. Also fixed small issue in code gen where we would not generate code to add annotation with null value (but we were adding it for old annotation).

Fixes #26014