### PR TITLE
Match indexer properties correctly

### DIFF
--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -1000,7 +1000,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 property =>
                     property.IsShadowProperty()
                     || (property.IsIndexerProperty()
-                        && (!AppContext.TryGetSwitch("Microsoft.Data.Sqlite.Issue26590", out var enabled) || !enabled)
+                        && (!AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26590", out var enabled) || !enabled)
                         ? property.PropertyInfo == entityType.FindIndexerPropertyInfo()
                         : ((property.PropertyInfo != null
                                     && entityType.GetRuntimeProperties().ContainsKey(property.Name))

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -999,10 +999,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => properties.All(
                 property =>
                     property.IsShadowProperty()
-                    || ((property.PropertyInfo != null
-                            && entityType.GetRuntimeProperties().ContainsKey(property.Name))
-                        || (property.FieldInfo != null
-                            && entityType.GetRuntimeFields().ContainsKey(property.Name))));
+                    || (property.IsIndexerProperty()
+                        ? property.PropertyInfo == entityType.FindIndexerPropertyInfo()
+                        : ((property.PropertyInfo != null
+                                    && entityType.GetRuntimeProperties().ContainsKey(property.Name))
+                                || (property.FieldInfo != null
+                                    && entityType.GetRuntimeFields().ContainsKey(property.Name)))));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -1000,6 +1000,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 property =>
                     property.IsShadowProperty()
                     || (property.IsIndexerProperty()
+                        && (!AppContext.TryGetSwitch("Microsoft.Data.Sqlite.Issue26590", out var enabled) || !enabled)
                         ? property.PropertyInfo == entityType.FindIndexerPropertyInfo()
                         : ((property.PropertyInfo != null
                                     && entityType.GetRuntimeProperties().ContainsKey(property.Name))

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -1580,6 +1580,51 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public virtual void ForeignKey_to_ForeignKey_on_many_to_many()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<Login16>(entity =>
+            {
+                entity.HasMany(d => d.Profile16s)
+                    .WithMany(p => p.Login16s)
+                    .UsingEntity<Dictionary<string, object>>(
+                        "Login16Profile16",
+                        l => l.HasOne<Profile16>().WithMany().HasForeignKey("Profile16Id"),
+                        r => r.HasOne<Login16>().WithMany().HasForeignKey("Login16Id"),
+                        j =>
+                        {
+                            j.HasKey("Login16Id", "Profile16Id");
+
+                            j.ToTable("Login16Profile16");
+                        });
+            });
+
+            var model = Validate(modelBuilder);
+
+            var login = modelBuilder.Model.FindEntityType(typeof(Login16));
+            var logins = login.FindSkipNavigation(nameof(Login16.Profile16s));
+            var join = logins.JoinEntityType;
+            Assert.Equal(2, join.GetProperties().Count());
+            Assert.False(GetProperty<Login16>(model, "Login16Id").IsForeignKey());
+            Assert.False(GetProperty<Profile16>(model, "Profile16Id").IsForeignKey());
+        }
+
+        public partial class Login16
+        {
+            public int Login16Id { get; set; }
+            [ForeignKey("Login16Id")]
+            public virtual ICollection<Profile16> Profile16s { get; set; }
+        }
+
+        public partial class Profile16
+        {
+            public int Profile16Id { get; set; }
+            [ForeignKey("Profile16Id")]
+            public virtual ICollection<Login16> Login16s { get; set; }
+        }
+
+        [ConditionalFact]
         public virtual void ForeignKeyAttribute_configures_relationships_when_inverse_on_derived()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fixes #26590

**Description**

When an FK attribute is used with a property on a property bag entity type EF ends up creating a property with a uniquified name instead of using the specified one.

This is made worse in 6.0 because now EF scaffolds this type of configuration for existing databases.

**Customer impact**

User queries will throw exception since the new property doesn't match a column in the database

**How found**

Customer reported on 6.0

**Regression**

Yes, this worked in 5.0

**Testing**

Added test for this scenario.

**Risk**

Low, only affects property bag entities (`Dictionary<string, object>`). Also added a quirk mode.
