### PR TITLE
[6.0] Respect AsNoTrackingWithIdentityResolution in AsTracking method

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2983,11 +2983,13 @@ namespace Microsoft.EntityFrameworkCore
             this IQueryable<TEntity> source,
             QueryTrackingBehavior track)
             where TEntity : class
-            => track == QueryTrackingBehavior.TrackAll
-                ? source.AsTracking()
-                : track == QueryTrackingBehavior.NoTrackingWithIdentityResolution
-                    ? source.AsNoTrackingWithIdentityResolution()
-                    : source.AsNoTracking();
+            => track switch
+            {
+                QueryTrackingBehavior.TrackAll => source.AsTracking(),
+                QueryTrackingBehavior.NoTracking => source.AsNoTracking(),
+                QueryTrackingBehavior.NoTrackingWithIdentityResolution => source.AsNoTrackingWithIdentityResolution(),
+                _ => throw new ArgumentOutOfRangeException(nameof(track))
+            };
 
         #endregion
 

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2985,7 +2985,9 @@ namespace Microsoft.EntityFrameworkCore
             where TEntity : class
             => track == QueryTrackingBehavior.TrackAll
                 ? source.AsTracking()
-                : source.AsNoTracking();
+                : track == QueryTrackingBehavior.NoTrackingWithIdentityResolution
+                    ? source.AsNoTrackingWithIdentityResolution()
+                    : source.AsNoTracking();
 
         #endregion
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4130,15 +4130,15 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] IN (""ALFKI"
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Perform_identity_resolution_reuses_same_instances(bool async)
+        public override Task Perform_identity_resolution_reuses_same_instances(bool async, bool useAsTracking)
         {
-            return base.Perform_identity_resolution_reuses_same_instances(async);
+            return base.Perform_identity_resolution_reuses_same_instances(async, useAsTracking);
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Perform_identity_resolution_reuses_same_instances_across_joins(bool async)
+        public override Task Perform_identity_resolution_reuses_same_instances_across_joins(bool async, bool useAsTracking)
         {
-            return base.Perform_identity_resolution_reuses_same_instances_across_joins(async);
+            return base.Perform_identity_resolution_reuses_same_instances_across_joins(async, useAsTracking);
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -461,9 +461,9 @@ WHERE c[""Discriminator""] IN (""OwnedPerson"", ""Branch"", ""LeafB"", ""LeafA""
         }
 
         [ConditionalTheory(Skip = "No SelectMany, No Ability to Include navigation back to owner #17246")]
-        public override Task NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(bool async)
+        public override Task NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(bool async, bool useAsTracking)
         {
-            return base.NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(async);
+            return base.NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(async, useAsTracking);
         }
 
         [ConditionalTheory(Skip = "No Composite index to process custom ordering #17246")]

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeNoTrackingQueryTestBase.cs
@@ -214,6 +214,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(bool async)
             => Task.CompletedTask;
 
+        public override Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
+            => Task.CompletedTask;
+
         protected override bool IgnoreEntryCount
             => true;
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -1652,6 +1652,18 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => (from i in ss.Set<Order>().Include(o => o.Customer.Orders)
+                       where i.OrderID < 10800
+                       select i)
+                    .AsTracking(QueryTrackingBehavior.NoTrackingWithIdentityResolution));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Outer_idenfier_correctly_determined_when_doing_include_on_right_side_of_left_join(bool async)
         {
             return AssertQuery(


### PR DESCRIPTION
Fixes #26227.

This fixes a :facepalm: bug where calling `AsTracking` with `NoTrackingWithIdentityResolution` was not being respecting and the query would be executed with `NoTracking` instead.

