### PR TITLE
Switch to 1ES servicing pools on release/3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,11 +47,11 @@ stages:
           - job: Windows
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCorePublic-Pool
-                queue: BuildPool.Server.Amd64.VS2017.Open
+                name: NetCore1ESPool-Svc-Public
+                demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                name: NetCoreInternal-Pool
-                queue: BuildPool.Server.Amd64.VS2017
+                name: NetCore1ESPool-Svc-Internal
+                demands: ImageOverride -equals Build.Server.Amd64.VS2017
             variables:
               - _InternalBuildArgs: ''
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/core-eng/issues/14276
