### PR TITLE
[6.0] Tools: Warn/error when using new features on old runtimes

### DIFF
--- a/src/ef/Commands/DbContextOptimizeCommand.cs
+++ b/src/ef/Commands/DbContextOptimizeCommand.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Tools.Properties;
+
 namespace Microsoft.EntityFrameworkCore.Tools.Commands
 {
     // ReSharper disable once ArrangeTypeModifiers
@@ -8,6 +11,11 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
     {
         protected override int Execute(string[] args)
         {
+            if (new SemanticVersionComparer().Compare(EFCoreVersion, "6.0.0") < 0)
+            {
+                throw new CommandException(Resources.VersionRequired("6.0.0"));
+            }
+
             using var executor = CreateExecutor(args);
             executor.OptimizeContext(
                 _outputDir!.Value(),

--- a/src/ef/Commands/MigrationsListCommand.cs
+++ b/src/ef/Commands/MigrationsListCommand.cs
@@ -60,18 +60,24 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
 
         private static void ReportResults(IEnumerable<IDictionary> migrations)
         {
+            var anyUnknown = false;
             var any = false;
             foreach (var migration in migrations)
             {
                 var id = migration["Id"] as string;
                 var applied = migration["Applied"] as bool?;
                 Reporter.WriteData($"{id}{(applied != false ? null : Resources.Pending)}");
+                anyUnknown |= !applied.HasValue;
                 any = true;
             }
 
             if (!any)
             {
                 Reporter.WriteInformation(Resources.NoMigrations);
+            }
+            else if (anyUnknown)
+            {
+                Reporter.WriteWarning(Resources.PendingUnknown);
             }
         }
     }

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -450,6 +450,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("Pending");
 
         /// <summary>
+        ///     Pending status not shown. Unable to determine which migrations have been applied. This can happen when your project uses a version of Entity Framework Core lower than 5.0.0 or when an error occurrs while accessing the database.
+        /// </summary>
+        public static string PendingUnknown
+            => GetString("PendingUnknown");
+
+        /// <summary>
         ///     Prefix output with level.
         /// </summary>
         public static string PrefixDescription

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -321,6 +321,9 @@
   <data name="Pending" xml:space="preserve">
     <value> (Pending)</value>
   </data>
+  <data name="PendingUnknown" xml:space="preserve">
+    <value>Pending status not shown. Unable to determine which migrations have been applied. This can happen when your project uses a version of Entity Framework Core lower than 5.0.0 or when an error occurrs while accessing the database.</value>
+  </data>
   <data name="PrefixDescription" xml:space="preserve">
     <value>Prefix output with level.</value>
   </data>


### PR DESCRIPTION
Fixes #25153

### Customer impact

Without this, users will get this lovely error if they try to run `dotnet ef dbcontext optimize` on projects using EF Core 5.0 and 3.1:

> Could not load type 'Microsoft.EntityFrameworkCore.Design.OperationExecutor+OptimizeContext' from assembly 'Microsoft.EntityFrameworkCore.Design, Version=5.0.10.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.

### Regression

No--feature is new in 6.0.

### Testing

Manually verified. We don't have any automated tests mixing EF Core 5.0 projects and 6.0 tools.

### Risk

Low.