### PR TITLE
[6.0] Mark internal the ValueConverter constructors that allow conversion of nulls

### DIFF
--- a/src/EFCore/Storage/ValueConversion/BytesToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BytesToStringConverter.cs
@@ -36,9 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public BytesToStringConverter(ConverterMappingHints? mappingHints)
             : base(
-                v => v == null ? null : Convert.ToBase64String(v),
-                v => v == null ? null : Convert.FromBase64String(v),
-                convertsNulls: true,
+                v => Convert.ToBase64String(v!),
+                v => Convert.FromBase64String(v!),
                 mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/IPAddressToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/IPAddressToBytesConverter.cs
@@ -38,9 +38,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public IPAddressToBytesConverter(ConverterMappingHints? mappingHints)
             : base(
-                v => v == null ? default : v.GetAddressBytes(),
-                v => v == null ? default : new IPAddress(v),
-                convertsNulls: true,
+                v => v!.GetAddressBytes(),
+                v => new IPAddress(v!),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/IPAddressToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/IPAddressToStringConverter.cs
@@ -40,7 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             : base(
                 ToString(),
                 ToIPAddress(),
-                convertsNulls: true,
                 _defaultHints.With(mappingHints))
         {
         }
@@ -52,9 +51,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             = new(typeof(IPAddress), typeof(string), i => new IPAddressToStringConverter(i.MappingHints), _defaultHints);
 
         private new static Expression<Func<IPAddress?, string?>> ToString()
-            => v => v == null ? default : v.ToString();
+            => v => v!.ToString();
 
         private static Expression<Func<string?, IPAddress?>> ToIPAddress()
-            => v => v == null ? default : IPAddress.Parse(v);
+            => v => IPAddress.Parse(v!);
     }
 }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
@@ -33,9 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         public StringNumberConverter(
             Expression<Func<TModel, TProvider>> convertToProviderExpression,
             Expression<Func<TProvider, TModel>> convertFromProviderExpression,
-            bool convertsNulls,
             ConverterMappingHints? mappingHints = null)
-            : base(convertToProviderExpression, convertFromProviderExpression, convertsNulls, mappingHints)
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
         {
         }
 

--- a/src/EFCore/Storage/ValueConversion/Internal/StringUriConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringUriConverter.cs
@@ -27,7 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
             : base(
                 convertToProviderExpression,
                 convertFromProviderExpression,
-                convertsNulls: true,
                 mappingHints)
         {
         }
@@ -39,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected new static Expression<Func<Uri?, string?>> ToString()
-            => v => v != null ? v.ToString() : null;
+            => v => v!.ToString();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -48,6 +47,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected static Expression<Func<string?, Uri?>> ToUri()
-            => v => v != null ? new Uri(v, UriKind.RelativeOrAbsolute) : null;
+            => v => new Uri(v!, UriKind.RelativeOrAbsolute);
     }
 }

--- a/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
@@ -39,7 +39,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             : base(
                 ToString(),
                 ToNumber(),
-                typeof(TNumber).IsNullableType(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/PhysicalAddressToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/PhysicalAddressToBytesConverter.cs
@@ -38,9 +38,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public PhysicalAddressToBytesConverter(ConverterMappingHints? mappingHints)
             : base(
-                v => v == null ? default : v.GetAddressBytes(),
-                v => v == null ? default : new PhysicalAddress(v),
-                convertsNulls: true,
+                v => v!.GetAddressBytes(),
+                v => new PhysicalAddress(v!),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/PhysicalAddressToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/PhysicalAddressToStringConverter.cs
@@ -42,7 +42,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             : base(
                 ToString(),
                 ToPhysicalAddress(),
-                convertsNulls: true,
                 _defaultHints.With(mappingHints))
         {
         }
@@ -54,9 +53,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             = new(typeof(PhysicalAddress), typeof(string), i => new PhysicalAddressToStringConverter(i.MappingHints), _defaultHints);
 
         private new static Expression<Func<PhysicalAddress?, string?>> ToString()
-            => v => v == null ? default! : v.ToString();
+            => v => v!.ToString();
 
         private static Expression<Func<string?, PhysicalAddress?>> ToPhysicalAddress()
-            => v => v == null ? default! : PhysicalAddress.Parse(v);
+            => v => PhysicalAddress.Parse(v!);
     }
 }

--- a/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBytesConverter.cs
@@ -28,9 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             Encoding encoding,
             ConverterMappingHints? mappingHints = null)
             : base(
-                v => v == null ? null : encoding.GetBytes(v),
-                v => v == null ? null : encoding.GetString(v),
-                convertsNulls: true,
+                v => encoding.GetBytes(v!),
+                v => encoding.GetString(v!),
                 mappingHints)
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
@@ -39,7 +39,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             : base(
                 ToNumber(),
                 ToString(),
-                typeof(TNumber).IsNullableType(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/ValueConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter.cs
@@ -49,7 +49,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ValueConverter" /> class.
+        ///     <para>
+        ///         Initializes a new instance of the <see cref="ValueConverter" /> class, allowing conversion of
+        ///         nulls.
+        ///     </para>
+        ///     <para>
+        ///         Warning: this is currently an internal API since converting nulls to and from the database can lead to broken
+        ///         queries and other issues. See https://github.com/dotnet/efcore/issues/26230 for more information.
+        ///     </para>
         /// </summary>
         /// <remarks>
         ///     See <see href="https://aka.ms/efcore-docs-value-converters">EF Core value converters</see> for more information.
@@ -72,6 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
+        [EntityFrameworkInternal]
         protected ValueConverter(
             LambdaExpression convertToProviderExpression,
             LambdaExpression convertFromProviderExpression,

--- a/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
@@ -40,7 +41,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ValueConverter{TModel,TProvider}" /> class.
+        ///     <para>
+        ///         Initializes a new instance of the <see cref="ValueConverter{TModel,TProvider}" /> class, allowing conversion of
+        ///         nulls.
+        ///     </para>
+        ///     <para>
+        ///         Warning: this is currently an internal API since converting nulls to and from the database can lead to broken
+        ///         queries and other issues. See https://github.com/dotnet/efcore/issues/26230 for more information.
+        ///     </para>
         /// </summary>
         /// <remarks>
         ///     See <see href="https://aka.ms/efcore-docs-value-converters">EF Core value converters</see> for more information.
@@ -55,6 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
         ///     facets for the converted data.
         /// </param>
+        [EntityFrameworkInternal]
         public ValueConverter(
             Expression<Func<TModel, TProvider>> convertToProviderExpression,
             Expression<Func<TProvider, TModel>> convertFromProviderExpression,

--- a/test/EFCore.Tests/Storage/BytesToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/BytesToStringConverterTest.cs
@@ -15,11 +15,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Can_convert_strings_to_bytes()
         {
             var converter = _bytesToStringConverter.ConvertToProviderExpression.Compile();
-            Assert.True(_bytesToStringConverter.ConvertsNulls);
+            Assert.False(_bytesToStringConverter.ConvertsNulls);
 
             Assert.Equal("U3DEsW7MiGFsIFRhcA==", converter(new byte[] { 83, 112, 196, 177, 110, 204, 136, 97, 108, 32, 84, 97, 112 }));
             Assert.Equal("", converter(Array.Empty<byte>()));
-            Assert.Null(converter(null));
         }
 
         [ConditionalFact]
@@ -29,7 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             Assert.Equal(new byte[] { 83, 112, 196, 177, 110, 204, 136, 97, 108, 32, 84, 97, 112 }, converter("U3DEsW7MiGFsIFRhcA=="));
             Assert.Equal(Array.Empty<byte>(), converter(""));
-            Assert.Null(converter(null));
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/Storage/IPAddressToBytesConverterTest.cs
+++ b/test/EFCore.Tests/Storage/IPAddressToBytesConverterTest.cs
@@ -25,8 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var bytes = ip.GetAddressBytes();
 
             Assert.Equal(bytes, converter(ip));
-
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]
@@ -57,8 +55,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             Assert.Throws<ArgumentException>(
                 () => converter(bytesIPV4Invalid));
-
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]
@@ -75,8 +71,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var bytes = ip.GetAddressBytes();
 
             Assert.Equal(ip, converter(bytes));
-
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Tests/Storage/IPAddressToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/IPAddressToStringConverterTest.cs
@@ -23,8 +23,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var converter = _ipAddressToString.ConvertToProviderExpression.Compile();
 
             Assert.Equal(ipv4, converter(IPAddress.Parse(ipv4)));
-
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]
@@ -38,8 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var converter = _ipAddressToString.ConvertToProviderExpression.Compile();
 
             Assert.Equal(ipv6, converter(IPAddress.Parse(ipv6)));
-
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]
@@ -55,8 +51,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(
                 IPAddress.Parse(ipv4),
                 converter(ipv4));
-
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]
@@ -72,8 +66,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(
                 IPAddress.Parse(ipv6),
                 converter(ipv6));
-
-            Assert.Null(converter(null));
         }
     }
 }

--- a/test/EFCore.Tests/Storage/PhysicalAddressToBytesConverterTest.cs
+++ b/test/EFCore.Tests/Storage/PhysicalAddressToBytesConverterTest.cs
@@ -21,7 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var bytes = physicalAddress.GetAddressBytes();
 
             Assert.Equal(bytes, converter(physicalAddress));
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]
@@ -46,7 +45,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var bytes = physicalAddress.GetAddressBytes();
 
             Assert.Equal(physicalAddress, converter(bytes));
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Tests/Storage/PhysicalAddressToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/PhysicalAddressToStringConverterTest.cs
@@ -26,8 +26,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(
                 alphaNumerics.Replace(physicalAddress, ""),
                 converter(PhysicalAddress.Parse(physicalAddress)));
-
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]
@@ -39,8 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(
                 PhysicalAddress.Parse(physicalAddress),
                 converter(physicalAddress));
-
-            Assert.Null(converter(null));
         }
 
         [ConditionalTheory]
@@ -59,7 +55,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     converter(physicalAddress);
                 });
 
-            Assert.Null(converter(null));
             Assert.Equal($"An invalid physical address was specified: '{physicalAddress}'.", exception.Message);
         }
 

--- a/test/EFCore.Tests/Storage/StringToBytesConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToBytesConverterTest.cs
@@ -19,7 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             Assert.Equal(new byte[] { 83, 112, 196, 177, 110, 204, 136, 97, 108, 32, 84, 97, 112 }, converter("Spın̈al Tap"));
             Assert.Equal(Array.Empty<byte>(), converter(""));
-            Assert.Null(converter(null));
         }
 
         [ConditionalFact]
@@ -29,7 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             Assert.Equal("Spın̈al Tap", converter(new byte[] { 83, 112, 196, 177, 110, 204, 136, 97, 108, 32, 84, 97, 112 }));
             Assert.Equal("", converter(Array.Empty<byte>()));
-            Assert.Null(converter(null));
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/Storage/StringToUriConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToUriConverterTest.cs
@@ -21,7 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(new Uri("ftp://www.github.com", UriKind.Absolute), converter("ftp://www.github.com/"));
             Assert.Equal(new Uri(".", UriKind.Relative), converter("."));
 
-            Assert.Null(converter(null));
             Assert.Throws<UriFormatException>(() => converter("http:///"));
         }
 
@@ -48,7 +47,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal("/relative/path", converter(new Uri("/relative/path", UriKind.Relative)));
             Assert.Equal("ftp://www.github.com/", converter(new Uri("ftp://www.github.com/", UriKind.Absolute)));
             Assert.Equal(".", converter(new Uri(".", UriKind.Relative)));
-            Assert.Null(converter(null));
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Resolves #26230.

Also revert built-in converters that were changed to allow this in 6.0 back to their 5.0 behavior.
