### PR TITLE
[6.0] Fix SQL Server NTS scaffolding code generation

### DIFF
--- a/src/EFCore.SqlServer.NTS/Scaffolding/Internal/SqlServerNetTopologySuiteCodeGeneratorPlugin.cs
+++ b/src/EFCore.SqlServer.NTS/Scaffolding/Internal/SqlServerNetTopologySuiteCodeGeneratorPlugin.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
         private static readonly MethodInfo _useNetTopologySuiteMethodInfo
             = typeof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions).GetRequiredRuntimeMethod(
                 nameof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite),
-                typeof(Action<SqlServerDbContextOptionsBuilder>));
+                typeof(SqlServerDbContextOptionsBuilder));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.SqlServer.Tests/Scaffolding/SqlServerCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Scaffolding/SqlServerCodeGeneratorTest.cs
@@ -55,6 +55,29 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
             Assert.Null(result.ChainedCall);
         }
 
+        [ConditionalFact]
+        public virtual void Use_provider_method_is_generated_correctly_with_NetTopologySuite()
+        {
+            var codeGenerator = new SqlServerCodeGenerator(
+                new ProviderCodeGeneratorDependencies(
+                    new[] { new SqlServerNetTopologySuiteCodeGeneratorPlugin() }));
+
+            var result = ((IProviderConfigurationCodeGenerator)codeGenerator).GenerateUseProvider("Data Source=Test");
+
+            Assert.Equal("UseSqlServer", result.Method);
+            Assert.Collection(
+                result.Arguments,
+                a => Assert.Equal("Data Source=Test", a),
+                a =>
+                {
+                    var nestedClosure = Assert.IsType<NestedClosureCodeFragment>(a);
+
+                    Assert.Equal("x", nestedClosure.Parameter);
+                    Assert.Equal("UseNetTopologySuite", nestedClosure.MethodCalls[0].Method);
+                });
+            Assert.Null(result.ChainedCall);
+        }
+
         private static readonly MethodInfo _setProviderOptionMethodInfo
             = typeof(SqlServerCodeGeneratorTest).GetRuntimeMethod(nameof(SetProviderOption), new[] { typeof(DbContextOptionsBuilder) });
 

--- a/test/EFCore.Sqlite.Tests/Scaffolding/SqliteCodeGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Scaffolding/SqliteCodeGeneratorTest.cs
@@ -54,6 +54,29 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
             Assert.Null(result.ChainedCall);
         }
 
+        [ConditionalFact]
+        public virtual void Use_provider_method_is_generated_correctly_with_NetTopologySuite()
+        {
+            var codeGenerator = new SqliteCodeGenerator(
+                new ProviderCodeGeneratorDependencies(
+                    new[] { new SqliteNetTopologySuiteCodeGeneratorPlugin() }));
+
+            var result = ((IProviderConfigurationCodeGenerator)codeGenerator).GenerateUseProvider("Data Source=Test");
+
+            Assert.Equal("UseSqlite", result.Method);
+            Assert.Collection(
+                result.Arguments,
+                a => Assert.Equal("Data Source=Test", a),
+                a =>
+                {
+                    var nestedClosure = Assert.IsType<NestedClosureCodeFragment>(a);
+
+                    Assert.Equal("x", nestedClosure.Parameter);
+                    Assert.Equal("UseNetTopologySuite", nestedClosure.MethodCalls[0].Method);
+                });
+            Assert.Null(result.ChainedCall);
+        }
+
         private static readonly MethodInfo _setProviderOptionMethodInfo
             = typeof(SqliteCodeGeneratorTest).GetRuntimeMethod(nameof(SetProviderOption), new[] { typeof(DbContextOptionsBuilder) });
 


### PR DESCRIPTION
Fixes #26133

### Description

An incorrect type reference prevents scaffolding from working correctly when NetTopologySuite is used.

### Customer impact

Customers cannot scaffold databases when using the NetTopologySuite spatial plugin.

### How found

Customer

### Regression

Yes

### Testing

Test for this scenario added in the PR.

### Risk

Very low, the fix is trivial and affects scaffolding only (no runtime impact)