### PR TITLE
Discover join type FK properties using the same naming convention as when creating them

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -324,6 +324,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             bool matchPk = false)
         {
             IReadOnlyList<IConventionProperty>? match;
+            if (onDependent)
+            {
+                foreach (var skipNavigation in foreignKey.GetReferencingSkipNavigations())
+                {
+                    if (skipNavigation.Inverse == null)
+                    {
+                        continue;
+                    }
+
+                    if (TryFindMatchingProperties(foreignKey, skipNavigation.Inverse.Name, onDependent, matchPk: true, out match))
+                    {
+                        return match;
+                    }
+                }
+            }
+
             var navigation = onDependent
                 ? foreignKey.DependentToPrincipal
                 : foreignKey.PrincipalToDependent;

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -927,6 +927,18 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public List<ManyToManyNavPrincipal>? ManyToManyPrincipals { get; set; }
         }
 
+        protected class NavDependentManyToManyNavPrincipalWithNavigationIds
+        {
+            public int DependentsId { get; set; }
+            public int ManyToManyPrincipalsId { get; set; }
+        }
+
+        protected class NavDependentManyToManyNavPrincipalWithTypeIds
+        {
+            public int NavDependentId { get; set; }
+            public int ManyToManyNavPrincipalId { get; set; }
+        }
+
         protected class OneToManyNavPrincipalOwner
         {
             public int Id { get; set; }


### PR DESCRIPTION
Fixes #26208

### Description

When an explicit join entity type is used we don't discover the foreign key properties that would have match the name for the shadow properties we created.

### Customer impact

Users would need to add additional configuration for the foreign keys, diluting the value of the new simpler `UsingEntity` overloads.

### How found

Docs writing

### Regression

No, this mainly impacts the new `UsingEntity` overloads

### Testing

Test for this scenario added in the PR.

### Risk

Low, this mainly impacts the new `UsingEntity` overloads. It is a breaking change from RC2 if the shadow FKs were left unconfigured, though this shouldn't be common.