### PR TITLE
[6.0] Fix to #24490 - Update exception message when correlated collection cannot be projected

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -690,10 +690,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 valuesCount, columnsCount, table);
 
         /// <summary>
-        ///     Unable to translate a collection subquery in a projection since the parent query doesn't project the key columns of all tables required to generate results on the client side. This can happen when trying to correlate on keyless entity or when using 'Distinct' or 'GroupBy' operations without projecting all of the key columns.
+        ///     Unable to translate a collection subquery in a projection since either parent or the subquery doesn't project necessary information required to uniquely identify it and correctly generate results on the client side. This can happen when trying to correlate on keyless entity type. This can also happen for some cases of projection before 'Distinct' or some shapes of grouping key in case of 'GroupBy'. These should either contain all key properties of the entity that the operation is applied on, or only contain simple property access expressions.
         /// </summary>
-        public static string InsufficientInformationToIdentifyOuterElementOfCollectionJoin
-            => GetString("InsufficientInformationToIdentifyOuterElementOfCollectionJoin");
+        public static string InsufficientInformationToIdentifyElementOfCollectionJoin
+            => GetString("InsufficientInformationToIdentifyElementOfCollectionJoin");
 
         /// <summary>
         ///     The specified 'CommandTimeout' value '{value}' is not valid. It must be a positive number.

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -375,8 +375,8 @@
   <data name="InsertDataOperationValuesCountMismatch" xml:space="preserve">
     <value>The number of values ({valuesCount}) doesn't match the number of columns ({columnsCount}) for the data insertion operation on '{table}'. Provide the same number of values and columns.</value>
   </data>
-  <data name="InsufficientInformationToIdentifyOuterElementOfCollectionJoin" xml:space="preserve">
-    <value>Unable to translate a collection subquery in a projection since the parent query doesn't project the key columns of all tables required to generate results on the client side. This can happen when trying to correlate on keyless entity or when using 'Distinct' or 'GroupBy' operations without projecting all of the key columns.</value>
+  <data name="InsufficientInformationToIdentifyElementOfCollectionJoin" xml:space="preserve">
+    <value>Unable to translate a collection subquery in a projection since either parent or the subquery doesn't project necessary information required to uniquely identify it and correctly generate results on the client side. This can happen when trying to correlate on keyless entity type. This can also happen for some cases of projection before 'Distinct' or some shapes of grouping key in case of 'GroupBy'. These should either contain all key properties of the entity that the operation is applied on, or only contain simple property access expressions.</value>
   </data>
   <data name="InvalidCommandTimeout" xml:space="preserve">
     <value>The specified 'CommandTimeout' value '{value}' is not valid. It must be a positive number.</value>

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -591,7 +591,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                             if (_identifier.Count == 0
                                 || innerSelectExpression._identifier.Count == 0)
                             {
-                                throw new InvalidOperationException(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin);
+                                throw new InvalidOperationException(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin);
                             }
 
                             var innerShaperExpression = shapedQueryExpression.ShaperExpression;

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSharedTypeQueryRelationalTestBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
         {
             Assert.Equal(
-                RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin,
+                RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(async))).Message);
         }

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSplitSharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsCollectionsSplitSharedTypeQueryRelationalTestBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
         {
             Assert.Equal(
-                RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin,
+                RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(async))).Message);
         }

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
                   () => base.Correlated_collection_with_groupby_with_complex_grouping_key_not_projecting_identifier_column_with_group_aggregate_in_final_projection(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         public override async Task Correlated_collection_with_distinct_not_projecting_identifier_column_also_projecting_complex_expressions(bool async)
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
                   () => base.Correlated_collection_with_distinct_not_projecting_identifier_column_also_projecting_complex_expressions(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         public override async Task Client_eval_followed_by_aggregate_operation(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Complex_query_with_groupBy_in_subquery4(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         public override async Task Select_correlated_collection_after_GroupBy_aggregate_when_identifier_changes_to_complex(bool async)
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Select_correlated_collection_after_GroupBy_aggregate_when_identifier_changes_to_complex(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindKeylessEntitiesQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindKeylessEntitiesQueryRelationalTestBase.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             OrderDetailIds = ss.Set<Customer>().Where(c => c.City == cq.City).ToList()
                         }).OrderBy(x => x.City).Take(2)))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         [ConditionalTheory]
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         Collection = ss.Set<CustomerQuery>().Where(cq => cq.City == c.City).ToList(),
                     })))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         [ConditionalTheory]
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.KeylessEntity_with_included_navs_multi_level(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         [ConditionalTheory]
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.KeylessEntity_with_defining_query_and_correlated_collection(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         protected override QueryAsserter CreateQueryAsserter(TFixture fixture)

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindSelectQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindSelectQueryRelationalTestBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
               () => base.Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         public override Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindSetOperationsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindSetOperationsQueryRelationalTestBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Collection_projection_after_set_operation_fails_if_distinct(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
         }
 
         public override async Task Collection_projection_before_set_operation_fails(bool async)

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -1423,7 +1423,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             };
 
                 Assert.Equal(
-                    RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin,
+                    RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin,
                     Assert.Throws<InvalidOperationException>(() => query.ToList()).Message);
             }
         }
@@ -1544,7 +1544,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                                Prods = context.GetTopTwoSellingProducts().ToList(),
                            }).ToList()).Message;
 
-                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
+            }
+        }
+
+        [ConditionalFact(Skip = "issue #26078")]
+        public virtual void QF_Select_Direct_In_Anonymous_distinct()
+        {
+            using (var context = CreateContext())
+            {
+                var query = (from c in context.Customers
+                             select new
+                             {
+                                 c.Id,
+                                 Prods = context.GetTopTwoSellingProducts().Distinct().ToList(),
+                             }).ToList();
             }
         }
 
@@ -1638,7 +1652,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                }).ToList()
                            }).ToList()).Message;
 
-                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
             }
         }
 
@@ -1656,7 +1670,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                Prods = context.GetTopTwoSellingProducts().Where(p => p.AmountSold == 249).Select(p => p.ProductId).ToList()
                            }).ToList()).Message;
 
-                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
             }
         }
 
@@ -1673,7 +1687,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                Prods = context.GetTopTwoSellingProducts().Select(p => p.ProductId).ToList(),
                            }).ToList()).Message;
 
-                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
             }
         }
 
@@ -1691,7 +1705,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                Prods = context.GetTopTwoSellingProducts().Where(p => p.AmountSold == amount).Select(p => p.ProductId).ToList(),
                            }).ToList()).Message;
 
-                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+                Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin, message);
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -533,6 +533,14 @@ CROSS APPLY [dbo].[GetCustomerOrderCountByYear]([c].[Id]) AS [g]
 ORDER BY [g].[Year]");
         }
 
+        public override void QF_Select_Direct_In_Anonymous_distinct()
+        {
+            base.QF_Select_Direct_In_Anonymous_distinct();
+
+            AssertSql(
+                @"");
+        }
+
         public override void QF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous()
         {
             base.QF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous();


### PR DESCRIPTION
Updating the message and resource string name to reflect the changes in behavior after we've improved this scenario.

Fixes #24490