### PR TITLE
Add AutoRetry flag for commands

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Data.Sqlite
         private SqliteConnectionInternal? _innerConnection;
         private bool _extensionsEnabled;
         private int? _defaultTimeout;
+        private bool? _autoRetry;
 
         static SqliteConnection()
             => BundleInitializer.Initialize();
@@ -134,6 +135,17 @@ namespace Microsoft.Data.Sqlite
         {
             get => _defaultTimeout ?? ConnectionOptions.DefaultTimeout;
             set => _defaultTimeout = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether command created using this connection will be retried
+        ///     automatically when the database is busy or locked.
+        /// </summary>
+        /// <value>A value indicating whether commands will be retried automatically.</value>
+        public virtual bool AutoRetry
+        {
+            get => _autoRetry ?? ConnectionOptions.AutoRetry;
+            set => _autoRetry = value;
         }
 
         /// <summary>
@@ -395,7 +407,8 @@ namespace Microsoft.Data.Sqlite
             {
                 Connection = this,
                 CommandTimeout = DefaultTimeout,
-                Transaction = Transaction
+                Transaction = Transaction,
+                AutoRetry = AutoRetry
             };
 
         /// <summary>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Data.Sqlite
         private const string DefaultTimeoutKeyword = "Default Timeout";
         private const string CommandTimeoutKeyword = "Command Timeout";
         private const string PoolingKeyword = "Pooling";
+        private const string AutoRetryKeyword = "Auto Retry";
 
         private enum Keywords
         {
@@ -41,7 +42,8 @@ namespace Microsoft.Data.Sqlite
             ForeignKeys,
             RecursiveTriggers,
             DefaultTimeout,
-            Pooling
+            Pooling,
+            AutoRetry
         }
 
         private static readonly IReadOnlyList<string> _validKeywords;
@@ -55,10 +57,11 @@ namespace Microsoft.Data.Sqlite
         private bool _recursiveTriggers;
         private int _defaultTimeout = 30;
         private bool _pooling = true;
+        private bool _autoRetry = true;
 
         static SqliteConnectionStringBuilder()
         {
-            var validKeywords = new string[8];
+            var validKeywords = new string[9];
             validKeywords[(int)Keywords.DataSource] = DataSourceKeyword;
             validKeywords[(int)Keywords.Mode] = ModeKeyword;
             validKeywords[(int)Keywords.Cache] = CacheKeyword;
@@ -67,9 +70,10 @@ namespace Microsoft.Data.Sqlite
             validKeywords[(int)Keywords.RecursiveTriggers] = RecursiveTriggersKeyword;
             validKeywords[(int)Keywords.DefaultTimeout] = DefaultTimeoutKeyword;
             validKeywords[(int)Keywords.Pooling] = PoolingKeyword;
+            validKeywords[(int)Keywords.AutoRetry] = AutoRetryKeyword;
             _validKeywords = validKeywords;
 
-            _keywords = new Dictionary<string, Keywords>(11, StringComparer.OrdinalIgnoreCase)
+            _keywords = new Dictionary<string, Keywords>(12, StringComparer.OrdinalIgnoreCase)
             {
                 [DataSourceKeyword] = Keywords.DataSource,
                 [ModeKeyword] = Keywords.Mode,
@@ -79,6 +83,7 @@ namespace Microsoft.Data.Sqlite
                 [RecursiveTriggersKeyword] = Keywords.RecursiveTriggers,
                 [DefaultTimeoutKeyword] = Keywords.DefaultTimeout,
                 [PoolingKeyword] = Keywords.Pooling,
+                [AutoRetryKeyword] = Keywords.AutoRetry,
 
                 // aliases
                 [FilenameKeyword] = Keywords.DataSource,
@@ -218,6 +223,19 @@ namespace Microsoft.Data.Sqlite
         }
 
         /// <summary>
+        ///     Gets or sets a value indicating whether to automatically retry commands.
+        ///     When true, commands will be retried automatically until the command timeout
+        ///     when the underlying database is locked or busy. When false, commands will
+        ///     fail on the first attempt.
+        /// </summary>
+        /// <value>A value indicating whether to automatically retry commands.</value>
+        public bool AutoRetry
+        {
+            get => _autoRetry;
+            set => base[AutoRetryKeyword] = _autoRetry = value;
+        }
+
+        /// <summary>
         ///     Gets or sets the value associated with the specified key.
         /// </summary>
         /// <param name="keyword">The key.</param>
@@ -268,6 +286,10 @@ namespace Microsoft.Data.Sqlite
 
                     case Keywords.Pooling:
                         Pooling = Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+                        return;
+
+                    case Keywords.AutoRetry:
+                        AutoRetry = Convert.ToBoolean(value, CultureInfo.InvariantCulture);
                         return;
 
                     default:
@@ -418,6 +440,9 @@ namespace Microsoft.Data.Sqlite
                 case Keywords.Pooling:
                     return Pooling;
 
+                case Keywords.AutoRetry:
+                    return AutoRetry;
+
                 default:
                     Debug.Fail("Unexpected keyword: " + index);
                     return null;
@@ -463,6 +488,10 @@ namespace Microsoft.Data.Sqlite
 
                 case Keywords.Pooling:
                     _pooling = true;
+                    return;
+
+                case Keywords.AutoRetry:
+                    _autoRetry = true;
                     return;
 
                 default:

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -158,8 +158,9 @@ namespace Microsoft.Data.Sqlite
 
                     while (IsBusy(rc = sqlite3_step(stmt)))
                     {
-                        if (_command.CommandTimeout != 0
-                            && _timer.ElapsedMilliseconds >= _command.CommandTimeout * 1000L)
+                        if (!_command.AutoRetry ||
+                            (_command.CommandTimeout != 0
+                             && _timer.ElapsedMilliseconds >= _command.CommandTimeout * 1000L))
                         {
                             break;
                         }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
@@ -71,6 +71,14 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void Ctor_parses_AutoRetry()
+        {
+            var builder = new SqliteConnectionStringBuilder("Auto Retry=False");
+
+            Assert.False(builder.AutoRetry);
+        }
+
+        [Fact]
         public void ConnectionString_defaults_to_empty()
         {
             var builder = new SqliteConnectionStringBuilder();
@@ -154,13 +162,32 @@ namespace Microsoft.Data.Sqlite
             Assert.Equal(30, new SqliteConnectionStringBuilder().DefaultTimeout);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AutoRetry_works(bool autoRetry)
+        {
+            var builder = new SqliteConnectionStringBuilder()
+            {
+                AutoRetry = autoRetry
+            };
+
+            Assert.Equal(autoRetry, builder.AutoRetry);
+        }
+
+        [Fact]
+        public void AutoRetry_defaults_to_true()
+        {
+            Assert.True(new SqliteConnectionStringBuilder().AutoRetry);
+        }
+
         [Fact]
         public void Keys_works()
         {
             var keys = (ICollection<string>)new SqliteConnectionStringBuilder().Keys;
 
             Assert.True(keys.IsReadOnly);
-            Assert.Equal(8, keys.Count);
+            Assert.Equal(9, keys.Count);
             Assert.Contains("Data Source", keys);
             Assert.Contains("Mode", keys);
             Assert.Contains("Cache", keys);
@@ -169,6 +196,7 @@ namespace Microsoft.Data.Sqlite
             Assert.Contains("Recursive Triggers", keys);
             Assert.Contains("Default Timeout", keys);
             Assert.Contains("Pooling", keys);
+            Assert.Contains("Auto Retry", keys);
         }
 
         [Fact]
@@ -177,7 +205,7 @@ namespace Microsoft.Data.Sqlite
             var values = (ICollection<object>)new SqliteConnectionStringBuilder().Values;
 
             Assert.True(values.IsReadOnly);
-            Assert.Equal(8, values.Count);
+            Assert.Equal(9, values.Count);
         }
 
         [Fact]
@@ -280,7 +308,7 @@ namespace Microsoft.Data.Sqlite
         public void Clear_resets_everything()
         {
             var builder = new SqliteConnectionStringBuilder(
-                "Data Source=test.db;Mode=Memory;Cache=Shared;Password=test;Foreign Keys=True;Recursive Triggers=True;Default Timeout=1");
+                "Data Source=test.db;Mode=Memory;Cache=Shared;Password=test;Foreign Keys=True;Recursive Triggers=True;Default Timeout=1;Auto Retry=False");
 
             builder.Clear();
 
@@ -291,6 +319,7 @@ namespace Microsoft.Data.Sqlite
             Assert.Null(builder.ForeignKeys);
             Assert.False(builder.RecursiveTriggers);
             Assert.Equal(30, builder.DefaultTimeout);
+            Assert.True(builder.AutoRetry);
         }
 
         [Fact]
@@ -373,11 +402,12 @@ namespace Microsoft.Data.Sqlite
                 Password = "test",
                 ForeignKeys = true,
                 RecursiveTriggers = true,
-                DefaultTimeout = 1
+                DefaultTimeout = 1,
+                AutoRetry = false
             };
 
             Assert.Equal(
-                "Data Source=test.db;Mode=Memory;Cache=Shared;Password=test;Foreign Keys=True;Recursive Triggers=True;Default Timeout=1",
+                "Data Source=test.db;Mode=Memory;Cache=Shared;Password=test;Foreign Keys=True;Recursive Triggers=True;Default Timeout=1;Auto Retry=False",
                 builder.ToString());
         }
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -126,6 +126,37 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void AutoRetry_defaults_to_true()
+        {
+            var connection = new SqliteConnection();
+
+            Assert.True(connection.AutoRetry);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AutoRetry_takes_setting_from_connection_string(bool autoRetry)
+        {
+            var connection = new SqliteConnection($"Auto Retry={autoRetry}");
+
+            Assert.Equal(autoRetry, connection.AutoRetry);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AutoRetry_can_be_overridden(bool autoRetry)
+        {
+            var connection = new SqliteConnection($"Auto Retry={autoRetry}")
+            {
+                AutoRetry = !autoRetry
+            };
+
+            Assert.Equal(!autoRetry, connection.AutoRetry);
+        }
+
+        [Fact]
         public void ServerVersion_returns_value()
         {
             var connection = new SqliteConnection();


### PR DESCRIPTION
Add an AutoRetry flag to SqliteCommands, making the behavior of
automatically retrying commands when the database is busy or locked
into an optional behavior.  The default is True, so nothing has
changed if the flag is not set to False.

The flag is present at a few levels of the design:

* SqliteCommand has a new AutoRetry property, which takes its value
  from the SqliteConnection by default.  If there isn't a connection
  associated with the command, the default is true.
* SqliteConnection has a new AutoRetry property, which takes its
  value from the connection string by default.
* SqliteConnectionStringBuilder recognizes a new "Auto Retry" keyword
  in connection strings, with true being the default when not
  specified.

The flag is used in the two existing places in the design where
automatic retry behavior was implemented:

* In SqliteDataReader.NextResult().
* In SqliteCommand.PrepareAndEnumerateStatements().

A variety of unit tests are included, verifying aspects of the new
feature's implementation.

Fixes #26187.