### PR TITLE
Cosmos: Set ValueGenerated.Never for most integer properties

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures store value generation as <see cref="ValueGenerated.OnAdd" /> on properties that are
+    ///     part of the primary key and not part of any foreign keys or were configured to have a database default value.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> and
+    ///     <see href="https://aka.ms/efcore-docs-value-generation">EF Core value generation</see> for more information.
+    /// </remarks>
+    public class CosmosValueGenerationConvention :
+        ValueGenerationConvention,
+        IEntityTypeAnnotationChangedConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="CosmosValueGenerationConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public CosmosValueGenerationConvention(
+            ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <summary>
+        ///     Called after an annotation is changed on an entity type.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type. </param>
+        /// <param name="name"> The annotation name. </param>
+        /// <param name="annotation"> The new annotation. </param>
+        /// <param name="oldAnnotation"> The old annotation.  </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public virtual void ProcessEntityTypeAnnotationChanged(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            string name,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
+            IConventionContext<IConventionAnnotation> context)
+        {
+            if (name != CosmosAnnotationNames.ContainerName
+                || (annotation == null) == (oldAnnotation == null))
+            {
+                return;
+            }
+
+            var primaryKey = entityTypeBuilder.Metadata.FindPrimaryKey();
+            if (primaryKey == null)
+            {
+                return;
+            }
+
+            foreach (var property in primaryKey.Properties)
+            {
+                property.Builder.ValueGenerated(GetValueGenerated(property));
+            }
+        }
+
+        /// <summary>
+        ///     Returns the store value generation strategy to set for the given property.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The store value generation strategy to set for the given property. </returns>
+        protected override ValueGenerated? GetValueGenerated(IConventionProperty property)
+        {
+            var entityType = property.DeclaringEntityType;
+            var propertyType = property.ClrType.UnwrapNullableType();
+            if (propertyType == typeof(int))
+            {
+                var ownership = entityType.FindOwnership();
+                if (ownership != null
+                    && !ownership.IsUnique
+                    && !entityType.IsDocumentRoot())
+                {
+                    var pk = property.FindContainingPrimaryKey();
+                    if (pk != null
+                        && !ownership.Properties.Contains(property)
+                        && pk.Properties.Count == ownership.Properties.Count + 1
+                        && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
+                    {
+                        return base.GetValueGenerated(property);
+                    }
+                }
+            }
+
+            if (propertyType != typeof(Guid))
+            {
+                return null;
+            }
+
+            return base.GetValueGenerated(property);
+        }
+    }
+}

--- a/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
@@ -60,7 +60,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
             ReplaceConvention(conventionSet.EntityTypeRemovedConventions, (DiscriminatorConvention)discriminatorConvention);
             ReplaceConvention(conventionSet.EntityTypeRemovedConventions, inversePropertyAttributeConvention);
 
+            ValueGenerationConvention valueGenerationConvention = new CosmosValueGenerationConvention(Dependencies);
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(storeKeyConvention);
+            ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, valueGenerationConvention);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, (DiscriminatorConvention)discriminatorConvention);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, keyDiscoveryConvention);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, inversePropertyAttributeConvention);
@@ -71,6 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
             ReplaceConvention(conventionSet.EntityTypeMemberIgnoredConventions, relationshipDiscoveryConvention);
 
             conventionSet.EntityTypePrimaryKeyChangedConventions.Add(storeKeyConvention);
+            ReplaceConvention(conventionSet.EntityTypePrimaryKeyChangedConventions, valueGenerationConvention);
 
             conventionSet.KeyAddedConventions.Add(storeKeyConvention);
 
@@ -78,19 +81,23 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
             ReplaceConvention(conventionSet.KeyRemovedConventions, keyDiscoveryConvention);
 
             ReplaceConvention(conventionSet.ForeignKeyAddedConventions, keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyAddedConventions, valueGenerationConvention);
 
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, relationshipDiscoveryConvention);
             conventionSet.ForeignKeyRemovedConventions.Add(discriminatorConvention);
             conventionSet.ForeignKeyRemovedConventions.Add(storeKeyConvention);
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGenerationConvention);
 
             ReplaceConvention(conventionSet.ForeignKeyPropertiesChangedConventions, keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyPropertiesChangedConventions, valueGenerationConvention);
 
             ReplaceConvention(conventionSet.ForeignKeyUniquenessChangedConventions, keyDiscoveryConvention);
 
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(discriminatorConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(storeKeyConvention);
             ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, valueGenerationConvention);
             ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, relationshipDiscoveryConvention);
 
             ReplaceConvention(conventionSet.ForeignKeyNullNavigationSetConventions, relationshipDiscoveryConvention);
@@ -111,6 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
 
             conventionSet.EntityTypeAnnotationChangedConventions.Add(discriminatorConvention);
             conventionSet.EntityTypeAnnotationChangedConventions.Add(storeKeyConvention);
+            conventionSet.EntityTypeAnnotationChangedConventions.Add((CosmosValueGenerationConvention)valueGenerationConvention);
             conventionSet.EntityTypeAnnotationChangedConventions.Add((CosmosKeyDiscoveryConvention)keyDiscoveryConvention);
             conventionSet.EntityTypeAnnotationChangedConventions.Add((CosmosManyToManyJoinEntityTypeConvention)manyToManyJoinEntityTypeConvention);
 

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -90,6 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             ReplaceConvention(conventionSet.EntityTypePrimaryKeyChangedConventions, valueGenerationConvention);
 
             ReplaceConvention(conventionSet.ForeignKeyAddedConventions, valueGenerationConvention);
+
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGenerationConvention);
 
             conventionSet.PropertyFieldChangedConventions.Add(relationalColumnAttributeConvention);

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -1474,10 +1474,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Contains(nonPrimaryPrincipalKey, principalType.GetKeys());
                 var oldKeyProperty = principalType.FindProperty(nameof(BigMak.Id));
                 var newKeyProperty = principalType.FindProperty(nameof(BigMak.AlternateKey));
-                Assert.False(oldKeyProperty.RequiresValueGenerator());
-                Assert.Equal(ValueGenerated.Never, oldKeyProperty.ValueGenerated);
-                Assert.True(newKeyProperty.RequiresValueGenerator());
-                Assert.Equal(ValueGenerated.OnAdd, newKeyProperty.ValueGenerated);
                 Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
                 Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -679,7 +679,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Single(owned.GetForeignKeys());
                 var pk = owned.FindPrimaryKey();
                 Assert.Equal(new[] { nameof(Order.CustomerId), nameof(Order.OrderId) }, pk.Properties.Select(p => p.Name));
-                Assert.Equal(ValueGenerated.OnAdd, pk.Properties.Last().ValueGenerated);
                 Assert.Empty(owned.GetIndexes());
 
                 var chainedOwnership = owned.FindNavigation(nameof(Order.Products)).ForeignKey;
@@ -690,7 +689,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(new[] { "OrderCustomerId", "OrderId" }, chainedOwnership.Properties.Select(p => p.Name));
                 var chainedPk = chainedOwned.FindPrimaryKey();
                 Assert.Equal(new[] { "OrderCustomerId", "OrderId", nameof(Product.Id) }, chainedPk.Properties.Select(p => p.Name));
-                Assert.Equal(ValueGenerated.OnAdd, chainedPk.Properties.Last().ValueGenerated);
                 Assert.Empty(chainedOwned.GetIndexes());
 
                 Assert.Equal(4, model.GetEntityTypes().Count());
@@ -728,7 +726,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Single(owned.GetForeignKeys());
                 var pk = owned.FindPrimaryKey();
                 Assert.Equal(new[] { nameof(Order.CustomerId), "Id" }, pk.Properties.Select(p => p.Name));
-                Assert.Equal(ValueGenerated.OnAdd, pk.Properties.Last().ValueGenerated);
                 Assert.Empty(owned.GetIndexes());
 
                 var chainedOwnership = owned.FindNavigation(nameof(Order.Products)).ForeignKey;
@@ -739,7 +736,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(new[] { "OrderCustomerId", "OrderId" }, chainedOwnership.Properties.Select(p => p.Name));
                 var chainedPk = chainedOwned.FindPrimaryKey();
                 Assert.Equal(new[] { "OrderCustomerId", "OrderId", "Id1" }, chainedPk.Properties.Select(p => p.Name));
-                Assert.Equal(ValueGenerated.OnAdd, chainedPk.Properties.Last().ValueGenerated);
                 Assert.Empty(chainedOwned.GetIndexes());
 
                 Assert.Equal(4, model.GetEntityTypes().Count());


### PR DESCRIPTION
Fixes #25167

### Description

Cosmos doesn't support value generation, however integer properties were marked as `ValueGenerated.OnAdd`. Only `Guid` properties and the non-persisted `int` ordinals for embedded collections are generated on the client.

### Customer impact

Attaching an entity with an integer key will mark it as Updated instead of Added resulting in an error on the next `SaveChanges`

### How found

Customer

### Regression

No

### Testing

Test for this scenario added in the PR.

### Risk

Low, only affects scenarios with value generation, which are not supported in Cosmos.