### PR TITLE
[6.0] Fix snapshot generation with HiLo

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -64,6 +64,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
             = typeof(SqlServerPropertyBuilderExtensions).GetRequiredRuntimeMethod(
                 nameof(SqlServerPropertyBuilderExtensions.UseIdentityColumn), typeof(PropertyBuilder), typeof(long), typeof(int));
 
+        private static readonly MethodInfo _propertyUseHiLoMethodInfo
+            = typeof(SqlServerPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(SqlServerPropertyBuilderExtensions.UseHiLo), typeof(PropertyBuilder), typeof(string), typeof(string));
+
         private static readonly MethodInfo _indexIsClusteredMethodInfo
             = typeof(SqlServerIndexBuilderExtensions).GetRequiredRuntimeMethod(
                 nameof(SqlServerIndexBuilderExtensions.IsClustered), typeof(IndexBuilder), typeof(bool));
@@ -374,7 +378,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
                     var name = GetAndRemove<string>(annotations, SqlServerAnnotationNames.HiLoSequenceName);
                     var schema = GetAndRemove<string>(annotations, SqlServerAnnotationNames.HiLoSequenceSchema);
                     return new(
-                        _modelUseHiLoMethodInfo,
+                        onModel ? _modelUseHiLoMethodInfo : _propertyUseHiLoMethodInfo,
                         (name, schema) switch
                         {
                             (null, null) => Array.Empty<object>(),

--- a/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
@@ -169,6 +169,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var result = generator.GenerateFluentApiCalls((IModel)modelBuilder.Model, annotations).Single();
 
             Assert.Equal("UseIdentityColumns", result.Method);
+            Assert.Equal("SqlServerModelBuilderExtensions", result.DeclaringType);
 
             Assert.Collection(
                 result.Arguments,
@@ -188,6 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var result = generator.GenerateFluentApiCalls((IProperty)property, annotations).Single();
 
             Assert.Equal("UseIdentityColumn", result.Method);
+            Assert.Equal("SqlServerPropertyBuilderExtensions", result.DeclaringType);
 
             Assert.Collection(
                 result.Arguments,
@@ -207,6 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var result = generator.GenerateFluentApiCalls((IProperty)property, annotations).Single();
 
             Assert.Equal("UseIdentityColumn", result.Method);
+            Assert.Equal("SqlServerPropertyBuilderExtensions", result.DeclaringType);
 
             Assert.Collection(
                 result.Arguments,
@@ -225,6 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var result = generator.GenerateFluentApiCalls((IModel)modelBuilder.Model, annotations).Single();
 
             Assert.Equal("UseHiLo", result.Method);
+            Assert.Equal("SqlServerModelBuilderExtensions", result.DeclaringType);
 
             Assert.Collection(
                 result.Arguments,
@@ -244,6 +248,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var result = generator.GenerateFluentApiCalls((IProperty)property, annotations).Single();
 
             Assert.Equal("UseHiLo", result.Method);
+            Assert.Equal("SqlServerPropertyBuilderExtensions", result.DeclaringType);
 
             Assert.Collection(
                 result.Arguments,


### PR DESCRIPTION
Fixes #26134

### Description

Incorrect migration generated when the HiLo value generation strategy is configured.

### Customer impact

Generating migrations with a model-wide HiLo value generation strategy creates an invalid migration.

### How found

Customer

### Regression

Yes

### Testing

Test for this scenario added in the PR.

### Risk

Low, the bug is trivial and the modified code only annotation generation for this particular scenario; coverage is good in this area.