### PR TITLE
[6.0-rc2] Fully support int identity seed

### DIFF
--- a/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
+++ b/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
@@ -82,36 +82,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             return _modelRuntimeInitializer.Initialize((IModel)model, designTime: true, validationLogger: null);
         }
 
-        private void ProcessCollection(IEnumerable<IReadOnlyProperty> metadata, string version)
-        {
-            foreach (var element in metadata)
-            {
-                ProcessElement(element, version);
-            }
-        }
-
         private void ProcessCollection(IEnumerable<IReadOnlyAnnotatable> metadata, string version)
         {
             foreach (var element in metadata)
             {
                 ProcessElement(element, version);
-            }
-        }
-
-        private void ProcessElement(IReadOnlyModel model, string version)
-        {
-            ProcessElement((IReadOnlyAnnotatable)model, version);
-
-            if ((version.StartsWith("3.", StringComparison.Ordinal)
-                || version.StartsWith("5.", StringComparison.Ordinal))
-                    && model is IMutableModel mutableModel)
-            {
-                var seed = model["SqlServer:IdentitySeed"];
-                if (seed != null
-                    && seed is int intSeed)
-                {
-                    mutableModel["SqlServer:IdentitySeed"] = (long)intSeed;
-                }
             }
         }
 
@@ -125,23 +100,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 && !entityType.IsOwned())
             {
                 UpdateOwnedTypes(mutableEntityType);
-            }
-        }
-
-        private void ProcessElement(IReadOnlyProperty property, string version)
-        {
-            ProcessElement((IReadOnlyAnnotatable)property, version);
-
-            if ((version.StartsWith("3.", StringComparison.Ordinal)
-                || version.StartsWith("5.", StringComparison.Ordinal))
-                    && property is IMutableProperty mutableProperty)
-            {
-                var seed = property["SqlServer:IdentitySeed"];
-                if (seed != null
-                    && seed is int intSeed)
-                {
-                    mutableProperty["SqlServer:IdentitySeed"] = (long)intSeed;
-                }
             }
         }
 

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -231,7 +231,10 @@ namespace Microsoft.EntityFrameworkCore
             var annotation = property.FindAnnotation(SqlServerAnnotationNames.IdentitySeed);
             if (annotation != null)
             {
-                return (long?)annotation.Value;
+                // Support pre-6.0 IdentitySeed annotations, which contained an int rather than a long
+                return annotation.Value is int intValue
+                    ? intValue
+                    : (long?)annotation.Value;
             }
 
             var sharedProperty = property.FindSharedStoreObjectRootProperty(storeObject);

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -210,10 +210,20 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property. </param>
         /// <returns> The identity seed. </returns>
         public static long? GetIdentitySeed(this IReadOnlyProperty property)
-            => property is RuntimeProperty
-            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
-            : (long?)property[SqlServerAnnotationNames.IdentitySeed]
-                ?? property.DeclaringEntityType.Model.GetIdentitySeed();
+        {
+            if (property is RuntimeProperty)
+            {
+                throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData);
+            }
+
+            // Support pre-6.0 IdentitySeed annotations, which contained an int rather than a long
+            var annotation = property.FindAnnotation(SqlServerAnnotationNames.IdentitySeed);
+            return annotation is null
+                ? null
+                : annotation.Value is int intValue
+                    ? intValue
+                    : (long?)annotation.Value;
+        }
 
         /// <summary>
         ///     Returns the identity seed.
@@ -229,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             var annotation = property.FindAnnotation(SqlServerAnnotationNames.IdentitySeed);
-            if (annotation != null)
+            if (annotation is not null)
             {
                 // Support pre-6.0 IdentitySeed annotations, which contained an int rather than a long
                 return annotation.Value is int intValue

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -1084,7 +1084,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 modelBuilder
                     .HasAnnotation("ProductVersion", "3.0.0")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                    .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                    .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn)
+                    .HasAnnotation("SqlServer:IdentitySeed", 1);
 
                 modelBuilder.Entity(
                     "Ownership.OwningType1", b =>
@@ -1092,7 +1093,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         b.Property<int>("Id")
                             .ValueGeneratedOnAdd()
                             .HasColumnType("int")
-                            .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                            .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn)
+                            .HasAnnotation("SqlServer:IdentitySeed", 1);
 
                         b.HasKey("Id");
 

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -1084,8 +1084,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 modelBuilder
                     .HasAnnotation("ProductVersion", "3.0.0")
                     .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                    .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn)
-                    .HasAnnotation("SqlServer:IdentitySeed", 1);
+                    .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                 modelBuilder.Entity(
                     "Ownership.OwningType1", b =>
@@ -1093,8 +1092,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         b.Property<int>("Id")
                             .ValueGeneratedOnAdd()
                             .HasColumnType("int")
-                            .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn)
-                            .HasAnnotation("SqlServer:IdentitySeed", 1);
+                            .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                         b.HasKey("Id");
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3795,7 +3795,20 @@ namespace RootNamespace
         }
 
         [ConditionalFact]
-        public virtual void SQLServer_legacy_identity_seed_int_annotation()
+        public virtual void SQLServer_model_legacy_identity_seed_int_annotation()
+        {
+            Test(
+                builder => builder.HasAnnotation(SqlServerAnnotationNames.IdentitySeed, 8),
+                AddBoilerPlate(
+                    @"
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 8L, 1);"),
+                o => Assert.Equal(8L, o.GetIdentitySeed()));
+        }
+
+        [ConditionalFact]
+        public virtual void SQLServer_property_legacy_identity_seed_int_annotation()
         {
             Test(
                 builder =>

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3794,6 +3794,37 @@ namespace RootNamespace
                 o => Assert.Equal(1, o.GetEntityTypes().First().FindProperty("AlternateId").GetColumnOrder()));
         }
 
+        [ConditionalFact]
+        public virtual void SQLServer_legacy_identity_seed_int_annotation()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithTwoProperties>().Property(e => e.Id)
+                        .HasAnnotation(SqlServerAnnotationNames.IdentitySeed, 8);
+                    builder.Ignore<EntityWithOneProperty>();
+                },
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 8L, 1);
+
+                    b.Property<int>(""AlternateId"")
+                        .HasColumnType(""int"");
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
+                o => Assert.Equal(8L, o.GetEntityTypes().First().FindProperty("Id").GetIdentitySeed()));
+        }
+
         #endregion
 
         #region HasKey


### PR DESCRIPTION
Fixes #26062, replaces #25857.

**Description**

A change in EF Core 6 to allow for long values in SQL Server identity seed values cause older int values to no longer work.

**Customer Impact**

Some common migrations scaffolded with earlier versions of EF Core cause errors in EF Core 6.0.

**How found**

Customer reports on RC1

**Test coverage**

Added in this PR

**Regression?**

Yes

**Risk**

Low, this simply adds support for the legacy int annotation values in two code sites.