### PR TITLE
Always store join table schema in the snapshot.

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -770,14 +770,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 if (tableName != null
                     || tableNameAnnotation != null)
                 {
-                    var schemaAnnotation = annotations.Find(RelationalAnnotationNames.Schema);
                     stringBuilder
                         .AppendLine()
                         .Append(entityTypeBuilderName)
                         .Append(".ToTable(");
 
+                    var schemaAnnotation = annotations.Find(RelationalAnnotationNames.Schema);
+                    var schema = (string?)schemaAnnotation?.Value ?? entityType.GetSchema();
                     if (tableName == null
-                        && (schemaAnnotation == null || schemaAnnotation.Value == null))
+                        && (schemaAnnotation == null || schema == null))
                     {
                         stringBuilder.Append("(string)");
                     }
@@ -790,19 +791,19 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     }
 
                     var isExcludedAnnotation = annotations.Find(RelationalAnnotationNames.IsTableExcludedFromMigrations);
-                    if (schemaAnnotation != null
-                        && (tableName != null || schemaAnnotation.Value != null))
+                    if (schema != null
+                        || (schemaAnnotation != null && tableName != null))
                     {
                         stringBuilder
                             .Append(", ");
 
-                        if (schemaAnnotation.Value == null
+                        if (schema == null
                             && ((bool?)isExcludedAnnotation?.Value) != true)
                         {
                             stringBuilder.Append("(string)");
                         }
 
-                        stringBuilder.Append(Code.UnknownLiteral(schemaAnnotation.Value));
+                        stringBuilder.Append(Code.UnknownLiteral(schema));
                     }
 
                     if (isExcludedAnnotation != null)

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -1328,8 +1328,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     builder
                         .Entity<ManyToManyLeft>()
+                        .ToTable("ManyToManyLeft", "schema")
                         .HasMany(l => l.Rights)
                         .WithMany(r => r.Lefts);
+
+                    builder
+                        .Entity<ManyToManyRight>()
+                        .ToTable("ManyToManyRight", "schema");
                 },
                 AddBoilerPlate(
                     GetHeading()
@@ -1346,7 +1351,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.HasIndex(""RightsId"");
 
-                    b.ToTable(""ManyToManyLeftManyToManyRight"");
+                    b.ToTable(""ManyToManyLeftManyToManyRight"", ""schema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyLeft"", b =>
@@ -1362,7 +1367,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""ManyToManyLeft"");
+                    b.ToTable(""ManyToManyLeft"", ""schema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyRight"", b =>
@@ -1378,7 +1383,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""ManyToManyRight"");
+                    b.ToTable(""ManyToManyRight"", ""schema"");
                 });
 
             modelBuilder.Entity(""ManyToManyLeftManyToManyRight"", b =>
@@ -1459,6 +1464,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                     Assert.Equal("RightsId", p.Name);
                                 });
                         });
+
+                    Assert.Equal("ManyToManyLeftManyToManyRight", joinEntity.GetTableName());
+                    Assert.Equal("schema", joinEntity.GetSchema());
                 });
         }
 


### PR DESCRIPTION
Fixes #23937

**Description**

#22845 made the join entity type use the same schema as the related entity types, but it didn't persist the schema in the migration snapshot.

**Customer Impact**

A new migration is created even if there are no model changes.

**How found**

Customer report

**Test coverage**

Added in this PR

**Regression?**

No

**Risk**

Low, this only affects the migration snapshot, which can be fixed manually.