### PR TITLE
Do not scaffold a default constructor when OnConfiguring is suppressed

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             using (_builder.Indent())
             {
-                GenerateConstructors(contextName);
+                GenerateConstructors(contextName, generateDefaultConstructor: !suppressOnConfiguring);
                 GenerateDbSets(model);
                 GenerateEntityTypeErrors(model);
                 if (!suppressOnConfiguring)
@@ -179,12 +179,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _builder.AppendLine("}");
         }
 
-        private void GenerateConstructors(string contextName)
+        private void GenerateConstructors(string contextName, bool generateDefaultConstructor)
         {
-            _builder.AppendLine($"public {contextName}()")
-                .AppendLine("{")
-                .AppendLine("}")
-                .AppendLine();
+            if (generateDefaultConstructor)
+            {
+                _builder.AppendLine($"public {contextName}()")
+                    .AppendLine("{")
+                    .AppendLine("}")
+                    .AppendLine();
+            }
 
             _builder.AppendLine($"public {contextName}(DbContextOptions<{contextName}> options)")
                 .IncrementIndent()

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -146,10 +146,6 @@ namespace TestNamespace
 {
     public partial class TestDbContext : DbContext
     {
-        public TestDbContext()
-        {
-        }
-
         public TestDbContext(DbContextOptions<TestDbContext> options)
             : base(options)
         {
@@ -1047,10 +1043,6 @@ namespace TestNamespace
 {
     public partial class TestDbContext : DbContext
     {
-        public TestDbContext()
-        {
-        }
-
         public TestDbContext(DbContextOptions<TestDbContext> options)
             : base(options)
         {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
@@ -63,14 +63,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             if (!skipBuild)
             {
                 var assembly = build.BuildInMemory();
-                var contextNamespace = options.ContextNamespace ?? options.ModelNamespace;
-                var context = (DbContext)assembly.CreateInstance(
-                    !string.IsNullOrEmpty(contextNamespace)
-                        ? contextNamespace + "." + options.ContextName
-                        : options.ContextName);
 
                 if (assertModel != null)
                 {
+                    var contextNamespace = options.ContextNamespace ?? options.ModelNamespace;
+                    var context = (DbContext)assembly.CreateInstance(
+                        !string.IsNullOrEmpty(contextNamespace)
+                            ? contextNamespace + "." + options.ContextName
+                            : options.ContextName);
+
                     var compiledModel = context.GetService<IDesignTimeModel>().Model;
                     assertModel(compiledModel);
                 }


### PR DESCRIPTION
Version 5.0.0 of the dotnet-ef tool introduced the `--no-onconfiguring` option which is great if you plan to configure your DbContext outside of the context itself (which you probably should).

When using this option, the DbContext class is still generated with a default constructor. This default constructor becomes problematic without the `OnConfiguring` method since the context is unusable when created through the default constructor. As soon as you try to use a DbContext created by the default constructor, you get a `System.InvalidOperationException`:
> No database provider has been configured for this DbContext. A provider can be configured by overriding the 'DbContext.OnConfiguring' method or by using 'AddDbContext' on the application service provider. If 'AddDbContext' is used, then also ensure that your DbContext type accepts a DbContextOptions<TContext> object in its constructor and passes it to the base constructor for DbContext.

Fixes #23515