### PR TITLE
Throw a better exception for relationships to keyless entity types

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -2831,13 +2831,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     Metadata, null, navigationToTarget, !setTargetAsPrincipal, configurationSource, required);
             }
 
+            if (setTargetAsPrincipal == null
+                && targetEntityType.IsKeyless)
+            {
+                setTargetAsPrincipal = false;
+            }
+
             if (configurationSource == ConfigurationSource.Explicit
                 && setTargetAsPrincipal.HasValue)
             {
                 if (setTargetAsPrincipal.Value)
                 {
-                    if (targetEntityType.IsKeyless
-                        && targetEntityType.GetIsKeylessConfigurationSource() == ConfigurationSource.Explicit)
+                    if (targetEntityType.IsKeyless)
                     {
                         throw new InvalidOperationException(CoreStrings.PrincipalKeylessType(
                             targetEntityType.DisplayName(),
@@ -2853,8 +2858,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
                 else
                 {
-                    if (Metadata.IsKeyless
-                        && Metadata.GetIsKeylessConfigurationSource() == ConfigurationSource.Explicit)
+                    if (Metadata.IsKeyless)
                     {
                         throw new InvalidOperationException(CoreStrings.PrincipalKeylessType(
                             Metadata.DisplayName(),

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -2274,6 +2274,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(principalEntityTypeBuilder, nameof(principalEntityTypeBuilder));
             Check.NotNull(dependentEntityTypeBuilder, nameof(dependentEntityTypeBuilder));
 
+            if (configurationSource == ConfigurationSource.Explicit
+                && principalEntityTypeBuilder.Metadata.IsKeyless)
+            {
+                throw new InvalidOperationException(CoreStrings.PrincipalKeylessType(
+                    principalEntityTypeBuilder.Metadata.DisplayName(),
+                    principalEntityTypeBuilder.Metadata.DisplayName()
+                    + (navigationToDependent?.Name == null
+                        ? ""
+                        : "." + navigationToDependent.Value.Name),
+                    dependentEntityTypeBuilder.Metadata.DisplayName()
+                    + (navigationToPrincipal?.Name == null
+                        ? ""
+                        : "." + navigationToPrincipal.Value.Name)));
+            }
+
             Check.DebugAssert(
                 navigationToPrincipal?.Name == null
                 || navigationToPrincipal.Value.MemberInfo != null

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -816,6 +816,21 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Empty(Fixture.ListLoggerFactory.Log);
         }
 
+        [ConditionalFact]
+        public virtual void Fluent_API_relationship_throws_for_Keyless_attribute()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var entity = modelBuilder.Entity<KeyFluentApiAndKeylessAttribute>();
+
+            Assert.Equal(CoreStrings.PrincipalKeylessType(
+                nameof(KeyFluentApiAndKeylessAttribute), nameof(KeyFluentApiAndKeylessAttribute), nameof(CompositeKeyAttribute)),
+                Assert.Throws<InvalidOperationException>(() =>
+                    modelBuilder.Entity<CompositeKeyAttribute>()
+                .HasOne<KeyFluentApiAndKeylessAttribute>()
+                .WithOne()
+                .HasForeignKey<CompositeKeyAttribute>("fk")).Message);
+        }
+
         private class CompositeKeyAttribute
         {
             [Key]


### PR DESCRIPTION
Fixes #24373

### Description

Using a keyless entity type as the principal is invalid, however we didn't have an explicit check for this.

### Customer impact

Without this an NRE is thrown when a keyless entity type is used as the principal.

### How found

Customer

### Regression

No.

### Testing

Test for this scenario added in the PR.

### Risk

Low, just a better exception message.