### PR TITLE
Adding grouping tests from EF6

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/Query/Ef6GroupByInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/Ef6GroupByInMemoryTest.cs
@@ -31,44 +31,64 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+        {
+            await base.Grouping_by_all_columns_doesnt_produce_a_groupby_statement(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_2(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_3(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_4(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_5(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_6(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_7(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_8(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_9(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_10(async);
+        }
 
         public class Ef6GroupByInMemoryFixture : Ef6GroupByFixtureBase
         {

--- a/test/EFCore.InMemory.FunctionalTests/Query/Ef6GroupByInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/Ef6GroupByInMemoryTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -15,65 +16,59 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+        public override Task Average_Grouped_from_LINQ_101(bool async)
         {
-            await base.Grouping_by_all_columns_doesnt_produce_a_groupby_statement(async);
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          AveragePrice = g.Average(p => p.UnitPrice)
+                      });
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_2(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_3(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_4(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_5(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_6(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_7(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_8(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_9(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_10(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
+            => Task.CompletedTask;
+
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
+            => Task.CompletedTask;
 
         public class Ef6GroupByInMemoryFixture : Ef6GroupByFixtureBase
         {

--- a/test/EFCore.InMemory.FunctionalTests/Query/Ef6GroupByInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/Ef6GroupByInMemoryTest.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class Ef6GroupByInMemoryTest : Ef6GroupByTestBase<Ef6GroupByInMemoryTest.Ef6GroupByInMemoryFixture>
+    {
+        public Ef6GroupByInMemoryTest(Ef6GroupByInMemoryFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+        {
+            await base.Grouping_by_all_columns_doesnt_produce_a_groupby_statement(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_2(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_3(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_4(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_5(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_6(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_7(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_8(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_9(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_10(async);
+        }
+
+        public class Ef6GroupByInMemoryFixture : Ef6GroupByFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory
+                => InMemoryTestStoreFactory.Instance;
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
@@ -1,0 +1,963 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class Ef6GroupByTestBase<TFixture> : QueryTestBase<TFixture>
+        where TFixture : Ef6GroupByTestBase<TFixture>.Ef6GroupByFixtureBase, new()
+    {
+        protected Ef6GroupByTestBase(TFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_group_key(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o.FirstName).Select(g => g.Key));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_group_count(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o.FirstName).Select(g => g.Count()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_expression_containing_group_key(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o.Id).Select(g => g.Key * 2));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_aggregate_on_the_group(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o.FirstName).Select(g => g.Max(p => p.Id)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_anonymous_type_containing_group_key_and_group_aggregate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o.FirstName).Select(g => new { Key = g.Key, Aggregate = g.Max(p => p.Id) }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_anonymous_type_containing_group_key_and_multiple_group_aggregates(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o.FirstName).Select(
+                    g => new { key1 = g.Key, key2 = g.Key, max = g.Max(p => p.Id), min = g.Min(s => s.Id + 2) }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_conditional_expression_containing_group_key(bool async)
+        {
+            bool a = true;
+            bool b = false;
+            bool c = true;
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o.FirstName).Select(
+                    g => new { keyIsNull = g.Key == null ? "is null" : "not null", logicExpression = (a && b || b && c) }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_filerting_and_projecting_anonymous_type_with_group_key_and_function_aggregate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().Where(o => o.Id > 5).GroupBy(o => o.FirstName).Select(g => new { FirstName = g.Key, AverageId = g.Average(p => p.Id) }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_function_aggregate_with_expression(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(p => p.FirstName).Select(g => g.Max(p => p.Id * 2)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_projecting_expression_with_multiple_function_aggregates(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o.FirstName).Select(g => new { maxMinusMin = g.Max(p => p.Id) - g.Min(s => s.Id) }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_is_optimized_when_grouping_by_row_and_projecting_column_of_the_key_row(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().Where(o => o.Id < 4).GroupBy(g => new { g.FirstName }).Select(g => g.Key.FirstName));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o).Select(g => g.Key));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_1(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => new { o.Id, o.FirstName, o.LastName, o.Alias }, c => new { c.LastName, c.FirstName }, (k, g) => g.Count()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o, c => new { c.LastName, c.FirstName }, (k, g) => g.Count()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o, c => c, (k, g) => g.Count()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o, c => c, (k, g) => new { Count = g.Count() }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o, c => c, (k, g) => new { Id = k.Id, Count = g.Count() }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<ArubaOwner>().GroupBy(o => o, c => c, (k, g) => new { Id = k.Id, Alias = k.Alias, Count = g.Count() }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => from o in ss.Set<ArubaOwner>()
+                      group o by o
+                      into g
+                      select g.Count());
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from o in ss.Set<ArubaOwner>()
+                      group o by o into g
+                      select new { Id = g.Key.Id, Count = g.Count() });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from o in ss.Set<ArubaOwner>()
+                      group o by o into g
+                      select new { Id = g.Key.Id, Alias = g.Key.Alias, Count = g.Count() });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from o in ss.Set<ArubaOwner>()
+                      group o by o into g
+                      select new { Id = g.Key.Id, Sum = g.Sum(x => x.Id), Count = g.Count() });
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_Simple_1_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from n in ss.Set<NumberForLinq>()
+                      group n by n.Value % 5
+                      into g
+                      select new
+                      {
+                          Remainder = g.Key,
+                          Numbers = g
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_Simple_2_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from w in ss.Set<NumberForLinq>()
+                      group w by w.Name.Length
+                      into g
+                      select new
+                      {
+                          FirstLetter = g.Key,
+                          Words = g
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_Simple_3_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          Products = g
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_Nested_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<CustomerForLinq>()
+                      select new
+                      {
+                          c.CompanyName,
+                          YearGroups = from o in c.Orders
+                                       group o by o.OrderDate.Year
+                                       into yg
+                                       select new
+                                       {
+                                           Year = yg.Key,
+                                           MonthGroups = from o in yg
+                                                         group o by o.OrderDate.Month
+                                                         into mg
+                                                         select
+                                                             new
+                                                             {
+                                                                 Month = mg.Key,
+                                                                 Orders = mg
+                                                             }
+                                       }
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Translation of 'Select' which contains grouping parameter without composition is not supported.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Any_Grouped_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      where g.Any(p => p.UnitsInStock == 0)
+                      select new
+                      {
+                          Category = g.Key,
+                          Products = g
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Translation of 'Select' which contains grouping parameter without composition is not supported.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task All_Grouped_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      where g.All(p => p.UnitsInStock > 0)
+                      select new
+                      {
+                          Category = g.Key,
+                          Products = g
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Count_Grouped_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          ProductCount = g.Count()
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task LongCount_Grouped_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          ProductLongCount = g.LongCount()
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Sum_Grouped_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          TotalUnitsInStock = g.Sum(p => p.UnitsInStock)
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Min_Grouped_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          CheapestPrice = g.Min(p => p.UnitPrice)
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Min_Elements_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      let minPrice = g.Min(p => p.UnitPrice)
+                      select new
+                      {
+                          Category = g.Key,
+                          CheapestProducts = g.Where(p => p.UnitPrice == minPrice)
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Max_Grouped_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          MostExpensivePrice = g.Max(p => p.UnitPrice)
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Max_Elements_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      let minPrice = g.Max(p => p.UnitPrice)
+                      select new
+                      {
+                          Category = g.Key,
+                          MostExpensiveProducts = g.Where(p => p.UnitPrice == minPrice)
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Average_Grouped_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          AveragePrice = g.Average(p => p.UnitPrice)
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Group_Join_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<CustomerForLinq>()
+                      join o in ss.Set<OrderForLinq>() on c equals o.Customer into ps
+                      select new
+                      {
+                          Customer = c,
+                          Products = ps
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Cross_Join_with_Group_Join_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<CustomerForLinq>()
+                      join o in ss.Set<OrderForLinq>() on c equals o.Customer into ps
+                      from o in ps
+                      select new
+                      {
+                          Customer = c,
+                          o.Id
+                      });
+        }
+
+        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Left_Outer_Join_with_Group_Join_from_LINQ_101(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<CustomerForLinq>()
+                      join o in ss.Set<OrderForLinq>() on c equals o.Customer into ps
+                      from o in ps.DefaultIfEmpty()
+                      select new
+                      {
+                          Customer = c,
+                          OrderId = o == null ? -1 : o.Id
+                      });
+        }
+
+        protected ArubaContext CreateContext()
+            => Fixture.CreateContext();
+
+        protected virtual void ClearLog()
+        {
+        }
+
+        public abstract class Ef6GroupByFixtureBase : SharedStoreFixtureBase<ArubaContext>, IQueryFixtureBase
+        {
+            protected override string StoreName { get; } = "Ef6GroupByTest";
+
+            public Func<DbContext> GetContextCreator()
+                => () => CreateContext();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                modelBuilder.Entity<ArubaOwner>(
+                    b =>
+                    {
+                        b.Property(p => p.Id).ValueGeneratedNever();
+                        b.Property(o => o.FirstName).HasMaxLength(30);
+                    });
+
+                modelBuilder.Entity<NumberForLinq>();
+                modelBuilder.Entity<ProductForLinq>().Property(e => e.UnitPrice).HasPrecision(18, 2);
+                modelBuilder.Entity<FeaturedProductForLinq>();
+                modelBuilder.Entity<CustomerForLinq>();
+                modelBuilder.Entity<OrderForLinq>().Property(e => e.Total).HasPrecision(18, 2);
+            }
+
+            protected override void Seed(ArubaContext context)
+            {
+                var data = new ArubaData();
+                context.AddRange(data.ArubaOwners);
+                context.AddRange(data.NumbersForLinq);
+                context.SaveChanges();
+            }
+
+            public virtual ISetSource GetExpectedData()
+                => new ArubaData();
+
+            public IReadOnlyDictionary<Type, object> GetEntitySorters()
+                => new Dictionary<Type, Func<object, object>>
+                {
+                    { typeof(ArubaOwner), e => ((ArubaOwner)e)?.Id }
+                }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+        public IReadOnlyDictionary<Type, object> GetEntityAsserters()
+            => new Dictionary<Type, Action<object, object>>
+            {
+                {
+                    typeof(ArubaOwner), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (ArubaOwner)e;
+                            var aa = (ArubaOwner)a;
+
+                            Assert.Equal(ee.Id, aa.Id);
+                            Assert.Equal(ee.FirstName, aa.FirstName);
+                            Assert.Equal(ee.LastName, aa.LastName);
+                            Assert.Equal(ee.Alias, aa.Alias);
+                        }
+                    }
+                }
+            }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+        }
+
+        public class ArubaContext : PoolableDbContext
+        {
+            public ArubaContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
+
+        public class ArubaOwner
+        {
+            public int Id { get; set; }
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+            public string Alias { get; set; }
+        }
+
+        public class NumberForLinq
+        {
+            public NumberForLinq()
+            {
+            }
+
+            public NumberForLinq(int value, string name)
+            {
+                Value = value;
+                Name = name;
+            }
+
+            public int Id { get; set; }
+            public int Value { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class ProductForLinq
+        {
+            public int Id { get; set; }
+            public string ProductName { get; set; }
+            public string Category { get; set; }
+            public decimal UnitPrice { get; set; }
+            public int UnitsInStock { get; set; }
+        }
+
+        public class FeaturedProductForLinq : ProductForLinq
+        {
+        }
+
+        public class CustomerForLinq
+        {
+            public int Id { get; set; }
+            public string Region { get; set; }
+            public string CompanyName { get; set; }
+            public ICollection<OrderForLinq> Orders { get; set; }
+        }
+
+        public class OrderForLinq
+        {
+            public int Id { get; set; }
+            public decimal Total { get; set; }
+            public DateTime OrderDate { get; set; }
+            public CustomerForLinq Customer { get; set; }
+        }
+
+        public class ArubaData : ISetSource
+        {
+            public IReadOnlyList<ArubaOwner> ArubaOwners { get; }
+            public IReadOnlyList<NumberForLinq> NumbersForLinq { get; }
+            public IReadOnlyList<ProductForLinq> ProductsForLinq { get; }
+            public IReadOnlyList<CustomerForLinq> CustomersForLinq { get; }
+            public IReadOnlyList<OrderForLinq> OrdersForLinq { get; }
+
+            public ArubaData()
+            {
+                ArubaOwners = CreateArubaOwners();
+                NumbersForLinq = CreateNumbersForLinq();
+                ProductsForLinq = CreateProductsForLinq();
+                CustomersForLinq = CreateCustomersForLinq();
+                OrdersForLinq = CreateOrdersForLinq(CustomersForLinq);
+            }
+
+            public IQueryable<TEntity> Set<TEntity>()
+                where TEntity : class
+            {
+                if (typeof(TEntity) == typeof(ArubaOwner))
+                {
+                    return (IQueryable<TEntity>)ArubaOwners.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(NumberForLinq))
+                {
+                    return (IQueryable<TEntity>)NumbersForLinq.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(ProductForLinq))
+                {
+                    return (IQueryable<TEntity>)ProductsForLinq.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(CustomerForLinq))
+                {
+                    return (IQueryable<TEntity>)CustomersForLinq.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(OrderForLinq))
+                {
+                    return (IQueryable<TEntity>)OrdersForLinq.AsQueryable();
+                }
+
+                throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
+            }
+
+            private static IReadOnlyList<NumberForLinq> CreateNumbersForLinq()
+                => new List<NumberForLinq>
+                {
+                    new(5, "Five"),
+                    new(4, "Four"),
+                    new(1, "One"),
+                    new(3, "Three"),
+                    new(9, "Nine"),
+                    new(8, "Eight"),
+                    new(6, "Six"),
+                    new(7, "Seven"),
+                    new(2, "Two"),
+                    new(0, "Zero"),
+                };
+
+            private static IReadOnlyList<ProductForLinq> CreateProductsForLinq()
+                => new List<ProductForLinq>
+                {
+                    new()
+                    {
+                            ProductName = "Chai",
+                            Category = "Beverages",
+                            UnitPrice = 18.0000M,
+                            UnitsInStock = 39
+                        },
+                    new()
+                    {
+                            ProductName = "Chang",
+                            Category = "Beverages",
+                            UnitPrice = 19.0000M,
+                            UnitsInStock = 17
+                        },
+                    new()
+                    {
+                            ProductName = "Aniseed Syrup",
+                            Category = "Condiments",
+                            UnitPrice = 10.0000M,
+                            UnitsInStock = 13
+                        },
+                    new()
+                    {
+                            ProductName = "Chef Anton's Cajun Seasoning",
+                            Category = "Condiments",
+                            UnitPrice = 22.0000M,
+                            UnitsInStock = 53
+                        },
+                    new()
+                    {
+                            ProductName = "Chef Anton's Gumbo Mix",
+                            Category = "Condiments",
+                            UnitPrice = 21.3500M,
+                            UnitsInStock = 0
+                        },
+                    new()
+                    {
+                            ProductName = "Grandma's Boysenberry Spread",
+                            Category = "Condiments",
+                            UnitPrice = 25.0000M,
+                            UnitsInStock = 120
+                        },
+                    new()
+                    {
+                            ProductName = "Uncle Bob's Organic Dried Pears",
+                            Category = "Produce",
+                            UnitPrice = 30.0000M,
+                            UnitsInStock = 15
+                        },
+                    new FeaturedProductForLinq
+                        {
+                            ProductName = "Northwoods Cranberry Sauce",
+                            Category = "Condiments",
+                            UnitPrice = 40.0000M,
+                            UnitsInStock = 6
+                        },
+                    new()
+                    {
+                            ProductName = "Mishi Kobe Niku",
+                            Category = "Meat/Poultry",
+                            UnitPrice = 97.0000M,
+                            UnitsInStock = 29
+                        },
+                    new()
+                    {
+                            ProductName = "Ikura",
+                            Category = "Seafood",
+                            UnitPrice = 31.0000M,
+                            UnitsInStock = 31
+                        },
+                    new()
+                    {
+                            ProductName = "Queso Cabrales",
+                            Category = "Dairy Products",
+                            UnitPrice = 21.0000M,
+                            UnitsInStock = 22
+                        },
+                    new FeaturedProductForLinq
+                        {
+                            ProductName = "Queso Manchego La Pastora",
+                            Category = "Dairy Products",
+                            UnitPrice = 38.0000M,
+                            UnitsInStock = 86
+                        },
+                    new()
+                    {
+                            ProductName = "Konbu",
+                            Category = "Seafood",
+                            UnitPrice = 6.0000M,
+                            UnitsInStock = 24
+                        },
+                    new()
+                    {
+                            ProductName = "Tofu",
+                            Category = "Produce",
+                            UnitPrice = 23.2500M,
+                            UnitsInStock = 35
+                        },
+                    new()
+                    {
+                            ProductName = "Genen Shouyu",
+                            Category = "Condiments",
+                            UnitPrice = 15.5000M,
+                            UnitsInStock = 39
+                        },
+                    new()
+                    {
+                            ProductName = "Pavlova",
+                            Category = "Confections",
+                            UnitPrice = 17.4500M,
+                            UnitsInStock = 29
+                        },
+                    new FeaturedProductForLinq
+                        {
+                            ProductName = "Alice Mutton",
+                            Category = "Meat/Poultry",
+                            UnitPrice = 39.0000M,
+                            UnitsInStock = 0
+                        },
+                    new FeaturedProductForLinq
+                        {
+                            ProductName = "Carnarvon Tigers",
+                            Category = "Seafood",
+                            UnitPrice = 62.5000M,
+                            UnitsInStock = 42
+                        },
+                    new()
+                    {
+                            ProductName = "Teatime Chocolate Biscuits",
+                            Category = "Confections",
+                            UnitPrice = 9.2000M,
+                            UnitsInStock = 25
+                        },
+                    new()
+                    {
+                            ProductName = "Sir Rodney's Marmalade",
+                            Category = "Confections",
+                            UnitPrice = 81.0000M,
+                            UnitsInStock = 40
+                        },
+                    new()
+                    {
+                            ProductName = "Sir Rodney's Scones",
+                            Category = "Confections",
+                            UnitPrice = 10.0000M,
+                            UnitsInStock = 3
+                        }
+                };
+
+            private static IReadOnlyList<CustomerForLinq> CreateCustomersForLinq()
+                => new List<CustomerForLinq>
+                {
+                    new()
+                    {
+                        Region = "WA",
+                        CompanyName = "Microsoft"
+                    },
+                    new()
+                    {
+                        Region = "WA",
+                        CompanyName = "NewMonics"
+                    },
+                    new()
+                    {
+                        Region = "OR",
+                        CompanyName = "NewMonics"
+                    },
+                    new()
+                    {
+                        Region = "CA",
+                        CompanyName = "Microsoft"
+                    }
+                };
+
+
+            private static IReadOnlyList<OrderForLinq> CreateOrdersForLinq(IReadOnlyList<CustomerForLinq> customers)
+                => new List<OrderForLinq>
+                {
+                    new()
+                    {
+                        Total = 111M,
+                        OrderDate = new DateTime(1997, 9, 3),
+                        Customer = customers[0]
+                    },
+                    new()
+                    {
+                        Total = 222M,
+                        OrderDate = new DateTime(2006, 9, 3),
+                        Customer = customers[1]
+                    },
+                    new()
+                    {
+                        Total = 333M,
+                        OrderDate = new DateTime(1999, 9, 3),
+                        Customer = customers[0]
+                    },
+                    new()
+                    {
+                        Total = 444M,
+                        OrderDate = new DateTime(2010, 9, 3),
+                        Customer = customers[1]
+                    },
+                    new()
+                    {
+                        Total = 2555M,
+                        OrderDate = new DateTime(2009, 9, 3),
+                        Customer = customers[2]
+                    },
+                    new()
+                    {
+                        Total = 6555M,
+                        OrderDate = new DateTime(1976, 9, 3),
+                        Customer = customers[3]
+                    },
+                    new()
+                    {
+                        Total = 555M,
+                        OrderDate = new DateTime(1985, 9, 3),
+                        Customer = customers[2]
+                    },
+                };
+
+            private static ArubaOwner[] CreateArubaOwners()
+            {
+                var owners = new ArubaOwner[10];
+                for (var i = 0; i < 10; i++)
+                {
+                    var owner = new ArubaOwner
+                    {
+                        Id = i,
+                        Alias = "Owner Alias " + i,
+                        FirstName = "First Name " + i % 3,
+                        LastName = "Last Name " + i,
+                    };
+                    owners[i] = owner;
+                }
+
+                return owners;
+            }
+        }
+   }
+}
+

--- a/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
@@ -231,7 +231,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select new { Id = g.Key.Id, Sum = g.Sum(x => x.Id), Count = g.Count() });
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #19929")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Simple_1_from_LINQ_101(bool async)
         {
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #19929")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Simple_2_from_LINQ_101(bool async)
         {
@@ -263,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #19929")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Simple_3_from_LINQ_101(bool async)
         {
@@ -279,7 +279,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #19929")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_Nested_from_LINQ_101(bool async)
         {
@@ -308,7 +308,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Translation of 'Select' which contains grouping parameter without composition is not supported.")]
+        [ConditionalTheory (Skip = "Issue #19929")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Any_Grouped_from_LINQ_101(bool async)
         {
@@ -325,7 +325,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Translation of 'Select' which contains grouping parameter without composition is not supported.")]
+        [ConditionalTheory (Skip = "Issue #19929")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_Grouped_from_LINQ_101(bool async)
         {
@@ -342,7 +342,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Count_Grouped_from_LINQ_101(bool async)
         {
@@ -358,7 +358,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task LongCount_Grouped_from_LINQ_101(bool async)
         {
@@ -374,7 +374,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Sum_Grouped_from_LINQ_101(bool async)
         {
@@ -390,7 +390,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Min_Grouped_from_LINQ_101(bool async)
         {
@@ -406,7 +406,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #18923")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Min_Elements_from_LINQ_101(bool async)
         {
@@ -423,7 +423,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_Grouped_from_LINQ_101(bool async)
         {
@@ -439,7 +439,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #18923")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_Elements_from_LINQ_101(bool async)
         {
@@ -456,7 +456,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Average_Grouped_from_LINQ_101(bool async)
         {
@@ -469,10 +469,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                       {
                           Category = g.Key,
                           AveragePrice = g.Average(p => p.UnitPrice)
+                      },
+                ss => from p in ss.Set<ProductForLinq>()
+                      group p by p.Category
+                      into g
+                      select new
+                      {
+                          Category = g.Key,
+                          AveragePrice = Math.Round(g.Average(p => p.UnitPrice) - 0.0000005m, 6)
                       });
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #19930")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Group_Join_from_LINQ_101(bool async)
         {
@@ -487,7 +495,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       });
         }
 
-        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Cross_Join_with_Group_Join_from_LINQ_101(bool async)
         {
@@ -500,10 +508,27 @@ namespace Microsoft.EntityFrameworkCore.Query
                       {
                           Customer = c,
                           o.Id
-                      });
+                      },
+                ss => from c in ss.Set<CustomerForLinq>()
+                      join o in ss.Set<OrderForLinq>() on c.Id equals o.Customer.Id into ps
+                      from o in ps
+                      select new
+                      {
+                          Customer = c,
+                          o.Id
+                      },
+                r => (r.Id, r.Customer.Id),
+                (l, r) =>
+                {
+                    Assert.Equal(l.Id, r.Id);
+                    Assert.Equal(l.Customer.Id, r.Customer.Id);
+                    Assert.Equal(l.Customer.Region, r.Customer.Region);
+                    Assert.Equal(l.Customer.CompanyName, r.Customer.CompanyName);
+                },
+                entryCount: 4);
         }
 
-        [ConditionalTheory (Skip = "Expected 7; Actual 0")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Left_Outer_Join_with_Group_Join_from_LINQ_101(bool async)
         {
@@ -516,7 +541,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                       {
                           Customer = c,
                           OrderId = o == null ? -1 : o.Id
-                      });
+                      },
+                ss => from c in ss.Set<CustomerForLinq>()
+                      join o in ss.Set<OrderForLinq>() on c.Id equals o.Customer.Id into ps
+                      from o in ps.DefaultIfEmpty()
+                      select new
+                      {
+                          Customer = c,
+                          OrderId = o == null ? -1 : o.Id
+                      },
+                r => (r.OrderId, r.Customer.Id),
+                (l, r) =>
+                {
+                    Assert.Equal(l.OrderId, r.OrderId);
+                    Assert.Equal(l.Customer.Id, r.Customer.Id);
+                    Assert.Equal(l.Customer.Region, r.Customer.Region);
+                    Assert.Equal(l.Customer.CompanyName, r.Customer.CompanyName);
+                },
+                entryCount: 4);
         }
 
         protected ArubaContext CreateContext()
@@ -543,51 +585,31 @@ namespace Microsoft.EntityFrameworkCore.Query
                     });
 
                 modelBuilder.Entity<NumberForLinq>();
-                modelBuilder.Entity<ProductForLinq>().Property(e => e.UnitPrice).HasPrecision(18, 2);
+                modelBuilder.Entity<ProductForLinq>().Property(e => e.UnitPrice).HasPrecision(18, 6);
                 modelBuilder.Entity<FeaturedProductForLinq>();
-                modelBuilder.Entity<CustomerForLinq>();
-                modelBuilder.Entity<OrderForLinq>().Property(e => e.Total).HasPrecision(18, 2);
+                modelBuilder.Entity<CustomerForLinq>().Property(e => e.Id).ValueGeneratedNever();
+
+                modelBuilder.Entity<OrderForLinq>(
+                    b =>
+                    {
+                        b.Property(e => e.Id).ValueGeneratedNever();
+                        b.Property(e => e.Total).HasPrecision(18, 6);
+                    });
             }
 
             protected override void Seed(ArubaContext context)
             {
-                var data = new ArubaData();
-                context.AddRange(data.ArubaOwners);
-                context.AddRange(data.NumbersForLinq);
-                context.SaveChanges();
+                new ArubaData(context);
             }
 
             public virtual ISetSource GetExpectedData()
                 => new ArubaData();
 
             public IReadOnlyDictionary<Type, object> GetEntitySorters()
-                => new Dictionary<Type, Func<object, object>>
-                {
-                    { typeof(ArubaOwner), e => ((ArubaOwner)e)?.Id }
-                }.ToDictionary(e => e.Key, e => (object)e.Value);
+                => new Dictionary<Type, object>();
 
-        public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-            => new Dictionary<Type, Action<object, object>>
-            {
-                {
-                    typeof(ArubaOwner), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            var ee = (ArubaOwner)e;
-                            var aa = (ArubaOwner)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.FirstName, aa.FirstName);
-                            Assert.Equal(ee.LastName, aa.LastName);
-                            Assert.Equal(ee.Alias, aa.Alias);
-                        }
-                    }
-                }
-            }.ToDictionary(e => e.Key, e => (object)e.Value);
-
+            public IReadOnlyDictionary<Type, object> GetEntityAsserters()
+                => new Dictionary<Type, object>();
         }
 
         public class ArubaContext : PoolableDbContext
@@ -660,13 +682,23 @@ namespace Microsoft.EntityFrameworkCore.Query
             public IReadOnlyList<CustomerForLinq> CustomersForLinq { get; }
             public IReadOnlyList<OrderForLinq> OrdersForLinq { get; }
 
-            public ArubaData()
+            public ArubaData(ArubaContext context = null)
             {
                 ArubaOwners = CreateArubaOwners();
                 NumbersForLinq = CreateNumbersForLinq();
                 ProductsForLinq = CreateProductsForLinq();
                 CustomersForLinq = CreateCustomersForLinq();
                 OrdersForLinq = CreateOrdersForLinq(CustomersForLinq);
+
+                if (context != null)
+                {
+                    context.AddRange(ArubaOwners = CreateArubaOwners());
+                    context.AddRange(NumbersForLinq = CreateNumbersForLinq());
+                    context.AddRange(ProductsForLinq = CreateProductsForLinq());
+                    context.AddRange(CustomersForLinq = CreateCustomersForLinq());
+                    context.AddRange(OrdersForLinq = CreateOrdersForLinq(CustomersForLinq));
+                    context.SaveChanges();
+                }
             }
 
             public IQueryable<TEntity> Set<TEntity>()
@@ -872,21 +904,25 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     new()
                     {
+                        Id = 1,
                         Region = "WA",
                         CompanyName = "Microsoft"
                     },
                     new()
                     {
+                        Id = 2,
                         Region = "WA",
                         CompanyName = "NewMonics"
                     },
                     new()
                     {
+                        Id = 3,
                         Region = "OR",
                         CompanyName = "NewMonics"
                     },
                     new()
                     {
+                        Id = 4,
                         Region = "CA",
                         CompanyName = "Microsoft"
                     }
@@ -898,42 +934,49 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     new()
                     {
+                        Id = 1,
                         Total = 111M,
                         OrderDate = new DateTime(1997, 9, 3),
                         Customer = customers[0]
                     },
                     new()
                     {
+                        Id = 2,
                         Total = 222M,
                         OrderDate = new DateTime(2006, 9, 3),
                         Customer = customers[1]
                     },
                     new()
                     {
+                        Id = 3,
                         Total = 333M,
                         OrderDate = new DateTime(1999, 9, 3),
                         Customer = customers[0]
                     },
                     new()
                     {
+                        Id = 4,
                         Total = 444M,
                         OrderDate = new DateTime(2010, 9, 3),
                         Customer = customers[1]
                     },
                     new()
                     {
+                        Id = 5,
                         Total = 2555M,
                         OrderDate = new DateTime(2009, 9, 3),
                         Customer = customers[2]
                     },
                     new()
                     {
+                        Id = 6,
                         Total = 6555M,
                         OrderDate = new DateTime(1976, 9, 3),
                         Customer = customers[3]
                     },
                     new()
                     {
+                        Id = 7,
                         Total = 555M,
                         OrderDate = new DateTime(1985, 9, 3),
                         Customer = customers[2]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
@@ -256,7 +256,7 @@ GROUP BY [a].[FirstName]");
             // )  AS [Distinct1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
         {
             await base.Grouping_by_all_columns_doesnt_produce_a_groupby_statement(async);
@@ -291,7 +291,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     FROM [dbo].[ArubaOwners] AS [Extent1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_2(async);
@@ -308,7 +308,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     FROM [dbo].[ArubaOwners] AS [Extent1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_3(async);
@@ -325,7 +325,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     FROM [dbo].[ArubaOwners] AS [Extent1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_4(async);
@@ -348,7 +348,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     )  AS [GroupBy1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_5(async);
@@ -371,7 +371,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     )  AS [GroupBy1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_6(async);
@@ -395,7 +395,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     )  AS [GroupBy1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_7(async);
@@ -412,7 +412,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     FROM [dbo].[ArubaOwners] AS [Extent1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_8(async);
@@ -435,7 +435,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     )  AS [GroupBy1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_9(async);
@@ -459,7 +459,7 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
             //     )  AS [GroupBy1]";
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
+        [ConditionalTheory (Skip = "Issue #17653")]
         public override async Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
         {
             await base.Grouping_by_all_columns_with_aggregate_function_works_10(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
@@ -1,0 +1,499 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class Ef6GroupBySqlServerTest : Ef6GroupByTestBase<Ef6GroupBySqlServerTest.Ef6GroupBySqlServerFixture>
+    {
+        public Ef6GroupBySqlServerTest(Ef6GroupBySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public override async Task GroupBy_is_optimized_when_projecting_group_key(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_group_key(async);
+
+            AssertSql(
+                @"SELECT [a].[FirstName]
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // [Distinct1].[FirstName] AS [FirstName]
+            // FROM ( SELECT DISTINCT
+            // [Extent1].[FirstName] AS [FirstName]
+            // FROM [dbo].[ArubaOwners] AS [Extent1]
+            // )  AS [Distinct1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_projecting_group_count(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_group_count(async);
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // [GroupBy1].[A1] AS [C1]
+            // FROM ( SELECT
+            // 	[Extent1].[FirstName] AS [K1],
+            // 	COUNT(1) AS [A1]
+            // 	FROM [dbo].[ArubaOwners] AS [Extent1]
+            // 	GROUP BY [Extent1].[FirstName]
+            // )  AS [GroupBy1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_projecting_expression_containing_group_key(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_expression_containing_group_key(async);
+
+            AssertSql(
+                @"SELECT [a].[Id] * 2
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[Id]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // [Extent1].[Id] * 2 AS [C1]
+            // FROM [dbo].[ArubaOwners] AS [Extent1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_projecting_aggregate_on_the_group(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_aggregate_on_the_group(async);
+
+            AssertSql(
+                @"SELECT MAX([a].[Id])
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // [GroupBy1].[A1] AS [C1]
+            // FROM ( SELECT
+            // 	[Extent1].[FirstName] AS [K1],
+            // 	MAX([Extent1].[Id]) AS [A1]
+            // 	FROM [dbo].[ArubaOwners] AS [Extent1]
+            // 	GROUP BY [Extent1].[FirstName]
+            // )  AS [GroupBy1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_projecting_anonymous_type_containing_group_key_and_group_aggregate(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_anonymous_type_containing_group_key_and_group_aggregate(async);
+
+            AssertSql(
+                @"SELECT [a].[FirstName] AS [Key], MAX([a].[Id]) AS [Aggregate]
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // 1 AS [C1],
+            // [GroupBy1].[K1] AS [FirstName],
+            // [GroupBy1].[A1] AS [C2]
+            // FROM ( SELECT
+            // 	[Extent1].[FirstName] AS [K1],
+            // 	MAX([Extent1].[Id]) AS [A1]
+            // 	FROM [dbo].[ArubaOwners] AS [Extent1]
+            // 	GROUP BY [Extent1].[FirstName]
+            // )  AS [GroupBy1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_projecting_anonymous_type_containing_group_key_and_multiple_group_aggregates(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_anonymous_type_containing_group_key_and_multiple_group_aggregates(async);
+
+            AssertSql(
+                @"SELECT [a].[FirstName] AS [key1], MAX([a].[Id]) AS [max], MIN([a].[Id] + 2) AS [min]
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // 1 AS [C1],
+            // [GroupBy1].[K1] AS [FirstName],
+            // [GroupBy1].[A1] AS [C2],
+            // [GroupBy1].[A2] AS [C3]
+            // FROM ( SELECT
+            // 	[Extent1].[K1] AS [K1],
+            // 	MAX([Extent1].[A1_0]) AS [A1],
+            // 	MIN([Extent1].[A2_0]) AS [A2]
+            // 	FROM ( SELECT
+            // 		[Extent1].[FirstName] AS [K1],
+            // 		[Extent1].[Id] AS [A1_0],
+            // 		[Extent1].[Id] + 2 AS [A2_0]
+            // 		FROM [dbo].[ArubaOwners] AS [Extent1]
+            // 	)  AS [Extent1]
+            // 	GROUP BY [K1]
+            // )  AS [GroupBy1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_projecting_conditional_expression_containing_group_key(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_conditional_expression_containing_group_key(async);
+
+            AssertSql(
+                @"@__p_0='False'
+
+SELECT CASE
+    WHEN [a].[FirstName] IS NULL THEN N'is null'
+    ELSE N'not null'
+END AS [keyIsNull], @__p_0 AS [logicExpression]
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // 1 AS [C1],
+            // CASE WHEN ([Distinct1].[FirstName] IS NULL) THEN N'is null' ELSE N'not null' END AS [C2],
+            // CASE WHEN (((@p__linq__0 = 1) AND (@p__linq__1 = 1)) OR ((@p__linq__2 = 1) AND (@p__linq__3 = 1))) THEN cast(1 as bit) WHEN ( NOT (((@p__linq__0 = 1) AND (@p__linq__1 = 1)) OR ((@p__linq__2 = 1) AND (@p__linq__3 = 1)))) THEN cast(0 as bit) END AS [C3]
+            // FROM ( SELECT DISTINCT
+            // 	[Extent1].[FirstName] AS [FirstName]
+            // 	FROM [dbo].[ArubaOwners] AS [Extent1]
+            // )  AS [Distinct1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_filerting_and_projecting_anonymous_type_with_group_key_and_function_aggregate(bool async)
+        {
+            await base.GroupBy_is_optimized_when_filerting_and_projecting_anonymous_type_with_group_key_and_function_aggregate(async);
+
+            AssertSql(
+                @"SELECT [a].[FirstName], AVG(CAST([a].[Id] AS float)) AS [AverageId]
+FROM [ArubaOwner] AS [a]
+WHERE [a].[Id] > 5
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // 1 AS [C1],
+            // [GroupBy1].[K1] AS [FirstName],
+            // [GroupBy1].[A1] AS [C2]
+            // FROM ( SELECT
+            // 	[Extent1].[FirstName] AS [K1],
+            // 	AVG( CAST( [Extent1].[Id] AS float)) AS [A1]
+            // 	FROM [dbo].[ArubaOwners] AS [Extent1]
+            // 	WHERE [Extent1].[Id] > 5
+            // 	GROUP BY [Extent1].[FirstName]
+            // )  AS [GroupBy1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_projecting_function_aggregate_with_expression(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_function_aggregate_with_expression(async);
+
+            AssertSql(
+                @"SELECT MAX([a].[Id] * 2)
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // [GroupBy1].[A1] AS [C1]
+            // FROM ( SELECT
+            // 	[Extent1].[K1] AS [K1],
+            // 	MAX([Extent1].[A1_0]) AS [A1]
+            // 	FROM ( SELECT
+            // 		[Extent1].[FirstName] AS [K1],
+            // 		[Extent1].[Id] * 2 AS [A1_0]
+            // 		FROM [dbo].[ArubaOwners] AS [Extent1]
+            // 	)  AS [Extent1]
+            // 	GROUP BY [K1]
+            // )  AS [GroupBy1]";
+                    }
+
+        public override async Task GroupBy_is_optimized_when_projecting_expression_with_multiple_function_aggregates(bool async)
+        {
+            await base.GroupBy_is_optimized_when_projecting_expression_with_multiple_function_aggregates(async);
+
+            AssertSql(
+                @"SELECT MAX([a].[Id]) - MIN([a].[Id]) AS [maxMinusMin]
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // 1 AS [C1],
+            // [GroupBy1].[A1] - [GroupBy1].[A2] AS [C2]
+            // FROM ( SELECT
+            // 	[Extent1].[FirstName] AS [K1],
+            // 	MAX([Extent1].[Id]) AS [A1],
+            // 	MIN([Extent1].[Id]) AS [A2]
+            // 	FROM [dbo].[ArubaOwners] AS [Extent1]
+            // 	GROUP BY [Extent1].[FirstName]
+            // )  AS [GroupBy1]";
+        }
+
+        public override async Task GroupBy_is_optimized_when_grouping_by_row_and_projecting_column_of_the_key_row(bool async)
+        {
+            await base.GroupBy_is_optimized_when_grouping_by_row_and_projecting_column_of_the_key_row(async);
+
+            AssertSql(
+                @"SELECT [a].[FirstName]
+FROM [ArubaOwner] AS [a]
+WHERE [a].[Id] < 4
+GROUP BY [a].[FirstName]");
+
+            // EF6 SQL:
+            // @"SELECT
+            // [Distinct1].[FirstName] AS [FirstName]
+            // FROM ( SELECT DISTINCT
+            // 	[Extent1].[FirstName] AS [FirstName]
+            // 	FROM [dbo].[ArubaOwners] AS [Extent1]
+            // 	WHERE [Extent1].[Id] < 4
+            // )  AS [Distinct1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+        {
+            await base.Grouping_by_all_columns_doesnt_produce_a_groupby_statement(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     [Extent1].[Id] AS [Id],
+            //     [Extent1].[FirstName] AS [FirstName],
+            //     [Extent1].[LastName] AS [LastName],
+            //     [Extent1].[Alias] AS [Alias]
+            //     FROM [dbo].[ArubaOwners] AS [Extent1]";
+        }
+
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_1(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_1(async);
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [ArubaOwner] AS [a]
+GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     (SELECT
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent2]
+            //         WHERE [Extent1].[Id] = [Extent2].[Id]) AS [C1]
+            //     FROM [dbo].[ArubaOwners] AS [Extent1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_2(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     (SELECT
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent2]
+            //         WHERE [Extent1].[Id] = [Extent2].[Id]) AS [C1]
+            //     FROM [dbo].[ArubaOwners] AS [Extent1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_3(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     (SELECT
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent2]
+            //         WHERE [Extent1].[Id] = [Extent2].[Id]) AS [C1]
+            //     FROM [dbo].[ArubaOwners] AS [Extent1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_4(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     [GroupBy1].[K1] AS [Id],
+            //     [GroupBy1].[A1] AS [C1]
+            //     FROM ( SELECT
+            //         [Extent1].[Id] AS [K1],
+            //         [Extent1].[FirstName] AS [K2],
+            //         [Extent1].[LastName] AS [K3],
+            //         [Extent1].[Alias] AS [K4],
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent1]
+            //         GROUP BY [Extent1].[Id], [Extent1].[FirstName], [Extent1].[LastName], [Extent1].[Alias]
+            //     )  AS [GroupBy1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_5(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     [GroupBy1].[K1] AS [Id],
+            //     [GroupBy1].[A1] AS [C1]
+            //     FROM ( SELECT
+            //         [Extent1].[Id] AS [K1],
+            //         [Extent1].[FirstName] AS [K2],
+            //         [Extent1].[LastName] AS [K3],
+            //         [Extent1].[Alias] AS [K4],
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent1]
+            //         GROUP BY [Extent1].[Id], [Extent1].[FirstName], [Extent1].[LastName], [Extent1].[Alias]
+            //     )  AS [GroupBy1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_6(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     [GroupBy1].[K1] AS [Id],
+            //     [GroupBy1].[K4] AS [Alias],
+            //     [GroupBy1].[A1] AS [C1]
+            //     FROM ( SELECT
+            //         [Extent1].[Id] AS [K1],
+            //         [Extent1].[FirstName] AS [K2],
+            //         [Extent1].[LastName] AS [K3],
+            //         [Extent1].[Alias] AS [K4],
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent1]
+            //         GROUP BY [Extent1].[Id], [Extent1].[FirstName], [Extent1].[LastName], [Extent1].[Alias]
+            //     )  AS [GroupBy1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_7(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     (SELECT
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent2]
+            //         WHERE [Extent1].[Id] = [Extent2].[Id]) AS [C1]
+            //     FROM [dbo].[ArubaOwners] AS [Extent1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_8(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     [GroupBy1].[K1] AS [Id],
+            //     [GroupBy1].[A1] AS [C1]
+            //     FROM ( SELECT
+            //         [Extent1].[Id] AS [K1],
+            //         [Extent1].[FirstName] AS [K2],
+            //         [Extent1].[LastName] AS [K3],
+            //         [Extent1].[Alias] AS [K4],
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent1]
+            //         GROUP BY [Extent1].[Id], [Extent1].[FirstName], [Extent1].[LastName], [Extent1].[Alias]
+            //     )  AS [GroupBy1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_9(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     [GroupBy1].[K1] AS [Id],
+            //     [GroupBy1].[K4] AS [Alias],
+            //     [GroupBy1].[A1] AS [C1]
+            //     FROM ( SELECT
+            //         [Extent1].[Id] AS [K1],
+            //         [Extent1].[FirstName] AS [K2],
+            //         [Extent1].[LastName] AS [K3],
+            //         [Extent1].[Alias] AS [K4],
+            //         COUNT(1) AS [A1]
+            //         FROM [dbo].[ArubaOwners] AS [Extent1]
+            //         GROUP BY [Extent1].[Id], [Extent1].[FirstName], [Extent1].[LastName], [Extent1].[Alias]
+            //     )  AS [GroupBy1]";
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_10(async);
+
+            AssertSql(
+                @"");
+
+            // EF6 SQL:
+            // @"SELECT
+            //     [GroupBy1].[K1] AS [Id],
+            //     [GroupBy1].[A1] AS [C1],
+            //     [GroupBy1].[A2] AS [C2]
+            //     FROM ( SELECT
+            //         [Extent1].[Id] AS [K1],
+            //         [Extent1].[FirstName] AS [K2],
+            //         [Extent1].[LastName] AS [K3],
+            //         [Extent1].[Alias] AS [K4],
+            //         SUM([Extent1].[Id]) AS [A1],
+            //         COUNT(1) AS [A2]
+            //         FROM [dbo].[ArubaOwners] AS [Extent1]
+            //         GROUP BY [Extent1].[Id], [Extent1].[FirstName], [Extent1].[LastName], [Extent1].[Alias]
+            //     )  AS [GroupBy1]";
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        public class Ef6GroupBySqlServerFixture : Ef6GroupByFixtureBase
+        {
+            public TestSqlLoggerFactory TestSqlLoggerFactory
+                => (TestSqlLoggerFactory)ListLoggerFactory;
+
+            protected override ITestStoreFactory TestStoreFactory
+                => SqlServerTestStoreFactory.Instance;
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class Ef6GroupBySqliteTest : Ef6GroupByTestBase<Ef6GroupBySqliteTest.Ef6GroupBySqliteFixture>
+    {
+        public Ef6GroupBySqliteTest(Ef6GroupBySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+        {
+            await base.Grouping_by_all_columns_doesnt_produce_a_groupby_statement(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_2(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_3(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_4(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_5(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_6(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_7(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_8(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_9(async);
+        }
+
+        [ConditionalTheory (Skip = "Could not be translated.")]
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_10(async);
+        }
+
+        public class Ef6GroupBySqliteFixture : Ef6GroupByFixtureBase
+        {
+            public TestSqlLoggerFactory TestSqlLoggerFactory
+                => (TestSqlLoggerFactory)ListLoggerFactory;
+
+            protected override ITestStoreFactory TestStoreFactory
+                => SqliteTestStoreFactory.Instance;
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
@@ -18,56 +18,82 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalTheory (Skip = "Issue #19635")]
-        public override Task Average_Grouped_from_LINQ_101(bool async)
-            => Task.CompletedTask;
+        public override async Task Average_Grouped_from_LINQ_101(bool async)
+        {
+            await base.Average_Grouped_from_LINQ_101(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #19635")]
-        public override Task Max_Grouped_from_LINQ_101(bool async)
-            => Task.CompletedTask;
+        public override async Task Max_Grouped_from_LINQ_101(bool async)
+        {
+            await base.Max_Grouped_from_LINQ_101(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #19635")]
-        public override Task Min_Grouped_from_LINQ_101(bool async)
-            => Task.CompletedTask;
+        public override async Task Min_Grouped_from_LINQ_101(bool async)
+        {
+            await base.Min_Grouped_from_LINQ_101(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+        {
+            await base.Grouping_by_all_columns_doesnt_produce_a_groupby_statement(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_2(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_3(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_4(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_5(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_6(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_7(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_8(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_9(async);
+        }
 
         [ConditionalTheory (Skip = "Issue #17653")]
-        public override Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
-            => Task.CompletedTask;
+        public override async Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
+        {
+            await base.Grouping_by_all_columns_with_aggregate_function_works_10(async);
+        }
 
         public class Ef6GroupBySqliteFixture : Ef6GroupByFixtureBase
         {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
@@ -17,65 +17,57 @@ namespace Microsoft.EntityFrameworkCore.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
-        {
-            await base.Grouping_by_all_columns_doesnt_produce_a_groupby_statement(async);
-        }
+        [ConditionalTheory (Skip = "Issue #19635")]
+        public override Task Average_Grouped_from_LINQ_101(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_2(async);
-        }
+        [ConditionalTheory (Skip = "Issue #19635")]
+        public override Task Max_Grouped_from_LINQ_101(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_3(async);
-        }
+        [ConditionalTheory (Skip = "Issue #19635")]
+        public override Task Min_Grouped_from_LINQ_101(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_4(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_doesnt_produce_a_groupby_statement(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_5(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_2(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_6(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_3(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_7(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_4(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_8(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_5(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_9(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_6(bool async)
+            => Task.CompletedTask;
 
-        [ConditionalTheory (Skip = "Could not be translated.")]
-        public override async Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
-        {
-            await base.Grouping_by_all_columns_with_aggregate_function_works_10(async);
-        }
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_7(bool async)
+            => Task.CompletedTask;
+
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_8(bool async)
+            => Task.CompletedTask;
+
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_9(bool async)
+            => Task.CompletedTask;
+
+        [ConditionalTheory (Skip = "Issue #17653")]
+        public override Task Grouping_by_all_columns_with_aggregate_function_works_10(bool async)
+            => Task.CompletedTask;
 
         public class Ef6GroupBySqliteFixture : Ef6GroupByFixtureBase
         {


### PR DESCRIPTION
As a crude measure of the gap between EF Core and EF6.

Currently:
- 20 tests pass
- 2 tests fail with "Translation of 'Select' which contains grouping parameter without composition is not supported."
- 17 tests fail with general "Could not be translated."
- ~~8 tests fail with different results~~
