### PR TITLE
[6.0.2] Query: Defer inline-ing owned navigation expansion till all joins are generated

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -1358,14 +1358,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                         ?? methodCallExpression.Update(null!, new[] { source, methodCallExpression.Arguments[1] });
                 }
 
-                if (methodCallExpression.TryGetEFPropertyArguments(out source, out navigationName))
-                {
-                    source = Visit(source);
-
-                    return TryExpand(source, MemberIdentity.Create(navigationName))
-                        ?? methodCallExpression.Update(source, new[] { methodCallExpression.Arguments[0] });
-                }
-
                 return base.VisitMethodCall(methodCallExpression);
             }
 

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -1154,11 +1155,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             private static readonly MethodInfo _objectEqualsMethodInfo
                 = typeof(object).GetRequiredRuntimeMethod(nameof(object.Equals), typeof(object), typeof(object));
+            private static readonly bool _useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26592", out var enabled)
+                && enabled;
 
             private readonly RelationalSqlTranslatingExpressionVisitor _sqlTranslator;
             private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
             private SelectExpression _selectExpression;
+            private DeferredOwnedExpansionRemovingVisitor _deferredOwnedExpansionRemover;
 
             public SharedTypeEntityExpandingExpressionVisitor(
                 RelationalSqlTranslatingExpressionVisitor sqlTranslator,
@@ -1167,13 +1171,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 _sqlTranslator = sqlTranslator;
                 _sqlExpressionFactory = sqlExpressionFactory;
                 _selectExpression = null!;
+                _deferredOwnedExpansionRemover = null!;
             }
 
             public Expression Expand(SelectExpression selectExpression, Expression lambdaBody)
             {
                 _selectExpression = selectExpression;
 
-                return Visit(lambdaBody);
+                if (_useOldBehavior)
+                {
+                    return Visit(lambdaBody);
+                }
+
+                _deferredOwnedExpansionRemover = new(_selectExpression);
+
+                return _deferredOwnedExpansionRemover.Visit(Visit(lambdaBody));
             }
 
             protected override Expression VisitMember(MemberExpression memberExpression)
@@ -1198,14 +1210,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                         ?? methodCallExpression.Update(null!, new[] { source, methodCallExpression.Arguments[1] });
                 }
 
-                if (methodCallExpression.TryGetEFPropertyArguments(out source, out navigationName))
-                {
-                    source = Visit(source);
-
-                    return TryExpand(source, MemberIdentity.Create(navigationName))
-                        ?? methodCallExpression.Update(source, new[] { methodCallExpression.Arguments[1] });
-                }
-
                 return base.VisitMethodCall(methodCallExpression);
             }
 
@@ -1221,179 +1225,459 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             private Expression? TryExpand(Expression? source, MemberIdentity member)
             {
-                source = source.UnwrapTypeConversion(out var convertedType);
-                if (source is not EntityShaperExpression entityShaperExpression)
+                if (_useOldBehavior)
                 {
-                    return null;
-                }
-
-                var entityType = entityShaperExpression.EntityType;
-                if (convertedType != null)
-                {
-                    entityType = entityType.GetRootType().GetDerivedTypesInclusive()
-                        .FirstOrDefault(et => et.ClrType == convertedType);
-
-                    if (entityType == null)
+                    source = source.UnwrapTypeConversion(out var convertedType);
+                    if (source is not EntityShaperExpression entityShaperExpression)
                     {
                         return null;
                     }
-                }
 
-                var navigation = member.MemberInfo != null
-                    ? entityType.FindNavigation(member.MemberInfo)
-                    : entityType.FindNavigation(member.Name!);
-
-                if (navigation == null)
-                {
-                    return null;
-                }
-
-                var targetEntityType = navigation.TargetEntityType;
-                if (targetEntityType == null
-                    || !targetEntityType.IsOwned())
-                {
-                    return null;
-                }
-
-                var foreignKey = navigation.ForeignKey;
-                if (navigation.IsCollection)
-                {
-                    var innerShapedQuery = CreateShapedQueryExpression(
-                        targetEntityType, _sqlExpressionFactory.Select(targetEntityType));
-
-                    var makeNullable = foreignKey.PrincipalKey.Properties
-                        .Concat(foreignKey.Properties)
-                        .Select(p => p.ClrType)
-                        .Any(t => t.IsNullableType());
-
-                    var innerSequenceType = innerShapedQuery.Type.GetSequenceType();
-                    var correlationPredicateParameter = Expression.Parameter(innerSequenceType);
-
-                    var outerKey = entityShaperExpression.CreateKeyValuesExpression(
-                        navigation.IsOnDependent
-                            ? foreignKey.Properties
-                            : foreignKey.PrincipalKey.Properties,
-                        makeNullable);
-                    var innerKey = correlationPredicateParameter.CreateKeyValuesExpression(
-                        navigation.IsOnDependent
-                            ? foreignKey.PrincipalKey.Properties
-                            : foreignKey.Properties,
-                        makeNullable);
-
-                    var keyComparison = Expression.Call(
-                        _objectEqualsMethodInfo, AddConvertToObject(outerKey), AddConvertToObject(innerKey));
-
-                    var predicate = makeNullable
-                        ? Expression.AndAlso(
-                            outerKey is NewArrayExpression newArrayExpression
-                                ? newArrayExpression.Expressions
-                                    .Select(
-                                        e =>
-                                            {
-                                                var left = (e as UnaryExpression)?.Operand ?? e;
-
-                                                return Expression.NotEqual(left, Expression.Constant(null, left.Type));
-                                            })
-                                    .Aggregate((l, r) => Expression.AndAlso(l, r))
-                                : Expression.NotEqual(outerKey, Expression.Constant(null, outerKey.Type)),
-                            keyComparison)
-                        : (Expression)keyComparison;
-
-                    var correlationPredicate = Expression.Lambda(predicate, correlationPredicateParameter);
-
-                    return Expression.Call(
-                        QueryableMethods.Where.MakeGenericMethod(innerSequenceType),
-                        innerShapedQuery,
-                        Expression.Quote(correlationPredicate));
-                }
-
-                var entityProjectionExpression = (EntityProjectionExpression)
-                    (entityShaperExpression.ValueBufferExpression is ProjectionBindingExpression projectionBindingExpression
-                        ? _selectExpression.GetProjection(projectionBindingExpression)
-                        : entityShaperExpression.ValueBufferExpression);
-
-                var innerShaper = entityProjectionExpression.BindNavigation(navigation);
-                if (innerShaper == null)
-                {
-                    // Owned types don't support inheritance See https://github.com/dotnet/efcore/issues/9630
-                    // So there is no handling for dependent having TPT
-                    // If navigation is defined on derived type and entity type is part of TPT then we need to get ITableBase for derived type.
-                    // TODO: The following code should also handle Function and SqlQuery mappings
-                    var table = navigation.DeclaringEntityType.BaseType == null
-                        || entityType.FindDiscriminatorProperty() != null
-                            ? navigation.DeclaringEntityType.GetViewOrTableMappings().Single().Table
-                            : navigation.DeclaringEntityType.GetViewOrTableMappings().Select(tm => tm.Table)
-                                .Except(navigation.DeclaringEntityType.BaseType.GetViewOrTableMappings().Select(tm => tm.Table))
-                                .Single();
-                    if (table.GetReferencingRowInternalForeignKeys(foreignKey.PrincipalEntityType)?.Contains(foreignKey) == true)
+                    var entityType = entityShaperExpression.EntityType;
+                    if (convertedType != null)
                     {
-                        // Mapped to same table
-                        // We get identifying column to figure out tableExpression to pull columns from and nullability of most principal side
-                        var identifyingColumn = entityProjectionExpression.BindProperty(entityType.FindPrimaryKey()!.Properties.First());
-                        var principalNullable = identifyingColumn.IsNullable
-                            // Also make nullable if navigation is on derived type and and principal is TPT
-                            // Since identifying PK would be non-nullable but principal can still be null
-                            // Derived owned navigation does not de-dupe the PK column which for principal is from base table
-                            // and for dependent on derived table
-                            || (entityType.FindDiscriminatorProperty() == null
-                                && navigation.DeclaringEntityType.IsStrictlyDerivedFrom(entityShaperExpression.EntityType));
+                        entityType = entityType.GetRootType().GetDerivedTypesInclusive()
+                            .FirstOrDefault(et => et.ClrType == convertedType);
 
-                        var entityProjection = _selectExpression.GenerateWeakEntityProjectionExpression(
-                            targetEntityType, table, identifyingColumn.Name, identifyingColumn.Table, principalNullable);
-
-                        if (entityProjection != null)
+                        if (entityType == null)
                         {
-                            innerShaper = new RelationalEntityShaperExpression(targetEntityType, entityProjection, principalNullable);
+                            return null;
                         }
                     }
 
-                    if (innerShaper == null)
+                    var navigation = member.MemberInfo != null
+                        ? entityType.FindNavigation(member.MemberInfo)
+                        : entityType.FindNavigation(member.Name!);
+
+                    if (navigation == null)
                     {
-                        // InnerShaper is still null if either it is not table sharing or we failed to find table to pick data from
-                        // So we find the table it is mapped to and generate join with it.
-                        // Owned types don't support inheritance See https://github.com/dotnet/efcore/issues/9630
-                        // So there is no handling for dependent having TPT
-                        table = targetEntityType.GetViewOrTableMappings().Single().Table;
-                        var innerSelectExpression = _sqlExpressionFactory.Select(targetEntityType);
-                        var innerShapedQuery = CreateShapedQueryExpression(targetEntityType, innerSelectExpression);
+                        return null;
+                    }
+
+                    var targetEntityType = navigation.TargetEntityType;
+                    if (targetEntityType == null
+                        || !targetEntityType.IsOwned())
+                    {
+                        return null;
+                    }
+
+                    var foreignKey = navigation.ForeignKey;
+                    if (navigation.IsCollection)
+                    {
+                        var innerShapedQuery = CreateShapedQueryExpression(
+                            targetEntityType, _sqlExpressionFactory.Select(targetEntityType));
 
                         var makeNullable = foreignKey.PrincipalKey.Properties
                             .Concat(foreignKey.Properties)
                             .Select(p => p.ClrType)
                             .Any(t => t.IsNullableType());
 
+                        var innerSequenceType = innerShapedQuery.Type.GetSequenceType();
+                        var correlationPredicateParameter = Expression.Parameter(innerSequenceType);
+
                         var outerKey = entityShaperExpression.CreateKeyValuesExpression(
                             navigation.IsOnDependent
                                 ? foreignKey.Properties
                                 : foreignKey.PrincipalKey.Properties,
                             makeNullable);
-                        var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValuesExpression(
+                        var innerKey = correlationPredicateParameter.CreateKeyValuesExpression(
                             navigation.IsOnDependent
                                 ? foreignKey.PrincipalKey.Properties
                                 : foreignKey.Properties,
                             makeNullable);
 
-                        var joinPredicate = _sqlTranslator.Translate(Expression.Equal(outerKey, innerKey))!;
-                        _selectExpression.AddLeftJoin(innerSelectExpression, joinPredicate);
-                        var leftJoinTable = _selectExpression.Tables.Last();
+                        var keyComparison = Expression.Call(
+                            _objectEqualsMethodInfo, AddConvertToObject(outerKey), AddConvertToObject(innerKey));
 
-                        innerShaper = new RelationalEntityShaperExpression(
-                            targetEntityType,
-                            _selectExpression.GenerateWeakEntityProjectionExpression(
-                                targetEntityType, table, null, leftJoinTable, nullable: true)!,
-                            nullable: true);
+                        var predicate = makeNullable
+                            ? Expression.AndAlso(
+                                outerKey is NewArrayExpression newArrayExpression
+                                    ? newArrayExpression.Expressions
+                                        .Select(
+                                            e =>
+                                            {
+                                                var left = (e as UnaryExpression)?.Operand ?? e;
+
+                                                return Expression.NotEqual(left, Expression.Constant(null, left.Type));
+                                            })
+                                        .Aggregate((l, r) => Expression.AndAlso(l, r))
+                                    : Expression.NotEqual(outerKey, Expression.Constant(null, outerKey.Type)),
+                                keyComparison)
+                            : (Expression)keyComparison;
+
+                        var correlationPredicate = Expression.Lambda(predicate, correlationPredicateParameter);
+
+                        return Expression.Call(
+                            QueryableMethods.Where.MakeGenericMethod(innerSequenceType),
+                            innerShapedQuery,
+                            Expression.Quote(correlationPredicate));
                     }
 
-                    entityProjectionExpression.AddNavigationBinding(navigation, innerShaper);
-                }
+                    var entityProjectionExpression = (EntityProjectionExpression)
+                        (entityShaperExpression.ValueBufferExpression is ProjectionBindingExpression projectionBindingExpression
+                        ? _selectExpression.GetProjection(projectionBindingExpression)
+                        : entityShaperExpression.ValueBufferExpression);
+                    var innerShaper = entityProjectionExpression.BindNavigation(navigation);
+                    if (innerShaper == null)
+                    {
+                        // Owned types don't support inheritance See https://github.com/dotnet/efcore/issues/9630
+                        // So there is no handling for dependent having TPT
+                        // If navigation is defined on derived type and entity type is part of TPT then we need to get ITableBase for derived type.
+                        // TODO: The following code should also handle Function and SqlQuery mappings
+                        var table = navigation.DeclaringEntityType.BaseType == null
+                            || entityType.FindDiscriminatorProperty() != null
+                                ? navigation.DeclaringEntityType.GetViewOrTableMappings().Single().Table
+                                : navigation.DeclaringEntityType.GetViewOrTableMappings().Select(tm => tm.Table)
+                                    .Except(navigation.DeclaringEntityType.BaseType.GetViewOrTableMappings().Select(tm => tm.Table))
+                                    .Single();
+                        if (table.GetReferencingRowInternalForeignKeys(foreignKey.PrincipalEntityType)?.Contains(foreignKey) == true)
+                        {
+                            // Mapped to same table
+                            // We get identifying column to figure out tableExpression to pull columns from and nullability of most principal side
+                            var identifyingColumn = entityProjectionExpression.BindProperty(entityType.FindPrimaryKey()!.Properties.First());
+                            var principalNullable = identifyingColumn.IsNullable
+                                // Also make nullable if navigation is on derived type and and principal is TPT
+                                // Since identifying PK would be non-nullable but principal can still be null
+                                // Derived owned navigation does not de-dupe the PK column which for principal is from base table
+                                // and for dependent on derived table
+                                || (entityType.FindDiscriminatorProperty() == null
+                                    && navigation.DeclaringEntityType.IsStrictlyDerivedFrom(entityShaperExpression.EntityType));
 
-                return innerShaper;
+                            var entityProjection = _selectExpression.GenerateWeakEntityProjectionExpression(
+                                targetEntityType, table, identifyingColumn.Name, identifyingColumn.Table, principalNullable);
+
+                            if (entityProjection != null)
+                            {
+                                innerShaper = new RelationalEntityShaperExpression(targetEntityType, entityProjection, principalNullable);
+                            }
+                        }
+
+                        if (innerShaper == null)
+                        {
+                            // InnerShaper is still null if either it is not table sharing or we failed to find table to pick data from
+                            // So we find the table it is mapped to and generate join with it.
+                            // Owned types don't support inheritance See https://github.com/dotnet/efcore/issues/9630
+                            // So there is no handling for dependent having TPT
+                            table = targetEntityType.GetViewOrTableMappings().Single().Table;
+                            var innerSelectExpression = _sqlExpressionFactory.Select(targetEntityType);
+                            var innerShapedQuery = CreateShapedQueryExpression(targetEntityType, innerSelectExpression);
+
+                            var makeNullable = foreignKey.PrincipalKey.Properties
+                                .Concat(foreignKey.Properties)
+                                .Select(p => p.ClrType)
+                                .Any(t => t.IsNullableType());
+
+                            var outerKey = entityShaperExpression.CreateKeyValuesExpression(
+                                navigation.IsOnDependent
+                                    ? foreignKey.Properties
+                                    : foreignKey.PrincipalKey.Properties,
+                                makeNullable);
+                            var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValuesExpression(
+                                navigation.IsOnDependent
+                                    ? foreignKey.PrincipalKey.Properties
+                                    : foreignKey.Properties,
+                                makeNullable);
+
+                            var joinPredicate = _sqlTranslator.Translate(Expression.Equal(outerKey, innerKey))!;
+                            _selectExpression.AddLeftJoin(innerSelectExpression, joinPredicate);
+                            var leftJoinTable = _selectExpression.Tables.Last();
+
+                            innerShaper = new RelationalEntityShaperExpression(
+                                targetEntityType,
+                                _selectExpression.GenerateWeakEntityProjectionExpression(
+                                    targetEntityType, table, null, leftJoinTable, nullable: true)!,
+                                nullable: true);
+                        }
+
+                        entityProjectionExpression.AddNavigationBinding(navigation, innerShaper);
+                    }
+
+                    return innerShaper;
+                }
+                else
+                {
+                    source = source.UnwrapTypeConversion(out var convertedType);
+                    var doee = source as DeferredOwnedExpansionExpression;
+                    if (doee is not null)
+                    {
+                        source = _deferredOwnedExpansionRemover.UnwrapDeferredEntityProjectionExpression(doee);
+                    }
+                    if (source is not EntityShaperExpression entityShaperExpression)
+                    {
+                        return null;
+                    }
+
+                    var entityType = entityShaperExpression.EntityType;
+                    if (convertedType != null)
+                    {
+                        entityType = entityType.GetRootType().GetDerivedTypesInclusive()
+                            .FirstOrDefault(et => et.ClrType == convertedType);
+
+                        if (entityType == null)
+                        {
+                            return null;
+                        }
+                    }
+
+                    var navigation = member.MemberInfo != null
+                        ? entityType.FindNavigation(member.MemberInfo)
+                        : entityType.FindNavigation(member.Name!);
+
+                    if (navigation == null)
+                    {
+                        return null;
+                    }
+
+                    var targetEntityType = navigation.TargetEntityType;
+                    if (targetEntityType == null
+                        || !targetEntityType.IsOwned())
+                    {
+                        return null;
+                    }
+
+                    var foreignKey = navigation.ForeignKey;
+                    if (navigation.IsCollection)
+                    {
+                        var innerShapedQuery = CreateShapedQueryExpression(
+                            targetEntityType, _sqlExpressionFactory.Select(targetEntityType));
+
+                        var makeNullable = foreignKey.PrincipalKey.Properties
+                            .Concat(foreignKey.Properties)
+                            .Select(p => p.ClrType)
+                            .Any(t => t.IsNullableType());
+
+                        var innerSequenceType = innerShapedQuery.Type.GetSequenceType();
+                        var correlationPredicateParameter = Expression.Parameter(innerSequenceType);
+
+                        var outerKey = entityShaperExpression.CreateKeyValuesExpression(
+                            navigation.IsOnDependent
+                                ? foreignKey.Properties
+                                : foreignKey.PrincipalKey.Properties,
+                            makeNullable);
+                        var innerKey = correlationPredicateParameter.CreateKeyValuesExpression(
+                            navigation.IsOnDependent
+                                ? foreignKey.PrincipalKey.Properties
+                                : foreignKey.Properties,
+                            makeNullable);
+
+                        var keyComparison = Expression.Call(
+                            _objectEqualsMethodInfo, AddConvertToObject(outerKey), AddConvertToObject(innerKey));
+
+                        var predicate = makeNullable
+                            ? Expression.AndAlso(
+                                outerKey is NewArrayExpression newArrayExpression
+                                    ? newArrayExpression.Expressions
+                                        .Select(
+                                            e =>
+                                                {
+                                                    var left = (e as UnaryExpression)?.Operand ?? e;
+
+                                                    return Expression.NotEqual(left, Expression.Constant(null, left.Type));
+                                                })
+                                        .Aggregate((l, r) => Expression.AndAlso(l, r))
+                                    : Expression.NotEqual(outerKey, Expression.Constant(null, outerKey.Type)),
+                                keyComparison)
+                            : (Expression)keyComparison;
+
+                        var correlationPredicate = Expression.Lambda(predicate, correlationPredicateParameter);
+
+                        return Expression.Call(
+                            QueryableMethods.Where.MakeGenericMethod(innerSequenceType),
+                            innerShapedQuery,
+                            Expression.Quote(correlationPredicate));
+                    }
+
+                    var entityProjectionExpression = GetEntityProjectionExpression(entityShaperExpression);
+                    var innerShaper = entityProjectionExpression.BindNavigation(navigation);
+                    if (innerShaper == null)
+                    {
+                        // Owned types don't support inheritance See https://github.com/dotnet/efcore/issues/9630
+                        // So there is no handling for dependent having TPT
+                        // If navigation is defined on derived type and entity type is part of TPT then we need to get ITableBase for derived type.
+                        // TODO: The following code should also handle Function and SqlQuery mappings
+                        var table = navigation.DeclaringEntityType.BaseType == null
+                            || entityType.FindDiscriminatorProperty() != null
+                                ? navigation.DeclaringEntityType.GetViewOrTableMappings().Single().Table
+                                : navigation.DeclaringEntityType.GetViewOrTableMappings().Select(tm => tm.Table)
+                                    .Except(navigation.DeclaringEntityType.BaseType.GetViewOrTableMappings().Select(tm => tm.Table))
+                                    .Single();
+                        if (table.GetReferencingRowInternalForeignKeys(foreignKey.PrincipalEntityType)?.Contains(foreignKey) == true)
+                        {
+                            // Mapped to same table
+                            // We get identifying column to figure out tableExpression to pull columns from and nullability of most principal side
+                            var identifyingColumn = entityProjectionExpression.BindProperty(entityType.FindPrimaryKey()!.Properties.First());
+                            var principalNullable = identifyingColumn.IsNullable
+                                // Also make nullable if navigation is on derived type and and principal is TPT
+                                // Since identifying PK would be non-nullable but principal can still be null
+                                // Derived owned navigation does not de-dupe the PK column which for principal is from base table
+                                // and for dependent on derived table
+                                || (entityType.FindDiscriminatorProperty() == null
+                                    && navigation.DeclaringEntityType.IsStrictlyDerivedFrom(entityShaperExpression.EntityType));
+
+                            var entityProjection = _selectExpression.GenerateWeakEntityProjectionExpression(
+                                targetEntityType, table, identifyingColumn.Name, identifyingColumn.Table, principalNullable);
+
+                            if (entityProjection != null)
+                            {
+                                innerShaper = new RelationalEntityShaperExpression(targetEntityType, entityProjection, principalNullable);
+                            }
+                        }
+
+                        if (innerShaper == null)
+                        {
+                            // InnerShaper is still null if either it is not table sharing or we failed to find table to pick data from
+                            // So we find the table it is mapped to and generate join with it.
+                            // Owned types don't support inheritance See https://github.com/dotnet/efcore/issues/9630
+                            // So there is no handling for dependent having TPT
+                            table = targetEntityType.GetViewOrTableMappings().Single().Table;
+                            var innerSelectExpression = _sqlExpressionFactory.Select(targetEntityType);
+                            var innerShapedQuery = CreateShapedQueryExpression(targetEntityType, innerSelectExpression);
+
+                            var makeNullable = foreignKey.PrincipalKey.Properties
+                                .Concat(foreignKey.Properties)
+                                .Select(p => p.ClrType)
+                                .Any(t => t.IsNullableType());
+
+                            var outerKey = entityShaperExpression.CreateKeyValuesExpression(
+                                navigation.IsOnDependent
+                                    ? foreignKey.Properties
+                                    : foreignKey.PrincipalKey.Properties,
+                                makeNullable);
+                            var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValuesExpression(
+                                navigation.IsOnDependent
+                                    ? foreignKey.PrincipalKey.Properties
+                                    : foreignKey.Properties,
+                                makeNullable);
+
+                            var joinPredicate = _sqlTranslator.Translate(Expression.Equal(outerKey, innerKey))!;
+                            // Following conditions should match conditions for pushdown on outer during SelectExpression.AddJoin method
+                            var pushdownRequired = _selectExpression.Limit != null
+                                || _selectExpression.Offset != null
+                                || _selectExpression.IsDistinct
+                                || _selectExpression.GroupBy.Count > 0;
+                            _selectExpression.AddLeftJoin(innerSelectExpression, joinPredicate);
+
+                            // If pushdown was required on SelectExpression then we need to fetch the updated entity projection
+                            if (pushdownRequired)
+                            {
+                                if (doee is not null)
+                                {
+                                    entityShaperExpression = _deferredOwnedExpansionRemover.UnwrapDeferredEntityProjectionExpression(doee);
+                                }
+                                entityProjectionExpression = GetEntityProjectionExpression(entityShaperExpression);
+                            }
+
+                            var leftJoinTable = _selectExpression.Tables.Last();
+
+                            innerShaper = new RelationalEntityShaperExpression(
+                                targetEntityType,
+                                _selectExpression.GenerateWeakEntityProjectionExpression(
+                                    targetEntityType, table, null, leftJoinTable, nullable: true)!,
+                                nullable: true);
+                        }
+
+                        entityProjectionExpression.AddNavigationBinding(navigation, innerShaper);
+                    }
+
+                    return doee is not null
+                        ? doee.AddNavigation(targetEntityType, navigation)
+                        : new DeferredOwnedExpansionExpression(targetEntityType,
+                        (ProjectionBindingExpression)entityShaperExpression.ValueBufferExpression,
+                        navigation);
+                }
             }
 
             private static Expression AddConvertToObject(Expression expression)
                 => expression.Type.IsValueType
                     ? Expression.Convert(expression, typeof(object))
                     : expression;
+
+            private EntityProjectionExpression GetEntityProjectionExpression(EntityShaperExpression entityShaperExpression)
+                => entityShaperExpression.ValueBufferExpression switch
+            {
+                ProjectionBindingExpression projectionBindingExpression
+                    => (EntityProjectionExpression)_selectExpression.GetProjection(projectionBindingExpression),
+                EntityProjectionExpression entityProjectionExpression => entityProjectionExpression,
+                _ => throw new InvalidOperationException(),
+            };
+
+            private sealed class DeferredOwnedExpansionExpression : Expression
+            {
+                private readonly IEntityType _entityType;
+
+                public DeferredOwnedExpansionExpression(
+                    IEntityType entityType,
+                    ProjectionBindingExpression projectionBindingExpression,
+                    INavigation navigation)
+                {
+                    _entityType = entityType;
+                    ProjectionBindingExpression = projectionBindingExpression;
+                    NavigationChain = new List<INavigation> { navigation };
+                }
+
+                private DeferredOwnedExpansionExpression(
+                    IEntityType entityType,
+                    ProjectionBindingExpression projectionBindingExpression,
+                    List<INavigation> navigationChain)
+                {
+                    _entityType = entityType;
+                    ProjectionBindingExpression = projectionBindingExpression;
+                    NavigationChain = navigationChain;
+                }
+
+                public ProjectionBindingExpression ProjectionBindingExpression { get; }
+                public List<INavigation> NavigationChain { get; }
+
+                public DeferredOwnedExpansionExpression AddNavigation(IEntityType entityType, INavigation navigation)
+                {
+                    var navigationChain = new List<INavigation>(NavigationChain.Count + 1);
+                    navigationChain.AddRange(NavigationChain);
+                    navigationChain.Add(navigation);
+
+                    return new DeferredOwnedExpansionExpression(
+                        entityType,
+                        ProjectionBindingExpression,
+                        navigationChain);
+                }
+
+                public override Type Type => _entityType.ClrType;
+
+                public override ExpressionType NodeType => ExpressionType.Extension;
+            }
+
+            private sealed class DeferredOwnedExpansionRemovingVisitor : ExpressionVisitor
+            {
+                private readonly SelectExpression _selectExpression;
+
+                public DeferredOwnedExpansionRemovingVisitor(SelectExpression selectExpression)
+                {
+                    _selectExpression = selectExpression;
+                }
+
+                [return: NotNullIfNotNull("expression")]
+                public override Expression? Visit(Expression? expression)
+                    => expression switch
+                {
+                    DeferredOwnedExpansionExpression doee => UnwrapDeferredEntityProjectionExpression(doee),
+                    // For the source entity shaper or owned collection expansion
+                    EntityShaperExpression _ or ShapedQueryExpression _ => expression,
+                    _ => base.Visit(expression),
+                };
+
+                public EntityShaperExpression UnwrapDeferredEntityProjectionExpression(DeferredOwnedExpansionExpression doee)
+                {
+                    var entityProjection = (EntityProjectionExpression)_selectExpression.GetProjection(doee.ProjectionBindingExpression);
+                    var entityShaper = entityProjection.BindNavigation(doee.NavigationChain[0])!;
+
+                    for (var i = 1; i < doee.NavigationChain.Count; i++)
+                    {
+                        entityProjection = (EntityProjectionExpression)entityShaper.ValueBufferExpression;
+                        entityShaper = entityProjection.BindNavigation(doee.NavigationChain[i])!;
+                    }
+
+                    return entityShaper;
+                }
+            }
         }
 
         private ShapedQueryExpression TranslateTwoParameterSelector(ShapedQueryExpression source, LambdaExpression resultSelector)

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedEntityQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedEntityQueryInMemoryTest.cs
@@ -72,5 +72,33 @@ namespace Microsoft.EntityFrameworkCore.Query
             public virtual Bar? Bar { get; set; }
         }
 #nullable disable
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Owned_references_on_same_level_expanded_at_different_times_around_take(bool async)
+        {
+            var contextFactory = await InitializeAsync<MyContext26592>(seed: c => c.Seed());
+            using var context = contextFactory.CreateContext();
+
+            await base.Owned_references_on_same_level_expanded_at_different_times_around_take_helper(context, async);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Owned_references_on_same_level_nested_expanded_at_different_times_around_take(bool async)
+        {
+            var contextFactory = await InitializeAsync<MyContext26592>(seed: c => c.Seed());
+            using var context = contextFactory.CreateContext();
+
+            await base.Owned_references_on_same_level_nested_expanded_at_different_times_around_take_helper(context, async);
+        }
+
+        protected class MyContext26592 : MyContext26592Base
+        {
+            public MyContext26592(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
@@ -99,5 +99,44 @@ FROM [Location25680] AS [l]
 WHERE [l].[Id] = @__id_0
 ORDER BY [l].[Id]");
         }
+
+        public override async Task Owned_reference_mapped_to_different_table_updated_correctly_after_subquery_pushdown(bool async)
+        {
+            await base.Owned_reference_mapped_to_different_table_updated_correctly_after_subquery_pushdown(async);
+
+            AssertSql(
+                @"@__p_0='10'
+
+SELECT [t].[Id], [t].[Name], [t].[CompanyId], [t].[AdditionalCustomerData], [t].[Id0], [s].[CompanyId], [s].[AdditionalSupplierData], [s].[Id]
+FROM (
+    SELECT TOP(@__p_0) [c].[Id], [c].[Name], [c0].[CompanyId], [c0].[AdditionalCustomerData], [c0].[Id] AS [Id0]
+    FROM [Companies] AS [c]
+    LEFT JOIN [CustomerData] AS [c0] ON [c].[Id] = [c0].[CompanyId]
+    WHERE [c0].[CompanyId] IS NOT NULL
+    ORDER BY [c].[Id]
+) AS [t]
+LEFT JOIN [SupplierData] AS [s] ON [t].[Id] = [s].[CompanyId]
+ORDER BY [t].[Id]");
+        }
+
+        public override async Task Owned_reference_mapped_to_different_table_nested_updated_correctly_after_subquery_pushdown(bool async)
+        {
+            await base.Owned_reference_mapped_to_different_table_nested_updated_correctly_after_subquery_pushdown(async);
+
+            AssertSql(
+                @"@__p_0='10'
+
+SELECT [t].[Id], [t].[Name], [t].[OwnerId], [t].[Id0], [t].[Name0], [t].[IntermediateOwnedEntityOwnerId], [t].[AdditionalCustomerData], [t].[Id1], [i1].[IntermediateOwnedEntityOwnerId], [i1].[AdditionalSupplierData], [i1].[Id]
+FROM (
+    SELECT TOP(@__p_0) [o].[Id], [o].[Name], [i].[OwnerId], [i].[Id] AS [Id0], [i].[Name] AS [Name0], [i0].[IntermediateOwnedEntityOwnerId], [i0].[AdditionalCustomerData], [i0].[Id] AS [Id1]
+    FROM [Owners] AS [o]
+    LEFT JOIN [IntermediateOwnedEntity] AS [i] ON [o].[Id] = [i].[OwnerId]
+    LEFT JOIN [IM_CustomerData] AS [i0] ON [i].[OwnerId] = [i0].[IntermediateOwnedEntityOwnerId]
+    WHERE [i0].[IntermediateOwnedEntityOwnerId] IS NOT NULL
+    ORDER BY [o].[Id]
+) AS [t]
+LEFT JOIN [IM_SupplierData] AS [i1] ON [t].[OwnerId] = [i1].[IntermediateOwnedEntityOwnerId]
+ORDER BY [t].[Id]");
+        }
     }
 }


### PR DESCRIPTION
Issue: Expanding owned navigations in relational falls into 3 categories
- Collection navigation - which always generates a subquery. The predicate is generated in LINQ to allow mutation of outer SelectExpression
- Reference navigation sharing table - which picks column from same table without needing to add additional join. This only mutate the projection list for SelectExpression at subquery level
- Reference navigation mapped to separate table - which generates additional joins. Generating join can cause push down on outer SelectExpression if it has facets (e.g. limit/offset). This pushdown causes owned expansion from category 2 to be outdated and invalid SQL since they get pushed down to subquery. While their relevant entity projection is updated inside SelectExpression we already inlined older object in the tree at this point.

In order to avoid issue with outdated owned expansion, we defer actual inline-ing while processing owned navigations so that all navigations are expanded (causing any mutation on SelectExpression) before we inline values.

This PR introduces DeferredOwnedExpansionExpression which remembers the source projection binding to SelectExpression (which will remain accurate through pushdown), and navigation chain to traverse entity projections to reach entity shaper for final owned navigation. This way, we get up-to-date information from SelectExpression after all joins are generated.
We also find updated entity projection through binding after we generate a join if pushdown was required.

Resolves #26592

The issue was also present in 5.0 release causing non-performant SQL rather than invalid SQL. During 5.0 we expanded owned navigations again while during client eval phase (which happens in customer scenario due to include). This caused to earlier owned reference to have correct columns. Though the entity projection for owner was changed due to pushdown so we didn't add latter reference navigation binding in correct entity projection causing us to expand it again during 2nd pass.

The exact same issue doesn't occur for InMemory provider (due to slightly different implementation) though we should also make InMemory provider work this way, which we can do in 7.0.


**Description**

In a query if owned reference navigations mapped to separate tables are expanded at different time with a subquery causing operation in between (like skip/take/distinct), then the columns of already expanded reference navigation are incorrect.

**Customer impact**

Query with such scenario will generate invalid SQL causing an exception.

**How found**

Customer reported on 6.0 package.

**Regression**

Partially. If the query doesn't have any form of client eval then it fails in 5.0 with same error. If it has client eval then it translated in 5.0 with inefficient SQL.

**Testing**

Added test for the scenario. Also there are existing tests to validate expansion working correctly in usual cases.

**Risk**

Medium. This PR changes how owned navigations are expanded in relational layer. While we have good test coverage, this is still significant impact code path. We have added quirk in order to revert to previous behavior if any issue arises.