### PR TITLE
Query: Defer inline-ing owned navigation expansion till all joins are…

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -1197,14 +1197,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                         ?? methodCallExpression.Update(null!, new[] { source, methodCallExpression.Arguments[1] });
                 }
 
-                if (methodCallExpression.TryGetEFPropertyArguments(out source, out navigationName))
-                {
-                    source = Visit(source);
-
-                    return TryExpand(source, MemberIdentity.Create(navigationName))
-                        ?? methodCallExpression.Update(source, new[] { methodCallExpression.Arguments[0] });
-                }
-
                 return base.VisitMethodCall(methodCallExpression);
             }
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedEntityQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedEntityQueryInMemoryTest.cs
@@ -72,5 +72,33 @@ namespace Microsoft.EntityFrameworkCore.Query
             public virtual Bar? Bar { get; set; }
         }
 #nullable disable
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Owned_references_on_same_level_expanded_at_different_times_around_take(bool async)
+        {
+            var contextFactory = await InitializeAsync<MyContext26592>(seed: c => c.Seed());
+            using var context = contextFactory.CreateContext();
+
+            await base.Owned_references_on_same_level_expanded_at_different_times_around_take_helper(context, async);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Owned_references_on_same_level_nested_expanded_at_different_times_around_take(bool async)
+        {
+            var contextFactory = await InitializeAsync<MyContext26592>(seed: c => c.Seed());
+            using var context = contextFactory.CreateContext();
+
+            await base.Owned_references_on_same_level_nested_expanded_at_different_times_around_take_helper(context, async);
+        }
+
+        protected class MyContext26592 : MyContext26592Base
+        {
+            public MyContext26592(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
@@ -99,5 +99,44 @@ FROM [Location25680] AS [l]
 WHERE [l].[Id] = @__id_0
 ORDER BY [l].[Id]");
         }
+
+        public override async Task Owned_reference_mapped_to_different_table_updated_correctly_after_subquery_pushdown(bool async)
+        {
+            await base.Owned_reference_mapped_to_different_table_updated_correctly_after_subquery_pushdown(async);
+
+            AssertSql(
+                @"@__p_0='10'
+
+SELECT [t].[Id], [t].[Name], [t].[CompanyId], [t].[AdditionalCustomerData], [t].[Id0], [s].[CompanyId], [s].[AdditionalSupplierData], [s].[Id]
+FROM (
+    SELECT TOP(@__p_0) [c].[Id], [c].[Name], [c0].[CompanyId], [c0].[AdditionalCustomerData], [c0].[Id] AS [Id0]
+    FROM [Companies] AS [c]
+    LEFT JOIN [CustomerData] AS [c0] ON [c].[Id] = [c0].[CompanyId]
+    WHERE [c0].[CompanyId] IS NOT NULL
+    ORDER BY [c].[Id]
+) AS [t]
+LEFT JOIN [SupplierData] AS [s] ON [t].[Id] = [s].[CompanyId]
+ORDER BY [t].[Id]");
+        }
+
+        public override async Task Owned_reference_mapped_to_different_table_nested_updated_correctly_after_subquery_pushdown(bool async)
+        {
+            await base.Owned_reference_mapped_to_different_table_nested_updated_correctly_after_subquery_pushdown(async);
+
+            AssertSql(
+                @"@__p_0='10'
+
+SELECT [t].[Id], [t].[Name], [t].[OwnerId], [t].[Id0], [t].[Name0], [t].[IntermediateOwnedEntityOwnerId], [t].[AdditionalCustomerData], [t].[Id1], [i1].[IntermediateOwnedEntityOwnerId], [i1].[AdditionalSupplierData], [i1].[Id]
+FROM (
+    SELECT TOP(@__p_0) [o].[Id], [o].[Name], [i].[OwnerId], [i].[Id] AS [Id0], [i].[Name] AS [Name0], [i0].[IntermediateOwnedEntityOwnerId], [i0].[AdditionalCustomerData], [i0].[Id] AS [Id1]
+    FROM [Owners] AS [o]
+    LEFT JOIN [IntermediateOwnedEntity] AS [i] ON [o].[Id] = [i].[OwnerId]
+    LEFT JOIN [IM_CustomerData] AS [i0] ON [i].[OwnerId] = [i0].[IntermediateOwnedEntityOwnerId]
+    WHERE [i0].[IntermediateOwnedEntityOwnerId] IS NOT NULL
+    ORDER BY [o].[Id]
+) AS [t]
+LEFT JOIN [IM_SupplierData] AS [i1] ON [t].[OwnerId] = [i1].[IntermediateOwnedEntityOwnerId]
+ORDER BY [t].[Id]");
+        }
     }
 }


### PR DESCRIPTION
… generated

Issue: Expanding owned navigations in relational falls into 3 categories
- Collection navigation - which always generates a subquery. The predicate is generated in LINQ to allow mutation of outer SelectExpression
- Reference navigation sharing table - which picks column from same table without needing to add additional join. This only mutate the projection list for SelectExpression at subquery level
- Reference navigation mapped to separate table - which generates additional joins. Generating join can cause push down on outer SelectExpression if it has facets (e.g. limit/offset). This pushdown causes owned expansion from category 2 to be outdated and invalid SQL since they get pushed down to subquery. While their relevant entity projection is updated inside SelectExpression we already inlined older object in the tree at this point.

In order to avoid issue with outdated owned expansion, we defer actual inline-ing while processing owned navigations so that all navigations are expanded (causing any mutation on SelectExpression) before we inline values.

This PR introduces DeferredOwnedExpansionExpression which remembers the source projection binding to SelectExpression (which will remain accurate through pushdown), and navigation chain to traverse entity projections to reach entity shaper for final owned navigation. This way, we get up-to-date information from SelectExpression after all joins are generated.
We also find updated entity projection through binding after we generate a join if pushdown was required.

Resolves #26592

The issue was also present in 5.0 release causing non-performant SQL rather than invalid SQL. During 5.0 we expanded owned navigations again while during client eval phase (which happens in customer scenario due to include). This caused to earlier owned reference to have correct columns. Though the entity projection for owner was changed due to pushdown so we didn't add latter reference navigation binding in correct entity projection causing us to expand it again during 2nd pass.
The exact same issue doesn't occur for InMemory provider (due to slightly different implementation) though we should also make InMemory provider work this way, submitting in a different PR in case we need to cherry-pick this for patch.
