### PR TITLE
Avoid NRE in ForeignKeyAttributeConvention

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
@@ -345,7 +345,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 }
             }
 
-            return newRelationshipBuilder.HasForeignKey(fkPropertiesToSet, fromDataAnnotation: true);
+            return newRelationshipBuilder?.HasForeignKey(fkPropertiesToSet, fromDataAnnotation: true);
         }
 
         private static IConventionForeignKeyBuilder? SplitNavigationsToSeparateRelationships(

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -1106,6 +1106,25 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public virtual void Required_and_ForeignKey_to_ForeignKey_can_be_overridden()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<Login3>()
+                .HasOne(p => p.Profile)
+                .WithOne(p => p.User)
+                .HasForeignKey<Login3>("ProfileId");
+
+            var model = Validate(modelBuilder);
+
+            var loginFk = GetProperty<Login3>(model, "ProfileId").GetContainingForeignKeys().Single();
+            Assert.True(loginFk.IsRequired); // This will be False after #15898 is fixed
+            Assert.True(loginFk.IsRequiredDependent);
+
+            Assert.False(GetProperty<Profile3>(model, nameof(Profile3.Profile3Id)).IsForeignKey());
+        }
+
+        [ConditionalFact]
         public virtual void ForeignKey_to_nothing()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fixes #26436

### Description

An exception is thrown when configuring a foreign key on the principal side of the foreign key configured by data annotations.

### Customer impact

There aren't simple workarounds other than removing the attribute, because the exception is thrown during a convention invocation.

### How found

Customer report on RC2.

### Regression

Yes, from 5.0, introduced in https://github.com/dotnet/efcore/pull/25211.

### Testing

Test for this scenario added in the PR.

### Risk

Low; the fix is adding a `null` check that existed previously. Not adding a quirk mode as that would just result in an exception being thrown.
