### PR TITLE
Preserve extension registration order

### DIFF
--- a/test/EFCore.Specification.Tests/LoggingTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoggingTestBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Logs_context_initialization_no_tracking()
         {
             Assert.Equal(
-                ExpectedMessage(DefaultOptions + "NoTracking"),
+                ExpectedMessage("NoTracking " + DefaultOptions),
                 ActualMessage(s => CreateOptionsBuilder(s).UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)));
         }
 
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Logs_context_initialization_sensitive_data_logging()
         {
             Assert.Equal(
-                ExpectedMessage(DefaultOptions + "SensitiveDataLoggingEnabled"),
+                ExpectedMessage("SensitiveDataLoggingEnabled " + DefaultOptions),
                 ActualMessage(s => CreateOptionsBuilder(s).EnableSensitiveDataLogging()));
         }
 


### PR DESCRIPTION
Fixes #26071

### Description

The extension services are applied in alphabetic order instead of the order in which they were added.

The fix requires breaking some protected API on `DbContextOptions`, but this class is designed to use composition, not inheritance, so it shouldn't affect any external code.

### Customer impact

Extensions that depend on a provider being registered will throw errors if they happen to be sorted before the provider.

### How found

Customer

### Regression

Yes, introduced in rc1 by 4e3ce4e13036eaeac700b2a08faa0d45270beb6e

### Testing

Test for this scenario added in the PR.

### Risk

Low, this reverts the behavior to pre-rc1.