### PR TITLE
[6.0.1] Query: Copy client projections when updating SelectExpression

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalValueConverterCompensatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalValueConverterCompensatingExpressionVisitor.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
@@ -54,8 +55,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         private Expression VisitShapedQueryExpression(ShapedQueryExpression shapedQueryExpression)
         {
-            return shapedQueryExpression.Update(
-                Visit(shapedQueryExpression.QueryExpression), shapedQueryExpression.ShaperExpression);
+            if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26428", out var enabled)
+                && enabled)
+            {
+                return shapedQueryExpression.Update(
+                    Visit(shapedQueryExpression.QueryExpression), shapedQueryExpression.ShaperExpression);
+            }
+
+            var selectExpression = shapedQueryExpression.QueryExpression;
+            var updatedSelectExpression = Visit(selectExpression);
+            return updatedSelectExpression != selectExpression
+                ? shapedQueryExpression.Update(updatedSelectExpression,
+                    ReplacingExpressionVisitor.Replace(
+                        selectExpression, updatedSelectExpression, shapedQueryExpression.ShaperExpression))
+                : shapedQueryExpression;
         }
 
         private Expression VisitCase(CaseExpression caseExpression)

--- a/src/EFCore.Relational/Query/RelationalQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryTranslationPostprocessor.cs
@@ -52,8 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             query = new TableAliasVerifyingExpressionVisitor().Visit(query);
 #endif
             query = new SelectExpressionPruningExpressionVisitor().Visit(query);
-            query =
-                new SqlExpressionSimplifyingExpressionVisitor(RelationalDependencies.SqlExpressionFactory, _useRelationalNulls)
+            query = new SqlExpressionSimplifyingExpressionVisitor(RelationalDependencies.SqlExpressionFactory, _useRelationalNulls)
                     .Visit(query);
             query = new RelationalValueConverterCompensatingExpressionVisitor(RelationalDependencies.SqlExpressionFactory).Visit(query);
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -3550,6 +3550,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 alias, projections.ToList(), tables.ToList(), newTableReferences, groupBy.ToList(), orderings.ToList())
             {
                 _projectionMapping = projectionMapping,
+                _clientProjections = _clientProjections.ToList(),
                 Predicate = predicate,
                 Having = having,
                 Offset = offset,
@@ -3557,6 +3558,12 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 IsDistinct = distinct,
                 Tags = Tags
             };
+
+            if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26428", out var enabled)
+                && enabled)
+            {
+                newSelectExpression._clientProjections = new();
+            }
 
             // We don't copy identifiers because when we are doing reconstruction so projection is already applied.
             // Update method should not be used pre-projection application. There are other methods to change SelectExpression.

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -324,5 +324,103 @@ namespace Microsoft.EntityFrameworkCore
 
             public int NumberOfPhotos { get; set; }
         }
+
+#nullable enable
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task IsDeleted_query_filter_with_conversion_to_int_works(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context26428>(seed: c => c.Seed());
+            using var context = contextFactory.CreateContext();
+
+            var query = context.Suppliers.Include(s => s.Location).OrderBy(s => s.Name);
+
+            var suppliers = async
+                ? await query.ToListAsync()
+                : query.ToList();
+
+            Assert.Equal(4, suppliers.Count);
+            Assert.Single(suppliers.Where(e => e.Location != null));
+        }
+
+        protected class Context26428 : DbContext
+        {
+            public Context26428(DbContextOptions options)
+                   : base(options)
+            {
+            }
+
+            public DbSet<Supplier> Suppliers => Set<Supplier>();
+            public DbSet<Location> Locations => Set<Location>();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Supplier>().Property(s => s.IsDeleted).HasConversion<int>();
+                modelBuilder.Entity<Supplier>().HasQueryFilter(s => !s.IsDeleted);
+
+                modelBuilder.Entity<Location>().Property(l => l.IsDeleted).HasConversion<int>();
+                modelBuilder.Entity<Location>().HasQueryFilter(l => !l.IsDeleted);
+            }
+
+            public void Seed()
+            {
+                var activeAddress = new Location
+                {
+                    Address = "Active address",
+                    IsDeleted = false
+                };
+                var deletedAddress = new Location
+                {
+                    Address = "Deleted address",
+                    IsDeleted = true
+                };
+
+                var activeSupplier1 = new Supplier
+                {
+                    Name = "Active supplier 1",
+                    IsDeleted = false,
+                    Location = activeAddress
+                };
+                var activeSupplier2 = new Supplier
+                {
+                    Name = "Active supplier 2",
+                    IsDeleted = false,
+                    Location = deletedAddress
+                };
+                var activeSupplier3 = new Supplier
+                {
+                    Name = "Active supplier 3",
+                    IsDeleted = false
+                };
+                var deletedSupplier = new Supplier
+                {
+                    Name = "Deleted supplier",
+                    IsDeleted = false
+                };
+
+                AddRange(activeAddress, deletedAddress);
+                AddRange(activeSupplier1, activeSupplier2, activeSupplier3, deletedSupplier);
+
+                SaveChanges();
+            }
+        }
+
+        protected class Supplier
+        {
+            public Guid SupplierId { get; set; }
+            public string Name { get; set; } = null!;
+            public Location? Location { get; set; }
+            public bool IsDeleted { get; set; }
+        }
+
+        protected class Location
+        {
+            public Guid LocationId { get; set; }
+            public string Address { get; set; } = null!;
+            public bool IsDeleted { get; set; }
+        }
+
+#nullable disable
     }
 }


### PR DESCRIPTION
Resolves #26428

### Description

An exception is thrown when running query which has value converters used for predicate.

### Customer impact

Query which could work will not work and throw exception.

### How found

Customer report on RC2.

### Regression

Yes, from EF Core 5.0

### Testing

Test for this scenario added in the PR. Other tests verifies that change is not generating something incorrect.

### Risk

Low; the fix is to update SelectExpression through Update method correctly.
