### PR TITLE
Allow HasKey to override HasNoKey

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -226,10 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     return null;
                 }
 
-                if (Metadata.GetIsKeylessConfigurationSource() != ConfigurationSource.Explicit)
-                {
-                    Metadata.SetIsKeyless(false, configurationSource.Value);
-                }
+                Metadata.SetIsKeyless(false, configurationSource.Value);
 
                 var containingForeignKeys = actualProperties
                     .SelectMany(p => p.GetContainingForeignKeys().Where(k => k.DeclaringEntityType != Metadata))

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1332,10 +1332,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal(ConfigurationSource.Explicit, entityType.GetIsKeylessConfigurationSource());
             Assert.Empty(entityType.GetKeys());
 
-            Assert.Equal(
-                CoreStrings.KeylessTypeWithKey("{'CustomerId'}", nameof(Order)),
-                Assert.Throws<InvalidOperationException>(
-                    () => entityBuilder.HasKey(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Explicit)).Message);
+            Assert.NotNull(entityBuilder.HasKey(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Explicit));
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -125,13 +125,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_set_entity_key_from_clr_property_when_property_ignored()
+            public virtual void Can_set_entity_key_from_clr_property_when_property_ignored_on_keyless()
             {
                 var modelBuilder = CreateModelBuilder();
 
                 modelBuilder.Entity<Customer>(
                     b =>
                     {
+                        b.HasNoKey();
                         b.Ignore(Customer.IdProperty.Name);
                         b.HasKey(e => e.Id);
                     });


### PR DESCRIPTION
Fixes #24789

### Description

Once `HasNoKey` is called there is no way of override it using Fluent API.

### Customer impact

When extending an external model or a model created by scaffolding customers need to use low-level Metadata API to override `HasNoKey`

### How found

Customer

### Regression

No.

### Testing

Test for this scenario added in the PR.

### Risk

Low, the effect of the change is straightforward.