### PR TITLE
Improve exception message for a shadow skip navigation

### DIFF
--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -130,6 +130,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                             CoreStrings.SkipNavigationNoInverse(
                                 skipNavigation.Name, skipNavigation.DeclaringEntityType.DisplayName()));
                     }
+
+                    if (skipNavigation.IsShadowProperty())
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.ShadowManyToManyNavigation(
+                                skipNavigation.DeclaringEntityType.DisplayName(),
+                                skipNavigation.Name,
+                                skipNavigation.Inverse.DeclaringEntityType.DisplayName(),
+                                skipNavigation.Inverse.Name));
+                    }
                 }
             }
         }

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -95,6 +95,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public new virtual CollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(string navigationName)
         {
+            if (Builder != null
+                && Builder.Metadata.PrincipalToDependent == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.MissingInverseManyToManyNavigation(
+                        Builder.Metadata.PrincipalEntityType.DisplayName(),
+                        Builder.Metadata.DeclaringEntityType.DisplayName()));
+            }
+
             var leftName = Builder?.Metadata.PrincipalToDependent!.Name;
             var collectionCollectionBuilder =
                 new CollectionCollectionBuilder<TRelatedEntity, TEntity>(

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -352,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, derivedType);
 
         /// <summary>
-        ///     The entity type '{entityType}' cannot be configured as owned because it has already been configured as a non-owned. If you want to override previous configuration first remove the entity type from the model by calling 'Ignore'. See https://aka.ms/efcore-docs-owned for more information.
+        ///     The entity type '{entityType}' cannot be configured as owned because it has already been configured as a non-owned. If you want to override previous configuration first remove the entity type from the model by calling 'Ignore'.  See https://aka.ms/efcore-docs-owned for more information.
         /// </summary>
         public static string ClashingNonOwnedEntityType(object? entityType)
             => string.Format(
@@ -1546,11 +1546,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type);
 
         /// <summary>
-        ///     The navigation '{entityType}.{navigation}' cannot be used for both sides of a many-to-many relationship. Many-to-many relationships must use different navigation properties for either end of the relationship.
+        ///     The navigation '{entityType}.{navigation}' cannot be used for both sides of a many-to-many relationship. Many-to-many relationships must use two distinct navigation properties.
         /// </summary>
         public static string ManyToManyOneNav(object? entityType, object? navigation)
             => string.Format(
-                GetString("ManyToManyOneNav", "entityType", "navigation"),
+                GetString("ManyToManyOneNav", nameof(entityType), nameof(navigation)),
                 entityType, navigation);
 
         /// <summary>
@@ -1562,7 +1562,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 field, property, entityType);
 
         /// <summary>
-        ///     Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Provide a navigation in the 'HasMany' call in 'OnModelCreating'.
+        ///     Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Provide a navigation in the 'HasMany' call in 'OnModelCreating'. Consider adding a private property for this.
         /// </summary>
         public static string MissingInverseManyToManyNavigation(object? principalEntityType, object? declaringEntityType)
             => string.Format(
@@ -2602,6 +2602,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("ShadowEntity", nameof(entityType)),
                 entityType);
+
+        /// <summary>
+        ///     Unable to set up a many-to-many relationship between '{leftEntityType}.{leftNavigation}' and '{rightEntityType}.{rightNavigation}' because one or both of the navigations don't have a corresponding CLR property. Consider adding a corresponding private property to the entity CLR type.
+        /// </summary>
+        public static string ShadowManyToManyNavigation(object? leftEntityType, object? leftNavigation, object? rightEntityType, object? rightNavigation)
+            => string.Format(
+                GetString("ShadowManyToManyNavigation", nameof(leftEntityType), nameof(leftNavigation), nameof(rightEntityType), nameof(rightNavigation)),
+                leftEntityType, leftNavigation, rightEntityType, rightNavigation);
 
         /// <summary>
         ///     The shared-type entity type '{entityType}' cannot have a base type.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1025,7 +1025,7 @@
     <value>The specified field '{field}' could not be found for property '{2_entityType}.{1_property}'.</value>
   </data>
   <data name="MissingInverseManyToManyNavigation" xml:space="preserve">
-    <value>Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Provide a navigation in the 'HasMany' call in 'OnModelCreating'.</value>
+    <value>Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Provide a navigation in the 'HasMany' call in 'OnModelCreating'. Consider adding a private property for this.</value>
   </data>
   <data name="ModelMutable" xml:space="preserve">
     <value>Runtime metadata changes are not allowed when the model hasn't been marked as read-only.</value>
@@ -1436,6 +1436,9 @@
   <data name="ShadowEntity" xml:space="preserve">
     <value>The entity type '{entityType}' is in shadow state. A valid model requires all entity types to have a corresponding CLR type.</value>
     <comment>Obsolete</comment>
+  </data>
+  <data name="ShadowManyToManyNavigation" xml:space="preserve">
+    <value>Unable to set up a many-to-many relationship between '{leftEntityType}.{leftNavigation}' and '{rightEntityType}.{rightNavigation}' because one or both of the navigations don't have a corresponding CLR property. Consider adding a corresponding private property to the entity CLR type.</value>
   </data>
   <data name="SharedTypeDerivedType" xml:space="preserve">
     <value>The shared-type entity type '{entityType}' cannot have a base type.</value>

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -468,6 +468,29 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Throws_for_many_to_many_with_a_shadow_navigation()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Ignore<OneToOneNavPrincipal>();
+                modelBuilder.Ignore<OneToManyNavPrincipal>();
+                modelBuilder.Entity<NavDependent>().Ignore(d => d.ManyToManyPrincipals);
+
+                modelBuilder.Entity<ManyToManyNavPrincipal>()
+                            .HasMany(d => d.Dependents)
+                            .WithMany("Shadow");
+
+                Assert.Equal(
+                    CoreStrings.ShadowManyToManyNavigation(
+                        nameof(NavDependent),
+                        "Shadow",
+                        nameof(ManyToManyNavPrincipal),
+                        nameof(ManyToManyNavPrincipal.Dependents)),
+                    Assert.Throws<InvalidOperationException>(
+                        () => modelBuilder.FinalizeModel()).Message);
+            }
+
+            [ConditionalFact]
             public virtual void Throws_for_self_ref_with_same_navigation()
             {
                 var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
@@ -28,6 +28,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new GenericStringTestModelBuilder(testHelpers, configure);
         }
 
+        public class GenericManyToManyString : ManyToManyTestBase
+        {
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers, Action<ModelConfigurationBuilder>? configure)
+                => new GenericStringTestModelBuilder(testHelpers, configure);
+        }
+
         public class GenericOneToOneString : OneToOneTestBase
         {
             protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers, Action<ModelConfigurationBuilder>? configure)


### PR DESCRIPTION
Fixes #23362

### Description

Shadow skip navigations are not supported, but currently we don't explicitly validate this.

### Customer impact

Without this an obscure `ArgumentException` is thrown when the navigation is used in a query.

### How found

Customer

### Regression

No.

### Testing

Test for this scenario added in the PR.

### Risk

Low, just a better exception message.