### PR TITLE
[6.0] Add a check to ShouldUseSameServiceProvider even when the extension has no options

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -446,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             /// <param name="other"> The other extension. </param>
             /// <returns> A value indicating whether all of the options that require a new service provider are the same. </returns>
             public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
-                => true;
+                => other is RelationalExtensionInfo;
 
             /// <summary>
             ///     A message fragment for logging typically containing information about

--- a/src/EFCore.SqlServer.NTS/Infrastructure/Internal/SqlServerNetTopologySuiteOptionsExtension.cs
+++ b/src/EFCore.SqlServer.NTS/Infrastructure/Internal/SqlServerNetTopologySuiteOptionsExtension.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
                 => 0;
 
             public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
-                => true;
+                => other is ExtensionInfo;
 
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
                 => debugInfo["SqlServer:" + nameof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite)] = "1";

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
@@ -83,6 +83,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal
             public override bool IsDatabaseProvider
                 => true;
 
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+                => other is ExtensionInfo;
+
             public override string LogFragment
             {
                 get

--- a/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteOptionsExtension.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteOptionsExtension.cs
@@ -109,6 +109,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal
             public override bool IsDatabaseProvider
                 => true;
 
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+                => other is ExtensionInfo;
+
             public override string LogFragment
             {
                 get

--- a/src/EFCore.Sqlite.NTS/Infrastructure/Internal/SqliteNetTopologySuiteOptionsExtension.cs
+++ b/src/EFCore.Sqlite.NTS/Infrastructure/Internal/SqliteNetTopologySuiteOptionsExtension.cs
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal
                 => 0;
 
             public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
-                => true;
+                => other is ExtensionInfo;
 
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
                 => debugInfo["NetTopologySuite"] = "1";


### PR DESCRIPTION
Fixes #26109

### Description

Currently different optionless extensions return `true` in `ShouldUseSameServiceProvider` this could still cause a collision if the hash codes of their types happen to be the same.

### Customer impact

Without this an incompatible cached service provider could be resolved, causing a DI exception.

### Regression

No, this method is new in 6.0.

### Testing

No additional tests as regression tests for this wouldn't be meaningful due to the nature of hash collisions.

### Risk

Low, the new method is only used in a single place.