### PR TITLE
Set ValueGenerated.OnUpdateSometimes when more than two properties share the same colum

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
@@ -215,8 +215,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 {
                     if (property.GetAfterSaveBehavior() == PropertySaveBehavior.Save
                         && otherProperty.GetAfterSaveBehavior() == PropertySaveBehavior.Save
-                        && property.ValueGenerated == ValueGenerated.Never
-                        && otherProperty.ValueGenerated == ValueGenerated.Never)
+                        && (property.ValueGenerated == ValueGenerated.Never
+                            || property.ValueGenerated == ValueGenerated.OnUpdateSometimes)
+                        && (otherProperty.ValueGenerated == ValueGenerated.Never
+                            || otherProperty.ValueGenerated == ValueGenerated.OnUpdateSometimes))
                     {
                         // Handle this with a default value convention #9329
                         property.Builder.ValueGenerated(ValueGenerated.OnUpdateSometimes);


### PR DESCRIPTION
Fixes #25388

### Description

One more than two properties share a column we fail to mark them as `ValueGenerated.OnUpdateSometimes`

### Customer impact

`SaveChanges` with an entity involving a shared column will fail unless the customer calls `ValueGeneratedOnUpdateSometimes` explicitly on every property sharing the column.

### How found

Customer

### Regression

Yes. Regressed in 5.0.0. Previously we didn't validate whether a given property could get its value from a different property sharing the same column.

### Testing

Test for this scenario added in the PR.

### Risk

Low, only affects scenarios with more than two properties sharing any given column.