### PR TITLE
[6.0] Microsoft.Data.Sqlite: Also try the .NET 5+ ApplicationData API

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/Utilities/ApplicationDataHelper.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/ApplicationDataHelper.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Data.Sqlite.Utilities
             try
             {
                 return Type.GetType("Windows.Storage.ApplicationData, Windows, ContentType=WindowsRuntime")
+                    ?? Type.GetType("Windows.Storage.ApplicationData, Microsoft.Windows.SDK.NET")
                     ?.GetRuntimeProperty("Current")!.GetValue(null);
             }
             catch

--- a/src/Microsoft.Data.Sqlite.Core/Utilities/BundleInitializer.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/BundleInitializer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using static SQLitePCL.raw;
 
@@ -34,12 +35,12 @@ namespace Microsoft.Data.Sqlite.Utilities
                 var rc = sqlite3_win32_set_directory(
                     SQLITE_WIN32_DATA_DIRECTORY_TYPE,
                     ApplicationDataHelper.LocalFolderPath);
-                SqliteException.ThrowExceptionForRC(rc, db: null);
+                Debug.Assert(rc == SQLITE_OK);
 
                 rc = sqlite3_win32_set_directory(
                     SQLITE_WIN32_TEMP_DIRECTORY_TYPE,
                     ApplicationDataHelper.TemporaryFolderPath);
-                SqliteException.ThrowExceptionForRC(rc, db: null);
+                Debug.Assert(rc == SQLITE_OK);
             }
         }
     }


### PR DESCRIPTION
We have code for UWP that sets the SQLite data and temp directories so that databases can be created when running inside an app container sandbox. .NET 5 added new bindings for WinRT APIs, and our code no longer ran on .NET 5/6 apps requiring users to manually set the SQLite directories.

Fixes #24213

/cc @Pilchie

### Customer impact

Without this, the experience of using SQLite in MSIX-packaged windows apps would continue requiring additional, non-obvious steps.

### Regression

Not in .NET 6, but the experience was regressed going from UWP to MSIX-packaged .NET 5 apps.

### Testing

We don't have any automated tests that run inside of a sandboxed app container. Manually verified that databases are now created correctly. (using winsqlite3.dll)

### Risk

Low. We're just probing for one additional assembly; if it fails, execution continues the same as when we didn't find the UWP API.