### PR TITLE
Move to OSX 11.0 for helix queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,12 +197,12 @@ stages:
                 value: $(_BuildConfig)
               - ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 - name: HelixTargetQueues
-                  value: Windows.10.Amd64.Open;Ubuntu.1804.Amd64.Open;Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20201109180804-3069967
+                  value: Windows.10.Amd64.Open;Ubuntu.1804.Amd64.Open;OSX.1100.Amd64.Open;(Ubuntu.1804.Amd64.SqlServer)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20201109180804-3069967
                 - name: _HelixAccessToken
                   value: '' # Needed for public queues
               - ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 - name: HelixTargetQueues
-                  value: Windows.10.Amd64;Ubuntu.1804.Amd64;Ubuntu.1604.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20201109180804-3069967
+                  value: Windows.10.Amd64;Ubuntu.1804.Amd64;OSX.1100.Amd64;(Ubuntu.1804.Amd64.SqlServer)Ubuntu.1604.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20201109180804-3069967
                 - name: _HelixAccessToken
                   value: $(HelixApiAccessToken) # Needed for internal queues
             steps:


### PR DESCRIPTION
The build was earlier removed due another issue, re-adding and moving
