### PR TITLE
[6.0-rc2] RevEng: Generate correct FK configuration for scaffolding

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -793,8 +793,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                         _builder.AppendLine($"{_code.Literal(joinEntityType.Name)},");
                         var lines = new List<string>();
 
-                        GenerateForeignKeyConfigurationLines(skipNavigation.ForeignKey, skipNavigation.TargetEntityType.Name, "l");
-                        GenerateForeignKeyConfigurationLines(inverse.ForeignKey, inverse.TargetEntityType.Name, "r");
+                        GenerateForeignKeyConfigurationLines(inverse.ForeignKey, inverse.ForeignKey.PrincipalEntityType.Name, "l");
+                        GenerateForeignKeyConfigurationLines(skipNavigation.ForeignKey, skipNavigation.ForeignKey.PrincipalEntityType.Name, "r");
                         _builder.AppendLine("j =>");
                         _builder.AppendLine("{");
 


### PR DESCRIPTION
Resolves #26086

**Description**

Code scaffolded for many-to-many join table is configuring wrong FKs for join table.

**Customer Impact**

An exception is thrown for entities with different key types on either end of the relationship. This is how it was discovered. It could cause silent data corruption for the more common case where entities have the same key type.

**How found**

Customer reported on RC1.

**Test coverage**

Added regression tests for the scenario. Also manually tested scaffolding Northwind database where issue was found. We also have #25543 tracking better coverage in general for this area.

**Regression?**

No. This is new feature in 6.0

**Risk**

Low. Since the scenario was fully broken, this doesn't have potential to make it worse. Testing on Northwind database also gives us confidence that we are correcting bug here.
