### PR TITLE
[6.0.1] Microsoft.Data.Sqlite: Handle more nulls in ApplicationDataHelper

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/Utilities/ApplicationDataHelper.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/ApplicationDataHelper.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Sqlite.Utilities
         private static string? GetFolderPath(string propertyName)
         {
             var appDataType = CurrentApplicationData?.GetType();
-            var temporaryFolder = appDataType?.GetRuntimeProperty(propertyName)!.GetValue(CurrentApplicationData);
+            var temporaryFolder = appDataType?.GetRuntimeProperty(propertyName)?.GetValue(CurrentApplicationData);
 
             return temporaryFolder?.GetType().GetRuntimeProperty("Path")!.GetValue(temporaryFolder) as string;
         }


### PR DESCRIPTION
In 6.0, we enabled our UWP code for detecting the temp and data directory to work on the new `net5.0-windows` (and 6.0) TFMs. For some reason on .NET Core 3.1, this also causes `GetType("Windows.Storage.ApplicationData")` to return non-null now but `GetProperty("LocalFolder")` to return null leading to a NullReferenceException.

Fixes #26574

### Customer impact

Because this code runs during static initialization of the ADO.NET connection type it is impossible to work around this issue making it impossible to use the 6.0.0 version of Microsoft.Data.Sqlite on .NET Core 3.1 on Windows.

### Regression?

Yes, from 5.0.

### Risk

Low. The new handling of `null` results in the same code path that has been used for several releases.

Verification. Manually verified that the library can be used on .NET Core 3.1. Our automated tests only execute on the latest runtime.