### PR TITLE
[6.0] Separate design time and runtime service for NamedConnectionStringResolver

### DIFF
--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -12,7 +12,6 @@ using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -68,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                         .TryAddSingleton<ICompiledModelCodeGenerator, CSharpRuntimeModelCodeGenerator>()
                         .TryAddSingleton<ICompiledModelCodeGeneratorSelector, CompiledModelCodeGeneratorSelector>()
                         .TryAddSingleton<ICompiledModelScaffolder, CompiledModelScaffolder>()
-                        .TryAddSingleton<INamedConnectionStringResolver>(
+                        .TryAddSingleton<IDesignTimeConnectionStringResolver>(
                             new DesignTimeConnectionStringResolver(applicationServiceProviderAccessor))
                         .TryAddSingleton<IPluralizer, HumanizerPluralizer>()
                         .TryAddSingleton<IScaffoldingModelFactory, RelationalScaffoldingModelFactory>()

--- a/src/EFCore.Design/Design/Internal/DesignTimeConnectionStringResolver.cs
+++ b/src/EFCore.Design/Design/Internal/DesignTimeConnectionStringResolver.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
     ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
-    public class DesignTimeConnectionStringResolver : NamedConnectionStringResolverBase
+    public class DesignTimeConnectionStringResolver : NamedConnectionStringResolverBase, IDesignTimeConnectionStringResolver
     {
         private readonly Func<IServiceProvider>? _applicationServiceProviderAccessor;
 

--- a/src/EFCore.Design/Design/Internal/IDesignTimeConnectionStringResolver.cs
+++ b/src/EFCore.Design/Design/Internal/IDesignTimeConnectionStringResolver.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    /// </summary>
+    public interface IDesignTimeConnectionStringResolver : INamedConnectionStringResolver
+    {
+    }
+}

--- a/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private readonly IScaffoldingModelFactory _factory;
         private readonly ICSharpUtilities _cSharpUtilities;
         private readonly ICSharpHelper _code;
-        private readonly INamedConnectionStringResolver _connectionStringResolver;
+        private readonly IDesignTimeConnectionStringResolver _connectionStringResolver;
         private readonly IOperationReporter _reporter;
         private const string DbContextSuffix = "Context";
         private const string DefaultDbContextName = "Model" + DbContextSuffix;
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             IModelCodeGeneratorSelector modelCodeGeneratorSelector,
             ICSharpUtilities cSharpUtilities,
             ICSharpHelper cSharpHelper,
-            INamedConnectionStringResolver connectionStringResolver,
+            IDesignTimeConnectionStringResolver connectionStringResolver,
             IOperationReporter reporter)
         {
             Check.NotNull(databaseModelFactory, nameof(databaseModelFactory));

--- a/src/EFCore.Relational/Storage/Internal/NamedConnectionStringResolver.cs
+++ b/src/EFCore.Relational/Storage/Internal/NamedConnectionStringResolver.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
-    public class NamedConnectionStringResolver : NamedConnectionStringResolverBase
+    public class NamedConnectionStringResolver : NamedConnectionStringResolverBase, INamedConnectionStringResolver
     {
         private readonly IDbContextOptions _options;
 

--- a/src/EFCore.Relational/Storage/Internal/NamedConnectionStringResolverBase.cs
+++ b/src/EFCore.Relational/Storage/Internal/NamedConnectionStringResolverBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
-    public abstract class NamedConnectionStringResolverBase : INamedConnectionStringResolver
+    public abstract class NamedConnectionStringResolverBase
     {
         private const string DefaultSection = "ConnectionStrings:";
 

--- a/test/EFCore.Design.Tests/Design/DesignTimeServicesTest.cs
+++ b/test/EFCore.Design.Tests/Design/DesignTimeServicesTest.cs
@@ -10,10 +10,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Design;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -81,7 +85,41 @@ public class UserMigrationsIdGenerator : IMigrationsIdGenerator
                 useContext ? context : null).CreateScope().ServiceProvider;
 
             // Base design-time services are resolved
-            Assert.Equal("HumanizerPluralizer", serviceProvider.GetRequiredService<IPluralizer>().GetType().Name);
+            Assert.Equal(typeof(CSharpMigrationOperationGeneratorDependencies), serviceProvider.GetRequiredService<CSharpMigrationOperationGeneratorDependencies>().GetType());
+            Assert.Equal(typeof(CSharpMigrationsGeneratorDependencies), serviceProvider.GetRequiredService<CSharpMigrationsGeneratorDependencies>().GetType());
+            Assert.Equal(typeof(CSharpSnapshotGeneratorDependencies), serviceProvider.GetRequiredService<CSharpSnapshotGeneratorDependencies>().GetType());
+            Assert.Equal(typeof(CandidateNamingService), serviceProvider.GetRequiredService<ICandidateNamingService>().GetType());
+            Assert.Equal(typeof(CSharpDbContextGenerator), serviceProvider.GetRequiredService<ICSharpDbContextGenerator>().GetType());
+            Assert.Equal(typeof(CSharpEntityTypeGenerator), serviceProvider.GetRequiredService<ICSharpEntityTypeGenerator>().GetType());
+            Assert.Equal(typeof(CSharpHelper), serviceProvider.GetRequiredService<ICSharpHelper>().GetType());
+            Assert.Equal(typeof(CSharpMigrationOperationGenerator), serviceProvider.GetRequiredService<ICSharpMigrationOperationGenerator>().GetType());
+            Assert.Equal(typeof(CSharpSnapshotGenerator), serviceProvider.GetRequiredService<ICSharpSnapshotGenerator>().GetType());
+            Assert.Equal(typeof(CSharpUtilities), serviceProvider.GetRequiredService<ICSharpUtilities>().GetType());
+            Assert.Equal(typeof(CSharpMigrationsGenerator), serviceProvider.GetRequiredService<IMigrationsCodeGenerator>().GetType());
+            Assert.Equal(typeof(MigrationsCodeGeneratorSelector), serviceProvider.GetRequiredService<IMigrationsCodeGeneratorSelector>().GetType());
+            Assert.Equal(typeof(CSharpModelGenerator), serviceProvider.GetRequiredService<IModelCodeGenerator>().GetType());
+            Assert.Equal(typeof(ModelCodeGeneratorSelector), serviceProvider.GetRequiredService<IModelCodeGeneratorSelector>().GetType());
+            Assert.Equal(typeof(CSharpRuntimeModelCodeGenerator), serviceProvider.GetRequiredService<ICompiledModelCodeGenerator>().GetType());
+            Assert.Equal(typeof(CompiledModelCodeGeneratorSelector), serviceProvider.GetRequiredService<ICompiledModelCodeGeneratorSelector>().GetType());
+            Assert.Equal(typeof(CompiledModelScaffolder), serviceProvider.GetRequiredService<ICompiledModelScaffolder>().GetType());
+            Assert.Equal(typeof(DesignTimeConnectionStringResolver), serviceProvider.GetRequiredService<IDesignTimeConnectionStringResolver>().GetType());
+            Assert.Equal(typeof(HumanizerPluralizer), serviceProvider.GetRequiredService<IPluralizer>().GetType());
+            Assert.Equal(typeof(RelationalScaffoldingModelFactory), serviceProvider.GetRequiredService<IScaffoldingModelFactory>().GetType());
+            Assert.Equal(typeof(ScaffoldingTypeMapper), serviceProvider.GetRequiredService<IScaffoldingTypeMapper>().GetType());
+            Assert.Equal(typeof(MigrationsCodeGeneratorDependencies), serviceProvider.GetRequiredService<MigrationsCodeGeneratorDependencies>().GetType());
+            Assert.Equal(typeof(ModelCodeGeneratorDependencies), serviceProvider.GetRequiredService<ModelCodeGeneratorDependencies>().GetType());
+            Assert.Equal(typeof(ReverseEngineerScaffolder), serviceProvider.GetRequiredService<IReverseEngineerScaffolder>().GetType());
+
+            if (useContext)
+            {
+                Assert.Equal(
+                    typeof(MigrationsScaffolderDependencies),
+                    serviceProvider.GetRequiredService<MigrationsScaffolderDependencies>().GetType());
+                Assert.Equal(typeof(MigrationsScaffolder), serviceProvider.GetRequiredService<IMigrationsScaffolder>().GetType());
+                Assert.Equal(typeof(SnapshotModelProcessor), serviceProvider.GetRequiredService<ISnapshotModelProcessor>().GetType());
+            }
+
+            Assert.Equal(typeof(TestOperationReporter), serviceProvider.GetRequiredService<IOperationReporter>().GetType());
 
             // Provider design-time services are resolved
             Assert.Equal(typeof(SqlServerAnnotationCodeGenerator),

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     new TestOperationReporter(),
                     new string[0])
                 .CreateServiceCollection("Microsoft.EntityFrameworkCore.SqlServer")
-                .AddSingleton<INamedConnectionStringResolver>(resolver)
+                .AddSingleton<IDesignTimeConnectionStringResolver>(resolver)
                 .AddScoped<IDatabaseModelFactory>(p => databaseModelFactory)
                 .BuildServiceProvider(validateScopes: true)
                 .CreateScope()
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     new TestOperationReporter(),
                     new string[0])
                 .CreateServiceCollection("Microsoft.EntityFrameworkCore.SqlServer")
-                .AddSingleton<INamedConnectionStringResolver>(resolver)
+                .AddSingleton<IDesignTimeConnectionStringResolver>(resolver)
                 .AddScoped<IDatabaseModelFactory>(p => databaseModelFactory)
                 .BuildServiceProvider(validateScopes: true)
                 .CreateScope()
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             Assert.DoesNotContain("Data Source=Test", result.ContextFile.Code);
         }
 
-        private class TestNamedConnectionStringResolver : INamedConnectionStringResolver
+        private class TestNamedConnectionStringResolver : IDesignTimeConnectionStringResolver
         {
             private readonly string _resolvedConnectionString;
 


### PR DESCRIPTION
Fixes #26169

The issue here is that we started TryAdding design time services, which is good since it allows for overrides. However, it meant that for INamedConnectionStringResolver we were not replacing the runtime service, which then null-reffed at design time. Fix is to make them different services so one does not have to override the other.
