### PR TITLE
Switch to 1ES servicing pools on release/2.1

### DIFF
--- a/build/templates/default-build.yml
+++ b/build/templates/default-build.yml
@@ -74,11 +74,11 @@ jobs:
       vmImage: ubuntu-18.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCorePublic-Pool
-        queue: BuildPool.Server.Amd64.VS2017.Open
+        name: NetCore1ESPool-Svc-Public
+        demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Server.Amd64.VS2017
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2017
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/core-eng/issues/14276
