### PR TITLE
[6.0] Query: Throw for FromSql+Any pattern which has been mutated

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -298,7 +298,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         protected override ShapedQueryExpression TranslateAny(ShapedQueryExpression source, LambdaExpression predicate)
         {
             Check.NotNull(source, nameof(source));
-            Check.NotNull(predicate, nameof(predicate));
 
             return null;
         }

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -986,6 +986,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, table);
 
         /// <summary>
+        ///     The query contains usage of 'Any' or 'AnyAsync' operation after 'FromSqlRaw' or 'FromSqlInterpolated' method. Using this raw SQL query more than once isn't currently supported. Replace the use of 'Any' or 'AnyAsync' with 'Count' or 'CountAsync'. See https://go.microsoft.com/fwlink/?linkid=2174053 for more information.
+        /// </summary>
+        public static string QueryFromSqlInsideExists
+            => GetString("QueryFromSqlInsideExists");
+
+        /// <summary>
         ///     The entity type '{entityType}' is not mapped to a table, therefore the entities cannot be persisted to the database. Call 'ToTable' in 'OnModelCreating' to map it to a table.
         /// </summary>
         public static string ReadonlyEntitySaved(object? entityType)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -731,6 +731,9 @@
   <data name="PropertyNotMappedToTable" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' is not mapped to '{table}'.</value>
   </data>
+  <data name="QueryFromSqlInsideExists" xml:space="preserve">
+    <value>The query contains usage of 'Any' or 'AnyAsync' operation after 'FromSqlRaw' or 'FromSqlInterpolated' method. Using this raw SQL query more than once isn't currently supported. Replace the use of 'Any' or 'AnyAsync' with 'Count' or 'CountAsync'. See https://go.microsoft.com/fwlink/?linkid=2174053 for more information.</value>
+  </data>
   <data name="ReadonlyEntitySaved" xml:space="preserve">
     <value>The entity type '{entityType}' is not mapped to a table, therefore the entities cannot be persisted to the database. Call 'ToTable' in 'OnModelCreating' to map it to a table.</value>
   </data>

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -1258,6 +1258,86 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSql_used_twice_without_parameters(bool async)
+        {
+            using var context = CreateContext();
+
+            var query = context.Set<OrderQuery>()
+                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT 'ALFKI' AS [CustomerID]"))
+                .IgnoreQueryFilters();
+
+            var result1 = async
+                ? await query.AnyAsync()
+                : query.Any();
+
+            Assert.Equal(
+                RelationalStrings.QueryFromSqlInsideExists,
+                async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.AnyAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.Any()).Message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSql_used_twice_with_parameters(bool async)
+        {
+            using var context = CreateContext();
+
+            var query = context.Set<OrderQuery>()
+                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT {0} AS [CustomerID]"), "ALFKI")
+                .IgnoreQueryFilters();
+
+            var result1 = async
+                ? await query.AnyAsync()
+                : query.Any();
+
+            Assert.Equal(
+                RelationalStrings.QueryFromSqlInsideExists,
+                async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.AnyAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.Any()).Message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSql_Count_used_twice_without_parameters(bool async)
+        {
+            using var context = CreateContext();
+
+            var query = context.Set<OrderQuery>()
+                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT 'ALFKI' AS [CustomerID]"))
+                .IgnoreQueryFilters();
+
+            var result1 = async
+                ? await query.CountAsync() > 0
+                : query.Count() > 0;
+
+            var result2 = async
+                ? await query.CountAsync() > 0
+                : query.Count() > 0;
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSql_Count_used_twice_with_parameters(bool async)
+        {
+            using var context = CreateContext();
+
+            var query = context.Set<OrderQuery>()
+                .FromSqlRaw(NormalizeDelimitersInRawString("SELECT {0} AS [CustomerID]"), "ALFKI")
+                .IgnoreQueryFilters();
+
+            var result1 = async
+                ? await query.CountAsync() > 0
+                : query.Count() > 0;
+
+            var result2 = async
+                ? await query.CountAsync() > 0
+                : query.Count() > 0;
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual async Task Line_endings_after_Select(bool async)
         {
             using var context = CreateContext();


### PR DESCRIPTION
Part of #26167

### Description

An exception is thrown for a certain pattern of raw SQL query that then uses `.Any` in LINQ. Fixing this for 6.0 is considered too risky, but we can detect when we're going to throw the exception, so we are making that exception more helpful. The workaround is to use `.Count` instead, which is pretty easy once it is known.

### Customer impact

This is a relatively simple query, so we expect more customers to hit this. Helping them find the workaround will be useful.

### How found

Customer reported.

### Regression

Yes, in 6.0.

### Testing

Tests added to make sure that the new exception is thrown.

### Risk

Low. The fix just changes the exception thrown.
