### PR TITLE
Allow non-nullable value comparer to be applied on nullable properties

### DIFF
--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -869,7 +869,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual string? CheckValueComparer(ValueComparer? comparer)
             => comparer != null
-                && comparer.Type != ClrType
+                && comparer.Type.UnwrapNullableType() != ClrType.UnwrapNullableType()
                     ? CoreStrings.ComparerPropertyMismatch(
                         comparer.Type.ShortDisplayName(),
                         DeclaringEntityType.DisplayName(),


### PR DESCRIPTION
Fixes #26429

### Description

An exception is thrown when configuring nullable properties with a non-nullable value comparer via pre-convention model configuration.

### Customer impact

The only workaround is to avoid using pre-convention model configuration and configure each property explicitly.

### How found

Customer report on RC2.

### Regression

Yes, from RC1 in https://github.com/dotnet/efcore/pull/25969. However, this is a new feature in 6.0

### Testing

Test for this scenario added in the PR. Tests for value comparers with different nullability are already present, but don't use model building.

### Risk

Low; the fix is to not throw an exception for a specific case.
