### PR TITLE
[6.0] ModelBuilding: Check for navigation compatibility with keyless type w…

### DIFF
--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -455,18 +455,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             EnsureMutable();
 
             var name = propertyIdentity?.Name;
-            if (pointsToPrincipal
-                && PrincipalEntityType.IsKeyless)
+            if (name != null)
             {
-                throw new InvalidOperationException(
-                    CoreStrings.NavigationToKeylessType(name, PrincipalEntityType.DisplayName()));
-            }
+                if (pointsToPrincipal
+                    && PrincipalEntityType.IsKeyless)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.NavigationToKeylessType(name, PrincipalEntityType.DisplayName()));
+                }
 
-            if (!pointsToPrincipal
-                && DeclaringEntityType.IsKeyless)
-            {
-                throw new InvalidOperationException(
-                    CoreStrings.NavigationToKeylessType(name, DeclaringEntityType.DisplayName()));
+                if (!pointsToPrincipal
+                    && DeclaringEntityType.IsKeyless)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.NavigationToKeylessType(name, DeclaringEntityType.DisplayName()));
+                }
             }
 
             var oldNavigation = pointsToPrincipal ? DependentToPrincipal : PrincipalToDependent;

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -1162,5 +1162,16 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         protected class DreJr : Dre
         {
         }
+
+        protected class Store
+        {
+            public int StoreId { get; set; }
+        }
+
+        protected class Discount
+        {
+            public int? StoreId { get; set; }
+            public Store? Store { get; set; }
+        }
     }
 }


### PR DESCRIPTION
…hen navigation is non-null

Resolves #26073

**Description**
Configuring relationship from keyless entity using HasOne.WithMany API throws exception message even in valid configuration.

**Customer Impact**
Customer cannot build a perfectly valid model.

**How found**
Reported by customer in #26703

**Test coverage**
Added coverage for affected scenario

**Regression?**
Yes, from 5.0.

**Risk**
Low. The fix only avoid throwing exception in incorrect case.
