### PR TITLE
Update the entity type on check constraints when it's converted to a STET

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/CheckConstraintConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/CheckConstraintConvention.cs
@@ -64,10 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     continue;
                 }
 
-                if (constraintsToReattach == null)
-                {
-                    constraintsToReattach = new();
-                }
+                constraintsToReattach ??= new();
 
                 constraintsToReattach.Add(checkConstraint);
             }

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -67,19 +67,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.PropertyAddedConventions.Add(relationalColumnAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(relationalCommentAttributeConvention);
 
+            var checkConstraintConvention = new CheckConstraintConvention(Dependencies, RelationalDependencies);
             var tableNameFromDbSetConvention = new TableNameFromDbSetConvention(Dependencies, RelationalDependencies);
             conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention(Dependencies, RelationalDependencies));
             conventionSet.EntityTypeAddedConventions.Add(
                 new RelationalTableCommentAttributeConvention(Dependencies, RelationalDependencies));
             conventionSet.EntityTypeAddedConventions.Add(tableNameFromDbSetConvention);
+            conventionSet.EntityTypeAddedConventions.Add(checkConstraintConvention);
 
             ValueGenerationConvention valueGenerationConvention =
                 new RelationalValueGenerationConvention(Dependencies, RelationalDependencies);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, valueGenerationConvention);
-            ReplaceConvention(conventionSet.ForeignKeyPropertiesChangedConventions, valueGenerationConvention);
-            ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, valueGenerationConvention);
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(tableNameFromDbSetConvention);
-            conventionSet.EntityTypeBaseTypeChangedConventions.Add(new CheckConstraintConvention(Dependencies, RelationalDependencies));
+            conventionSet.EntityTypeBaseTypeChangedConventions.Add(checkConstraintConvention);
+
+            ReplaceConvention(conventionSet.ForeignKeyPropertiesChangedConventions, valueGenerationConvention);
+
+            ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, valueGenerationConvention);
 
             conventionSet.EntityTypeAnnotationChangedConventions.Add((RelationalValueGenerationConvention)valueGenerationConvention);
 

--- a/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
@@ -172,6 +172,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public static void Attach(IConventionEntityType entityType, IConventionCheckConstraint detachedCheckConstraint)
+        {
+            var newCheckConstraint = new CheckConstraint(
+                (IMutableEntityType)entityType,
+                detachedCheckConstraint.ModelName,
+                detachedCheckConstraint.Sql,
+                detachedCheckConstraint.GetConfigurationSource());
+
+            Attach(detachedCheckConstraint, newCheckConstraint);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static void Attach(IConventionCheckConstraint detachedCheckConstraint, IConventionCheckConstraint existingCheckConstraint)
         {
             var nameConfigurationSource = detachedCheckConstraint.GetNameConfigurationSource();
@@ -180,6 +197,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ((InternalCheckConstraintBuilder)existingCheckConstraint.Builder).HasName(
                     detachedCheckConstraint.Name, nameConfigurationSource.Value);
             }
+
+            ((InternalCheckConstraintBuilder)existingCheckConstraint.Builder).MergeAnnotationsFrom((CheckConstraint)detachedCheckConstraint);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/InternalCheckConstraintBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalCheckConstraintBuilder.cs
@@ -16,8 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public class InternalCheckConstraintBuilder :
-        AnnotatableBuilder<CheckConstraint,
-        IConventionModelBuilder>,
+        AnnotatableBuilder<CheckConstraint, IConventionModelBuilder>,
         IConventionCheckConstraintBuilder
     {
         /// <summary>


### PR DESCRIPTION
Fixes #23399

### Description

Currently when an entity type is converted to a shared-type entity type the check constraints are just copied over, without updating the back reference to the entity type.

### Customer impact

Without this fix migrations throw an error when performing the diff.

### How found

Customer

### Regression

No.

### Testing

Test for this scenario added in the PR.

### Risk

Low, the modified code only affects STETs with check constraints - a relatively rare scenario.