### PR TITLE
[6.0.1] Microsoft.Data.Sqlite: Clean up on application exit

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionFactory.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionFactory.cs
@@ -20,7 +20,11 @@ namespace Microsoft.Data.Sqlite
         private Dictionary<string, SqliteConnectionPoolGroup> _poolGroups = new();
 
         protected SqliteConnectionFactory()
-            => _pruneTimer = new Timer(PruneCallback, null, TimeSpan.FromMinutes(4), TimeSpan.FromSeconds(30));
+        {
+            AppDomain.CurrentDomain.DomainUnload += (_, _) => ClearPools();
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => ClearPools();
+            _pruneTimer = new Timer(PruneCallback, null, TimeSpan.FromMinutes(4), TimeSpan.FromSeconds(30));
+        }
 
         public SqliteConnectionInternal GetConnection(SqliteConnection outerConnection)
         {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionFactory.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionFactory.cs
@@ -21,8 +21,12 @@ namespace Microsoft.Data.Sqlite
 
         protected SqliteConnectionFactory()
         {
-            AppDomain.CurrentDomain.DomainUnload += (_, _) => ClearPools();
-            AppDomain.CurrentDomain.ProcessExit += (_, _) => ClearPools();
+            if (!AppContext.TryGetSwitch("Microsoft.Data.Sqlite.Issue26422", out var enabled) || !enabled)
+            {
+                AppDomain.CurrentDomain.DomainUnload += (_, _) => ClearPools();
+                AppDomain.CurrentDomain.ProcessExit += (_, _) => ClearPools();
+            }
+
             _pruneTimer = new Timer(PruneCallback, null, TimeSpan.FromMinutes(4), TimeSpan.FromSeconds(30));
         }
 


### PR DESCRIPTION
Hooks AppDomain.ProcessExit to clean up native resources.

Fixes #26422

### Customer Impact

Databases using the write-ahead journal mode (the default for ones created by EF Core) create additional temporary files next to the database file. These files are cleaned up when the native connection is closed.

Previously, Microsoft.Data.Sqlite relied on DbConnection.Close, IDisposable, and finalizers to close the native connection.

A connection pool was added in 6.0 which keeps the native connection open after the DbConnection is closed/disposed/finalized.

Even though we leverage SafeHandle to close native connections, these finalizers are not called when the application is exits. This results in the temporary files not being properly cleaned up.

### Regression?

Yes, the connection pool was added in 6.0. The temporary files were always cleaned up if the DbConnection was disposed.

### Risk

Low. This is the same mechanism used by other ADO.NET providers.

### Verification

Manually verified that the temporary journal files are now cleaned up on application exit.

