### PR TITLE
When sorting update commands add Deleted + Inserted number of edges instead of Deleted * Inserted

### DIFF
--- a/benchmark/EFCore.Benchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/benchmark/EFCore.Benchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -36,11 +36,11 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.UpdatePipeline
             {
                 _fixture = CreateFixture();
                 _fixture.Initialize(0, 1000, 0, 0);
+                _context = _fixture.CreateContext(disableBatching: Batching);
             }
 
             public virtual void InitializeContext()
             {
-                _context = _fixture.CreateContext(disableBatching: Batching);
                 _transaction = _context.Database.BeginTransaction();
             }
 
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.UpdatePipeline
                 }
 
                 _transaction.Dispose();
-                _context.Dispose();
+                _context.ChangeTracker.Clear();
             }
 
             [Benchmark]

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -32,6 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
     {
         private readonly int _minBatchSize;
         private readonly bool _sensitiveLoggingEnabled;
+        private readonly Multigraph<IReadOnlyModificationCommand, IAnnotatable> _modificationCommandGraph = new();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -278,18 +279,18 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         /// </summary>
         protected virtual IReadOnlyList<List<IReadOnlyModificationCommand>> TopologicalSort(IEnumerable<IReadOnlyModificationCommand> commands)
         {
-            var modificationCommandGraph = new Multigraph<IReadOnlyModificationCommand, IAnnotatable>();
-            modificationCommandGraph.AddVertices(commands);
+            _modificationCommandGraph.Clear();
+            _modificationCommandGraph.AddVertices(commands);
 
             // The predecessors map allows to populate the graph in linear time
-            var predecessorsMap = CreateKeyValuePredecessorMap(modificationCommandGraph);
-            AddForeignKeyEdges(modificationCommandGraph, predecessorsMap);
+            var predecessorsMap = CreateKeyValuePredecessorMap(_modificationCommandGraph);
+            AddForeignKeyEdges(_modificationCommandGraph, predecessorsMap);
 
-            AddUniqueValueEdges(modificationCommandGraph);
+            AddUniqueValueEdges(_modificationCommandGraph);
 
-            AddSameTableEdges(modificationCommandGraph);
+            AddSameTableEdges(_modificationCommandGraph);
 
-            return modificationCommandGraph.BatchingTopologicalSort(static (_, _, edges) => edges.All(e => e is IEntityType), FormatCycle);
+            return _modificationCommandGraph.BatchingTopologicalSort(static (_, _, edges) => edges.All(e => e is IEntityType), FormatCycle);
         }
 
         private string FormatCycle(IReadOnlyList<Tuple<IReadOnlyModificationCommand, IReadOnlyModificationCommand, IEnumerable<IAnnotatable>>> data)
@@ -488,12 +489,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                         var entry = command.Entries[i];
                         foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
                         {
-                            var constraints = foreignKey.GetMappedConstraints()
-                                .Where(c => c.PrincipalTable.Name == command.TableName && c.PrincipalTable.Schema == command.Schema);
-
-                            if (!constraints.Any()
-                                || (entry.EntityState == EntityState.Modified
-                                    && !foreignKey.PrincipalKey.Properties.Any(p => entry.IsModified(p))))
+                            if (!IsMapped(foreignKey, command, principal: true)
+                                || !IsModified(foreignKey.PrincipalKey.Properties, entry))
                             {
                                 continue;
                             }
@@ -523,12 +520,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     {
                         foreach (var foreignKey in entry.EntityType.GetForeignKeys())
                         {
-                            var constraints = foreignKey.GetMappedConstraints()
-                                .Where(c => c.Table.Name == command.TableName && c.Table.Schema == command.Schema);
-
-                            if (!constraints.Any()
-                                || (entry.EntityState == EntityState.Modified
-                                    && !foreignKey.Properties.Any(p => entry.IsModified(p))))
+                            if (!IsMapped(foreignKey, command, principal: false)
+                                || !IsModified(foreignKey.Properties, entry))
                             {
                                 continue;
                             }
@@ -571,10 +564,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                             var entry = command.Entries[entryIndex];
                             foreach (var foreignKey in entry.EntityType.GetForeignKeys())
                             {
-                                if (!foreignKey.GetMappedConstraints()
-                                        .Any(c => c.Table.Name == command.TableName && c.Table.Schema == command.Schema)
-                                    || (entry.EntityState == EntityState.Modified
-                                        && !foreignKey.Properties.Any(p => entry.IsModified(p))))
+                                if (!IsMapped(foreignKey, command, principal: false)
+                                    || !IsModified(foreignKey.Properties, entry))
                                 {
                                     continue;
                                 }
@@ -600,9 +591,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                             var entry = command.Entries[entryIndex];
                             foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
                             {
-                                var constraints = foreignKey.GetMappedConstraints()
-                                    .Where(c => c.PrincipalTable.Name == command.TableName && c.PrincipalTable.Schema == command.Schema);
-                                if (!constraints.Any())
+                                if (!IsMapped(foreignKey, command, principal: true))
                                 {
                                     continue;
                                 }
@@ -621,6 +610,49 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                         break;
                 }
             }
+        }
+
+        private static bool IsMapped(IForeignKey foreignKey, IReadOnlyModificationCommand command, bool principal)
+        {
+            foreach (var constraint in foreignKey.GetMappedConstraints())
+            {
+                if (principal)
+                {
+                    if (constraint.PrincipalTable.Name == command.TableName
+                        && constraint.PrincipalTable.Schema == command.Schema)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (constraint.Table.Name == command.TableName
+                        && constraint.Table.Schema == command.Schema)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsModified(IReadOnlyList<IProperty> properties, IUpdateEntry entry)
+        {
+            if (entry.EntityState != EntityState.Modified)
+            {
+                return true;
+            }
+
+            foreach (var property in properties)
+            {
+                if (entry.IsModified(property))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void AddMatchingPredecessorEdge<T>(
@@ -658,10 +690,11 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 for (var entryIndex = 0; entryIndex < command.Entries.Count; entryIndex++)
                 {
                     var entry = command.Entries[entryIndex];
-                    foreach (var index in entry.EntityType.GetIndexes().Where(i => i.IsUnique && i.GetMappedTableIndexes().Any()))
+                    foreach (var index in entry.EntityType.GetIndexes())
                     {
-                        if (entry.EntityState == EntityState.Modified
-                            && !index.Properties.Any(p => entry.IsModified(p)))
+                        if (!index.IsUnique
+                            || !index.GetMappedTableIndexes().Any()
+                            || !IsModified(index.Properties, entry))
                         {
                             continue;
                         }
@@ -688,8 +721,13 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                         continue;
                     }
 
-                    foreach (var key in entry.EntityType.GetKeys().Where(k => k.GetMappedConstraints().Any()))
+                    foreach (var key in entry.EntityType.GetKeys())
                     {
+                        if (!key.GetMappedConstraints().Any())
+                        {
+                            continue;
+                        }
+
                         var principalKeyValue = Dependencies.KeyValueIndexFactorySource
                             .GetKeyValueIndexFactory(key)
                             .CreatePrincipalKeyValue(entry, null);
@@ -719,10 +757,11 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
                     foreach (var entry in command.Entries)
                     {
-                        foreach (var index in entry.EntityType.GetIndexes().Where(i => i.IsUnique && i.GetMappedTableIndexes().Any()))
+                        foreach (var index in entry.EntityType.GetIndexes())
                         {
-                            if (entry.EntityState == EntityState.Modified
-                                && !index.Properties.Any(p => entry.IsModified(p)))
+                            if (!index.IsUnique
+                                || !index.GetMappedTableIndexes().Any()
+                                || !IsModified(index.Properties, entry))
                             {
                                 continue;
                             }
@@ -751,8 +790,13 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
                     foreach (var entry in command.Entries)
                     {
-                        foreach (var key in entry.EntityType.GetKeys().Where(k => k.GetMappedConstraints().Any()))
+                        foreach (var key in entry.EntityType.GetKeys())
                         {
+                            if (!key.GetMappedConstraints().Any())
+                            {
+                                continue;
+                            }
+
                             var principalKeyValue = Dependencies.KeyValueIndexFactorySource
                                 .GetKeyValueIndexFactory(key)
                                 .CreatePrincipalKeyValue(entry, null);
@@ -770,13 +814,19 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
         private static void AddSameTableEdges(Multigraph<IReadOnlyModificationCommand, IAnnotatable> modificationCommandGraph)
         {
-            var deletedDictionary = new Dictionary<(string, string?), List<IReadOnlyModificationCommand>>();
+            var deletedDictionary = new Dictionary<(string, string?), (List<IReadOnlyModificationCommand> List, bool EdgesAdded)>();
 
             foreach (var command in modificationCommandGraph.Vertices)
             {
                 if (command.EntityState == EntityState.Deleted)
                 {
-                    deletedDictionary.GetOrAddNew((command.TableName, command.Schema)).Add(command);
+                    var table = (command.TableName, command.Schema);
+                    if (!deletedDictionary.TryGetValue(table, out var deletedCommands))
+                    {
+                        deletedCommands = (new List<IReadOnlyModificationCommand>(), false);
+                        deletedDictionary.Add(table, deletedCommands);
+                    }
+                    deletedCommands.List.Add(command);
                 }
             }
 
@@ -784,12 +834,22 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             {
                 if (command.EntityState == EntityState.Added)
                 {
-                    if (deletedDictionary.TryGetValue((command.TableName, command.Schema), out var deletedList))
+                    var table = (command.TableName, command.Schema);
+                    if (deletedDictionary.TryGetValue(table, out var deletedCommands))
                     {
-                        foreach (var deleted in deletedList)
+                        var lastDelete = deletedCommands.List[^1];
+                        if (!deletedCommands.EdgesAdded)
                         {
-                            modificationCommandGraph.AddEdge(deleted, command, command.Entries[0].EntityType);
+                            for (var i = 0; i < deletedCommands.List.Count - 1; i++)
+                            {
+                                var deleted = deletedCommands.List[i];
+                                modificationCommandGraph.AddEdge(deleted, lastDelete, deleted.Entries[0].EntityType);
+                            }
+
+                            deletedDictionary[table] = (deletedCommands.List, true);
                         }
+
+                        modificationCommandGraph.AddEdge(lastDelete, command, command.Entries[0].EntityType);
                     }
                 }
             }

--- a/test/EFCore.Tests/Utilities/MultigraphTest.cs
+++ b/test/EFCore.Tests/Utilities/MultigraphTest.cs
@@ -139,9 +139,6 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             graph.AddEdge(vertexOne, vertexTwo, edgeOne);
             graph.AddEdge(vertexOne, vertexTwo, edgeTwo);
 
-            Assert.Equal(2, graph.Edges.Count());
-            Assert.Equal(2, graph.Edges.Intersect(new[] { edgeOne, edgeTwo }).Count());
-
             Assert.Empty(graph.GetEdges(vertexTwo, vertexOne));
             Assert.Equal(2, graph.GetEdges(vertexOne, vertexTwo).Count());
             Assert.Equal(2, graph.GetEdges(vertexOne, vertexTwo).Intersect(new[] { edgeOne, edgeTwo }).Count());


### PR DESCRIPTION
**Description**

https://github.com/dotnet/efcore/pull/25952 decreased throughput in mixed update scenario by about 20-40%. These changes mostly remove this degradation:
- When sorting update commands add Deleted + Inserted number of edges instead of Deleted * Inserted
- Don't allocate a collection for edges if there's only one edge between given two vertices
- Reuse the `Multigraph` instance
- Change the benchmark to reuse the context instance to simulate pooling behavior

<details>
<summary>Before #25952</summary>

|         Method | Async | Batching |     Mean |   Error |  StdDev |  Op/s |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |------ |--------- |--------- |-------- |-------- |------ |---------- |------ |------ |---------- |
| UpdatePipeline | False |    False | 122.4 ms | 1.78 ms | 1.49 ms | 8.169 | 1000.0000 |     - |     - |  11.31 MB |
| UpdatePipeline | False |     True | 227.3 ms | 4.48 ms | 5.16 ms | 4.400 | 2000.0000 |     - |     - |  15.33 MB |
| UpdatePipeline |  True |    False | 129.5 ms | 1.35 ms | 1.20 ms | 7.725 | 1000.0000 |     - |     - |  11.53 MB |
| UpdatePipeline |  True |     True | 243.4 ms | 1.13 ms | 0.94 ms | 4.109 | 2000.0000 |     - |     - |  17.51 MB |

</details>


<details>
<summary>After #25952</summary>

|         Method | Async | Batching |     Mean |   Error |   StdDev |  Op/s |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|--------------- |------ |--------- |--------- |-------- |--------- |------ |---------- |---------- |---------- |---------- |
| UpdatePipeline | False |    False | 201.0 ms | 3.80 ms |  5.08 ms | 4.975 | 5000.0000 | 3000.0000 | 1000.0000 |  32.94 MB |
| UpdatePipeline | False |     True | 279.2 ms | 4.44 ms |  3.93 ms | 3.581 | 5000.0000 | 3000.0000 | 1000.0000 |  36.96 MB |
| UpdatePipeline |  True |    False | 196.6 ms | 3.72 ms |  4.43 ms | 5.087 | 5000.0000 | 3000.0000 | 1000.0000 |  33.15 MB |
| UpdatePipeline |  True |     True | 370.5 ms | 7.09 ms | 12.79 ms | 2.699 | 6000.0000 | 4000.0000 | 1000.0000 |  39.16 MB |

</details>


<details>
<summary>After this fix</summary>

|         Method | Async | Batching |     Mean |   Error |  StdDev |  Op/s |     Gen 0 |     Gen 1 | Gen 2 | Allocated |
|--------------- |------ |--------- |--------- |-------- |-------- |------ |---------- |---------- |------ |---------- |
| UpdatePipeline | False |    False | 125.8 ms | 2.51 ms | 6.44 ms | 7.950 | 1000.0000 |         - |     - |  11.08 MB |
| UpdatePipeline | False |     True | 226.3 ms | 3.06 ms | 2.71 ms | 4.420 | 2000.0000 | 1000.0000 |     - |  15.11 MB |
| UpdatePipeline |  True |    False | 126.8 ms | 2.42 ms | 2.69 ms | 7.883 | 1000.0000 |         - |     - |  11.29 MB |
| UpdatePipeline |  True |     True | 277.9 ms | 5.54 ms | 5.93 ms | 3.599 | 2000.0000 | 1000.0000 |     - |  17.29 MB |

</details>

**Customer Impact**

`SaveChanges` with mixed deletes and inserts is significantly slower.

**How found**

Automated benchmarks

**Test coverage**

Already covered

**Regression?**

Yes, from 6.0-rc1

**Risk**

Low, no functional changes.