### PR TITLE
Query: Throw error for unhandled derived query root expression

### DIFF
--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryRootExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryRootExpression.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class FromSqlQueryRootExpression : QueryRootExpression
+    public sealed class FromSqlQueryRootExpression : QueryRootExpression
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string Sql { get; }
+        public string Sql { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Expression Argument { get; }
+        public Expression Argument { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/Internal/TableValuedFunctionQueryRootExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/TableValuedFunctionQueryRootExpression.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class TableValuedFunctionQueryRootExpression : QueryRootExpression
+    public sealed class TableValuedFunctionQueryRootExpression : QueryRootExpression
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IStoreFunction Function { get; }
+        public IStoreFunction Function { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IReadOnlyCollection<Expression> Arguments { get; }
+        public IReadOnlyCollection<Expression> Arguments { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         _sqlExpressionFactory.Select(
                             fromSqlQueryRootExpression.EntityType,
                             new FromSqlExpression(
-                                fromSqlQueryRootExpression.EntityType.GetDefaultMappings().Single().Table.Name.Substring(0, 1)
+                                fromSqlQueryRootExpression.EntityType.GetDefaultMappings().Single().Table.Name[..1]
                                     .ToLowerInvariant(),
                                 fromSqlQueryRootExpression.Sql,
                                 fromSqlQueryRootExpression.Argument)));
@@ -134,7 +134,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return CreateShapedQueryExpression(entityType, queryExpression);
 
                 case QueryRootExpression queryRootExpression
-                    when queryRootExpression.EntityType.GetSqlQueryMappings().FirstOrDefault(m => m.IsDefaultSqlQueryMapping)?.SqlQuery is
+                    when queryRootExpression.GetType() == typeof(QueryRootExpression)
+                    && queryRootExpression.EntityType.GetSqlQueryMappings().FirstOrDefault(m => m.IsDefaultSqlQueryMapping)?.SqlQuery is
                         ISqlQuery sqlQuery:
                     return Visit(
                         new FromSqlQueryRootExpression(

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2353,6 +2353,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("QueryUnableToTranslateStringEqualsWithStringComparison");
 
         /// <summary>
+        ///     Query root of type '{type}' wasn't handled by provider code. This issue happens when using a provider specific method on a different provider where it is not supported.
+        /// </summary>
+        public static string QueryUnhandledQueryRootExpression(object? type)
+            => string.Format(
+                GetString("QueryUnhandledQueryRootExpression", nameof(type)),
+                type);
+
+        /// <summary>
         ///     An attempt was made to use the context instance while it is being configured. A DbContext instance cannot be used inside 'OnConfiguring' since it is still being configured at this point. This can happen if a second operation is started on this context instance before a previous operation completed. Any instance members are not guaranteed to be thread safe.
         /// </summary>
         public static string RecursiveOnConfiguring

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1334,6 +1334,9 @@
   <data name="QueryUnableToTranslateStringEqualsWithStringComparison" xml:space="preserve">
     <value>Translation of the 'string.Equals' overload with a 'StringComparison' parameter is not supported. See https://go.microsoft.com/fwlink/?linkid=2129535 for more information.</value>
   </data>
+  <data name="QueryUnhandledQueryRootExpression" xml:space="preserve">
+    <value>Query root of type '{type}' wasn't handled by provider code. This issue happens when using a provider specific method on a different provider where it is not supported.</value>
+  </data>
   <data name="RecursiveOnConfiguring" xml:space="preserve">
     <value>An attempt was made to use the context instance while it is being configured. A DbContext instance cannot be used inside 'OnConfiguring' since it is still being configured at this point. This can happen if a second operation is started on this context instance before a previous operation completed. Any instance members are not guaranteed to be thread safe.</value>
   </data>

--- a/test/EFCore.CrossStore.FunctionalTests/QueryTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/QueryTest.cs
@@ -1,0 +1,266 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+// ReSharper disable InconsistentNaming
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class QueryTest
+    {
+        public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { false }, new object[] { true } };
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task AsSplitQuery_does_not_throw_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.Include(e => e.Posts).AsSplitQuery();
+            if (async)
+            {
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
+            }
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task AsSingleQuery_does_not_throw_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.Include(e => e.Posts).AsSingleQuery();
+            if (async)
+            {
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
+            }
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_throws_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.FromSqlRaw("Select 1");
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(FromSqlQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlInterpolated_throws_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.FromSqlInterpolated($"Select 1");
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(FromSqlQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalAsOf_throws_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.TemporalAsOf(DateTime.Now);
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalAsOfQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalAll_throws_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.TemporalAll();
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalAllQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalBetween_throws_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.TemporalBetween(DateTime.Now, DateTime.Now.AddDays(7));
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalBetweenQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalContainedIn_throws_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.TemporalContainedIn(DateTime.Now, DateTime.Now.AddDays(7));
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalContainedInQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalFromTo_throws_for_InMemory(bool async)
+        {
+            using var context = new InMemoryQueryContext();
+            var query = context.Blogs.TemporalFromTo(DateTime.Now, DateTime.Now.AddDays(7));
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalFromToQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalAsOf_throws_for_Sqlite(bool async)
+        {
+            using var context = new SqliteQueryContext();
+            var query = context.Blogs.TemporalAsOf(DateTime.Now);
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalAsOfQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalAll_throws_for_Sqlite(bool async)
+        {
+            using var context = new SqliteQueryContext();
+            var query = context.Blogs.TemporalAll();
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalAllQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalBetween_throws_for_Sqlite(bool async)
+        {
+            using var context = new SqliteQueryContext();
+            var query = context.Blogs.TemporalBetween(DateTime.Now, DateTime.Now.AddDays(7));
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalBetweenQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalContainedIn_throws_for_Sqlite(bool async)
+        {
+            using var context = new SqliteQueryContext();
+            var query = context.Blogs.TemporalContainedIn(DateTime.Now, DateTime.Now.AddDays(7));
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalContainedInQueryRootExpression)), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task TemporalFromTo_throws_for_Sqlite(bool async)
+        {
+            using var context = new SqliteQueryContext();
+            var query = context.Blogs.TemporalFromTo(DateTime.Now, DateTime.Now.AddDays(7));
+
+            var message = async
+                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
+                : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
+
+            Assert.Equal(CoreStrings.QueryUnhandledQueryRootExpression(nameof(TemporalFromToQueryRootExpression)), message);
+        }
+
+        private class Blog
+        {
+            public int Id { get; set; }
+            public List<Post> Posts { get; set; }
+        }
+
+        private class Post
+        {
+            public int Id { get; set; }
+            public Blog Blog { get; set; }
+        }
+
+        private abstract class QueryContextBase : DbContext
+        {
+            public DbSet<Blog> Blogs { get; set; }
+            public DbSet<Post> Posts { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder builder)
+            {
+            }
+        }
+
+        private class InMemoryQueryContext : QueryContextBase
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInMemoryDatabase(nameof(InMemoryQueryContext));
+        }
+
+
+        private class SqliteQueryContext : QueryContextBase
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseSqlite(((RelationalTestStore)SqliteTestStoreFactory.Instance.Create(nameof(SqliteQueryContext))).ConnectionString);
+        }
+
+        private class SqlServerQueryContext : QueryContextBase
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseSqlite(((RelationalTestStore)SqlServerTestStoreFactory.Instance.Create(nameof(SqlServerQueryContext))).ConnectionString);
+        }
+    }
+}


### PR DESCRIPTION
Query root design

Core exposes QueryRootExpression which is base class for any query root so we can access EntityType out of it. This is needed for nav expansion and any potential future use case.
Since any derived query root would derive from it, core assembly translates it only when type is exact match to QueryRootExpression.
Relational layer also processes QueryRootExpression when they are mapped to default SqlQuery, which also uses exact type match now.

Apart from QueryRootExpression, no other kind of query root which can appear in different providers should be derivable (else they need to use exact type match too).
This rule makes relational ones sealed class. In case any one needs to derive from it, they need to add additional processing anyway.

Provider specific derived query roots can be non-sealed. If anyone is deriving from it then they should be using their derived provider which process those nodes too and if the derived provider wasn't used and shipped provider is used then it is an error from user perspective. If derived query root is used on other provider (targeting diff database) then it will fail since even the base shipped query root is unknown.

Resolves #26502
