### PR TITLE
[6.0.1] Query: Optimize Contains to Any recursively

### DIFF
--- a/src/EFCore/Query/Internal/QueryOptimizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizingExpressionVisitor.cs
@@ -285,8 +285,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         anyLambdaParameter,
                         methodCallExpression.Arguments[1]),
                     anyLambdaParameter);
+                var source = methodCallExpression.Arguments[0];
+                if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26593", out var enabled) && enabled))
+                {
+                    source = Visit(source);
+                }
 
-                return Expression.Call(null, anyMethod, new[] { methodCallExpression.Arguments[0], anyLambda });
+                return Expression.Call(null, anyMethod, new[] { source, anyLambda });
             }
 
             var @object = default(Expression);

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -347,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore
         protected class Context26428 : DbContext
         {
             public Context26428(DbContextOptions options)
-                   : base(options)
+                : base(options)
             {
             }
 
@@ -422,5 +422,134 @@ namespace Microsoft.EntityFrameworkCore
         }
 
 #nullable disable
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Unwrap_convert_node_over_projection_when_translating_contains_over_subquery(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context26593>(seed: c => c.Seed());
+            using var context = contextFactory.CreateContext();
+
+            var currentUserId = 1;
+
+            var currentUserGroupIds = context.Memberships
+                .Where(m => m.UserId == currentUserId)
+                .Select(m => m.GroupId);
+
+            var hasMembership = context.Memberships
+                .Where(m => currentUserGroupIds.Contains(m.GroupId))
+                .Select(m => m.User);
+
+            var query = context.Users
+                .Select(u => new
+                {
+                    HasAccess = hasMembership.Contains(u)
+                });
+
+            var users = async
+                ? await query.ToListAsync()
+                : query.ToList();
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Unwrap_convert_node_over_projection_when_translating_contains_over_subquery_2(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context26593>(seed: c => c.Seed());
+            using var context = contextFactory.CreateContext();
+
+            var currentUserId = 1;
+
+            var currentUserGroupIds = context.Memberships
+                .Where(m => m.UserId == currentUserId)
+                .Select(m => m.Group);
+
+            var hasMembership = context.Memberships
+                .Where(m => currentUserGroupIds.Contains(m.Group))
+                .Select(m => m.User);
+
+            var query = context.Users
+                .Select(u => new
+                {
+                    HasAccess = hasMembership.Contains(u)
+                });
+
+            var users = async
+                ? await query.ToListAsync()
+                : query.ToList();
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Unwrap_convert_node_over_projection_when_translating_contains_over_subquery_3(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context26593>(seed: c => c.Seed());
+            using var context = contextFactory.CreateContext();
+
+            var currentUserId = 1;
+
+            var currentUserGroupIds = context.Memberships
+                .Where(m => m.UserId == currentUserId)
+                .Select(m => m.GroupId);
+
+            var hasMembership = context.Memberships
+                .Where(m => currentUserGroupIds.Contains(m.GroupId))
+                .Select(m => m.User);
+
+            var query = context.Users
+                .Select(u => new
+                {
+                    HasAccess = hasMembership.Any(e => e == u)
+                });
+
+            var users = async
+                ? await query.ToListAsync()
+                : query.ToList();
+        }
+
+        protected class Context26593 : DbContext
+        {
+            public Context26593(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<User> Users { get; set; }
+            public DbSet<Group> Groups { get; set; }
+            public DbSet<Membership> Memberships { get; set; }
+
+            public void Seed()
+            {
+                var user = new User();
+                var group = new Group();
+                var membership = new Membership { Group = group, User = user };
+                AddRange(user, group, membership);
+
+                SaveChanges();
+            }
+        }
+
+        protected class User
+        {
+            public int Id { get; set; }
+
+            public ICollection<Membership> Memberships { get; set; }
+        }
+
+        protected class Group
+        {
+            public int Id { get; set; }
+
+            public ICollection<Membership> Memberships { get; set; }
+        }
+
+        protected class Membership
+        {
+            public int Id { get; set; }
+            public User User { get; set; }
+            public int UserId { get; set; }
+            public Group Group { get; set; }
+            public int GroupId { get; set; }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -63,5 +63,70 @@ WHERE [i].[Taste] = 1");
 FROM [Food] AS [f]
 WHERE [f].[Taste] = CAST(1 AS tinyint)");
         }
+
+        public override async Task Unwrap_convert_node_over_projection_when_translating_contains_over_subquery(bool async)
+        {
+            await base.Unwrap_convert_node_over_projection_when_translating_contains_over_subquery(async);
+
+            AssertSql(
+                @"@__currentUserId_0='1'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Memberships] AS [m]
+        INNER JOIN [Users] AS [u0] ON [m].[UserId] = [u0].[Id]
+        WHERE EXISTS (
+            SELECT 1
+            FROM [Memberships] AS [m0]
+            WHERE ([m0].[UserId] = @__currentUserId_0) AND ([m0].[GroupId] = [m].[GroupId])) AND ([u0].[Id] = [u].[Id])) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [HasAccess]
+FROM [Users] AS [u]");
+        }
+
+        public override async Task Unwrap_convert_node_over_projection_when_translating_contains_over_subquery_2(bool async)
+        {
+            await base.Unwrap_convert_node_over_projection_when_translating_contains_over_subquery_2(async);
+
+            AssertSql(
+                @"@__currentUserId_0='1'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Memberships] AS [m]
+        INNER JOIN [Groups] AS [g] ON [m].[GroupId] = [g].[Id]
+        INNER JOIN [Users] AS [u0] ON [m].[UserId] = [u0].[Id]
+        WHERE EXISTS (
+            SELECT 1
+            FROM [Memberships] AS [m0]
+            INNER JOIN [Groups] AS [g0] ON [m0].[GroupId] = [g0].[Id]
+            WHERE ([m0].[UserId] = @__currentUserId_0) AND ([g0].[Id] = [g].[Id])) AND ([u0].[Id] = [u].[Id])) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [HasAccess]
+FROM [Users] AS [u]");
+        }
+
+        public override async Task Unwrap_convert_node_over_projection_when_translating_contains_over_subquery_3(bool async)
+        {
+            await base.Unwrap_convert_node_over_projection_when_translating_contains_over_subquery_3(async);
+
+            AssertSql(
+                @"@__currentUserId_0='1'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Memberships] AS [m]
+        INNER JOIN [Users] AS [u0] ON [m].[UserId] = [u0].[Id]
+        WHERE EXISTS (
+            SELECT 1
+            FROM [Memberships] AS [m0]
+            WHERE ([m0].[UserId] = @__currentUserId_0) AND ([m0].[GroupId] = [m].[GroupId])) AND ([u0].[Id] = [u].[Id])) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [HasAccess]
+FROM [Users] AS [u]");
+        }
     }
 }


### PR DESCRIPTION
- Also unwrap convert node around projection when translating Contains

Resolves #26593

**Description**

When writing query which has multiple subquery Contains if the inner Contains is on entity type or value type then translation fails.

**Customer impact**

User query will throw exception with no easy way to figure out work-around

**How found**

Customer reported on RTM package

**Regression**

Yes, the query worked in 5.0 release.

**Testing**

Added test for customer scenario and similar kind of queries.

**Risk**

Low. Recursive visit should be no-op if there is no other relevant parts inside. Also added quirk to go back to earlier behavior.
