### PR TITLE
Use the correct value when the discriminator is part of the key.

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -658,6 +658,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     .Append(_code.Literal(true));
             }
 
+            var discriminatorValue = entityType.GetDiscriminatorValue();
+            if (discriminatorValue != null)
+            {
+                AddNamespace(discriminatorValue.GetType(), parameters.Namespaces);
+
+                mainBuilder.AppendLine(",")
+                    .Append("discriminatorValue: ")
+                    .Append(_code.UnknownLiteral(discriminatorValue));
+            }
+
             mainBuilder
                 .AppendLine(");")
                 .AppendLine()

--- a/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -160,10 +160,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         private ValueGenerator GetValueGenerator(InternalEntityEntry entry, IProperty property)
-            => _valueGeneratorSelector.Select(
-                property, property.IsKey()
-                    ? property.DeclaringEntityType
-                    : entry.EntityType);
+            => _valueGeneratorSelector.Select(property, property.DeclaringEntityType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Design/Internal/CSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore/Design/Internal/CSharpRuntimeAnnotationCodeGenerator.cs
@@ -67,7 +67,6 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 foreach (var annotation in annotations)
                 {
                     if (CoreAnnotationNames.AllNames.Contains(annotation.Key)
-                        && annotation.Key != CoreAnnotationNames.DiscriminatorValue
                         && annotation.Key != CoreAnnotationNames.DiscriminatorMappingComplete)
                     {
                         annotations.Remove(annotation.Key);

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -223,7 +223,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 entityType.GetDiscriminatorPropertyName(),
                 entityType.GetChangeTrackingStrategy(),
                 entityType.FindIndexerPropertyInfo(),
-                entityType.IsPropertyBag);
+                entityType.IsPropertyBag,
+                entityType.GetDiscriminatorValue());
 
         private ParameterBinding Create(ParameterBinding parameterBinding, RuntimeEntityType entityType)
             => parameterBinding.With(parameterBinding.ConsumedProperties.Select(property =>
@@ -256,7 +257,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     if (CoreAnnotationNames.AllNames.Contains(annotation.Key)
                         && annotation.Key != CoreAnnotationNames.QueryFilter
                         && annotation.Key != CoreAnnotationNames.DefiningQuery
-                        && annotation.Key != CoreAnnotationNames.DiscriminatorValue
                         && annotation.Key != CoreAnnotationNames.DiscriminatorMappingComplete)
                     {
                         annotations.Remove(annotation.Key);

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -59,6 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         private InstantiationBinding? _serviceOnlyConstructorBinding;
         private readonly PropertyInfo? _indexerPropertyInfo;
         private readonly bool _isPropertyBag;
+        private readonly object? _discriminatorValue;
 
         // Warning: Never access these fields directly as access needs to be thread-safe
         private PropertyCounts? _counts;
@@ -89,7 +90,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             string? discriminatorProperty,
             ChangeTrackingStrategy changeTrackingStrategy,
             PropertyInfo? indexerPropertyInfo,
-            bool propertyBag)
+            bool propertyBag,
+            object? discriminatorValue)
         {
             Name = name;
             _clrType = type;
@@ -104,6 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             _indexerPropertyInfo = indexerPropertyInfo;
             _isPropertyBag = propertyBag;
             SetAnnotation(CoreAnnotationNames.DiscriminatorProperty, discriminatorProperty);
+            _discriminatorValue = discriminatorValue;
 
             _properties = new SortedDictionary<string, RuntimeProperty>(new PropertyNameComparer(this));
         }
@@ -859,6 +862,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             return (string?)this[CoreAnnotationNames.DiscriminatorProperty];
         }
+
+        /// <inheritdoc/>
+        [DebuggerStepThrough]
+        object? IReadOnlyEntityType.GetDiscriminatorValue()
+            => _discriminatorValue;
 
         /// <inheritdoc/>
         bool IReadOnlyTypeBase.HasSharedClrType

--- a/src/EFCore/Metadata/RuntimeModel.cs
+++ b/src/EFCore/Metadata/RuntimeModel.cs
@@ -69,6 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     A value indicating whether this entity type has an indexer which is able to contain arbitrary properties
         ///     and a method that can be used to determine whether a given indexer property contains a value.
         /// </param>
+        /// <param name="discriminatorValue">the discriminator value for this entity type.</param>
         /// <returns> The new entity type. </returns>
         public virtual RuntimeEntityType AddEntityType(
             string name,
@@ -78,7 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             string? discriminatorProperty = null,
             ChangeTrackingStrategy changeTrackingStrategy = ChangeTrackingStrategy.Snapshot,
             PropertyInfo? indexerPropertyInfo = null,
-            bool propertyBag = false)
+            bool propertyBag = false,
+            object? discriminatorValue = null)
         {
             var entityType = new RuntimeEntityType(
                 name,
@@ -89,7 +91,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 discriminatorProperty,
                 changeTrackingStrategy,
                 indexerPropertyInfo,
-                propertyBag);
+                propertyBag,
+                discriminatorValue);
 
             if (sharedClrType)
             {

--- a/src/EFCore/ValueGeneration/DiscriminatorValueGeneratorFactory.cs
+++ b/src/EFCore/ValueGeneration/DiscriminatorValueGeneratorFactory.cs
@@ -17,6 +17,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
     {
         /// <inheritdoc />
         public override ValueGenerator Create(IProperty property, IEntityType entityType)
-            => new DiscriminatorValueGenerator(entityType.GetDiscriminatorValue()!);
+            => new DiscriminatorValueGenerator();
     }
 }

--- a/src/EFCore/ValueGeneration/Internal/DiscriminatorValueGenerator.cs
+++ b/src/EFCore/ValueGeneration/Internal/DiscriminatorValueGenerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -13,19 +15,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     /// </summary>
     public class DiscriminatorValueGenerator : ValueGenerator
     {
-        private readonly object _discriminator;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public DiscriminatorValueGenerator(object discriminator)
-        {
-            _discriminator = discriminator;
-        }
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -33,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected override object NextValue(EntityEntry entry)
-            => _discriminator;
+            => entry.GetInfrastructure().EntityType.GetDiscriminatorValue()!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -652,7 +652,8 @@ namespace Internal
                 ""Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity.IdentityUser"",
                 typeof(IdentityUser),
                 baseEntityType,
-                discriminatorProperty: ""Discriminator"");
+                discriminatorProperty: ""Discriminator"",
+                discriminatorValue: ""IdentityUser"");
 
             var id = runtimeEntityType.AddProperty(
                 ""Id"",
@@ -769,7 +770,6 @@ namespace Internal
 
         public static void CreateAnnotations(RuntimeEntityType runtimeEntityType)
         {
-            runtimeEntityType.AddAnnotation(""DiscriminatorValue"", ""IdentityUser"");
 
             Customize(runtimeEntityType);
         }
@@ -801,14 +801,14 @@ namespace Internal
                 ""Microsoft.EntityFrameworkCore.Scaffolding.Internal.IdentityUser"",
                 typeof(IdentityUser),
                 baseEntityType,
-                discriminatorProperty: ""Discriminator"");
+                discriminatorProperty: ""Discriminator"",
+                discriminatorValue: ""DerivedIdentityUser"");
 
             return runtimeEntityType;
         }
 
         public static void CreateAnnotations(RuntimeEntityType runtimeEntityType)
         {
-            runtimeEntityType.AddAnnotation(""DiscriminatorValue"", ""DerivedIdentityUser"");
 
             Customize(runtimeEntityType);
         }
@@ -958,7 +958,8 @@ namespace TestNamespace
                 ""Microsoft.EntityFrameworkCore.Scaffolding.Internal.CSharpRuntimeModelCodeGeneratorTest+DependentBase<byte?>"",
                 typeof(CSharpRuntimeModelCodeGeneratorTest.DependentBase<byte?>),
                 baseEntityType,
-                discriminatorProperty: ""EnumDiscriminator"");
+                discriminatorProperty: ""EnumDiscriminator"",
+                discriminatorValue: CSharpMigrationsGeneratorTest.Enum1.One);
 
             var principalId = runtimeEntityType.AddProperty(
                 ""PrincipalId"",
@@ -1040,7 +1041,6 @@ namespace TestNamespace
 
         public static void CreateAnnotations(RuntimeEntityType runtimeEntityType)
         {
-            runtimeEntityType.AddAnnotation(""DiscriminatorValue"", CSharpMigrationsGeneratorTest.Enum1.One);
             runtimeEntityType.AddAnnotation(""Relational:FunctionName"", null);
             runtimeEntityType.AddAnnotation(""Relational:Schema"", null);
             runtimeEntityType.AddAnnotation(""Relational:SqlQuery"", null);
@@ -1480,7 +1480,8 @@ namespace TestNamespace
                 ""Microsoft.EntityFrameworkCore.Scaffolding.Internal.CSharpRuntimeModelCodeGeneratorTest+DependentDerived<byte?>"",
                 typeof(CSharpRuntimeModelCodeGeneratorTest.DependentDerived<byte?>),
                 baseEntityType,
-                discriminatorProperty: ""EnumDiscriminator"");
+                discriminatorProperty: ""EnumDiscriminator"",
+                discriminatorValue: CSharpMigrationsGeneratorTest.Enum1.Two);
 
             var data = runtimeEntityType.AddProperty(
                 ""Data"",
@@ -1505,7 +1506,6 @@ namespace TestNamespace
 
         public static void CreateAnnotations(RuntimeEntityType runtimeEntityType)
         {
-            runtimeEntityType.AddAnnotation(""DiscriminatorValue"", CSharpMigrationsGeneratorTest.Enum1.Two);
             runtimeEntityType.AddAnnotation(""Relational:FunctionName"", null);
             runtimeEntityType.AddAnnotation(""Relational:Schema"", null);
             runtimeEntityType.AddAnnotation(""Relational:SqlQuery"", null);

--- a/test/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
+++ b/test/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
@@ -26,13 +26,16 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = CreateContext())
             {
-                context.Add(
+                var pegasus = context.Add(
                     new Pegasus
                     {
                         Id1 = ticks,
                         Id2 = ticks + 1,
                         Name = "Rainbow Dash"
                     });
+
+                Assert.Equal("Pegasus", pegasus.Entity.Discriminator);
+
                 await context.SaveChangesAsync();
             }
 
@@ -40,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var pegasus = context.Pegasuses.Single(e => e.Id1 == ticks && e.Id2 == ticks + 1);
 
+                Assert.Equal("Pegasus", pegasus.Discriminator);
                 pegasus.Name = "Rainbow Crash";
 
                 await context.SaveChangesAsync();
@@ -212,12 +216,14 @@ namespace Microsoft.EntityFrameworkCore
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Pegasus>(
+                modelBuilder.Entity<Flyer>(
                     b =>
                     {
                         b.HasKey(
-                            e => new { e.Id1, e.Id2 });
+                            e => new { e.Id1, e.Id2, e.Discriminator });
                     });
+
+                modelBuilder.Entity<Pegasus>();
 
                 modelBuilder.Entity<Unicorn>(
                     b =>
@@ -243,10 +249,15 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        protected class Pegasus
+        protected abstract class Flyer
         {
+            public string Discriminator { get; set; }
             public long Id1 { get; set; }
             public long Id2 { get; set; }
+        }
+
+        protected class Pegasus : Flyer
+        {
             public string Name { get; set; }
         }
 


### PR DESCRIPTION
Optimize the discriminator value in the runtime model

Fixes #18126