### PR TITLE
[6.0] Tools: Check for unsupported OS-specific TFMs

### DIFF
--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -1234,6 +1234,14 @@ function EF($project, $startupProject, $params, $applicationArgs, [switch] $skip
     }
     elseif ($targetFramework -eq '.NETCoreApp')
     {
+        $targetPlatformIdentifier = GetCpsProperty $startupProject 'TargetPlatformIdentifier'
+        if ($targetPlatformIdentifier -and $targetPlatformIdentifier -ne 'Windows')
+        {
+            throw "Startup project '$($startupProject.ProjectName)' targets platform '$targetPlatformIdentifier'. The Entity Framework " +
+                'Core Package Manager Console Tools don''t support this platform. See https://aka.ms/efcore-docs-pmc-tfms for more ' +
+                'information.'
+        }
+
         $exePath = (Get-Command 'dotnet').Path
 
         $startupTargetName = GetProperty $startupProject.Properties 'AssemblyName'
@@ -1279,8 +1287,8 @@ function EF($project, $startupProject, $params, $applicationArgs, [switch] $skip
     }
     else
     {
-        throw "Startup project '$($startupProject.ProjectName)' targets framework '$targetFramework'. " +
-            'The Entity Framework Core Package Manager Console Tools don''t support this framework.'
+        throw "Startup project '$($startupProject.ProjectName)' targets framework '$targetFramework'. The Entity Framework Core Package " +
+            'Manager Console Tools don''t support this framework. See https://aka.ms/efcore-docs-pmc-tfms for more information.'
     }
 
     $projectDir = GetProperty $project.Properties 'FullPath'

--- a/src/dotnet-ef/Project.cs
+++ b/src/dotnet-ef/Project.cs
@@ -41,6 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
         public string? TargetFrameworkMoniker { get; set; }
         public string? Nullable { get; set; }
         public string? TargetFramework { get; set; }
+        public string? TargetPlatformIdentifier { get; set; }
 
         public static Project FromFile(
             string file,
@@ -137,7 +138,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
                 TargetFileName = metadata["TargetFileName"],
                 TargetFrameworkMoniker = metadata["TargetFrameworkMoniker"],
                 Nullable = metadata["Nullable"],
-                TargetFramework = metadata["TargetFramework"]
+                TargetFramework = metadata["TargetFramework"],
+                TargetPlatformIdentifier = metadata["TargetPlatformIdentifier"]
             };
         }
 

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -442,12 +442,20 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("TablesDescription");
 
         /// <summary>
-        ///     Startup project '{startupProject}' targets framework '{targetFramework}'. The Entity Framework Core .NET Command-line Tools don't support this framework.
+        ///     Startup project '{startupProject}' targets framework '{targetFramework}'. The Entity Framework Core .NET Command-line Tools don't support this framework. See https://aka.ms/efcore-docs-cli-tfms for more information.
         /// </summary>
         public static string UnsupportedFramework(object? startupProject, object? targetFramework)
             => string.Format(
                 GetString("UnsupportedFramework", nameof(startupProject), nameof(targetFramework)),
                 startupProject, targetFramework);
+
+        /// <summary>
+        ///     Startup project '{startupProject}' targets platform '{targetPlatform}'. The Entity Framework Core .NET Command-line Tools don't support this platform. See https://aka.ms/efcore-docs-cli-tfms for more information.
+        /// </summary>
+        public static string UnsupportedPlatform(object? startupProject, object? targetPlatform)
+            => string.Format(
+                GetString("UnsupportedPlatform", nameof(startupProject), nameof(targetPlatform)),
+                startupProject, targetPlatform);
 
         /// <summary>
         ///     Use table and column names directly from the database.

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -325,7 +325,10 @@
     <value>The tables to generate entity types for.</value>
   </data>
   <data name="UnsupportedFramework" xml:space="preserve">
-    <value>Startup project '{startupProject}' targets framework '{targetFramework}'. The Entity Framework Core .NET Command-line Tools don't support this framework.</value>
+    <value>Startup project '{startupProject}' targets framework '{targetFramework}'. The Entity Framework Core .NET Command-line Tools don't support this framework. See https://aka.ms/efcore-docs-cli-tfms for more information.</value>
+  </data>
+  <data name="UnsupportedPlatform" xml:space="preserve">
+    <value>Startup project '{startupProject}' targets platform '{targetPlatform}'. The Entity Framework Core .NET Command-line Tools don't support this platform. See https://aka.ms/efcore-docs-cli-tfms for more information.</value>
   </data>
   <data name="UseDatabaseNamesDescription" xml:space="preserve">
     <value>Use table and column names directly from the database.</value>

--- a/src/dotnet-ef/Resources/EntityFrameworkCore.targets
+++ b/src/dotnet-ef/Resources/EntityFrameworkCore.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="GetEFProjectMetadata" Condition="">
+  <Target Name="GetEFProjectMetadata">
     <MSBuild Condition=" '$(TargetFramework)' == '' "
              Projects="$(MSBuildProjectFile)"
              Targets="GetEFProjectMetadata"
@@ -19,6 +19,7 @@
       <EFProjectMetadata Include="TargetFrameworkMoniker: $(TargetFrameworkMoniker)" />
       <EFProjectMetadata Include="Nullable: $(Nullable)" />
       <EFProjectMetadata Include="TargetFramework: $(TargetFramework)" />
+      <EFProjectMetadata Include="TargetPlatformIdentifier: $(TargetPlatformIdentifier)" />
     </ItemGroup>
     <WriteLinesToFile Condition=" '$(TargetFramework)' != '' "
                       File="$(EFProjectMetadataFile)"

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -124,6 +124,13 @@ namespace Microsoft.EntityFrameworkCore.Tools
                         Resources.NETCoreApp1StartupProject(startupProject.ProjectName, targetFramework.Version));
                 }
 
+                var targetPlatformIdentifier = startupProject.TargetPlatformIdentifier!;
+                if (targetPlatformIdentifier.Length != 0
+                    && !string.Equals(targetPlatformIdentifier, "Windows", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new CommandException(Resources.UnsupportedPlatform(startupProject.ProjectName, targetPlatformIdentifier));
+                }
+
                 executable = "dotnet";
                 args.Add("exec");
                 args.Add("--depsfile");


### PR DESCRIPTION
The new OS-specific TFMs introduced in .NET 6 (net6.0-android, net6.0-ios, etc.) currently aren't compatible with dotnet-ef and the PMC commands. This adds additional checking like the ones we already have for unsupported TFMs (Xamarin.Android, Xamarin.iOS, etc.) and throws a better error message.

Fixes #25938

Note, another issue (#7152) tracks making them actually work when we can.

### Customer impact

Without this, customers will continue getting obscure errors about missing .deps.json files.

### Regression

Yes, kind of. While the OS-specific TFMs are new to .NET 6, the *experience* of working with Android and iOS projects has regressed from .NET 5.

### Testing

Manually verified the new experience on VS 2022 Preview 4. We have not invested in automated functional testing for dotnet-ef and the PMC commands since this made the build system overly complex and was very flakey in EF6 (but we do have some unit tests covering the parts we can).

### Risk

Low. Non-OS-specific TFMs, and the Windows TFM are allowed, so only OSes new to .NET 6 are blocked.