### PR TITLE
[6.0.1] RevEng: Consider skip navigation names when generating identifier for members of class

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -1003,6 +1003,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             existingIdentifiers.AddRange(entityType.GetNavigations().Select(p => p.Name));
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26496", out var enabled)
+                && enabled))
+            {
+                existingIdentifiers.AddRange(entityType.GetSkipNavigations().Select(p => p.Name));
+            }
             return existingIdentifiers;
         }
 


### PR DESCRIPTION
Resolves #26496

We had mechanism to generate unique identifiers to assign to skip navigations but the code to find existing identifiers lacked skip navigations. So skip navigation names were not unique-fied throwing error when trying to add skip navigation with same name

**Description**

An exception is thrown when trying to scaffold model from database where a table has multiple skip navigations to different entity type but same fk properties giving same name to skip navigation.

**Customer impact**

A database containing such table cannot be scaffolded into model. There are no work-arounds.

**How found**

Customer report on nightly rtm package.

**Regression**

No, feature to scaffold many to many join table is new in 6.0. However, a database that could have been scaffolded previously to a model without many-to-many relationships will now cause the scaffolder to fail. 

**Testing**

Test for this scenario added in the PR.

**Risk**

Low; Skip navigation names are part of identifiers and should be added to the list. Also added quirk.
