### PR TITLE
[6.0-rc2] Fix Fluent APIs on keys in model snapshot

### DIFF
--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -875,6 +875,37 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         [ConditionalFact]
+        public virtual void EntityType_Fluent_APIs_are_properly_generated()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithOneProperty>().IsMemoryOptimized();
+                    builder.Ignore<EntityWithTwoProperties>();
+                },
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
+
+                    b.HasKey(""Id"");
+
+                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey(""Id""), false);
+
+                    b.ToTable(""EntityWithOneProperty"");
+
+                    SqlServerEntityTypeBuilderExtensions.IsMemoryOptimized(b);
+                });"),
+                o => Assert.True(o.GetEntityTypes().Single().IsMemoryOptimized()));
+        }
+
+        [ConditionalFact]
         public virtual void BaseType_is_stored_in_snapshot()
         {
             Test(
@@ -3834,6 +3865,35 @@ namespace RootNamespace
         }
 
         [ConditionalFact]
+        public virtual void Key_Fluent_APIs_are_properly_generated()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithOneProperty>().HasKey(t => t.Id).IsClustered();
+                    builder.Ignore<EntityWithTwoProperties>();
+                },
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
+
+                    b.HasKey(""Id"");
+
+                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey(""Id""));
+
+                    b.ToTable(""EntityWithOneProperty"");
+                });"),
+                o => Assert.True(o.GetEntityTypes().First().GetKeys().Single(k => k.IsPrimaryKey()).IsClustered()));
+        }
+
+        [ConditionalFact]
         public virtual void Key_name_annotation_is_stored_in_snapshot_as_fluent_api()
         {
             Test(
@@ -3944,6 +4004,40 @@ namespace RootNamespace
                     b.ToTable(""EntityWithTwoProperties"");
                 });"),
                 o => Assert.Equal("AnnotationValue", o.GetEntityTypes().First().GetIndexes().First()["AnnotationName"]));
+        }
+
+        [ConditionalFact]
+        public virtual void Index_Fluent_APIs_are_properly_generated()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithTwoProperties>().HasIndex(t => t.AlternateId).IsClustered();
+                    builder.Ignore<EntityWithOneProperty>();
+                },
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
+
+                    b.Property<int>(""AlternateId"")
+                        .HasColumnType(""int"");
+
+                    b.HasKey(""Id"");
+
+                    b.HasIndex(""AlternateId"");
+
+                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex(""AlternateId""));
+
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
+                o => Assert.True(o.GetEntityTypes().Single().GetIndexes().Single().IsClustered()));
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
@@ -323,6 +323,29 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Assert.Equal("'foo'", Assert.Single(result.Arguments));
         }
 
+        [ConditionalFact]
+        public void GenerateFluentApi_IEntityType_works_when_IsMemoryOptimized()
+        {
+            var generator = CreateGenerator();
+
+            var modelBuilder = SqlServerConventionSetBuilder.CreateModelBuilder();
+            modelBuilder.Entity(
+                "Post",
+                x =>
+                {
+                    x.Property<int>("Id");
+                    x.IsMemoryOptimized();
+                });
+            var entityType = (IEntityType)modelBuilder.Model.FindEntityType("Post");
+
+            var result = generator.GenerateFluentApiCalls(entityType, entityType.GetAnnotations().ToDictionary(a => a.Name, a => a))
+                .Single();
+
+            Assert.Equal(nameof(SqlServerEntityTypeBuilderExtensions.IsMemoryOptimized), result.Method);
+
+            Assert.Equal(0, result.Arguments.Count);
+        }
+
         private SqlServerAnnotationCodeGenerator CreateGenerator()
             => new(
                 new AnnotationCodeGeneratorDependencies(


### PR DESCRIPTION
Fixes #26045

**Description**

Invalid migrations snapshot generated for key Fluent APIs

**Customer Impact**

Generated migrations which contain Fluent API configurations for keys (e.g. clustered) do not compile. Discovered by customer on RC1.

**How found**

User report: #26045 trying RC1

**Test coverage**

Added as part of this PR

**Regression?**

Yes, introduced as part of recent improvements to migration code generation.

**Risk**

Low, the issue is simple, the fix is well-understood, and the area is relatively well-covered.

Also generate Fluent API for IsMemoryOptimized.

@Pilchie @dotnet/efteam - This fixes a bug reported on rc1, and needs to go into rc2.