### PR TITLE
Register design-time LoggerFactory as Scoped

### DIFF
--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -79,8 +79,10 @@ namespace Microsoft.EntityFrameworkCore.Design
                         .TryAddScoped<IMigrationsScaffolder, MigrationsScaffolder>()
                         .TryAddScoped<ISnapshotModelProcessor, SnapshotModelProcessor>());
 
-            return services
-                .AddLogging(b => b.SetMinimumLevel(LogLevel.Debug).AddProvider(new OperationLoggerProvider(reporter)));
+            var loggerFactory = new LoggerFactory(new[] { new OperationLoggerProvider(reporter) }, new LoggerFilterOptions { MinLevel = LogLevel.Debug });
+            services.AddScoped<ILoggerFactory>(_ => loggerFactory);
+
+            return services;
         }
 
         /// <summary>

--- a/src/EFCore/Design/EntityFrameworkDesignServicesBuilder.cs
+++ b/src/EFCore/Design/EntityFrameworkDesignServicesBuilder.cs
@@ -48,8 +48,6 @@ namespace Microsoft.EntityFrameworkCore.Design
         public static readonly IDictionary<Type, ServiceCharacteristics> Services
             = new Dictionary<Type, ServiceCharacteristics>
             {
-                { typeof(IDbContextLogger), new ServiceCharacteristics(ServiceLifetime.Singleton) },
-                { typeof(IDiagnosticsLogger<>), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(ICSharpRuntimeAnnotationCodeGenerator), new ServiceCharacteristics(ServiceLifetime.Singleton) }
             };
 
@@ -81,9 +79,6 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <returns>This builder, such that further calls can be chained.</returns>
         public override EntityFrameworkServicesBuilder TryAddCoreServices()
         {
-            TryAdd<IDbContextLogger, NullDbContextLogger>();
-            TryAdd(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>));
-            TryAdd<ILoggingOptions, LoggingOptions>();
             TryAdd<ICSharpRuntimeAnnotationCodeGenerator, CSharpRuntimeAnnotationCodeGenerator>();
 
             ServiceCollectionMap.GetInfrastructure()

--- a/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
@@ -34,8 +34,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public async Task FromSqlRaw_queryable_simple(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>()
-                .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""ContactName""] LIKE '%z%'");
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""ContactName""] LIKE '%z%'");
 
             var actual = async
                 ? await query.ToArrayAsync()
@@ -56,8 +56,8 @@ FROM (
         public async Task FromSqlRaw_queryable_incorrect_discriminator_throws(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>()
-                .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Order""");
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Order""");
 
             var exception = async
                 ? await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToArrayAsync())
@@ -73,7 +73,7 @@ FROM (
         public async Task FromSqlRaw_queryable_simple_columns_out_of_order(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                 @"SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c WHERE c[""Discriminator""] = ""Customer""");
 
             var actual = async
@@ -95,7 +95,7 @@ FROM (
         public async Task FromSqlRaw_queryable_simple_columns_out_of_order_and_extra_columns(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                 @"SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""PostalCode""] AS Foo, c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c WHERE c[""Discriminator""] = ""Customer""");
 
             var actual = async
@@ -117,7 +117,7 @@ FROM (
         public async Task FromSqlRaw_queryable_composed(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                 @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""").Where(c => c.ContactName.Contains("z"));
 
             var sql = query.ToQueryString();
@@ -142,7 +142,7 @@ WHERE CONTAINS(c[""ContactName""], ""z"")");
         public virtual async Task FromSqlRaw_queryable_composed_after_removing_whitespaces(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                     _eol + "    " + _eol + _eol + _eol + "SELECT" + _eol + @"* FROM root c WHERE c[""Discriminator""] = ""Customer""")
                 .Where(c => c.ContactName.Contains("z"));
 
@@ -172,8 +172,8 @@ WHERE CONTAINS(c[""ContactName""], ""z"")");
             if (async)
             {
                 var query = EF.CompileAsyncQuery(
-                    (NorthwindContext context) => context.Set<Customer>()
-                        .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+                    (NorthwindContext context) => CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                        @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
                         .Where(c => c.ContactName.Contains("z")));
 
                 using (var context = CreateContext())
@@ -186,8 +186,8 @@ WHERE CONTAINS(c[""ContactName""], ""z"")");
             else
             {
                 var query = EF.CompileQuery(
-                    (NorthwindContext context) => context.Set<Customer>()
-                        .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+                    (NorthwindContext context) => CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                        @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
                         .Where(c => c.ContactName.Contains("z")));
 
                 using (var context = CreateContext())
@@ -213,8 +213,8 @@ WHERE CONTAINS(c[""ContactName""], ""z"")");
             if (async)
             {
                 var query = EF.CompileAsyncQuery(
-                    (NorthwindContext context) => context.Set<Customer>()
-                        .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = {0}", "CONSH")
+                    (NorthwindContext context) => CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                        @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = {0}", "CONSH")
                         .Where(c => c.ContactName.Contains("z")));
 
                 using (var context = CreateContext())
@@ -227,8 +227,8 @@ WHERE CONTAINS(c[""ContactName""], ""z"")");
             else
             {
                 var query = EF.CompileQuery(
-                    (NorthwindContext context) => context.Set<Customer>()
-                        .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = {0}", "CONSH")
+                    (NorthwindContext context) => CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                        @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = {0}", "CONSH")
                         .Where(c => c.ContactName.Contains("z")));
 
                 using (var context = CreateContext())
@@ -252,7 +252,7 @@ WHERE CONTAINS(c[""ContactName""], ""z"")");
         public virtual async Task FromSqlRaw_queryable_multiple_line_query(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                 @"SELECT *
 FROM root c
 WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'London'");
@@ -278,7 +278,7 @@ FROM (
         public virtual async Task FromSqlRaw_queryable_composed_multiple_line_query(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                     @"SELECT *
 FROM root c
 WHERE c[""Discriminator""] = ""Customer""")
@@ -309,7 +309,7 @@ WHERE (c[""City""] = ""London"")");
             var contactTitle = "Sales Representative";
 
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                     @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}", city,
                     contactTitle);
 
@@ -336,7 +336,7 @@ FROM (
         public async Task FromSqlRaw_queryable_with_parameters_inline(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                     @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}", "London",
                     "Sales Representative");
 
@@ -365,7 +365,7 @@ FROM (
             uint? reportsTo = null;
 
             using var context = CreateContext();
-            var query = context.Set<Employee>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Employee>(),
                     @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Employee"" AND c[""ReportsTo""] = {0} OR (IS_NULL(c[""ReportsTo""]) AND IS_NULL({0}))", reportsTo);
 
             var actual = async
@@ -391,7 +391,7 @@ FROM (
             var contactTitle = "Sales Representative";
 
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
                     @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0}", city)
                 .Where(c => c.ContactTitle == contactTitle);
             var queryString = query.ToQueryString();
@@ -420,8 +420,8 @@ WHERE (c[""ContactTitle""] = @__contactTitle_1)");
         public virtual async Task FromSqlRaw_queryable_simple_cache_key_includes_query_string(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>()
-                .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'London'");
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'London'");
 
             var actual = async
                 ? await query.ToArrayAsync()
@@ -430,8 +430,8 @@ WHERE (c[""ContactTitle""] = @__contactTitle_1)");
             Assert.Equal(6, actual.Length);
             Assert.True(actual.All(c => c.City == "London"));
 
-            query = context.Set<Customer>()
-                .FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'Seattle'");
+            query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = 'Seattle'");
 
             actual = async
                 ? await query.ToArrayAsync()
@@ -461,7 +461,7 @@ FROM (
             var sql = @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = {0} AND c[""ContactTitle""] = {1}";
 
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(sql, city, contactTitle);
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(), sql, city, contactTitle);
 
             var actual = async
                 ? await query.ToArrayAsync()
@@ -474,7 +474,7 @@ FROM (
             city = "Madrid";
             contactTitle = "Accounting Manager";
 
-            query = context.Set<Customer>().FromSqlRaw(sql, city, contactTitle);
+            query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(), sql, city, contactTitle);
 
             actual = async
                 ? await query.ToArrayAsync()
@@ -507,7 +507,8 @@ FROM (
         public virtual async Task FromSqlRaw_queryable_simple_as_no_tracking_not_composed(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
                 .AsNoTracking();
 
             var actual = async
@@ -529,7 +530,7 @@ FROM (
         public virtual async Task FromSqlRaw_queryable_simple_projection_composed(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Product>().FromSqlRaw(
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Product>(),
                     @"SELECT *
 FROM root c
 WHERE c[""Discriminator""] = ""Product"" AND NOT c[""Discontinued""] AND ((c[""UnitsInStock""] + c[""UnitsOnOrder""]) < c[""ReorderLevel""])")
@@ -555,7 +556,8 @@ FROM (
         public virtual async Task FromSqlRaw_composed_with_nullable_predicate(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
                 .Where(c => c.ContactName == c.CompanyName);
 
             var actual = async
@@ -579,7 +581,8 @@ WHERE (c[""ContactName""] = c[""CompanyName""])");
             using var context = CreateContext();
             var propertyName = "OrderID";
             var max = 10250;
-            var query = context.Orders.FromSqlRaw($@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Order"" AND c[""{propertyName}""] < {{0}}", max);
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Orders,
+                $@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Order"" AND c[""{propertyName}""] < {{0}}", max);
 
             var actual = async
                 ? await query.ToListAsync()
@@ -593,7 +596,8 @@ WHERE (c[""ContactName""] = c[""CompanyName""])");
         public virtual async Task FromSqlRaw_queryable_simple_projection_not_composed(bool async)
         {
             using var context = CreateContext();
-            var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
+            var query = CosmosQueryableExtensions.FromSqlRaw(context.Set<Customer>(),
+                @"SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer""")
                 .Select(
                     c => new { c.CustomerID, c.City })
                 .AsNoTracking();

--- a/test/EFCore.Design.Tests/Design/Internal/OperationLoggerTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/OperationLoggerTest.cs
@@ -27,7 +27,11 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             Assert.Collection(
                 reporter.Messages,
-                x => Assert.Equal("verbose: -- Can't stop the SQL", x));
+                x =>
+                {
+                    Assert.Equal("-- Can't stop the SQL", x.Message);
+                    Assert.Equal(LogLevel.Debug, x.Level);
+                });
         }
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Ownership;
 using Xunit;
 
@@ -95,7 +96,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             new SnapshotModelProcessor(reporter, DummyModelRuntimeInitializer.Instance).Process(model);
 
-            Assert.Equal("warn: " + DesignStrings.MultipleAnnotationConflict("DefaultSchema"), reporter.Messages.Single());
+            var (level, message) = reporter.Messages.Single();
+            Assert.Equal(LogLevel.Warning, level);
+            Assert.Equal(DesignStrings.MultipleAnnotationConflict("DefaultSchema"), message);
             Assert.Equal(2, model.GetAnnotations().Count());
 
             var actual = (string)model["Relational:DefaultSchema"];
@@ -116,7 +119,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             new SnapshotModelProcessor(reporter, DummyModelRuntimeInitializer.Instance).Process(model);
 
-            Assert.Equal("warn: " + DesignStrings.MultipleAnnotationConflict("DefaultSchema"), reporter.Messages.Single());
+            var (level, message) = reporter.Messages.Single();
+            Assert.Equal(LogLevel.Warning, level);
+            Assert.Equal(DesignStrings.MultipleAnnotationConflict("DefaultSchema"), message);
             Assert.Equal(2, model.GetAnnotations().Count());
 
             var actual = (string)model["Relational:DefaultSchema"];

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -455,7 +456,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 });
 
             Assert.Single(_factory.Create(info, new ModelReverseEngineerOptions()).FindEntityType("E").GetProperties());
-            Assert.Single(_reporter.Messages, t => t.Contains(DesignStrings.CannotFindTypeMappingForColumn("E.Coli", StoreType)));
+
+            var (level, message) = _reporter.Messages.Single();
+            Assert.Equal(LogLevel.Warning, level);
+            Assert.Equal(DesignStrings.CannotFindTypeMappingForColumn("E.Coli", StoreType), message);
         }
 
         [ConditionalTheory]
@@ -1135,11 +1139,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 new DatabaseModel { Tables = { parentTable, childrenTable } },
                 new ModelReverseEngineerOptions());
 
-            Assert.Single(
-                _reporter.Messages, t => t.Contains(
-                    "warn: "
-                    + DesignStrings.ForeignKeyScaffoldErrorPrincipalKeyNotFound(
-                        childrenTable.ForeignKeys.ElementAt(0).DisplayName(), "NotPkId", "Parent")));
+            var (level, message) = _reporter.Messages.Single();
+            Assert.Equal(LogLevel.Warning, level);
+            Assert.Equal(DesignStrings.ForeignKeyScaffoldErrorPrincipalKeyNotFound(
+                childrenTable.ForeignKeys.ElementAt(0).DisplayName(), "NotPkId", "Parent"), message);
         }
 
         [ConditionalFact]
@@ -1194,10 +1197,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 new DatabaseModel { Tables = { parentTable, childrenTable } },
                 new ModelReverseEngineerOptions());
 
-            Assert.Single(
-                _reporter.Messages, t => t.Contains(
-                    "warn: "
-                    + DesignStrings.ForeignKeyWithSameFacetsExists(childrenTable.ForeignKeys.ElementAt(1).DisplayName(), "FK_Foo")));
+            var (level, message) = _reporter.Messages.Single();
+            Assert.Equal(LogLevel.Warning, level);
+            Assert.Equal(DesignStrings.ForeignKeyWithSameFacetsExists(childrenTable.ForeignKeys.ElementAt(1).DisplayName(), "FK_Foo"), message);
         }
 
         [ConditionalFact]
@@ -1305,11 +1307,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
             var alternateKey = model.GetKeys().Single(k => !k.IsPrimaryKey());
             Assert.Equal(alternateKey, fk.PrincipalKey);
 
-            Assert.Single(
-                _reporter.Messages, t => t.Contains(
-                    "warn: "
-                    + DesignStrings.ForeignKeyPrincipalEndContainsNullableColumns(
-                        table.ForeignKeys.ElementAt(0).DisplayName(), "FriendsNameUniqueIndex", "Friends.BuddyId")));
+            var (level, message) = _reporter.Messages.Single();
+            Assert.Equal(LogLevel.Warning, level);
+            Assert.Equal(DesignStrings.ForeignKeyPrincipalEndContainsNullableColumns(
+                table.ForeignKeys.ElementAt(0).DisplayName(), "FriendsNameUniqueIndex", "Friends.BuddyId"), message);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Design.Tests/TestUtilities/DesignTestHelpers.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/DesignTestHelpers.cs
@@ -1,24 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
-    public class RelationalTestHelpers : TestHelpers
+    public class DesignTestHelpers : TestHelpers
     {
-        protected RelationalTestHelpers()
+        protected DesignTestHelpers()
         {
         }
 
-        public static RelationalTestHelpers Instance { get; } = new();
-
-        protected override EntityFrameworkDesignServicesBuilder CreateEntityFrameworkDesignServicesBuilder(
-            IServiceCollection services)
-            => new EntityFrameworkRelationalDesignServicesBuilder(services);
+        public static DesignTestHelpers Instance { get; } = new();
 
         public override IServiceCollection AddProviderServices(IServiceCollection services)
             => FakeRelationalOptionsExtension.AddEntityFrameworkRelationalDatabase(services);

--- a/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\EFCore.Design\EFCore.Design.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Relational\EFCore.Relational.csproj" />
     <ProjectReference Include="..\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>

--- a/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\EFCore\EFCore.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Proxies\EFCore.Proxies.csproj" />
+    <ProjectReference Include="..\..\src\EFCore.Design\EFCore.Design.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -4,14 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,6 +63,72 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
 
             return services.BuildServiceProvider(); // No scope validation; test doubles violate scopes, but only resolved once.
+        }
+
+        protected virtual EntityFrameworkDesignServicesBuilder CreateEntityFrameworkDesignServicesBuilder(IServiceCollection services)
+            => new EntityFrameworkDesignServicesBuilder(services);
+
+        public IServiceProvider CreateDesignServiceProvider(
+            IServiceCollection customServices = null,
+            Action<EntityFrameworkDesignServicesBuilder> replaceServices = null,
+            Type additionalDesignTimeServices = null,
+            IOperationReporter reporter = null)
+            => CreateDesignServiceProvider(
+                CreateContext().GetService<IDatabaseProvider>().Name,
+                customServices,
+                replaceServices,
+                additionalDesignTimeServices,
+                reporter);
+
+        public IServiceProvider CreateDesignServiceProvider(
+            string provider,
+            IServiceCollection customServices = null,
+            Action<EntityFrameworkDesignServicesBuilder> replaceServices = null,
+            Type additionalDesignTimeServices = null,
+            IOperationReporter reporter = null)
+            => CreateServiceProvider(customServices, services =>
+            {
+                if (replaceServices != null)
+                {
+                    var builder = CreateEntityFrameworkDesignServicesBuilder(services);
+                    replaceServices(builder);
+                }
+
+                if (additionalDesignTimeServices != null)
+                {
+                    ConfigureDesignTimeServices(additionalDesignTimeServices, services);
+                }
+
+                ConfigureProviderServices(provider, services);
+                services.AddEntityFrameworkDesignTimeServices(reporter);
+
+                return services;
+            });
+
+        private void ConfigureProviderServices(string provider, IServiceCollection services)
+        {
+            var providerAssembly = Assembly.Load(new AssemblyName(provider));
+
+            var providerServicesAttribute = providerAssembly.GetCustomAttribute<DesignTimeProviderServicesAttribute>();
+            if (providerServicesAttribute == null)
+            {
+                throw new InvalidOperationException(DesignStrings.CannotFindDesignTimeProviderAssemblyAttribute(provider));
+            }
+
+            var designTimeServicesType = providerAssembly.GetType(
+                providerServicesAttribute.TypeName,
+                throwOnError: true,
+                ignoreCase: false)!;
+
+            ConfigureDesignTimeServices(designTimeServicesType, services);
+        }
+
+        private static void ConfigureDesignTimeServices(
+            Type designTimeServicesType,
+            IServiceCollection services)
+        {
+            var designTimeServices = (IDesignTimeServices)Activator.CreateInstance(designTimeServicesType)!;
+            designTimeServices.ConfigureDesignTimeServices(services);
         }
 
         public abstract IServiceCollection AddProviderServices(IServiceCollection services);

--- a/test/EFCore.Specification.Tests/TestUtilities/TestOperationReporter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestOperationReporter.cs
@@ -3,29 +3,30 @@
 
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class TestOperationReporter : IOperationReporter
     {
-        private readonly List<string> _messages = new();
+        private readonly List<(LogLevel, string)> _messages = new();
 
-        public IReadOnlyList<string> Messages
+        public IReadOnlyList<(LogLevel Level, string Message)> Messages
             => _messages;
 
         public void Clear()
             => _messages.Clear();
 
         public void WriteInformation(string message)
-            => _messages.Add("info: " + message);
+            => _messages.Add((LogLevel.Information, message));
 
         public void WriteVerbose(string message)
-            => _messages.Add("verbose: " + message);
+            => _messages.Add((LogLevel.Debug, message));
 
         public void WriteWarning(string message)
-            => _messages.Add("warn: " + message);
+            => _messages.Add((LogLevel.Warning, message));
 
         public void WriteError(string message)
-            => _messages.Add("error: " + message);
+            => _messages.Add((LogLevel.Error, message));
     }
 }


### PR DESCRIPTION
Fixes #26384

### Description

Log messages produced by provider-specific services invoked by the EF CLI tools are no longer displayed.

### Customer impact

There isn't a practical workaround as the reporter object is not accessible by the user.

### How found

Customer report on RC2.

### Regression

Yes, from 5.0, introduced in https://github.com/dotnet/efcore/pull/25509

### Testing

This PR changes tests to use DI to add coverage for this scenario.

### Risk

Low; the fix only affects design-time logging. Quirk mode not added as there isn't a practical way to access `AppContext` used by CLI tools.
