### PR TITLE
[5.0.x] Fix context pooling concurrency issue

### DIFF
--- a/src/EFCore/Internal/DbContextLease.cs
+++ b/src/EFCore/Internal/DbContextLease.cs
@@ -15,7 +15,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
     public struct DbContextLease
     {
         private IDbContextPool _contextPool;
-        private readonly bool _standalone;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public bool IsStandalone { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -34,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public DbContextLease([NotNull] IDbContextPool contextPool, bool standalone)
         {
             _contextPool = contextPool;
-            _standalone = standalone;
+            IsStandalone = standalone;
 
             var context = _contextPool.Rent();
             Context = context;
@@ -65,16 +72,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool ContextDisposed()
+        public void ContextDisposed()
         {
-            if (_standalone)
+            if (IsStandalone)
             {
                 Release();
-
-                return true;
             }
-
-            return false;
         }
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -1264,6 +1264,33 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Concurrency_test2(bool async)
+        {
+            var factory = BuildServiceProviderWithFactory<PooledContext>()
+                .GetService<IDbContextFactory<PooledContext>>();
+
+            await Task.WhenAll(
+                Enumerable.Range(0, 10).Select(_ => Task.Run(async () =>
+                {
+                    for (var j = 0; j < 1_000_000; j++)
+                    {
+                        var ctx = factory.CreateDbContext();
+
+                        if (async)
+                        {
+                            await ctx.DisposeAsync();
+                        }
+                        else
+                        {
+                            ctx.Dispose();
+                        }
+                    }
+                })));
+        }
+
         private async Task Dispose(IDisposable disposable, bool async)
         {
             if (async)


### PR DESCRIPTION
Backports #26226 to 5.0.x, fixes #26202.

### Description

When using DbContext pooling, the DbContext disposal logic modifies the state after the context has been returned to the pool, creating a race condition with possible consumers renting the context out of the pool.

### Customer impact

When using DbContext pooling, an ObjectDisposedException may occur when using a pooled context. This is the kind of bug that only happens very occasionally but then will cause the application to fail unexpectedly and in a way that is difficult to diagnose. This means lack of customer reports doesn't mean it isn't impacting overall reliability of apps that use EF Core.

### How found

Customer reported.

### Regression

Yes, was not present in 3.1.

### Testing

Test for this scenario added in the PR.

### Risk

Low, the fix is quite simple.
