### PR TITLE
[release/6.0] Put parentheses around IS NULL for non-bool operands

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -563,7 +563,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             => expression is SqlBinaryExpression
                 || expression is LikeExpression
                 || (expression is SqlUnaryExpression unary
-                    && unary.Operand.Type == typeof(bool)
                     && (unary.OperatorType == ExpressionType.Equal
                         || unary.OperatorType == ExpressionType.NotEqual));
 

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -28,6 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
         private IRelationalCommandBuilder _relationalCommandBuilder;
 
+        private static readonly bool _isNullParenthesesQuirkMode;
+
         private static readonly Dictionary<ExpressionType, string> _operatorMap = new()
         {
             { ExpressionType.Equal, " = " },
@@ -46,6 +48,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             { ExpressionType.And, " & " },
             { ExpressionType.Or, " | " }
         };
+
+        static QuerySqlGenerator()
+            => _isNullParenthesesQuirkMode =
+                AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26652", out var enabled) && enabled;
 
         /// <summary>
         ///     Creates a new instance of the <see cref="QuerySqlGenerator" /> class.
@@ -563,6 +569,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             => expression is SqlBinaryExpression
                 || expression is LikeExpression
                 || (expression is SqlUnaryExpression unary
+                    && (!_isNullParenthesesQuirkMode || unary.Operand.Type == typeof(bool))
                     && (unary.OperatorType == ExpressionType.Equal
                         || unary.OperatorType == ExpressionType.NotEqual));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -1598,6 +1598,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Bool_not_equal_nullable_int_HasValue(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(e => true != e.NullableIntA.HasValue));
+
+            var prm = false;
+            await AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(e => prm != e.NullableIntA.HasValue));
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(e => e.BoolB != e.NullableIntA.HasValue));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual async Task Bool_not_equal_nullable_bool_compared_to_null(bool async)
         {
             await AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -135,7 +135,7 @@ ORDER BY [l].[Id], [t].[Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND ([l].[Name] LIKE N'%03') THEN 1
+    WHEN ([l].[Name] IS NOT NULL) AND ([l].[Name] LIKE N'%03') THEN 1
     ELSE 2
 END, [l].[Id]");
         }
@@ -170,7 +170,7 @@ LEFT JOIN (
     FROM [LevelThree] AS [l1]
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
 ) AS [t] ON [l0].[Id] = [t].[OneToMany_Required_Inverse3Id]
-WHERE ([l0].[Name] <> N'L2 09') OR [l0].[Name] IS NULL
+WHERE ([l0].[Name] <> N'L2 09') OR ([l0].[Name] IS NULL)
 ORDER BY [l].[Id], [l0].[Id], [t].[Id]");
         }
 
@@ -251,7 +251,7 @@ LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[Level2_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l3] ON [l].[Id] = [l3].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l4] ON [l3].[Id] = [l4].[Level2_Optional_Id]
 LEFT JOIN [LevelThree] AS [l5] ON [l0].[Id] = [l5].[OneToMany_Optional_Inverse3Id]
-WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
 ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id], [l4].[Id]");
         }
 
@@ -467,7 +467,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l15]
     WHERE [l15].[Id] <> 42
 ) AS [t1] ON [t].[Id2] = [t1].[OneToMany_Optional_Self_Inverse2Id]
-WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
+WHERE ([l11].[Name] <> N'Foo') OR ([l11].[Name] IS NULL)
 ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id]");
         }
 
@@ -528,7 +528,7 @@ FROM [LevelOne] AS [l]
 LEFT JOIN (
     SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
     FROM [LevelTwo] AS [l0]
-    WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+    WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 WHERE [l].[Id] < 3
 ORDER BY [l].[Id]");
@@ -699,7 +699,7 @@ FROM (
     SELECT [l].[Name]
     FROM [LevelOne] AS [l]
     GROUP BY [l].[Name]
-    HAVING ([l].[Name] <> N'Foo') OR [l].[Name] IS NULL
+    HAVING ([l].[Name] <> N'Foo') OR ([l].[Name] IS NULL)
 ) AS [t]
 LEFT JOIN (
     SELECT [t1].[Id], [t1].[Date], [t1].[Name], [t1].[OneToMany_Optional_Self_Inverse1Id], [t1].[OneToMany_Required_Self_Inverse1Id], [t1].[OneToOne_Optional_Self1Id]
@@ -1024,7 +1024,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
-    WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)) > 0
+    WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))) > 0
 ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
         }
 
@@ -1297,7 +1297,7 @@ LEFT JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Name]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 4)
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -1317,7 +1317,7 @@ LEFT JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Name]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 4)
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -1336,7 +1336,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Name]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -1345,7 +1345,7 @@ LEFT JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Required_Inverse2Id] ORDER BY [l1].[Name] DESC) AS [row]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l1].[Name] <> N'Bar') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Bar') OR ([l1].[Name] IS NULL)
     ) AS [t2]
     WHERE 1 < [t2].[row]
 ) AS [t1] ON [l].[Id] = [t1].[OneToMany_Required_Inverse2Id]
@@ -1364,7 +1364,7 @@ OUTER APPLY (
     FROM (
         SELECT TOP(3) [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL)
+        WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL))
         ORDER BY [l0].[Name]
     ) AS [t]
     LEFT JOIN (
@@ -1372,7 +1372,7 @@ OUTER APPLY (
         FROM (
             SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Required_Inverse3Id] ORDER BY [l1].[Name] DESC) AS [row]
             FROM [LevelThree] AS [l1]
-            WHERE ([l1].[Name] <> N'Bar') OR [l1].[Name] IS NULL
+            WHERE ([l1].[Name] <> N'Bar') OR ([l1].[Name] IS NULL)
         ) AS [t1]
         WHERE 1 < [t1].[row]
     ) AS [t0] ON [t].[Id] = [t0].[OneToMany_Required_Inverse3Id]
@@ -1392,7 +1392,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id] DESC) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 2
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -1411,7 +1411,7 @@ OUTER APPLY (
     FROM (
         SELECT TOP(2) [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id]
         FROM [LevelTwo] AS [l2]
-        WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND (([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL)
+        WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND (([l2].[Name] <> N'Foo') OR ([l2].[Name] IS NULL))
         ORDER BY [l2].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[Level2_Required_Id]
@@ -1434,7 +1434,7 @@ OUTER APPLY (
     FROM (
         SELECT TOP(2) [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Optional_Self_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToMany_Required_Self_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l2].[OneToOne_Optional_Self2Id]
         FROM [LevelTwo] AS [l2]
-        WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND (([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL)
+        WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND (([l2].[Name] <> N'Foo') OR ([l2].[Name] IS NULL))
         ORDER BY [l2].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[Level2_Required_Id]
@@ -1455,7 +1455,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -1474,7 +1474,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -1493,7 +1493,7 @@ OUTER APPLY (
     FROM (
         SELECT TOP(1) [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)
+        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))
         ORDER BY [l1].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[OneToOne_Optional_PK_Inverse3Id]
@@ -1521,7 +1521,7 @@ LEFT JOIN (
         FROM (
             SELECT TOP(1) [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id]
             FROM [LevelThree] AS [l3]
-            WHERE ([l0].[Id] = [l3].[OneToMany_Optional_Inverse3Id]) AND (([l3].[Name] <> N'Foo') OR [l3].[Name] IS NULL)
+            WHERE ([l0].[Id] = [l3].[OneToMany_Optional_Inverse3Id]) AND (([l3].[Name] <> N'Foo') OR ([l3].[Name] IS NULL))
             ORDER BY [l3].[Id]
         ) AS [t]
         LEFT JOIN [LevelFour] AS [l1] ON [t].[Id] = [l1].[OneToMany_Optional_Inverse4Id]
@@ -1546,7 +1546,7 @@ LEFT JOIN (
         FROM (
             SELECT TOP(1) [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_Inverse3Id], [l3].[OneToMany_Optional_Self_Inverse3Id], [l3].[OneToMany_Required_Inverse3Id], [l3].[OneToMany_Required_Self_Inverse3Id], [l3].[OneToOne_Optional_PK_Inverse3Id], [l3].[OneToOne_Optional_Self3Id]
             FROM [LevelThree] AS [l3]
-            WHERE ([l0].[Id] = [l3].[OneToMany_Optional_Inverse3Id]) AND (([l3].[Name] <> N'Foo') OR [l3].[Name] IS NULL)
+            WHERE ([l0].[Id] = [l3].[OneToMany_Optional_Inverse3Id]) AND (([l3].[Name] <> N'Foo') OR ([l3].[Name] IS NULL))
             ORDER BY [l3].[Id]
         ) AS [t]
         LEFT JOIN [LevelFour] AS [l1] ON [t].[Id] = [l1].[OneToMany_Optional_Inverse4Id]
@@ -1570,7 +1570,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> @__prm_0) OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> @__prm_0) OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -1659,7 +1659,7 @@ LEFT JOIN (
     FROM (
         SELECT 1 AS [c], [l0].[Id], [l0].[OneToMany_Optional_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -1707,7 +1707,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l15]
     WHERE [l15].[Id] <> 42
 ) AS [t1] ON [t].[Id2] = [t1].[OneToMany_Optional_Self_Inverse2Id]
-WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
+WHERE ([l11].[Name] <> N'Foo') OR ([l11].[Name] IS NULL)
 ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id]");
         }
 
@@ -2079,7 +2079,7 @@ OUTER APPLY (
     FROM (
         SELECT [l0].[Date]
         FROM [LevelOne] AS [l0]
-        WHERE ([l0].[Name] = [l].[Name]) OR ([l0].[Name] IS NULL AND [l].[Name] IS NULL)
+        WHERE ([l0].[Name] = [l].[Name]) OR (([l0].[Name] IS NULL) AND ([l].[Name] IS NULL))
         GROUP BY [l0].[Date]
     ) AS [t]
     LEFT JOIN (
@@ -2087,7 +2087,7 @@ OUTER APPLY (
         FROM (
             SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_Inverse1Id], [l1].[OneToMany_Required_Self_Inverse1Id], [l1].[OneToOne_Optional_Self1Id], ROW_NUMBER() OVER(PARTITION BY [l1].[Date] ORDER BY [l1].[Name]) AS [row]
             FROM [LevelOne] AS [l1]
-            WHERE ([l1].[Name] = [l].[Name]) OR ([l1].[Name] IS NULL AND [l].[Name] IS NULL)
+            WHERE ([l1].[Name] = [l].[Name]) OR (([l1].[Name] IS NULL) AND ([l].[Name] IS NULL))
         ) AS [t1]
         WHERE (1 < [t1].[row]) AND ([t1].[row] <= 6)
     ) AS [t0] ON [t].[Date] = [t0].[Date]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -29,7 +29,7 @@ INNER JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l1].[Id] AS [Id0]
     FROM [Level1] AS [l0]
     INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-    WHERE ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id], [t1].[Id] AS [Id0], [t1].[Id0] AS [Id00]
@@ -38,11 +38,11 @@ LEFT JOIN (
         SELECT [l3].[Id], [l4].[Id] AS [Id0]
         FROM [Level1] AS [l3]
         INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
-        WHERE ([l3].[OneToOne_Required_PK_Date] IS NOT NULL AND [l3].[Level1_Required_Id] IS NOT NULL) AND [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([l3].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l3].[Level1_Required_Id] IS NOT NULL)) AND ([l3].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t1] ON [l2].[Id] = [t1].[Id]
-    WHERE [l2].[Level2_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL
+    WHERE ([l2].[Level2_Required_Id] IS NOT NULL) AND ([l2].[OneToMany_Required_Inverse3Id] IS NOT NULL)
 ) AS [t0] ON CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END = [t0].[OneToMany_Optional_Inverse3Id]
 ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0]");
         }
@@ -58,15 +58,15 @@ INNER JOIN (
     SELECT DISTINCT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
     FROM [Level1] AS [l0]
     INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-    WHERE ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l3].[Id] AS [Id0]
     FROM [Level1] AS [l2]
     INNER JOIN [Level1] AS [l3] ON [l2].[Id] = [l3].[Id]
-    WHERE ([l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL) AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l2].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l2].[Level1_Required_Id] IS NOT NULL)) AND ([l2].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-WHERE ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL
+WHERE (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ORDER BY [l].[Id], [t].[Id], [t0].[Id]");
         }
 
@@ -85,17 +85,17 @@ FROM (
 ) AS [t]
 OUTER APPLY (
     SELECT CASE
-        WHEN ([t1].[OneToOne_Required_PK_Date] IS NOT NULL AND [t1].[Level1_Required_Id] IS NOT NULL) AND [t1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t1].[Id]
+        WHEN (([t1].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t1].[Level1_Required_Id] IS NOT NULL)) AND ([t1].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t1].[Id]
     END AS [Id], [t1].[Level2_Name] AS [Name], [t1].[OneToMany_Required_Inverse2Id] AS [Level1Id], [t1].[Level1_Required_Id] AS [Level2Id], [l1].[Id] AS [Id0], [l1].[Date], [l1].[Name] AS [Name0], [t1].[Id] AS [Id1], [t1].[Id0] AS [Id00], [t1].[c]
     FROM (
         SELECT TOP(3) [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Required_Inverse2Id], [l2].[Id] AS [Id0], CASE
-            WHEN ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l0].[Id]
+            WHEN (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [l0].[Id]
         END AS [c]
         FROM [Level1] AS [l0]
         INNER JOIN [Level1] AS [l2] ON [l0].[Id] = [l2].[Id]
-        WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL) AND ([t].[Id] = [l0].[OneToMany_Required_Inverse2Id])
+        WHERE ((([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)) AND ([t].[Id] = [l0].[OneToMany_Required_Inverse2Id])
         ORDER BY CASE
-            WHEN ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l0].[Id]
+            WHEN (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [l0].[Id]
         END
     ) AS [t1]
     INNER JOIN [Level1] AS [l1] ON [t1].[Level1_Required_Id] = [l1].[Id]
@@ -119,17 +119,17 @@ FROM (
 ) AS [t]
 OUTER APPLY (
     SELECT CASE
-        WHEN ([t1].[OneToOne_Required_PK_Date] IS NOT NULL AND [t1].[Level1_Required_Id] IS NOT NULL) AND [t1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t1].[Id]
+        WHEN (([t1].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t1].[Level1_Required_Id] IS NOT NULL)) AND ([t1].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t1].[Id]
     END AS [Id], [t1].[Level2_Name] AS [Name], [t1].[OneToMany_Required_Inverse2Id] AS [Level1Id], [t1].[Level1_Required_Id] AS [Level2Id], [l1].[Id] AS [Id0], [l1].[Date], [l1].[Name] AS [Name0], [t1].[Id] AS [Id1], [t1].[Id0] AS [Id00], [t1].[c]
     FROM (
         SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Required_Inverse2Id], [l2].[Id] AS [Id0], CASE
-            WHEN ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l0].[Id]
+            WHEN (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [l0].[Id]
         END AS [c]
         FROM [Level1] AS [l0]
         INNER JOIN [Level1] AS [l2] ON [l0].[Id] = [l2].[Id]
-        WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL) AND ([t].[Id] = [l0].[OneToMany_Required_Inverse2Id])
+        WHERE ((([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)) AND ([t].[Id] = [l0].[OneToMany_Required_Inverse2Id])
         ORDER BY CASE
-            WHEN ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [l0].[Id]
+            WHEN (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [l0].[Id]
         END
         OFFSET 1 ROWS FETCH NEXT 3 ROWS ONLY
     ) AS [t1]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
@@ -238,7 +238,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Name]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 4)
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -263,7 +263,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Name]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 4)
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -286,7 +286,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Name]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -299,7 +299,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Required_Inverse2Id] ORDER BY [l0].[Name] DESC) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Bar') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Bar') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE 1 < [t].[row]
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Required_Inverse2Id]
@@ -322,7 +322,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Name]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -335,7 +335,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Name]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -344,7 +344,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Required_Inverse3Id] ORDER BY [l1].[Name] DESC) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Bar') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Bar') OR ([l1].[Name] IS NULL)
     ) AS [t2]
     WHERE 1 < [t2].[row]
 ) AS [t1] ON [t0].[Id] = [t1].[OneToMany_Required_Inverse3Id]
@@ -367,7 +367,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id] DESC) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 2
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -390,7 +390,7 @@ CROSS APPLY (
     FROM (
         SELECT TOP(2) [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)
+        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))
         ORDER BY [l1].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[Level2_Required_Id]
@@ -404,7 +404,7 @@ CROSS APPLY (
     FROM (
         SELECT TOP(2) [l1].[Id]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)
+        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))
         ORDER BY [l1].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[Level2_Required_Id]
@@ -429,7 +429,7 @@ CROSS APPLY (
     FROM (
         SELECT TOP(2) [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)
+        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))
         ORDER BY [l1].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[Level2_Required_Id]
@@ -443,7 +443,7 @@ CROSS APPLY (
     FROM (
         SELECT TOP(2) [l1].[Id]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)
+        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))
         ORDER BY [l1].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[Level2_Required_Id]
@@ -468,7 +468,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -491,7 +491,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -514,7 +514,7 @@ CROSS APPLY (
     FROM (
         SELECT TOP(1) [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)
+        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))
         ORDER BY [l1].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[OneToOne_Optional_PK_Inverse3Id]
@@ -528,7 +528,7 @@ CROSS APPLY (
     FROM (
         SELECT TOP(1) [l1].[Id]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)
+        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))
         ORDER BY [l1].[Id]
     ) AS [t]
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[OneToOne_Optional_PK_Inverse3Id]
@@ -563,7 +563,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Id]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -577,7 +577,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[OneToMany_Optional_Inverse3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Id]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -592,7 +592,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[OneToMany_Optional_Inverse3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Id]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -622,7 +622,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Id]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -636,7 +636,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[OneToMany_Optional_Inverse3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Id]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -651,7 +651,7 @@ INNER JOIN (
     FROM (
         SELECT [l1].[Id], [l1].[OneToMany_Optional_Inverse3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Id]) AS [row]
         FROM [LevelThree] AS [l1]
-        WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+        WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
@@ -677,7 +677,7 @@ INNER JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> @__prm_0) OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> @__prm_0) OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -814,7 +814,7 @@ LEFT JOIN [LevelThree] AS [l11] ON [l2].[OneToMany_Optional_Inverse4Id] = [l11].
 LEFT JOIN [LevelThree] AS [l12] ON [t].[Id2] = [l12].[Level2_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l13] ON [t0].[Level2_Optional_Id0] = [l13].[Id]
 LEFT JOIN [LevelThree] AS [l14] ON [l13].[Id] = [l14].[Level2_Required_Id]
-WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
+WHERE ([l11].[Name] <> N'Foo') OR ([l11].[Name] IS NULL)
 ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id]",
                 //
                 @"SELECT [t1].[Id], [t1].[Date], [t1].[Level1_Optional_Id], [t1].[Level1_Required_Id], [t1].[Name], [t1].[OneToMany_Optional_Inverse2Id], [t1].[OneToMany_Optional_Self_Inverse2Id], [t1].[OneToMany_Required_Inverse2Id], [t1].[OneToMany_Required_Self_Inverse2Id], [t1].[OneToOne_Optional_PK_Inverse2Id], [t1].[OneToOne_Optional_Self2Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l12].[Id], [l13].[Id], [l14].[Id]
@@ -845,7 +845,7 @@ INNER JOIN (
     FROM [LevelTwo] AS [l15]
     WHERE [l15].[Id] <> 42
 ) AS [t1] ON [t].[Id2] = [t1].[OneToMany_Optional_Self_Inverse2Id]
-WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
+WHERE ([l11].[Name] <> N'Foo') OR ([l11].[Name] IS NULL)
 ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id]");
         }
 
@@ -954,7 +954,7 @@ FROM [LevelOne] AS [l]
 INNER JOIN (
     SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
     FROM [LevelTwo] AS [l0]
-    WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+    WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 WHERE [l].[Id] < 3
 ORDER BY [l].[Id]");
@@ -1286,7 +1286,7 @@ LEFT JOIN (
     FROM (
         SELECT 1 AS [c], [l0].[Id], [l0].[OneToMany_Optional_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -1299,7 +1299,7 @@ LEFT JOIN (
     FROM (
         SELECT [l0].[Id], [l0].[OneToMany_Optional_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+        WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
@@ -1342,7 +1342,7 @@ LEFT JOIN [LevelThree] AS [l11] ON [l2].[OneToMany_Optional_Inverse4Id] = [l11].
 LEFT JOIN [LevelThree] AS [l12] ON [t].[Id2] = [l12].[Level2_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l13] ON [t0].[Level2_Optional_Id0] = [l13].[Id]
 LEFT JOIN [LevelThree] AS [l14] ON [l13].[Id] = [l14].[Level2_Required_Id]
-WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
+WHERE ([l11].[Name] <> N'Foo') OR ([l11].[Name] IS NULL)
 ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id]",
                 //
                 @"SELECT [t1].[Id], [t1].[Date], [t1].[Level1_Optional_Id], [t1].[Level1_Required_Id], [t1].[Name], [t1].[OneToMany_Optional_Inverse2Id], [t1].[OneToMany_Optional_Self_Inverse2Id], [t1].[OneToMany_Required_Inverse2Id], [t1].[OneToMany_Required_Self_Inverse2Id], [t1].[OneToOne_Optional_PK_Inverse2Id], [t1].[OneToOne_Optional_Self2Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l12].[Id], [l13].[Id], [l14].[Id]
@@ -1373,7 +1373,7 @@ INNER JOIN (
     FROM [LevelTwo] AS [l15]
     WHERE [l15].[Id] <> 42
 ) AS [t1] ON [t].[Id2] = [t1].[OneToMany_Optional_Self_Inverse2Id]
-WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
+WHERE ([l11].[Name] <> N'Foo') OR ([l11].[Name] IS NULL)
 ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id]");
         }
 
@@ -1616,7 +1616,7 @@ ORDER BY [l].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND ([l].[Name] LIKE N'%03') THEN 1
+    WHEN ([l].[Name] IS NOT NULL) AND ([l].[Name] LIKE N'%03') THEN 1
     ELSE 2
 END, [l].[Id]",
                 //
@@ -1624,7 +1624,7 @@ END, [l].[Id]",
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND ([l].[Name] LIKE N'%03') THEN 1
+    WHEN ([l].[Name] IS NOT NULL) AND ([l].[Name] LIKE N'%03') THEN 1
     ELSE 2
 END, [l].[Id]");
         }
@@ -1664,7 +1664,7 @@ ORDER BY [l].[Id], [l0].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE ([l0].[Name] <> N'L2 09') OR [l0].[Name] IS NULL
+WHERE ([l0].[Name] <> N'L2 09') OR ([l0].[Name] IS NULL)
 ORDER BY [l].[Id], [l0].[Id]",
                 //
                 @"SELECT [t].[Id], [t].[Level2_Optional_Id], [t].[Level2_Required_Id], [t].[Name], [t].[OneToMany_Optional_Inverse3Id], [t].[OneToMany_Optional_Self_Inverse3Id], [t].[OneToMany_Required_Inverse3Id], [t].[OneToMany_Required_Self_Inverse3Id], [t].[OneToOne_Optional_PK_Inverse3Id], [t].[OneToOne_Optional_Self3Id], [t].[Id0], [t].[Level3_Optional_Id], [t].[Level3_Required_Id], [t].[Name0], [t].[OneToMany_Optional_Inverse4Id], [t].[OneToMany_Optional_Self_Inverse4Id], [t].[OneToMany_Required_Inverse4Id], [t].[OneToMany_Required_Self_Inverse4Id], [t].[OneToOne_Optional_PK_Inverse4Id], [t].[OneToOne_Optional_Self4Id], [l].[Id], [l0].[Id]
@@ -1675,7 +1675,7 @@ INNER JOIN (
     FROM [LevelThree] AS [l1]
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
 ) AS [t] ON [l0].[Id] = [t].[OneToMany_Required_Inverse3Id]
-WHERE ([l0].[Name] <> N'L2 09') OR [l0].[Name] IS NULL
+WHERE ([l0].[Name] <> N'L2 09') OR ([l0].[Name] IS NULL)
 ORDER BY [l].[Id], [l0].[Id]");
         }
 
@@ -1823,7 +1823,7 @@ LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[Level2_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l3] ON [l].[Id] = [l3].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l4] ON [l3].[Id] = [l4].[Level2_Optional_Id]
-WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
 ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id], [l4].[Id]",
                 //
                 @"SELECT [l5].[Id], [l5].[Level2_Optional_Id], [l5].[Level2_Required_Id], [l5].[Name], [l5].[OneToMany_Optional_Inverse3Id], [l5].[OneToMany_Optional_Self_Inverse3Id], [l5].[OneToMany_Required_Inverse3Id], [l5].[OneToMany_Required_Self_Inverse3Id], [l5].[OneToOne_Optional_PK_Inverse3Id], [l5].[OneToOne_Optional_Self3Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id], [l4].[Id]
@@ -1834,7 +1834,7 @@ LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[Level2_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l3] ON [l].[Id] = [l3].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l4] ON [l3].[Id] = [l4].[Level2_Optional_Id]
 INNER JOIN [LevelThree] AS [l5] ON [l0].[Id] = [l5].[OneToMany_Optional_Inverse3Id]
-WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
+WHERE ([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL)
 ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id], [l4].[Id]");
         }
 
@@ -2301,7 +2301,7 @@ FROM (
     SELECT [l].[Name]
     FROM [LevelOne] AS [l]
     GROUP BY [l].[Name]
-    HAVING ([l].[Name] <> N'Foo') OR [l].[Name] IS NULL
+    HAVING ([l].[Name] <> N'Foo') OR ([l].[Name] IS NULL)
 ) AS [t]
 LEFT JOIN (
     SELECT [t1].[Id], [t1].[Date], [t1].[Name], [t1].[OneToMany_Optional_Self_Inverse1Id], [t1].[OneToMany_Required_Self_Inverse1Id], [t1].[OneToOne_Optional_Self1Id]
@@ -2318,7 +2318,7 @@ FROM (
     SELECT [l].[Name]
     FROM [LevelOne] AS [l]
     GROUP BY [l].[Name]
-    HAVING ([l].[Name] <> N'Foo') OR [l].[Name] IS NULL
+    HAVING ([l].[Name] <> N'Foo') OR ([l].[Name] IS NULL)
 ) AS [t]
 LEFT JOIN (
     SELECT [t1].[Id], [t1].[Name]
@@ -2658,7 +2658,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
-    WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)) > 0
+    WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))) > 0
 ORDER BY [l].[Id]",
                 //
                 @"SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Optional_Self_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToMany_Required_Self_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t].[OneToOne_Optional_Self2Id], [t].[Id0], [t].[Level2_Optional_Id], [t].[Level2_Required_Id], [t].[Name0], [t].[OneToMany_Optional_Inverse3Id], [t].[OneToMany_Optional_Self_Inverse3Id], [t].[OneToMany_Required_Inverse3Id], [t].[OneToMany_Required_Self_Inverse3Id], [t].[OneToOne_Optional_PK_Inverse3Id], [t].[OneToOne_Optional_Self3Id], [t].[Id1], [t].[Level3_Optional_Id], [t].[Level3_Required_Id], [t].[Name1], [t].[OneToMany_Optional_Inverse4Id], [t].[OneToMany_Optional_Self_Inverse4Id], [t].[OneToMany_Required_Inverse4Id], [t].[OneToMany_Required_Self_Inverse4Id], [t].[OneToOne_Optional_PK_Inverse4Id], [t].[OneToOne_Optional_Self4Id], [l].[Id]
@@ -2673,7 +2673,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
-    WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)) > 0
+    WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR ([l1].[Name] IS NULL))) > 0
 ORDER BY [l].[Id]");
         }
 
@@ -3158,7 +3158,7 @@ FROM [LevelOne] AS [l]
 CROSS APPLY (
     SELECT [l0].[Date]
     FROM [LevelOne] AS [l0]
-    WHERE ([l0].[Name] = [l].[Name]) OR ([l0].[Name] IS NULL AND [l].[Name] IS NULL)
+    WHERE ([l0].[Name] = [l].[Name]) OR (([l0].[Name] IS NULL) AND ([l].[Name] IS NULL))
     GROUP BY [l0].[Date]
 ) AS [t]
 ORDER BY [l].[Id], [t].[Date]",
@@ -3168,7 +3168,7 @@ FROM [LevelOne] AS [l]
 CROSS APPLY (
     SELECT [l0].[Date]
     FROM [LevelOne] AS [l0]
-    WHERE ([l0].[Name] = [l].[Name]) OR ([l0].[Name] IS NULL AND [l].[Name] IS NULL)
+    WHERE ([l0].[Name] = [l].[Name]) OR (([l0].[Name] IS NULL) AND ([l].[Name] IS NULL))
     GROUP BY [l0].[Date]
 ) AS [t]
 INNER JOIN (
@@ -3178,7 +3178,7 @@ INNER JOIN (
         FROM [LevelOne] AS [l1]
     ) AS [t1]
     WHERE (1 < [t1].[row]) AND ([t1].[row] <= 6)
-) AS [t0] ON (([l].[Name] = [t0].[Name]) OR ([l].[Name] IS NULL AND [t0].[Name] IS NULL)) AND ([t].[Date] = [t0].[Date])
+) AS [t0] ON (([l].[Name] = [t0].[Name]) OR (([l].[Name] IS NULL) AND ([t0].[Name] IS NULL))) AND ([t].[Date] = [t0].[Date])
 ORDER BY [l].[Id], [t].[Date], [t0].[Name], [t0].[Date]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -235,7 +235,7 @@ WHERE [l0].[Id] > 5");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
-WHERE [l0].[Name] IS NOT NULL AND ([l0].[Name] LIKE N'L%')");
+WHERE ([l0].[Name] IS NOT NULL) AND ([l0].[Name] LIKE N'L%')");
         }
 
         public override async Task Navigation_inside_method_call_translated_to_join2(bool async)
@@ -246,7 +246,7 @@ WHERE [l0].[Name] IS NOT NULL AND ([l0].[Name] LIKE N'L%')");
                 @"SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse3Id], [l].[OneToMany_Optional_Self_Inverse3Id], [l].[OneToMany_Required_Inverse3Id], [l].[OneToMany_Required_Self_Inverse3Id], [l].[OneToOne_Optional_PK_Inverse3Id], [l].[OneToOne_Optional_Self3Id]
 FROM [LevelThree] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Level2_Required_Id] = [l0].[Id]
-WHERE [l0].[Name] IS NOT NULL AND ([l0].[Name] LIKE N'L%')");
+WHERE ([l0].[Name] IS NOT NULL) AND ([l0].[Name] LIKE N'L%')");
         }
 
         public override async Task Optional_navigation_inside_method_call_translated_to_join(bool async)
@@ -257,7 +257,7 @@ WHERE [l0].[Name] IS NOT NULL AND ([l0].[Name] LIKE N'L%')");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE [l0].[Name] IS NOT NULL AND ([l0].[Name] LIKE N'L%')");
+WHERE ([l0].[Name] IS NOT NULL) AND ([l0].[Name] LIKE N'L%')");
         }
 
         public override async Task Optional_navigation_inside_property_method_translated_to_join(bool async)
@@ -279,7 +279,7 @@ WHERE [l0].[Name] = N'L2 01'");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE [l0].[Name] IS NOT NULL AND (UPPER([l0].[Name]) LIKE N'L%')");
+WHERE ([l0].[Name] IS NOT NULL) AND (UPPER([l0].[Name]) LIKE N'L%')");
         }
 
         public override async Task Method_call_on_optional_navigation_translates_to_null_conditional_properly_for_arguments(bool async)
@@ -290,7 +290,7 @@ WHERE [l0].[Name] IS NOT NULL AND (UPPER([l0].[Name]) LIKE N'L%')");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE ([l0].[Name] = N'') OR ([l0].[Name] IS NOT NULL AND (LEFT([l0].[Name], LEN([l0].[Name])) = [l0].[Name]))");
+WHERE ([l0].[Name] = N'') OR (([l0].[Name] IS NOT NULL) AND (LEFT([l0].[Name], LEN([l0].[Name])) = [l0].[Name]))");
         }
 
         public override async Task Optional_navigation_inside_method_call_translated_to_join_keeps_original_nullability(bool async)
@@ -591,7 +591,7 @@ WHERE ([l0].[Name] = N'L2 05') OR ([l1].[Name] = N'L2 07')");
                 @"SELECT [l].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE ([l0].[Name] = N'L2 05') OR (([l0].[Name] <> N'L2 42') OR [l0].[Name] IS NULL)");
+WHERE ([l0].[Name] = N'L2 05') OR (([l0].[Name] <> N'L2 42') OR ([l0].[Name] IS NULL))");
         }
 
         public override async Task Where_nav_prop_reference_optional2_via_DefaultIfEmpty(bool async)
@@ -603,7 +603,7 @@ WHERE ([l0].[Name] = N'L2 05') OR (([l0].[Name] <> N'L2 42') OR [l0].[Name] IS N
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
-WHERE ([l0].[Name] = N'L2 05') OR (([l1].[Name] <> N'L2 42') OR [l1].[Name] IS NULL)");
+WHERE ([l0].[Name] = N'L2 05') OR (([l1].[Name] <> N'L2 42') OR ([l1].[Name] IS NULL))");
         }
 
         public override async Task Select_multiple_nav_prop_reference_optional(bool async)
@@ -626,7 +626,7 @@ LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]
-WHERE ([l1].[Name] <> N'L3 05') OR [l1].[Name] IS NULL");
+WHERE ([l1].[Name] <> N'L3 05') OR ([l1].[Name] IS NULL)");
         }
 
         public override async Task Where_multiple_nav_prop_reference_optional_member_compared_to_null(bool async)
@@ -744,7 +744,7 @@ LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
-WHERE ([l1].[Name] <> N'L3 05') OR [l1].[Name] IS NULL");
+WHERE ([l1].[Name] <> N'L3 05') OR ([l1].[Name] IS NULL)");
         }
 
         public override async Task SelectMany_navigation_comparison1(bool async)
@@ -792,7 +792,7 @@ FROM [LevelOne] AS [l]
 CROSS JOIN [LevelTwo] AS [l0]
 LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 INNER JOIN [LevelOne] AS [l2] ON [l0].[Level1_Required_Id] = [l2].[Id]
-WHERE ([l1].[Name] = N'L2 01') OR (([l2].[Name] <> N'Bar') OR [l2].[Name] IS NULL)");
+WHERE ([l1].[Name] = N'L2 01') OR (([l2].[Name] <> N'Bar') OR ([l2].[Name] IS NULL))");
         }
 
         public override async Task Where_complex_predicate_with_with_nav_prop_and_OrElse2(bool async)
@@ -804,7 +804,7 @@ WHERE ([l1].[Name] = N'L2 01') OR (([l2].[Name] <> N'Bar') OR [l2].[Name] IS NUL
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
-WHERE ([l1].[Name] = N'L3 05') OR (([l0].[Name] <> N'L2 05') OR [l0].[Name] IS NULL)");
+WHERE ([l1].[Name] = N'L3 05') OR (([l0].[Name] <> N'L2 05') OR ([l0].[Name] IS NULL))");
         }
 
         public override async Task Where_complex_predicate_with_with_nav_prop_and_OrElse3(bool async)
@@ -817,7 +817,7 @@ FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l1].[Id] = [l2].[Level2_Optional_Id]
-WHERE (([l0].[Name] <> N'L2 05') OR [l0].[Name] IS NULL) OR ([l2].[Name] = N'L3 05')");
+WHERE (([l0].[Name] <> N'L2 05') OR ([l0].[Name] IS NULL)) OR ([l2].[Name] = N'L3 05')");
         }
 
         public override async Task Where_complex_predicate_with_with_nav_prop_and_OrElse4(bool async)
@@ -830,7 +830,7 @@ FROM [LevelThree] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Level2_Optional_Id] = [l0].[Id]
 INNER JOIN [LevelTwo] AS [l1] ON [l].[Level2_Required_Id] = [l1].[Id]
 LEFT JOIN [LevelOne] AS [l2] ON [l1].[Level1_Optional_Id] = [l2].[Id]
-WHERE (([l0].[Name] <> N'L2 05') OR [l0].[Name] IS NULL) OR ([l2].[Name] = N'L1 05')");
+WHERE (([l0].[Name] <> N'L2 05') OR ([l0].[Name] IS NULL)) OR ([l2].[Name] = N'L1 05')");
         }
 
         public override async Task Complex_navigations_with_predicate_projected_into_anonymous_type(bool async)
@@ -843,7 +843,7 @@ FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[Level2_Optional_Id]
-WHERE (([l1].[Id] = [l2].[Id]) OR ([l1].[Id] IS NULL AND [l2].[Id] IS NULL)) AND (([l2].[Id] <> 7) OR [l2].[Id] IS NULL)");
+WHERE (([l1].[Id] = [l2].[Id]) OR (([l1].[Id] IS NULL) AND ([l2].[Id] IS NULL))) AND (([l2].[Id] <> 7) OR ([l2].[Id] IS NULL))");
         }
 
         public override async Task Complex_navigations_with_predicate_projected_into_anonymous_type2(bool async)
@@ -856,7 +856,7 @@ FROM [LevelThree] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Level2_Required_Id] = [l0].[Id]
 INNER JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
 LEFT JOIN [LevelOne] AS [l2] ON [l0].[Level1_Optional_Id] = [l2].[Id]
-WHERE ([l1].[Id] = [l2].[Id]) AND (([l2].[Id] <> 7) OR [l2].[Id] IS NULL)");
+WHERE ([l1].[Id] = [l2].[Id]) AND (([l2].[Id] <> 7) OR ([l2].[Id] IS NULL))");
         }
 
         public override async Task Optional_navigation_projected_into_DTO(bool async)
@@ -975,7 +975,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE ([l0].[Name] <> N'L2 05') OR [l0].[Name] IS NULL");
+WHERE ([l0].[Name] <> N'L2 05') OR ([l0].[Name] IS NULL)");
         }
 
         public override async Task Join_flattening_bug_4539(bool async)
@@ -1133,7 +1133,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 WHERE (
     SELECT COUNT(*)
     FROM [LevelThree] AS [l1]
-    WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])) > 0");
+    WHERE ([l0].[Id] IS NOT NULL) AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])) > 0");
         }
 
         public override async Task Where_navigation_property_to_collection2(bool async)
@@ -1761,7 +1761,7 @@ WHERE EXISTS (
     FROM (
         SELECT DISTINCT [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse3Id], [l1].[OneToMany_Optional_Self_Inverse3Id], [l1].[OneToMany_Required_Inverse3Id], [l1].[OneToMany_Required_Self_Inverse3Id], [l1].[OneToOne_Optional_PK_Inverse3Id], [l1].[OneToOne_Optional_Self3Id]
         FROM [LevelThree] AS [l1]
-        WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])
+        WHERE ([l0].[Id] IS NOT NULL) AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])
     ) AS [t]
     WHERE [t].[Id] = 1)");
         }
@@ -1777,7 +1777,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE EXISTS (
     SELECT DISTINCT 1
     FROM [LevelThree] AS [l1]
-    WHERE ([l0].[Id] IS NOT NULL AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])) AND (CAST(LEN([l1].[Name]) AS int) = 1))");
+    WHERE (([l0].[Id] IS NOT NULL) AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])) AND (CAST(LEN([l1].[Name]) AS int) = 1))");
         }
 
         public override async Task Required_navigation_on_a_subquery_with_First_in_projection(bool async)
@@ -1832,7 +1832,7 @@ WHERE ([l].[Id] = 7) AND ((
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
-WHERE ([l1].[Name] <> N'L3 02') OR [l1].[Name] IS NULL");
+WHERE ([l1].[Name] <> N'L3 02') OR ([l1].[Name] IS NULL)");
         }
 
         public override async Task Optional_navigation_propagates_nullability_to_manually_created_left_join1(bool async)
@@ -2186,7 +2186,7 @@ ORDER BY [l1].[Id]");
 SELECT TOP(@__p_0) [l].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
 ORDER BY [l].[Id]");
         }
 
@@ -2200,7 +2200,7 @@ ORDER BY [l].[Id]");
 SELECT TOP(@__p_0) [l].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
 ORDER BY [l].[Id]");
         }
 
@@ -2214,7 +2214,7 @@ FROM (
     SELECT DISTINCT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-    WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+    WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
 ) AS [t]");
         }
 
@@ -2226,7 +2226,7 @@ FROM (
                 @"SELECT DISTINCT [l].[Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL");
+WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)");
         }
 
         public override async Task Explicit_GroupJoin_in_subquery_with_unrelated_projection4(bool async)
@@ -2241,7 +2241,7 @@ FROM (
     SELECT DISTINCT [l].[Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-    WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+    WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
 ) AS [t]
 ORDER BY [t].[Id]");
         }
@@ -2300,7 +2300,7 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             AssertSql(
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
-INNER JOIN [LevelTwo] AS [l0] ON ([l].[OneToMany_Optional_Self_Inverse1Id] = [l0].[Level1_Optional_Id]) OR ([l].[OneToMany_Optional_Self_Inverse1Id] IS NULL AND [l0].[Level1_Optional_Id] IS NULL)");
+INNER JOIN [LevelTwo] AS [l0] ON ([l].[OneToMany_Optional_Self_Inverse1Id] = [l0].[Level1_Optional_Id]) OR (([l].[OneToMany_Optional_Self_Inverse1Id] IS NULL) AND ([l0].[Level1_Optional_Id] IS NULL))");
         }
 
         public override async Task Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties(bool async)
@@ -2310,7 +2310,7 @@ INNER JOIN [LevelTwo] AS [l0] ON ([l].[OneToMany_Optional_Self_Inverse1Id] = [l0
             AssertSql(
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
-INNER JOIN [LevelTwo] AS [l0] ON (([l].[OneToMany_Optional_Self_Inverse1Id] = [l0].[Level1_Optional_Id]) OR ([l].[OneToMany_Optional_Self_Inverse1Id] IS NULL AND [l0].[Level1_Optional_Id] IS NULL)) AND (([l].[OneToOne_Optional_Self1Id] = [l0].[OneToMany_Optional_Self_Inverse2Id]) OR ([l].[OneToOne_Optional_Self1Id] IS NULL AND [l0].[OneToMany_Optional_Self_Inverse2Id] IS NULL))");
+INNER JOIN [LevelTwo] AS [l0] ON (([l].[OneToMany_Optional_Self_Inverse1Id] = [l0].[Level1_Optional_Id]) OR (([l].[OneToMany_Optional_Self_Inverse1Id] IS NULL) AND ([l0].[Level1_Optional_Id] IS NULL))) AND (([l].[OneToOne_Optional_Self1Id] = [l0].[OneToMany_Optional_Self_Inverse2Id]) OR (([l].[OneToOne_Optional_Self1Id] IS NULL) AND ([l0].[OneToMany_Optional_Self_Inverse2Id] IS NULL)))");
         }
 
         public override async Task Nested_group_join_with_take(bool async)
@@ -2339,7 +2339,7 @@ ORDER BY [t].[Id]");
                 @"SELECT [l].[Id]
 FROM [LevelTwo] AS [l]
 INNER JOIN [LevelOne] AS [l0] ON [l].[OneToMany_Required_Inverse2Id] = [l0].[Id]
-WHERE ([l0].[Name] <> N'L1 07') OR [l0].[Name] IS NULL");
+WHERE ([l0].[Name] <> N'L1 07') OR ([l0].[Name] IS NULL)");
         }
 
         public override async Task Multi_level_navigation_compared_to_null(bool async)
@@ -2363,7 +2363,7 @@ WHERE [l1].[Id] IS NOT NULL");
 FROM [LevelThree] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[OneToMany_Optional_Inverse3Id] = [l0].[Id]
 LEFT JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
-WHERE (([l1].[Name] <> N'L1 07') OR [l1].[Name] IS NULL) AND [l1].[Id] IS NOT NULL");
+WHERE (([l1].[Name] <> N'L1 07') OR ([l1].[Name] IS NULL)) AND ([l1].[Id] IS NOT NULL)");
         }
 
         public override async Task Navigations_compared_to_each_other1(bool async)
@@ -2412,7 +2412,7 @@ LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[Level2_Required_Id]
 WHERE EXISTS (
     SELECT 1
     FROM [LevelFour] AS [l1]
-    WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse4Id]))");
+    WHERE ([l0].[Id] IS NOT NULL) AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse4Id]))");
         }
 
         public override async Task Navigations_compared_to_each_other5(bool async)
@@ -2427,7 +2427,7 @@ LEFT JOIN [LevelThree] AS [l1] ON [l].[Id] = [l1].[OneToOne_Optional_PK_Inverse3
 WHERE EXISTS (
     SELECT 1
     FROM [LevelFour] AS [l2]
-    WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l2].[OneToMany_Optional_Inverse4Id]))");
+    WHERE ([l0].[Id] IS NOT NULL) AND ([l0].[Id] = [l2].[OneToMany_Optional_Inverse4Id]))");
         }
 
         public override async Task Level4_Include(bool async)
@@ -2480,11 +2480,11 @@ FROM [LevelTwo] AS [l]");
         SELECT TOP(1) [l1].[Name]
         FROM [LevelTwo] AS [l0]
         INNER JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
-        ORDER BY [l0].[Id]) = N'L1 02') AND (
+        ORDER BY [l0].[Id]) = N'L1 02') AND ((
         SELECT TOP(1) [l1].[Name]
         FROM [LevelTwo] AS [l0]
         INNER JOIN [LevelOne] AS [l1] ON [l0].[Level1_Required_Id] = [l1].[Id]
-        ORDER BY [l0].[Id]) IS NOT NULL THEN CAST(1 AS bit)
+        ORDER BY [l0].[Id]) IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [LevelTwo] AS [l]");
@@ -2546,7 +2546,7 @@ WHERE [l].[Id] < 3");
                 @"SELECT [l].[Id], (
     SELECT COUNT(*)
     FROM [LevelThree] AS [l1]
-    WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])) AS [Count]
+    WHERE ([l0].[Id] IS NOT NULL) AND ([l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id])) AS [Count]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]");
         }
@@ -2735,7 +2735,7 @@ WHERE [l0].[Id] IS NOT NULL");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE [l0].[Name] NOT IN (N'Name1', N'Name2') OR [l0].[Name] IS NULL");
+WHERE [l0].[Name] NOT IN (N'Name1', N'Name2') OR ([l0].[Name] IS NULL)");
         }
 
         public override async Task Include1(bool async)
@@ -2820,7 +2820,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToOne_Optional_PK_Inverse2Id
                 @"SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Date], [l0].[Name], [l0].[OneToMany_Optional_Self_Inverse1Id], [l0].[OneToMany_Required_Self_Inverse1Id], [l0].[OneToOne_Optional_Self1Id]
 FROM [LevelTwo] AS [l]
 LEFT JOIN [LevelOne] AS [l0] ON [l].[Level1_Optional_Id] = [l0].[Id]
-WHERE ([l0].[Name] <> N'Fubar') OR [l0].[Name] IS NULL");
+WHERE ([l0].[Name] <> N'Fubar') OR ([l0].[Name] IS NULL)");
         }
 
         public override async Task Include9(bool async)
@@ -2831,7 +2831,7 @@ WHERE ([l0].[Name] <> N'Fubar') OR [l0].[Name] IS NULL");
                 @"SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Date], [l0].[Name], [l0].[OneToMany_Optional_Self_Inverse1Id], [l0].[OneToMany_Required_Self_Inverse1Id], [l0].[OneToOne_Optional_Self1Id]
 FROM [LevelTwo] AS [l]
 LEFT JOIN [LevelOne] AS [l0] ON [l].[Level1_Optional_Id] = [l0].[Id]
-WHERE ([l0].[Name] <> N'Fubar') OR [l0].[Name] IS NULL");
+WHERE ([l0].[Name] <> N'Fubar') OR ([l0].[Name] IS NULL)");
         }
 
         public override async Task Include10(bool async)
@@ -2954,7 +2954,7 @@ FROM (
     SELECT DISTINCT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
     FROM [LevelOne] AS [l]
     LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
-    WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
+    WHERE ([l0].[Name] <> N'Foo') OR ([l0].[Name] IS NULL)
 ) AS [t]
 LEFT JOIN [LevelTwo] AS [l1] ON [t].[Id] = [l1].[Level1_Optional_Id]");
         }
@@ -3086,7 +3086,7 @@ FROM (
     WHEN NOT EXISTS (
         SELECT 1
         FROM [LevelOne] AS [l]
-        WHERE ([l].[Name] = N'Foo') AND [l].[Name] IS NOT NULL) THEN CAST(1 AS bit)
+        WHERE ([l].[Name] = N'Foo') AND ([l].[Name] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -3134,7 +3134,7 @@ WHERE ((
         ORDER BY [l1].[Id])
     FROM [LevelTwo] AS [l0]
     WHERE [l0].[Level1_Optional_Id] = [l].[Id]
-    ORDER BY [l0].[Id]) <> N'Foo') OR (
+    ORDER BY [l0].[Id]) <> N'Foo') OR ((
     SELECT TOP(1) (
         SELECT TOP(1) (
             SELECT TOP(1) [l2].[Name]
@@ -3146,7 +3146,7 @@ WHERE ((
         ORDER BY [l1].[Id])
     FROM [LevelTwo] AS [l0]
     WHERE [l0].[Level1_Optional_Id] = [l].[Id]
-    ORDER BY [l0].[Id]) IS NULL
+    ORDER BY [l0].[Id]) IS NULL)
 ORDER BY [l].[Id]");
         }
 
@@ -3220,11 +3220,11 @@ ORDER BY [l].[Id]");
         SELECT TOP(1) [l2].[Id]
         FROM [LevelTwo] AS [l2]
         WHERE [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
-        ORDER BY [l2].[Id]) = [l0].[OneToMany_Optional_Inverse3Id]) OR ((
+        ORDER BY [l2].[Id]) = [l0].[OneToMany_Optional_Inverse3Id]) OR (((
         SELECT TOP(1) [l2].[Id]
         FROM [LevelTwo] AS [l2]
         WHERE [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
-        ORDER BY [l2].[Id]) IS NULL AND [l0].[OneToMany_Optional_Inverse3Id] IS NULL))
+        ORDER BY [l2].[Id]) IS NULL) AND ([l0].[OneToMany_Optional_Inverse3Id] IS NULL)))
     ORDER BY [l0].[Id])
 FROM [LevelOne] AS [l]");
         }
@@ -3309,7 +3309,7 @@ LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
 ORDER BY (
     SELECT COUNT(*)
     FROM [LevelThree] AS [l2]
-    WHERE [l0].[Id] IS NOT NULL AND ([l0].[Id] = [l2].[OneToMany_Required_Inverse3Id])), [l1].[Name]");
+    WHERE ([l0].[Id] IS NOT NULL) AND ([l0].[Id] = [l2].[OneToMany_Required_Inverse3Id])), [l1].[Name]");
         }
 
         public override async Task Null_conditional_is_not_applied_explicitly_for_optional_navigation(bool async)
@@ -3320,7 +3320,7 @@ ORDER BY (
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE [l0].[Id] IS NOT NULL AND ([l0].[Name] = N'L2 01')");
+WHERE ([l0].[Id] IS NOT NULL) AND ([l0].[Name] = N'L2 01')");
         }
 
         public override async Task Sum_with_selector_cast_using_as(bool async)
@@ -3366,7 +3366,7 @@ FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
 INNER JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
-LEFT JOIN [LevelOne] AS [l3] ON ([l0].[Id] >= [l3].[Id]) AND (([l2].[Name] = [l3].[Name]) OR ([l2].[Name] IS NULL AND [l3].[Name] IS NULL))");
+LEFT JOIN [LevelOne] AS [l3] ON ([l0].[Id] >= [l3].[Id]) AND (([l2].[Name] = [l3].[Name]) OR (([l2].[Name] IS NULL) AND ([l3].[Name] IS NULL)))");
         }
 
         public override async Task Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(bool async)
@@ -3417,7 +3417,7 @@ END");
         SELECT 1
         FROM [LevelOne] AS [l1]
         LEFT JOIN [LevelTwo] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
-        WHERE ([l2].[Name] = [l0].[Name]) OR ([l2].[Name] IS NULL AND [l0].[Name] IS NULL)) THEN CAST(1 AS bit)
+        WHERE ([l2].[Name] = [l0].[Name]) OR (([l2].[Name] IS NULL) AND ([l0].[Name] IS NULL))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Contains]
 FROM [LevelOne] AS [l]
@@ -3434,7 +3434,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]");
         SELECT 1
         FROM [LevelOne] AS [l2]
         LEFT JOIN [LevelTwo] AS [l3] ON [l2].[Id] = [l3].[Level1_Optional_Id]
-        WHERE ([l3].[Id] = [l1].[Id]) OR ([l3].[Id] IS NULL AND [l1].[Id] IS NULL)) THEN CAST(1 AS bit)
+        WHERE ([l3].[Id] = [l1].[Id]) OR (([l3].[Id] IS NULL) AND ([l1].[Id] IS NULL))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Contains]
 FROM [LevelOne] AS [l]
@@ -3478,7 +3478,7 @@ GROUP BY [l].[Id], [l].[Date], [l].[Name], [l0].[Id], [l0].[Date], [l0].[Level1_
 FROM [LevelTwo] AS [l]
 INNER JOIN [LevelOne] AS [l0] ON [l].[OneToMany_Required_Inverse2Id] = [l0].[Id]
 GROUP BY [l0].[Id]
-HAVING (MAX([l].[Id]) <> 2) OR MAX([l].[Id]) IS NULL");
+HAVING (MAX([l].[Id]) <> 2) OR (MAX([l].[Id]) IS NULL)");
         }
 
         public override async Task GroupBy_aggregate_where_required_relationship_2(bool async)
@@ -3525,10 +3525,10 @@ LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]
 WHERE (CASE
     WHEN [l0].[Id] IS NULL THEN NULL
     ELSE [l1].[Name]
-END <> N'L') OR CASE
+END <> N'L') OR (CASE
     WHEN [l0].[Id] IS NULL THEN NULL
     ELSE [l1].[Name]
-END IS NULL");
+END IS NULL)");
         }
 
         public override async Task Distinct_skip_without_orderby(bool async)
@@ -3634,7 +3634,7 @@ LEFT JOIN (
     FROM [LevelThree] AS [l1]
     GROUP BY [l1].[Name]
 ) AS [t] ON [l].[Name] = [t].[Key]
-WHERE [l0].[Name] IS NOT NULL OR ([t].[Count] > 0)");
+WHERE ([l0].[Name] IS NOT NULL) OR ([t].[Count] > 0)");
         }
 
         public override async Task Collection_FirstOrDefault_property_accesses_in_projection(bool async)
@@ -3705,10 +3705,10 @@ ORDER BY [l].[Id], [t0].[Id]");
         WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND ([l1].[Name] = N'L2 02')) AND (((
         SELECT TOP(1) [l2].[Id]
         FROM [LevelTwo] AS [l2]
-        WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND ([l2].[Name] = N'L2 02')) = [l0].[OneToMany_Optional_Inverse3Id]) OR ((
+        WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND ([l2].[Name] = N'L2 02')) = [l0].[OneToMany_Optional_Inverse3Id]) OR (((
         SELECT TOP(1) [l2].[Id]
         FROM [LevelTwo] AS [l2]
-        WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND ([l2].[Name] = N'L2 02')) IS NULL AND [l0].[OneToMany_Optional_Inverse3Id] IS NULL))
+        WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND ([l2].[Name] = N'L2 02')) IS NULL) AND ([l0].[OneToMany_Optional_Inverse3Id] IS NULL)))
     ORDER BY [l0].[Id]) AS [Pushdown]
 FROM [LevelOne] AS [l]
 WHERE [l].[Id] < 2");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -29,9 +29,9 @@ LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
     FROM [Level1] AS [l0]
     INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-    WHERE ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t] ON [l].[Id] = CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END");
         }
 
@@ -54,9 +54,9 @@ LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
     FROM [Level1] AS [l0]
     INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-    WHERE ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t] ON [l].[Id] = CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id]
@@ -65,13 +65,13 @@ LEFT JOIN (
         SELECT [l3].[Id]
         FROM [Level1] AS [l3]
         INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
-        WHERE ([l3].[OneToOne_Required_PK_Date] IS NOT NULL AND [l3].[Level1_Required_Id] IS NOT NULL) AND [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([l3].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l3].[Level1_Required_Id] IS NOT NULL)) AND ([l3].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t1] ON [l2].[Id] = [t1].[Id]
-    WHERE [l2].[Level2_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL
+    WHERE ([l2].[Level2_Required_Id] IS NOT NULL) AND ([l2].[OneToMany_Required_Inverse3Id] IS NOT NULL)
 ) AS [t0] ON CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END = CASE
-    WHEN [t0].[Level2_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [t0].[Id]
+    WHEN ([t0].[Level2_Required_Id] IS NOT NULL) AND ([t0].[OneToMany_Required_Inverse3Id] IS NOT NULL) THEN [t0].[Id]
 END");
         }
 
@@ -86,9 +86,9 @@ LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[OneToMany_Required_Inverse2Id]
     FROM [Level1] AS [l0]
     INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-    WHERE ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t] ON [l].[Id] = CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Required_Inverse3Id]
@@ -97,13 +97,13 @@ LEFT JOIN (
         SELECT [l3].[Id]
         FROM [Level1] AS [l3]
         INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
-        WHERE ([l3].[OneToOne_Required_PK_Date] IS NOT NULL AND [l3].[Level1_Required_Id] IS NOT NULL) AND [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([l3].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l3].[Level1_Required_Id] IS NOT NULL)) AND ([l3].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t1] ON [l2].[Id] = [t1].[Id]
-    WHERE [l2].[Level2_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL
+    WHERE ([l2].[Level2_Required_Id] IS NOT NULL) AND ([l2].[OneToMany_Required_Inverse3Id] IS NOT NULL)
 ) AS [t0] ON CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END = CASE
-    WHEN [t0].[Level2_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [t0].[Id]
+    WHEN ([t0].[Level2_Required_Id] IS NOT NULL) AND ([t0].[OneToMany_Required_Inverse3Id] IS NOT NULL) THEN [t0].[Id]
 END
 GROUP BY [t0].[Level3_Name]");
         }
@@ -119,9 +119,9 @@ LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[OneToMany_Required_Inverse2Id]
     FROM [Level1] AS [l0]
     INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-    WHERE ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t] ON [l].[Id] = CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Required_Inverse3Id]
@@ -130,25 +130,25 @@ LEFT JOIN (
         SELECT [l3].[Id]
         FROM [Level1] AS [l3]
         INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
-        WHERE ([l3].[OneToOne_Required_PK_Date] IS NOT NULL AND [l3].[Level1_Required_Id] IS NOT NULL) AND [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([l3].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l3].[Level1_Required_Id] IS NOT NULL)) AND ([l3].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t1] ON [l2].[Id] = [t1].[Id]
-    WHERE [l2].[Level2_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL
+    WHERE ([l2].[Level2_Required_Id] IS NOT NULL) AND ([l2].[OneToMany_Required_Inverse3Id] IS NOT NULL)
 ) AS [t0] ON CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END = CASE
-    WHEN [t0].[Level2_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [t0].[Id]
+    WHEN ([t0].[Level2_Required_Id] IS NOT NULL) AND ([t0].[OneToMany_Required_Inverse3Id] IS NOT NULL) THEN [t0].[Id]
 END
 LEFT JOIN (
     SELECT [l5].[Id], [l5].[OneToOne_Required_PK_Date], [l5].[Level1_Required_Id], [l5].[OneToMany_Required_Inverse2Id]
     FROM [Level1] AS [l5]
     INNER JOIN [Level1] AS [l6] ON [l5].[Id] = [l6].[Id]
-    WHERE ([l5].[OneToOne_Required_PK_Date] IS NOT NULL AND [l5].[Level1_Required_Id] IS NOT NULL) AND [l5].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l5].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l5].[Level1_Required_Id] IS NOT NULL)) AND ([l5].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t2] ON [l].[Id] = CASE
-    WHEN ([t2].[OneToOne_Required_PK_Date] IS NOT NULL AND [t2].[Level1_Required_Id] IS NOT NULL) AND [t2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t2].[Id]
+    WHEN (([t2].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t2].[Level1_Required_Id] IS NOT NULL)) AND ([t2].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t2].[Id]
 END
 GROUP BY [t0].[Level3_Name]
 HAVING MIN(COALESCE(CASE
-    WHEN ([t2].[OneToOne_Required_PK_Date] IS NOT NULL AND [t2].[Level1_Required_Id] IS NOT NULL) AND [t2].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t2].[Id]
+    WHEN (([t2].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t2].[Level1_Required_Id] IS NOT NULL)) AND ([t2].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t2].[Id]
 END, 0)) > 0");
         }
 
@@ -163,9 +163,9 @@ LEFT JOIN (
     SELECT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
     FROM [Level1] AS [l0]
     INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
-    WHERE ([l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL) AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([l0].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l0].[Level1_Required_Id] IS NOT NULL)) AND ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t] ON [l].[Id] = CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END
 LEFT JOIN (
     SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Level3_Name], [l2].[OneToMany_Optional_Inverse3Id], [l2].[OneToMany_Required_Inverse3Id], [l2].[OneToOne_Optional_PK_Inverse3Id]
@@ -174,13 +174,13 @@ LEFT JOIN (
         SELECT [l3].[Id]
         FROM [Level1] AS [l3]
         INNER JOIN [Level1] AS [l4] ON [l3].[Id] = [l4].[Id]
-        WHERE ([l3].[OneToOne_Required_PK_Date] IS NOT NULL AND [l3].[Level1_Required_Id] IS NOT NULL) AND [l3].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([l3].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l3].[Level1_Required_Id] IS NOT NULL)) AND ([l3].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t1] ON [l2].[Id] = [t1].[Id]
-    WHERE [l2].[Level2_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL
+    WHERE ([l2].[Level2_Required_Id] IS NOT NULL) AND ([l2].[OneToMany_Required_Inverse3Id] IS NOT NULL)
 ) AS [t0] ON CASE
-    WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
 END = CASE
-    WHEN [t0].[Level2_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [t0].[Id]
+    WHEN ([t0].[Level2_Required_Id] IS NOT NULL) AND ([t0].[OneToMany_Required_Inverse3Id] IS NOT NULL) THEN [t0].[Id]
 END
 LEFT JOIN (
     SELECT [l5].[Id], [l5].[Level3_Optional_Id], [l5].[Level3_Required_Id], [l5].[Level4_Name], [l5].[OneToMany_Optional_Inverse4Id], [l5].[OneToMany_Required_Inverse4Id], [l5].[OneToOne_Optional_PK_Inverse4Id]
@@ -192,15 +192,15 @@ LEFT JOIN (
             SELECT [l7].[Id]
             FROM [Level1] AS [l7]
             INNER JOIN [Level1] AS [l8] ON [l7].[Id] = [l8].[Id]
-            WHERE ([l7].[OneToOne_Required_PK_Date] IS NOT NULL AND [l7].[Level1_Required_Id] IS NOT NULL) AND [l7].[OneToMany_Required_Inverse2Id] IS NOT NULL
+            WHERE (([l7].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l7].[Level1_Required_Id] IS NOT NULL)) AND ([l7].[OneToMany_Required_Inverse2Id] IS NOT NULL)
         ) AS [t4] ON [l6].[Id] = [t4].[Id]
-        WHERE [l6].[Level2_Required_Id] IS NOT NULL AND [l6].[OneToMany_Required_Inverse3Id] IS NOT NULL
+        WHERE ([l6].[Level2_Required_Id] IS NOT NULL) AND ([l6].[OneToMany_Required_Inverse3Id] IS NOT NULL)
     ) AS [t3] ON [l5].[Id] = [t3].[Id]
-    WHERE [l5].[Level3_Required_Id] IS NOT NULL AND [l5].[OneToMany_Required_Inverse4Id] IS NOT NULL
+    WHERE ([l5].[Level3_Required_Id] IS NOT NULL) AND ([l5].[OneToMany_Required_Inverse4Id] IS NOT NULL)
 ) AS [t2] ON CASE
-    WHEN [t0].[Level2_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse3Id] IS NOT NULL THEN [t0].[Id]
+    WHEN ([t0].[Level2_Required_Id] IS NOT NULL) AND ([t0].[OneToMany_Required_Inverse3Id] IS NOT NULL) THEN [t0].[Id]
 END = CASE
-    WHEN [t2].[Level3_Required_Id] IS NOT NULL AND [t2].[OneToMany_Required_Inverse4Id] IS NOT NULL THEN [t2].[Id]
+    WHEN ([t2].[Level3_Required_Id] IS NOT NULL) AND ([t2].[OneToMany_Required_Inverse4Id] IS NOT NULL) THEN [t2].[Id]
 END");
         }
 
@@ -222,11 +222,11 @@ FROM (
             SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[OneToMany_Required_Inverse2Id]
             FROM [Level1] AS [l1]
             INNER JOIN [Level1] AS [l2] ON [l1].[Id] = [l2].[Id]
-            WHERE ([l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL) AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL
+            WHERE (([l1].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l1].[Level1_Required_Id] IS NOT NULL)) AND ([l1].[OneToMany_Required_Inverse2Id] IS NOT NULL)
         ) AS [t] ON [l0].[Id] = CASE
-            WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+            WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
         END
-        WHERE ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t0] ON [l].[Id] = [t0].[Level1_Optional_Id]
     ORDER BY [l].[Id]
 ) AS [t1]
@@ -237,13 +237,13 @@ LEFT JOIN (
         SELECT [l4].[Id], [l4].[OneToOne_Required_PK_Date], [l4].[Level1_Optional_Id], [l4].[Level1_Required_Id], [l4].[Level2_Name], [l4].[OneToMany_Required_Inverse2Id]
         FROM [Level1] AS [l4]
         INNER JOIN [Level1] AS [l5] ON [l4].[Id] = [l5].[Id]
-        WHERE ([l4].[OneToOne_Required_PK_Date] IS NOT NULL AND [l4].[Level1_Required_Id] IS NOT NULL) AND [l4].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([l4].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l4].[Level1_Required_Id] IS NOT NULL)) AND ([l4].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t3] ON [l3].[Id] = CASE
-        WHEN ([t3].[OneToOne_Required_PK_Date] IS NOT NULL AND [t3].[Level1_Required_Id] IS NOT NULL) AND [t3].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t3].[Id]
+        WHEN (([t3].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t3].[Level1_Required_Id] IS NOT NULL)) AND ([t3].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t3].[Id]
     END
-    WHERE ([t3].[OneToOne_Required_PK_Date] IS NOT NULL AND [t3].[Level1_Required_Id] IS NOT NULL) AND [t3].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([t3].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t3].[Level1_Required_Id] IS NOT NULL)) AND ([t3].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t2] ON CASE
-    WHEN ([t1].[OneToOne_Required_PK_Date] IS NOT NULL AND [t1].[Level1_Required_Id] IS NOT NULL) AND [t1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t1].[Id00]
+    WHEN (([t1].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t1].[Level1_Required_Id] IS NOT NULL)) AND ([t1].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t1].[Id00]
 END = [t2].[Level1_Optional_Id]
 ORDER BY [t1].[Id]");
         }
@@ -264,13 +264,13 @@ FROM (
             SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Required_Inverse2Id]
             FROM [Level1] AS [l1]
             INNER JOIN [Level1] AS [l2] ON [l1].[Id] = [l2].[Id]
-            WHERE ([l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL) AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL
+            WHERE (([l1].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l1].[Level1_Required_Id] IS NOT NULL)) AND ([l1].[OneToMany_Required_Inverse2Id] IS NOT NULL)
         ) AS [t] ON [l0].[Id] = CASE
-            WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+            WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
         END
-        WHERE ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t0] ON [l].[Id] = [t0].[Level1_Optional_Id]
-    WHERE ([t0].[Level2_Name] <> N'Foo') OR [t0].[Level2_Name] IS NULL
+    WHERE ([t0].[Level2_Name] <> N'Foo') OR ([t0].[Level2_Name] IS NULL)
 ) AS [t1]");
         }
 
@@ -280,7 +280,7 @@ FROM (
 
             AssertSql(
                 @"SELECT COALESCE(SUM(CASE
-    WHEN ([t0].[OneToOne_Required_PK_Date] IS NULL OR [t0].[Level1_Required_Id] IS NULL) OR [t0].[OneToMany_Required_Inverse2Id] IS NULL THEN 0
+    WHEN (([t0].[OneToOne_Required_PK_Date] IS NULL) OR ([t0].[Level1_Required_Id] IS NULL)) OR ([t0].[OneToMany_Required_Inverse2Id] IS NULL) THEN 0
     ELSE [t0].[Level1_Required_Id]
 END), 0)
 FROM [Level1] AS [l]
@@ -291,11 +291,11 @@ LEFT JOIN (
         SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[OneToMany_Required_Inverse2Id]
         FROM [Level1] AS [l1]
         INNER JOIN [Level1] AS [l2] ON [l1].[Id] = [l2].[Id]
-        WHERE ([l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL) AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL
+        WHERE (([l1].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([l1].[Level1_Required_Id] IS NOT NULL)) AND ([l1].[OneToMany_Required_Inverse2Id] IS NOT NULL)
     ) AS [t] ON [l0].[Id] = CASE
-        WHEN ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+        WHEN (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL) THEN [t].[Id]
     END
-    WHERE ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    WHERE (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t0] ON [l].[Id] = [t0].[Level1_Optional_Id]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -445,7 +445,7 @@ FROM [Customers] AS [c]");
 FROM (
     SELECT * FROM ""Customers""
 ) AS [m]
-WHERE ([m].[ContactName] = [m].[CompanyName]) OR ([m].[ContactName] IS NULL AND [m].[CompanyName] IS NULL)");
+WHERE ([m].[ContactName] = [m].[CompanyName]) OR (([m].[ContactName] IS NULL) AND ([m].[CompanyName] IS NULL))");
         }
 
         public override async Task FromSqlRaw_with_dbParameter(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -139,11 +139,11 @@ WHERE NOT (([f0].[LastName] LIKE N'') OR (CHARINDEX([f0].[LastName], [f].[FirstN
             AssertSql(
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'\%B%' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'\%B%' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'a\_%' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'a\_%' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -154,11 +154,11 @@ FROM [FunkyCustomers] AS [f]",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'\_Ba\_%' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'\_Ba\_%' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND NOT ([f].[FirstName] LIKE N'\%B\%a\%r%' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND NOT ([f].[FirstName] LIKE N'\%B\%a\%r%' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -178,13 +178,13 @@ WHERE 0 = 1");
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm1_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0))",
+WHERE (@__prm1_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0))",
                 //
                 @"@__prm2_0='a_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm2_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0))",
+WHERE (@__prm2_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0))",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -194,25 +194,25 @@ WHERE 0 = 1",
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm4_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0))",
+WHERE (@__prm4_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0))",
                 //
                 @"@__prm5_0='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm5_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0))",
+WHERE (@__prm5_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0))",
                 //
                 @"@__prm6_0='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm6_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0))",
+WHERE (@__prm6_0 <> N'') AND (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0))",
                 //
                 @"@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm7_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0))",
+WHERE (@__prm7_0 <> N'') AND (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0))",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -226,37 +226,37 @@ WHERE 0 = 1");
             AssertSql(
                 @"SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'\[%' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'\[%' ESCAPE N'\')",
                 //
                 @"SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'B\[%' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'B\[%' ESCAPE N'\')",
                 //
                 @"SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'B\[\[a^%' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'B\[\[a^%' ESCAPE N'\')",
                 //
                 @"@__prm1_0='[' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm1_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0))",
+WHERE (@__prm1_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0))",
                 //
                 @"@__prm2_0='B[' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm2_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0))",
+WHERE (@__prm2_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0))",
                 //
                 @"@__prm3_0='B[[a^' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm3_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0))",
+WHERE (@__prm3_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0))",
                 //
                 @"SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE ([f].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f].[LastName] IS NOT NULL AND (LEFT([f].[FirstName], LEN([f].[LastName])) = [f].[LastName])))");
+WHERE ([f].[LastName] = N'') OR (([f].[FirstName] IS NOT NULL) AND (([f].[LastName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN([f].[LastName])) = [f].[LastName])))");
         }
 
         public override async Task String_starts_with_on_argument_with_wildcard_column(bool async)
@@ -267,7 +267,7 @@ WHERE ([f].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f].[LastName]
                 @"SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE ([f0].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (LEFT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName])))");
+WHERE ([f0].[LastName] = N'') OR (([f].[FirstName] IS NOT NULL) AND (([f0].[LastName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName])))");
         }
 
         public override async Task String_starts_with_on_argument_with_wildcard_column_negated(bool async)
@@ -278,7 +278,7 @@ WHERE ([f0].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastNam
                 @"SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (LEFT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName])))");
+WHERE (([f0].[LastName] <> N'') OR ([f0].[LastName] IS NULL)) AND (([f].[FirstName] IS NOT NULL) AND (([f0].[LastName] IS NOT NULL) AND (LEFT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName])))");
         }
 
         public override async Task String_ends_with_on_argument_with_wildcard_constant(bool async)
@@ -288,11 +288,11 @@ WHERE (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName]
             AssertSql(
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'%\%B' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'%\%B' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'%a\_' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'%a\_' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -303,11 +303,11 @@ FROM [FunkyCustomers] AS [f]",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND ([f].[FirstName] LIKE N'%\_Ba\_' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND ([f].[FirstName] LIKE N'%\_Ba\_' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND NOT ([f].[FirstName] LIKE N'%\%B\%a\%r' ESCAPE N'\')",
+WHERE ([f].[FirstName] IS NOT NULL) AND NOT ([f].[FirstName] LIKE N'%\%B\%a\%r' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -327,13 +327,13 @@ WHERE 0 = 1");
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm1_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0))",
+WHERE (@__prm1_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0))",
                 //
                 @"@__prm2_0='a_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm2_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0))",
+WHERE (@__prm2_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0))",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -343,25 +343,25 @@ WHERE 0 = 1",
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm4_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0))",
+WHERE (@__prm4_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0))",
                 //
                 @"@__prm5_0='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm5_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0))",
+WHERE (@__prm5_0 = N'') OR (([f].[FirstName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0))",
                 //
                 @"@__prm6_0='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm6_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0))",
+WHERE (@__prm6_0 <> N'') AND (([f].[FirstName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0))",
                 //
                 @"@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm7_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0))",
+WHERE (@__prm7_0 <> N'') AND (([f].[FirstName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0))",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -376,7 +376,7 @@ WHERE 0 = 1");
                 @"SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE ([f0].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName])))");
+WHERE ([f0].[LastName] = N'') OR (([f].[FirstName] IS NOT NULL) AND (([f0].[LastName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName])))");
         }
 
         public override async Task String_ends_with_on_argument_with_wildcard_column_negated(bool async)
@@ -387,7 +387,7 @@ WHERE ([f0].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastNam
                 @"SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName])))");
+WHERE (([f0].[LastName] <> N'') OR ([f0].[LastName] IS NULL)) AND (([f].[FirstName] IS NOT NULL) AND (([f0].[LastName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName])))");
         }
 
         public override async Task String_ends_with_inside_conditional(bool async)
@@ -399,7 +399,7 @@ WHERE (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN ([f0].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]))) THEN CAST(1 AS bit)
+    WHEN ([f0].[LastName] = N'') OR (([f].[FirstName] IS NOT NULL) AND (([f0].[LastName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)");
         }
@@ -413,7 +413,7 @@ END = CAST(1 AS bit)");
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]))) THEN CAST(1 AS bit)
+    WHEN (([f0].[LastName] <> N'') OR ([f0].[LastName] IS NULL)) AND (([f].[FirstName] IS NOT NULL) AND (([f0].[LastName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)");
         }
@@ -427,7 +427,7 @@ END = CAST(1 AS bit)");
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN (([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]))) THEN CAST(1 AS bit)
+    WHEN (([f0].[LastName] = N'') AND ([f0].[LastName] IS NOT NULL)) OR (([f].[FirstName] IS NOT NULL) AND (([f0].[LastName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = [f].[NullableBool]");
         }
@@ -441,7 +441,7 @@ END = [f].[NullableBool]");
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE (CASE
-    WHEN (([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]))) THEN CAST(1 AS bit)
+    WHEN (([f0].[LastName] = N'') AND ([f0].[LastName] IS NOT NULL)) OR (([f].[FirstName] IS NOT NULL) AND (([f0].[LastName] IS NOT NULL) AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> [f].[NullableBool]) OR ([f].[NullableBool] IS NULL)");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -51,7 +51,7 @@ WHERE [s].[Id] = -[s].[Id]");
             AssertSql(
                 @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE [s].[Name] IS NOT NULL AND NOT ([s].[Name] LIKE N'us%')");
+WHERE ([s].[Name] IS NOT NULL) AND NOT ([s].[Name] LIKE N'us%')");
         }
 
         public override async Task Entity_equality_empty(bool async)
@@ -216,7 +216,7 @@ FROM [Tags] AS [t]",
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
+WHERE ([t].[Id] IS NOT NULL) AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
         }
 
         public override async Task Include_where_list_contains_navigation2(bool async)
@@ -231,7 +231,7 @@ FROM [Tags] AS [t]",
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
+WHERE ([c].[Location] IS NOT NULL) AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
         }
 
         public override async Task Navigation_accessed_twice_outside_and_inside_subquery(bool async)
@@ -245,7 +245,7 @@ FROM [Tags] AS [t]",
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
+WHERE ([t].[Id] IS NOT NULL) AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
         }
 
         public override async Task Include_with_join_multi_level(bool async)
@@ -330,7 +330,7 @@ ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [g0].[Nickname]");
 FROM [Weapons] AS [w]
 LEFT JOIN [Gears] AS [g] ON [w].[OwnerFullName] = [g].[FullName]
 LEFT JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
-WHERE ([g].[Nickname] <> N'Paduk') OR [g].[Nickname] IS NULL
+WHERE ([g].[Nickname] <> N'Paduk') OR ([g].[Nickname] IS NULL)
 ORDER BY [c].[Name], [w].[Id]");
         }
 
@@ -563,10 +563,10 @@ WHERE (([g].[Rank] & (
     ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
-    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL",
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)",
                 //
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
@@ -576,10 +576,10 @@ WHERE ((2 & (
     ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
-    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL");
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)");
         }
 
         public override async Task Where_enum_has_flag_subquery_client_eval(bool async)
@@ -595,10 +595,10 @@ WHERE (([g].[Rank] & (
     ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
-    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL");
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)");
         }
 
         public override async Task Where_enum_has_flag_with_non_nullable_parameter(bool async)
@@ -688,7 +688,7 @@ WHERE [w].[IsAutomatic] = CAST(1 AS bit)");
                 @"@__ammunitionType_0='1' (Nullable = true)
 
 SELECT [w].[Id], CASE
-    WHEN ([w].[AmmunitionType] = @__ammunitionType_0) AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Cartridge]
 FROM [Weapons] AS [w]
@@ -754,11 +754,11 @@ FROM [Weapons] AS [w]");
 
             AssertSql(
                 @"SELECT [w].[Id], CASE
-    WHEN [w].[AmmunitionType] IS NOT NULL AND ([w].[AmmunitionType] = 1) THEN N'Yes'
+    WHEN ([w].[AmmunitionType] IS NOT NULL) AND ([w].[AmmunitionType] = 1) THEN N'Yes'
     ELSE N'No'
 END AS [IsCartridge]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] IS NOT NULL AND ([w].[AmmunitionType] = 1)");
+WHERE ([w].[AmmunitionType] IS NOT NULL) AND ([w].[AmmunitionType] = 1)");
         }
 
         public override async Task Select_ternary_operation_multiple_conditions(bool async)
@@ -791,7 +791,7 @@ FROM [Weapons] AS [w]");
 
             AssertSql(
                 @"SELECT [w].[Id], CASE
-    WHEN ([w].[IsAutomatic] = CAST(0 AS bit)) AND (([w].[SynergyWithId] = 1) AND [w].[SynergyWithId] IS NOT NULL) THEN CAST(1 AS bit)
+    WHEN ([w].[IsAutomatic] = CAST(0 AS bit)) AND (([w].[SynergyWithId] = 1) AND ([w].[SynergyWithId] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsCartridge]
 FROM [Weapons] AS [w]");
@@ -819,7 +819,7 @@ FROM [Weapons] AS [w]");
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE ([g].[LeaderNickname] = N'Marcus') AND [g].[LeaderNickname] IS NOT NULL");
+WHERE ([g].[LeaderNickname] = N'Marcus') AND ([g].[LeaderNickname] IS NOT NULL)");
         }
 
         public override async Task Null_propagation_optimization2(bool async)
@@ -833,7 +833,7 @@ FROM [Gears] AS [g]
 WHERE CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CASE
-        WHEN [g].[LeaderNickname] IS NOT NULL AND ([g].[LeaderNickname] LIKE N'%us') THEN CAST(1 AS bit)
+        WHEN ([g].[LeaderNickname] IS NOT NULL) AND ([g].[LeaderNickname] LIKE N'%us') THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)");
@@ -867,10 +867,10 @@ FROM [Gears] AS [g]
 WHERE (CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5) AND CASE
+END = 5) AND (CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CAST(LEN([g].[LeaderNickname]) AS int)
-END IS NOT NULL");
+END IS NOT NULL)");
         }
 
         public override async Task Null_propagation_optimization5(bool async)
@@ -884,10 +884,10 @@ FROM [Gears] AS [g]
 WHERE (CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
     ELSE NULL
-END = 5) AND CASE
+END = 5) AND (CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
     ELSE NULL
-END IS NOT NULL");
+END IS NOT NULL)");
         }
 
         public override async Task Null_propagation_optimization6(bool async)
@@ -901,10 +901,10 @@ FROM [Gears] AS [g]
 WHERE (CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
     ELSE NULL
-END = 5) AND CASE
+END = 5) AND (CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
     ELSE NULL
-END IS NOT NULL");
+END IS NOT NULL)");
         }
 
         public override async Task Select_null_propagation_optimization7(bool async)
@@ -972,7 +972,7 @@ CROSS JOIN [Gears] AS [g0]");
 
             AssertSql(
                 @"SELECT [g0].[Nickname], CASE
-    WHEN [g0].[Nickname] IS NOT NULL AND [g0].[SquadId] IS NOT NULL THEN CASE
+    WHEN ([g0].[Nickname] IS NOT NULL) AND ([g0].[SquadId] IS NOT NULL) THEN CASE
         WHEN [g0].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
@@ -989,7 +989,7 @@ ORDER BY [g0].[Nickname]");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [g0].[Nickname] IS NOT NULL AND [g0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([g0].[Nickname] IS NOT NULL) AND ([g0].[SquadId] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [g0].[Nickname]
 FROM [Gears] AS [g]
@@ -1003,7 +1003,7 @@ ORDER BY [g0].[Nickname]");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [g0].[Nickname] IS NOT NULL AND [g0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([g0].[Nickname] IS NOT NULL) AND ([g0].[SquadId] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [g0].[Nickname]
 FROM [Gears] AS [g]
@@ -1089,7 +1089,7 @@ LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[Gear
 END
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-LEFT JOIN [Tags] AS [t0] ON (([g].[Nickname] = [t0].[GearNickName]) OR ([g].[Nickname] IS NULL AND [t0].[GearNickName] IS NULL)) AND (([g].[SquadId] = [t0].[GearSquadId]) OR ([g].[SquadId] IS NULL AND [t0].[GearSquadId] IS NULL))
+LEFT JOIN [Tags] AS [t0] ON (([g].[Nickname] = [t0].[GearNickName]) OR (([g].[Nickname] IS NULL) AND ([t0].[GearNickName] IS NULL))) AND (([g].[SquadId] = [t0].[GearSquadId]) OR (([g].[SquadId] IS NULL) AND ([t0].[GearSquadId] IS NULL)))
 LEFT JOIN [Gears] AS [g0] ON ([t0].[GearNickName] = [g0].[Nickname]) AND ([t0].[GearSquadId] = [g0].[SquadId])
 LEFT JOIN [Cities] AS [c] ON [g0].[AssignedCityName] = [c].[Name]");
         }
@@ -1200,7 +1200,7 @@ FROM [Tags] AS [t]
 CROSS JOIN [Tags] AS [t0]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 LEFT JOIN [Gears] AS [g0] ON ([t0].[GearNickName] = [g0].[Nickname]) AND ([t0].[GearSquadId] = [g0].[SquadId])
-WHERE ([g].[Nickname] = [g0].[Nickname]) OR ([g].[Nickname] IS NULL AND [g0].[Nickname] IS NULL)");
+WHERE ([g].[Nickname] = [g0].[Nickname]) OR (([g].[Nickname] IS NULL) AND ([g0].[Nickname] IS NULL))");
         }
 
         public override async Task Select_Singleton_Navigation_With_Member_Access(bool async)
@@ -1211,7 +1211,7 @@ WHERE ([g].[Nickname] = [g0].[Nickname]) OR ([g].[Nickname] IS NULL AND [g0].[Ni
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([g].[Nickname] = N'Marcus') AND (([g].[CityOfBirthName] <> N'Ephyra') OR [g].[CityOfBirthName] IS NULL)");
+WHERE ([g].[Nickname] = N'Marcus') AND (([g].[CityOfBirthName] <> N'Ephyra') OR ([g].[CityOfBirthName] IS NULL))");
         }
 
         public override async Task Select_Where_Navigation(bool async)
@@ -1235,7 +1235,7 @@ FROM [Tags] AS [t]
 CROSS JOIN [Tags] AS [t0]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 LEFT JOIN [Gears] AS [g0] ON ([t0].[GearNickName] = [g0].[Nickname]) AND ([t0].[GearSquadId] = [g0].[SquadId])
-WHERE (([g].[Nickname] = [g0].[Nickname]) OR ([g].[Nickname] IS NULL AND [g0].[Nickname] IS NULL)) AND (([g].[SquadId] = [g0].[SquadId]) OR ([g].[SquadId] IS NULL AND [g0].[SquadId] IS NULL))");
+WHERE (([g].[Nickname] = [g0].[Nickname]) OR (([g].[Nickname] IS NULL) AND ([g0].[Nickname] IS NULL))) AND (([g].[SquadId] = [g0].[SquadId]) OR (([g].[SquadId] IS NULL) AND ([g0].[SquadId] IS NULL)))");
         }
 
         public override async Task Select_Where_Navigation_Null(bool async)
@@ -1246,7 +1246,7 @@ WHERE (([g].[Nickname] = [g0].[Nickname]) OR ([g].[Nickname] IS NULL AND [g0].[N
                 @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE [g].[Nickname] IS NULL OR [g].[SquadId] IS NULL");
+WHERE ([g].[Nickname] IS NULL) OR ([g].[SquadId] IS NULL)");
         }
 
         public override async Task Select_Where_Navigation_Null_Reverse(bool async)
@@ -1257,7 +1257,7 @@ WHERE [g].[Nickname] IS NULL OR [g].[SquadId] IS NULL");
                 @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE [g].[Nickname] IS NULL OR [g].[SquadId] IS NULL");
+WHERE ([g].[Nickname] IS NULL) OR ([g].[SquadId] IS NULL)");
         }
 
         public override async Task Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected(bool async)
@@ -1270,7 +1270,7 @@ FROM [Tags] AS [t]
 CROSS JOIN [Tags] AS [t0]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 LEFT JOIN [Gears] AS [g0] ON ([t0].[GearNickName] = [g0].[Nickname]) AND ([t0].[GearSquadId] = [g0].[SquadId])
-WHERE ([g].[Nickname] = [g0].[Nickname]) OR ([g].[Nickname] IS NULL AND [g0].[Nickname] IS NULL)");
+WHERE ([g].[Nickname] = [g0].[Nickname]) OR (([g].[Nickname] IS NULL) AND ([g0].[Nickname] IS NULL))");
         }
 
         public override async Task Optional_Navigation_Null_Coalesce_To_Clr_Type(bool async)
@@ -1707,7 +1707,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
                 @"SELECT [g].[CityOfBirthName] AS [B]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([g].[Nickname] = N'Marcus') AND (([g].[CityOfBirthName] <> N'Ephyra') OR [g].[CityOfBirthName] IS NULL)");
+WHERE ([g].[Nickname] = N'Marcus') AND (([g].[CityOfBirthName] <> N'Ephyra') OR ([g].[CityOfBirthName] IS NULL))");
         }
 
         public override async Task GroupJoin_Composite_Key(bool async)
@@ -2081,7 +2081,7 @@ WHERE ([w].[AmmunitionType] = 1) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)
 
             AssertSql(
                 @"SELECT CASE
-    WHEN (([w].[AmmunitionType] = 1) AND [w].[AmmunitionType] IS NOT NULL) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)) = CAST(1 AS bit)) THEN CAST(1 AS bit)
+    WHEN (([w].[AmmunitionType] = 1) AND ([w].[AmmunitionType] IS NOT NULL)) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)) = CAST(1 AS bit)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Weapons] AS [w]");
@@ -2095,7 +2095,7 @@ FROM [Weapons] AS [w]");
                 @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND ([g].[HasSoulPatch] = CAST(1 AS bit))");
+WHERE (([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)) AND ([g].[HasSoulPatch] = CAST(1 AS bit))");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_predicate2(bool async)
@@ -2194,7 +2194,7 @@ LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[Gear
                 @"SELECT [g].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_projection_into_anonymous_type(bool async)
@@ -2205,7 +2205,7 @@ WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
                 @"SELECT [g].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_DTOs(bool async)
@@ -2216,7 +2216,7 @@ WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
                 @"SELECT [g].[SquadId] AS [Id]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_list_initializers(bool async)
@@ -2227,7 +2227,7 @@ WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
                 @"SELECT [g].[SquadId], [g].[SquadId] + 1
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)
 ORDER BY [t].[Note]");
         }
 
@@ -2239,7 +2239,7 @@ ORDER BY [t].[Note]");
                 @"SELECT [g].[SquadId]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_orderby(bool async)
@@ -2250,7 +2250,7 @@ WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
                 @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)
 ORDER BY [g].[SquadId]");
         }
 
@@ -2264,7 +2264,7 @@ ORDER BY [g].[SquadId]");
         SELECT 1
         FROM [Tags] AS [t]
         LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-        WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND ([g].[HasSoulPatch] = CAST(0 AS bit))) THEN CAST(1 AS bit)
+        WHERE (([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)) AND ([g].[HasSoulPatch] = CAST(0 AS bit))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -2277,7 +2277,7 @@ END");
                 @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND ([g].[HasSoulPatch] = CAST(0 AS bit))");
+WHERE (([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)) AND ([g].[HasSoulPatch] = CAST(0 AS bit))");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_contains(bool async)
@@ -2288,7 +2288,7 @@ WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND ([g].[HasSoulPatch] 
                 @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND EXISTS (
+WHERE (([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     WHERE [g0].[SquadId] = [g].[SquadId])");
@@ -2412,7 +2412,7 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL
+    WHERE ([w].[Name] <> N'Lancer') OR ([w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [c].[Name] IN (N'Ephyra', N'Hanover')
 ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name]");
@@ -2716,7 +2716,7 @@ WHERE ([w].[Id] <> 50) AND ([g].[HasSoulPatch] = CAST(0 AS bit))");
                 @"SELECT DISTINCT [g].[HasSoulPatch]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Sum_with_optional_navigation_is_translated_to_sql(bool async)
@@ -2727,7 +2727,7 @@ WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
                 @"SELECT COALESCE(SUM([g].[SquadId]), 0)
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Count_with_optional_navigation_is_translated_to_sql(bool async)
@@ -2738,7 +2738,7 @@ WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
                 @"SELECT COUNT(*)
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task FirstOrDefault_with_manually_created_groupjoin_is_translated_to_sql(bool async)
@@ -2776,7 +2776,7 @@ WHERE NOT (EXISTS (
         SELECT 1
         FROM [Gears] AS [g]
         LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-        WHERE ([t].[Note] = N'Foo') AND [t].[Note] IS NOT NULL) THEN CAST(1 AS bit)
+        WHERE ([t].[Note] = N'Foo') AND ([t].[Note] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -2891,7 +2891,7 @@ ORDER BY [g].[Nickname]");
 FROM [Gears] AS [g]
 INNER JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName]
 INNER JOIN [Tags] AS [t0] ON [g].[Nickname] = [t0].[GearNickName]
-WHERE ([t].[GearNickName] <> N'Cole Train') OR [t].[GearNickName] IS NULL
+WHERE ([t].[GearNickName] <> N'Cole Train') OR ([t].[GearNickName] IS NULL)
 ORDER BY [g].[Nickname], [t0].[Id]");
         }
 
@@ -3291,7 +3291,7 @@ ORDER BY [g].[Nickname], [t].[Nickname]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
-WHERE ([g].[SquadId] < 2) AND (([c].[Name] = N'Ephyra') OR [c].[Name] IS NULL)");
+WHERE ([g].[SquadId] < 2) AND (([c].[Name] = N'Ephyra') OR ([c].[Name] IS NULL))");
         }
 
         public override async Task Optional_navigation_with_collection_composite_key(bool async)
@@ -3305,7 +3305,7 @@ LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[Gear
 WHERE ([g].[Discriminator] = N'Officer') AND ((
     SELECT COUNT(*)
     FROM [Gears] AS [g0]
-    WHERE (([g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL) AND (([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))) AND ([g0].[Nickname] = N'Dom')) > 0)");
+    WHERE ((([g].[Nickname] IS NOT NULL) AND ([g].[SquadId] IS NOT NULL)) AND (([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))) AND ([g0].[Nickname] = N'Dom')) > 0)");
         }
 
         public override async Task Select_null_conditional_with_inheritance(bool async)
@@ -3362,7 +3362,7 @@ LEFT JOIN (
     WHERE [l].[Discriminator] = N'LocustCommander'
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Gears] AS [g] ON ([t].[DefeatedByNickname] = [g].[Nickname]) AND ([t].[DefeatedBySquadId] = [g].[SquadId])
-LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
+LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR (([g].[Nickname] IS NULL) AND ([g0].[LeaderNickname] IS NULL))) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
@@ -3379,7 +3379,7 @@ LEFT JOIN (
     WHERE [l].[Discriminator] = N'LocustCommander'
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Gears] AS [g] ON ([t].[DefeatedByNickname] = [g].[Nickname]) AND ([t].[DefeatedBySquadId] = [g].[SquadId])
-LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
+LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR (([g].[Nickname] IS NULL) AND ([g0].[LeaderNickname] IS NULL))) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
@@ -3416,7 +3416,7 @@ LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], [c].[Name], [c].[Location], [c].[Nation]
     FROM [Gears] AS [g0]
     INNER JOIN [Cities] AS [c] ON [g0].[CityOfBirthName] = [c].[Name]
-) AS [t] ON (([g].[Nickname] = [t].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [t].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [t].[LeaderSquadId])
+) AS [t] ON (([g].[Nickname] = [t].[LeaderNickname]) OR (([g].[Nickname] IS NULL) AND ([t].[LeaderNickname] IS NULL))) AND ([g].[SquadId] = [t].[LeaderSquadId])
 ORDER BY [l].[Name], [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
         }
 
@@ -3520,7 +3520,7 @@ LEFT JOIN (
     WHERE [l].[Discriminator] = N'LocustCommander'
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Gears] AS [g] ON ([t].[DefeatedByNickname] = [g].[Nickname]) AND ([t].[DefeatedBySquadId] = [g].[SquadId])
-LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
+LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR (([g].[Nickname] IS NULL) AND ([g0].[LeaderNickname] IS NULL))) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
@@ -3567,7 +3567,7 @@ LEFT JOIN (
     WHERE [l].[Discriminator] = N'LocustCommander'
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Gears] AS [g] ON ([t].[DefeatedByNickname] = [g].[Nickname]) AND ([t].[DefeatedBySquadId] = [g].[SquadId])
-LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
+LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR (([g].[Nickname] IS NULL) AND ([g0].[LeaderNickname] IS NULL))) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
@@ -3593,7 +3593,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Id],
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL THEN [g].[HasSoulPatch]
+    WHEN ([g].[Nickname] IS NOT NULL) AND ([g].[SquadId] IS NOT NULL) THEN [g].[HasSoulPatch]
     ELSE CAST(0 AS bit)
 END AS [Prop]
 FROM [Tags] AS [t]
@@ -3683,7 +3683,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -3699,7 +3699,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -3715,7 +3715,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -3731,7 +3731,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name] DESC");
@@ -3763,7 +3763,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Name], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -3779,7 +3779,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT N'BFG' AS [c], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -3795,7 +3795,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT CAST(1 AS bit) AS [c], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -3906,7 +3906,7 @@ LEFT JOIN (
     LEFT JOIN (
         SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE ([w].[Name] <> N'Bar') OR [w].[Name] IS NULL
+        WHERE ([w].[Name] <> N'Bar') OR ([w].[Name] IS NULL)
     ) AS [t] ON [g0].[FullName] = [t].[OwnerFullName]
     WHERE [g0].[FullName] <> N'Foo'
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
@@ -4046,7 +4046,7 @@ LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [g2].[Nickname], [g2].[SquadId], (
         SELECT COUNT(*)
         FROM [Weapons] AS [w0]
-        WHERE [g2].[FullName] IS NOT NULL AND ([g2].[FullName] = [w0].[OwnerFullName])) AS [c]
+        WHERE ([g2].[FullName] IS NOT NULL) AND ([g2].[FullName] = [w0].[OwnerFullName])) AS [c]
     FROM [Weapons] AS [w]
     LEFT JOIN [Gears] AS [g2] ON [w].[OwnerFullName] = [g2].[FullName]
 ) AS [t0] ON [g1].[FullName] = [t0].[OwnerFullName]
@@ -4079,7 +4079,7 @@ LEFT JOIN (
             SELECT [g4].[Nickname], [g4].[HasSoulPatch], [g4].[SquadId]
             FROM [Gears] AS [g4]
         ) AS [t2] ON [s].[Id] = [t2].[SquadId]
-        WHERE ([w].[Name] <> N'Bar') OR [w].[Name] IS NULL
+        WHERE ([w].[Name] <> N'Bar') OR ([w].[Name] IS NULL)
     ) AS [t0] ON [g2].[FullName] = [t0].[OwnerFullName]
     WHERE [g2].[FullName] <> N'Foo'
 ) AS [t1] ON ([g].[Nickname] = [t1].[LeaderNickname]) AND ([g].[SquadId] = [t1].[LeaderSquadId])
@@ -4140,7 +4140,7 @@ LEFT JOIN (
     OUTER APPLY (
         SELECT [w].[Name], [g0].[Nickname], [w].[Id]
         FROM [Weapons] AS [w]
-        WHERE (([w].[Name] <> N'Bar') OR [w].[Name] IS NULL) AND ([g0].[FullName] = [w].[OwnerFullName])
+        WHERE (([w].[Name] <> N'Bar') OR ([w].[Name] IS NULL)) AND ([g0].[FullName] = [w].[OwnerFullName])
     ) AS [t]
     WHERE [g0].[FullName] <> N'Foo'
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
@@ -4161,7 +4161,7 @@ OUTER APPLY (
     LEFT JOIN (
         SELECT [w].[Name], [g].[Nickname], [w].[Id], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
-        WHERE ([w].[Name] <> N'Bar') OR [w].[Name] IS NULL
+        WHERE ([w].[Name] <> N'Bar') OR ([w].[Name] IS NULL)
     ) AS [t] ON [g0].[FullName] = [t].[OwnerFullName]
     WHERE ([g0].[FullName] <> N'Foo') AND (([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
 ) AS [t0]
@@ -4180,7 +4180,7 @@ CROSS JOIN [Squads] AS [s]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
@@ -4312,7 +4312,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] = N'Officer'
 ) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
-LEFT JOIN [Gears] AS [g0] ON (([t0].[Nickname] = [g0].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [g0].[LeaderSquadId])
+LEFT JOIN [Gears] AS [g0] ON (([t0].[Nickname] = [g0].[LeaderNickname]) OR (([t0].[Nickname] IS NULL) AND ([g0].[LeaderNickname] IS NULL))) AND ([t0].[SquadId] = [g0].[LeaderSquadId])
 ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [g0].[Nickname]");
         }
 
@@ -4548,7 +4548,7 @@ FROM (
     SELECT TOP(@__p_0) [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator] AS [Discriminator0], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[Note]
     FROM [LocustLeaders] AS [l]
     LEFT JOIN [Gears] AS [g] ON ([l].[DefeatedByNickname] = [g].[Nickname]) AND ([l].[DefeatedBySquadId] = [g].[SquadId])
-    LEFT JOIN [Tags] AS [t] ON (([g].[Nickname] = [t].[GearNickName]) OR ([g].[Nickname] IS NULL AND [t].[GearNickName] IS NULL)) AND (([g].[SquadId] = [t].[GearSquadId]) OR ([g].[SquadId] IS NULL AND [t].[GearSquadId] IS NULL))
+    LEFT JOIN [Tags] AS [t] ON (([g].[Nickname] = [t].[GearNickName]) OR (([g].[Nickname] IS NULL) AND ([t].[GearNickName] IS NULL))) AND (([g].[SquadId] = [t].[GearSquadId]) OR (([g].[SquadId] IS NULL) AND ([t].[GearSquadId] IS NULL)))
     ORDER BY [t].[Note]
 ) AS [t0]
 LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
@@ -5399,7 +5399,7 @@ END");
                 @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 ORDER BY CASE
-    WHEN ([w].[Name] = N'Marcus'' Lancer') AND [w].[Name] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([w].[Name] = N'Marcus'' Lancer') AND ([w].[Name] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [w].[Id]");
         }
@@ -5423,7 +5423,7 @@ ORDER BY [w].[Id] + 2");
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN ([w0].[Name] = N'Marcus'' Lancer') AND [w0].[Name] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([w0].[Name] = N'Marcus'' Lancer') AND ([w0].[Name] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -5437,7 +5437,7 @@ END");
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN (N'Marcus'' Lancer' = [w0].[Name]) AND [w0].[Name] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN (N'Marcus'' Lancer' = [w0].[Name]) AND ([w0].[Name] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -5779,7 +5779,7 @@ WHERE [g].[Nickname] <> N'Dom'");
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 LEFT JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]
-WHERE (SUBSTRING([t].[Note], 0 + 1, CAST(LEN([s].[Name]) AS int)) = [t].[GearNickName]) OR (([t].[Note] IS NULL OR [s].[Name] IS NULL) AND [t].[GearNickName] IS NULL)");
+WHERE (SUBSTRING([t].[Note], 0 + 1, CAST(LEN([s].[Name]) AS int)) = [t].[GearNickName]) OR ((([t].[Note] IS NULL) OR ([s].[Name] IS NULL)) AND ([t].[GearNickName] IS NULL))");
         }
 
         public override async Task Filter_with_new_Guid(bool async)
@@ -5819,7 +5819,7 @@ WHERE [t].[Id] = @__p_0");
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
 LEFT JOIN [Tags] AS [t0] ON ([g].[Nickname] = [t0].[GearNickName]) AND ([g].[SquadId] = [t0].[GearSquadId])
-WHERE ((([t].[Note] <> N'Foo') OR [t].[Note] IS NULL) AND ([g].[Discriminator] = N'Officer')) AND (([t0].[Note] <> N'Bar') OR [t0].[Note] IS NULL)");
+WHERE ((([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)) AND ([g].[Discriminator] = N'Officer')) AND (([t0].[Note] <> N'Bar') OR ([t0].[Note] IS NULL))");
         }
 
         public override async Task OfTypeNav2(bool async)
@@ -5831,7 +5831,7 @@ WHERE ((([t].[Note] <> N'Foo') OR [t].[Note] IS NULL) AND ([g].[Discriminator] =
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
-WHERE ((([t].[Note] <> N'Foo') OR [t].[Note] IS NULL) AND ([g].[Discriminator] = N'Officer')) AND (([c].[Location] <> 'Bar') OR [c].[Location] IS NULL)");
+WHERE ((([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)) AND ([g].[Discriminator] = N'Officer')) AND (([c].[Location] <> 'Bar') OR ([c].[Location] IS NULL))");
         }
 
         public override async Task OfTypeNav3(bool async)
@@ -5844,7 +5844,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
 INNER JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 LEFT JOIN [Tags] AS [t0] ON ([g].[Nickname] = [t0].[GearNickName]) AND ([g].[SquadId] = [t0].[GearSquadId])
-WHERE ((([t].[Note] <> N'Foo') OR [t].[Note] IS NULL) AND ([g].[Discriminator] = N'Officer')) AND (([t0].[Note] <> N'Bar') OR [t0].[Note] IS NULL)");
+WHERE ((([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)) AND ([g].[Discriminator] = N'Officer')) AND (([t0].[Note] <> N'Bar') OR ([t0].[Note] IS NULL))");
         }
 
         public override void Nav_rewrite_Distinct_with_convert()
@@ -5876,7 +5876,7 @@ LEFT JOIN (
     FROM [LocustLeaders] AS [l]
     WHERE [l].[Discriminator] = N'LocustCommander'
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
-WHERE ([c].[Name] <> N'Foo') OR [c].[Name] IS NULL");
+WHERE ([c].[Name] <> N'Foo') OR ([c].[Name] IS NULL)");
         }
 
         public override async Task Nav_rewrite_with_convert2(bool async)
@@ -5892,7 +5892,7 @@ LEFT JOIN (
     FROM [LocustLeaders] AS [l]
     WHERE [l].[Discriminator] = N'LocustCommander'
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
-WHERE (([c].[Name] <> N'Foo') OR [c].[Name] IS NULL) AND (([t].[Name] <> N'Bar') OR [t].[Name] IS NULL)");
+WHERE (([c].[Name] <> N'Foo') OR ([c].[Name] IS NULL)) AND (([t].[Name] <> N'Bar') OR ([t].[Name] IS NULL))");
         }
 
         public override async Task Nav_rewrite_with_convert3(bool async)
@@ -5908,7 +5908,7 @@ LEFT JOIN (
     FROM [LocustLeaders] AS [l]
     WHERE [l].[Discriminator] = N'LocustCommander'
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
-WHERE (([c].[Name] <> N'Foo') OR [c].[Name] IS NULL) AND (([t].[Name] <> N'Bar') OR [t].[Name] IS NULL)");
+WHERE (([c].[Name] <> N'Foo') OR ([c].[Name] IS NULL)) AND (([t].[Name] <> N'Bar') OR ([t].[Name] IS NULL))");
         }
 
         public override async Task Where_contains_on_navigation_with_composite_keys(bool async)
@@ -6004,7 +6004,7 @@ LEFT JOIN [Gears] AS [g0] ON [g].[LeaderNickname] = [g0].[Nickname]");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [g0].[Nickname] IS NULL OR [g0].[SquadId] IS NULL THEN CAST(1 AS bit)
+    WHEN ([g0].[Nickname] IS NULL) OR ([g0].[SquadId] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gears] AS [g]
@@ -6026,7 +6026,7 @@ LEFT JOIN (
         FROM [Gears] AS [g0]
     ) AS [t1]
     WHERE [t1].[row] <= 50
-) AS [t0] ON (([g].[Nickname] = [t0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [t0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [t0].[LeaderSquadId])
+) AS [t0] ON (([g].[Nickname] = [t0].[LeaderNickname]) OR (([g].[Nickname] IS NULL) AND ([t0].[LeaderNickname] IS NULL))) AND ([g].[SquadId] = [t0].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
 ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Nickname], [t0].[SquadId]");
         }
@@ -6039,7 +6039,7 @@ ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [t0].[LeaderNickname], [t0].[L
                 @"SELECT [t].[Id], [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
+LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR (([g].[Nickname] IS NULL) AND ([g0].[LeaderNickname] IS NULL))) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
 ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
@@ -6275,7 +6275,7 @@ ORDER BY [t].[Note]");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([g].[Nickname] IS NOT NULL) AND ([g].[SquadId] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [t].[Id], [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[Id], [t0].[SquadId]
 FROM [Tags] AS [t]
@@ -6586,11 +6586,11 @@ WHERE ([c].[Name] = (
     SELECT TOP(1) [c0].[Name]
     FROM [Gears] AS [g]
     INNER JOIN [Cities] AS [c0] ON [g].[CityOfBirthName] = [c0].[Name]
-    ORDER BY [g].[Nickname])) OR ([c].[Name] IS NULL AND (
+    ORDER BY [g].[Nickname])) OR (([c].[Name] IS NULL) AND ((
     SELECT TOP(1) [c0].[Name]
     FROM [Gears] AS [g]
     INNER JOIN [Cities] AS [c0] ON [g].[CityOfBirthName] = [c0].[Name]
-    ORDER BY [g].[Nickname]) IS NULL)");
+    ORDER BY [g].[Nickname]) IS NULL))");
         }
 
         public override async Task Bitwise_operation_with_non_null_parameter_optimizes_null_checks(bool async)
@@ -6645,7 +6645,7 @@ FROM [Weapons] AS [w]",
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE (([w].[AmmunitionType] & @__prm_0) <> 0) OR [w].[AmmunitionType] IS NULL",
+WHERE (([w].[AmmunitionType] & @__prm_0) <> 0) OR ([w].[AmmunitionType] IS NULL)",
                 //
                 @"@__prm_0='1' (Nullable = true)
 
@@ -6798,10 +6798,10 @@ WHERE CASE
         WHEN ((
             SELECT TOP(1) [w].[Name]
             FROM [Weapons] AS [w]
-            WHERE [w].[Id] = [g].[SquadId]) = @__prm2_1) AND (
+            WHERE [w].[Id] = [g].[SquadId]) = @__prm2_1) AND ((
             SELECT TOP(1) [w].[Name]
             FROM [Weapons] AS [w]
-            WHERE [w].[Id] = [g].[SquadId]) IS NOT NULL THEN CAST(1 AS bit)
+            WHERE [w].[Id] = [g].[SquadId]) IS NOT NULL) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE CAST(0 AS bit)
@@ -7018,7 +7018,7 @@ FROM [LocustLeaders] AS [l]
 WHERE EXISTS (
     SELECT 1
     FROM [LocustLeaders] AS [l0]
-    WHERE ([l0].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR ([l0].[ThreatLevelNullableByte] IS NULL AND [l].[ThreatLevelNullableByte] IS NULL))");
+    WHERE ([l0].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR (([l0].[ThreatLevelNullableByte] IS NULL) AND ([l].[ThreatLevelNullableByte] IS NULL)))");
         }
 
         public override async Task Contains_on_collection_of_nullable_byte_subquery_null_constant(bool async)
@@ -7107,7 +7107,7 @@ CROSS APPLY (
     WHERE EXISTS (
         SELECT 1
         FROM [LocustLeaders] AS [l0]
-        WHERE ([l0].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR ([l0].[ThreatLevelNullableByte] IS NULL AND [l].[ThreatLevelNullableByte] IS NULL))
+        WHERE ([l0].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR (([l0].[ThreatLevelNullableByte] IS NULL) AND ([l].[ThreatLevelNullableByte] IS NULL)))
 ) AS [t]");
         }
 
@@ -7124,7 +7124,7 @@ CROSS APPLY (
     WHERE NOT (EXISTS (
         SELECT 1
         FROM [LocustLeaders] AS [l0]
-        WHERE ([l0].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR ([l0].[ThreatLevelNullableByte] IS NULL AND [l].[ThreatLevelNullableByte] IS NULL)))
+        WHERE ([l0].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR (([l0].[ThreatLevelNullableByte] IS NULL) AND ([l].[ThreatLevelNullableByte] IS NULL))))
 ) AS [t]");
         }
 
@@ -7184,7 +7184,7 @@ ORDER BY [g].[Nickname]");
                 @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-WHERE [w0].[Id] IS NOT NULL AND (([w0].[AmmunitionType] = 1) OR [w0].[AmmunitionType] IS NULL)");
+WHERE ([w0].[Id] IS NOT NULL) AND (([w0].[AmmunitionType] = 1) OR ([w0].[AmmunitionType] IS NULL))");
         }
 
         [ConditionalTheory]
@@ -7240,7 +7240,7 @@ ORDER BY [c].[Location]");
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
-INNER JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL
+INNER JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR ([w].[OwnerFullName] IS NULL)
 ORDER BY [g].[Nickname], [w].[Id]");
         }
 
@@ -7251,7 +7251,7 @@ ORDER BY [g].[Nickname], [w].[Id]");
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
-LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR ([w].[OwnerFullName] IS NULL)
 ORDER BY [g].[Nickname], [w].[Id]");
         }
 
@@ -7267,7 +7267,7 @@ LEFT JOIN (
     SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM [Weapons] AS [w]
     LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-) AS [t] ON ([g].[FullName] <> [t].[OwnerFullName]) OR [t].[OwnerFullName] IS NULL
+) AS [t] ON ([g].[FullName] <> [t].[OwnerFullName]) OR ([t].[OwnerFullName] IS NULL)
 ORDER BY [g].[Nickname], [t].[Id]");
         }
 
@@ -7278,7 +7278,7 @@ ORDER BY [g].[Nickname], [t].[Id]");
             AssertSql(
                 @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
-LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL");
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR ([w].[OwnerFullName] IS NULL)");
         }
 
         public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join(bool async)
@@ -7324,7 +7324,7 @@ FROM [Gears] AS [g]
 CROSS APPLY (
     SELECT TOP(3) [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[OwnerFullName] <> [g].[FullName]) OR [w].[OwnerFullName] IS NULL
+    WHERE ([w].[OwnerFullName] <> [g].[FullName]) OR ([w].[OwnerFullName] IS NULL)
     ORDER BY [w].[Id]
 ) AS [t]
 ORDER BY [g].[Nickname], [t].[Id]");
@@ -7366,11 +7366,11 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
             AssertSql(
                 @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
 FROM [LocustLeaders] AS [l]
-WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0) OR [l].[HighCommandId] IS NULL)",
+WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0) OR ([l].[HighCommandId] IS NULL))",
                 //
                 @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
 FROM [LocustLeaders] AS [l]
-WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0) OR [l].[HighCommandId] IS NULL)");
+WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0) OR ([l].[HighCommandId] IS NULL))");
         }
 
         public override async Task Cast_to_derived_followed_by_include_and_FirstOrDefault(bool async)
@@ -7507,7 +7507,7 @@ WHERE ([g].[Nickname] <> [g0].[Nickname]) OR ([g].[SquadId] <> [g0].[SquadId])")
                 @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN [Gears] AS [g] ON ([l].[DefeatedByNickname] = [g].[Nickname]) AND ([l].[DefeatedBySquadId] = [g].[SquadId])
-WHERE ([l].[Discriminator] = N'LocustCommander') AND ([g].[Nickname] IS NULL OR [g].[SquadId] IS NULL)");
+WHERE ([l].[Discriminator] = N'LocustCommander') AND (([g].[Nickname] IS NULL) OR ([g].[SquadId] IS NULL))");
         }
 
         public override async Task Composite_key_entity_not_equal_null(bool async)
@@ -7518,7 +7518,7 @@ WHERE ([l].[Discriminator] = N'LocustCommander') AND ([g].[Nickname] IS NULL OR 
                 @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN [Gears] AS [g] ON ([l].[DefeatedByNickname] = [g].[Nickname]) AND ([l].[DefeatedBySquadId] = [g].[SquadId])
-WHERE ([l].[Discriminator] = N'LocustCommander') AND ([g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL)");
+WHERE ([l].[Discriminator] = N'LocustCommander') AND (([g].[Nickname] IS NOT NULL) AND ([g].[SquadId] IS NOT NULL))");
         }
 
         [ConditionalFact]
@@ -7638,7 +7638,7 @@ END IS NOT NULL");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL THEN CASE
+    WHEN ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL) THEN CASE
         WHEN [t].[GearNickName] IS NOT NULL THEN [g].[SquadId]
         ELSE NULL
     END
@@ -7752,10 +7752,10 @@ ORDER BY [t].[Note]");
                 @"SELECT [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE CASE
+WHERE (CASE
     WHEN [t].[GearNickName] IS NOT NULL THEN [g].[Nickname]
     ELSE NULL
-END IS NOT NULL AND (CASE
+END IS NOT NULL) AND (CASE
     WHEN [t].[GearNickName] IS NOT NULL THEN [g].[HasSoulPatch]
     ELSE NULL
 END = CAST(0 AS bit))
@@ -7770,7 +7770,7 @@ ORDER BY [t].[Note]");
                 @"SELECT [g].[Nickname]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE (DATEPART(month, [t].[IssueDate]) <> 5) OR [t].[IssueDate] IS NULL
+WHERE (DATEPART(month, [t].[IssueDate]) <> 5) OR ([t].[IssueDate] IS NULL)
 ORDER BY [g].[Nickname]");
         }
 
@@ -8183,7 +8183,7 @@ LEFT JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]");
 
             AssertSql(
                 @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
-    WHEN [g].[Nickname] IS NULL OR [g].[SquadId] IS NULL THEN CAST(1 AS bit)
+    WHEN ([g].[Nickname] IS NULL) OR ([g].[SquadId] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsNull], [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[ServerAddress], [f].[CommanderName], [f].[Eradicated], CASE
     WHEN [f].[Id] IS NULL THEN CAST(1 AS bit)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -90,7 +90,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseReferencesOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -104,7 +104,7 @@ FROM [BaseReferencesOnBase] AS [b]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -144,7 +144,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [ReferencesOnBase] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -158,7 +158,7 @@ FROM [ReferencesOnBase] AS [r]
 LEFT JOIN [BaseEntities] AS [b] ON [r].[ParentId] = [b].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([r].[Name] <> N'Bar') OR [r].[Name] IS NULL
+WHERE ([r].[Name] <> N'Bar') OR ([r].[Name] IS NULL)
 ORDER BY [r].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -198,7 +198,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseCollectionsOnBase] AS [b2] ON [b].[Id] = [b2].[BaseParentId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
@@ -212,7 +212,7 @@ FROM [BaseCollectionsOnBase] AS [b]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -252,7 +252,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
@@ -266,7 +266,7 @@ FROM [CollectionsOnBase] AS [c]
 LEFT JOIN [BaseEntities] AS [b] ON [c].[ParentId] = [b].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
+WHERE ([c].[Name] <> N'Bar') OR ([c].[Name] IS NULL)
 ORDER BY [c].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -343,7 +343,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseReferencesOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR [b].[Name] IS NULL)
+WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL))
 ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -357,7 +357,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseReferencesOnDerived] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR [b].[Name] IS NULL)
+WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL))
 ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -375,7 +375,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR [b].[Name] IS NULL)
+WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL))
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -393,7 +393,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [t].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -752,25 +752,25 @@ ORDER BY [b].[Id], [b0].[Id]");
             AssertSql(
                 @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [b].[OwnedReferenceOnBase_Id], [b].[OwnedReferenceOnBase_Name], [b].[OwnedReferenceOnDerived_Id], [b].[OwnedReferenceOnDerived_Name]
 FROM [BaseEntities] AS [b]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [b0].[DerivedInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b0] ON [b].[Id] = [b0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name], [b0].[DerivedProperty], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [BaseCollectionsOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]");
         }
 
@@ -782,21 +782,21 @@ ORDER BY [b].[Id]");
                 @"SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty], [b0].[Id], [b0].[Discriminator], [b0].[Name], [b0].[BaseId], [b0].[OwnedReferenceOnBase_Id], [b0].[OwnedReferenceOnBase_Name], [b0].[OwnedReferenceOnDerived_Id], [b0].[OwnedReferenceOnDerived_Name]
 FROM [BaseCollectionsOnBase] AS [b]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[Id]",
                 //
                 @"SELECT [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b1].[Name], [b].[Id], [b0].[Id]
 FROM [BaseCollectionsOnBase] AS [b]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 INNER JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[Id]",
                 //
                 @"SELECT [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [b1].[Name], [b].[Id], [b0].[Id]
 FROM [BaseCollectionsOnBase] AS [b]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 INNER JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b0].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[Id]");
         }
 
@@ -855,25 +855,25 @@ ORDER BY [c].[Id], [b].[Id]");
             AssertSql(
                 @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [b].[OwnedReferenceOnBase_Id], [b].[OwnedReferenceOnBase_Name], [b].[OwnedReferenceOnDerived_Id], [b].[OwnedReferenceOnDerived_Name]
 FROM [BaseEntities] AS [b]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [b0].[DerivedInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b0] ON [b].[Id] = [b0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]");
         }
 
@@ -885,21 +885,21 @@ ORDER BY [b].[Id]");
                 @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId], [b].[OwnedReferenceOnBase_Id], [b].[OwnedReferenceOnBase_Name], [b].[OwnedReferenceOnDerived_Id], [b].[OwnedReferenceOnDerived_Name]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN [BaseEntities] AS [b] ON [c].[ParentId] = [b].[Id]
-WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
+WHERE ([c].[Name] <> N'Bar') OR ([c].[Name] IS NULL)
 ORDER BY [c].[Id], [b].[Id]",
                 //
                 @"SELECT [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [c].[Id], [b].[Id]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN [BaseEntities] AS [b] ON [c].[ParentId] = [b].[Id]
 INNER JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
-WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
+WHERE ([c].[Name] <> N'Bar') OR ([c].[Name] IS NULL)
 ORDER BY [c].[Id], [b].[Id]",
                 //
                 @"SELECT [b0].[DerivedInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [c].[Id], [b].[Id]
 FROM [CollectionsOnBase] AS [c]
 LEFT JOIN [BaseEntities] AS [b] ON [c].[ParentId] = [b].[Id]
 INNER JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b0] ON [b].[Id] = [b0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
+WHERE ([c].[Name] <> N'Bar') OR ([c].[Name] IS NULL)
 ORDER BY [c].[Id], [b].[Id]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
@@ -104,7 +104,7 @@ ORDER BY (
         FROM [EntityRoots] AS [e0]
         WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE ([e].[Id] = [j].[EntityOneId]) AND ([t].[Name] IS NOT NULL AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
+    WHERE ([e].[Id] = [j].[EntityOneId]) AND (([t].[Name] IS NOT NULL) AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
         }
 
         public override async Task Skip_navigation_long_count_without_predicate(bool async)
@@ -132,7 +132,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND (([e1].[Name] IS NOT NULL) AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -103,7 +103,7 @@ ORDER BY (
         FROM [EntityRoots] AS [e0]
         WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE ([e].[Id] = [j].[EntityOneId]) AND ([t].[Name] IS NOT NULL AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
+    WHERE ([e].[Id] = [j].[EntityOneId]) AND (([t].[Name] IS NOT NULL) AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
         }
 
         public override async Task Skip_navigation_long_count_without_predicate(bool async)
@@ -131,7 +131,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND (([e1].[Name] IS NOT NULL) AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Orders] AS [o]
-        WHERE ([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL) THEN CAST(1 AS bit)
+        WHERE ([o].[CustomerID] <> N'ALFKI') OR ([o].[CustomerID] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -464,7 +464,7 @@ WHERE [o].[CustomerID] = N'ALFKI'");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] > 10) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL)");
+WHERE ([o].[OrderID] > 10) AND (([o].[CustomerID] <> N'ALFKI') OR ([o].[CustomerID] IS NULL))");
         }
 
         public override async Task Distinct(bool async)
@@ -1006,7 +1006,7 @@ ORDER BY [o].[OrderID]");
             AssertSql(
                 @"SELECT AVG(CAST(CAST([o].[OrderID] AS bigint) AS float))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')");
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task Max_with_non_matching_types_in_projection_introduces_explicit_cast(bool async)
@@ -1016,7 +1016,7 @@ WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')");
             AssertSql(
                 @"SELECT MAX(CAST([o].[OrderID] AS bigint))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')");
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task Min_with_non_matching_types_in_projection_introduces_explicit_cast(bool async)
@@ -1026,7 +1026,7 @@ WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')");
             AssertSql(
                 @"SELECT MIN(CAST([o].[OrderID] AS bigint))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')");
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task OrderBy_Take_Last_gives_correct_result(bool async)
@@ -1195,7 +1195,7 @@ FROM [Orders] AS [o]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o0]
-    WHERE ([o0].[CustomerID] = N'VINET') AND [o0].[CustomerID] IS NULL)");
+    WHERE ([o0].[CustomerID] = N'VINET') AND ([o0].[CustomerID] IS NULL))");
         }
 
         public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_negated(bool async)
@@ -1208,7 +1208,7 @@ FROM [Orders] AS [o]
 WHERE NOT (EXISTS (
     SELECT 1
     FROM [Orders] AS [o0]
-    WHERE ([o0].[CustomerID] = N'VINET') AND [o0].[CustomerID] IS NULL))");
+    WHERE ([o0].[CustomerID] = N'VINET') AND ([o0].[CustomerID] IS NULL)))");
         }
 
         public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_complex(bool async)
@@ -1222,13 +1222,13 @@ WHERE CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o0]
-        WHERE ([o0].[CustomerID] = N'VINET') AND [o0].[CustomerID] IS NULL) THEN CAST(1 AS bit)
+        WHERE ([o0].[CustomerID] = N'VINET') AND ([o0].[CustomerID] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o1]
-        WHERE (([o1].[CustomerID] <> N'VINET') OR [o1].[CustomerID] IS NULL) AND [o1].[CustomerID] IS NULL) THEN CAST(1 AS bit)
+        WHERE (([o1].[CustomerID] <> N'VINET') OR ([o1].[CustomerID] IS NULL)) AND ([o1].[CustomerID] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -1242,7 +1242,7 @@ END");
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o0]
-        WHERE ([o0].[CustomerID] = N'VINET') AND [o0].[CustomerID] IS NULL) THEN CAST(1 AS bit)
+        WHERE ([o0].[CustomerID] = N'VINET') AND ([o0].[CustomerID] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Orders] AS [o]");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'M%')");
+WHERE ([c].[ContactName] IS NOT NULL) AND ([c].[ContactName] LIKE N'M%')");
         }
 
         public override async Task String_StartsWith_Identity(bool async)
@@ -44,7 +44,7 @@ WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'M%')");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] = N'') OR ([c].[ContactName] IS NOT NULL AND (LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]))");
+WHERE ([c].[ContactName] = N'') OR (([c].[ContactName] IS NOT NULL) AND (LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]))");
         }
 
         public override async Task String_StartsWith_Column(bool async)
@@ -54,7 +54,7 @@ WHERE ([c].[ContactName] = N'') OR ([c].[ContactName] IS NOT NULL AND (LEFT([c].
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] = N'') OR ([c].[ContactName] IS NOT NULL AND (LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]))");
+WHERE ([c].[ContactName] = N'') OR (([c].[ContactName] IS NOT NULL) AND (LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]))");
         }
 
         public override async Task String_StartsWith_MethodCall(bool async)
@@ -64,7 +64,7 @@ WHERE ([c].[ContactName] = N'') OR ([c].[ContactName] IS NOT NULL AND (LEFT([c].
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'M%')");
+WHERE ([c].[ContactName] IS NOT NULL) AND ([c].[ContactName] LIKE N'M%')");
         }
 
         public override async Task String_EndsWith_Literal(bool async)
@@ -74,7 +74,7 @@ WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'M%')");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'%b')");
+WHERE ([c].[ContactName] IS NOT NULL) AND ([c].[ContactName] LIKE N'%b')");
         }
 
         public override async Task String_EndsWith_Identity(bool async)
@@ -84,7 +84,7 @@ WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'%b')");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] = N'') OR ([c].[ContactName] IS NOT NULL AND (RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]))");
+WHERE ([c].[ContactName] = N'') OR (([c].[ContactName] IS NOT NULL) AND (RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]))");
         }
 
         public override async Task String_EndsWith_Column(bool async)
@@ -94,7 +94,7 @@ WHERE ([c].[ContactName] = N'') OR ([c].[ContactName] IS NOT NULL AND (RIGHT([c]
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] = N'') OR ([c].[ContactName] IS NOT NULL AND (RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]))");
+WHERE ([c].[ContactName] = N'') OR (([c].[ContactName] IS NOT NULL) AND (RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]))");
         }
 
         public override async Task String_EndsWith_MethodCall(bool async)
@@ -104,7 +104,7 @@ WHERE ([c].[ContactName] = N'') OR ([c].[ContactName] IS NOT NULL AND (RIGHT([c]
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'%m')");
+WHERE ([c].[ContactName] IS NOT NULL) AND ([c].[ContactName] LIKE N'%m')");
         }
 
         public override async Task String_Contains_Literal(bool async)
@@ -370,7 +370,7 @@ WHERE ([c].[CustomerID] >= N'ALFKI') AND ([c].[CustomerID] < N'CACTU')",
                 //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactTitle] = N'Owner') AND (([c].[Country] <> N'USA') OR [c].[Country] IS NULL)");
+WHERE ([c].[ContactTitle] = N'Owner') AND (([c].[Country] <> N'USA') OR ([c].[Country] IS NULL))");
         }
 
         public override async Task String_Compare_to_simple_zero(bool async)
@@ -546,7 +546,7 @@ WHERE ([c].[CustomerID] >= N'ALFKI') AND ([c].[CustomerID] < N'CACTU')",
                 //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactTitle] = N'Owner') AND (([c].[Country] <> N'USA') OR [c].[Country] IS NULL)");
+WHERE ([c].[ContactTitle] = N'Owner') AND (([c].[Country] <> N'USA') OR ([c].[Country] IS NULL))");
         }
 
         public override async Task DateTime_Compare_to_simple_zero(bool async, bool compareTo)
@@ -564,7 +564,7 @@ WHERE [o].[OrderDate] = @__myDatetime_0",
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderDate] <> @__myDatetime_0) OR [o].[OrderDate] IS NULL",
+WHERE ([o].[OrderDate] <> @__myDatetime_0) OR ([o].[OrderDate] IS NULL)",
                 //
                 @"@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
 
@@ -1653,7 +1653,7 @@ WHERE [c].[CustomerID] = N'ALFKI'");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[Region] IS NULL OR ([c].[Region] LIKE N'')");
+WHERE ([c].[Region] IS NULL) OR ([c].[Region] LIKE N'')");
         }
 
         public override async Task IsNullOrEmpty_in_projection(bool async)
@@ -1662,7 +1662,7 @@ WHERE [c].[Region] IS NULL OR ([c].[Region] LIKE N'')");
 
             AssertSql(
                 @"SELECT [c].[CustomerID] AS [Id], CASE
-    WHEN [c].[Region] IS NULL OR ([c].[Region] LIKE N'') THEN CAST(1 AS bit)
+    WHEN ([c].[Region] IS NULL) OR ([c].[Region] LIKE N'') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Value]
 FROM [Customers] AS [c]");
@@ -1675,7 +1675,7 @@ FROM [Customers] AS [c]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[Region] IS NOT NULL AND NOT ([c].[Region] LIKE N'')");
+WHERE ([c].[Region] IS NOT NULL) AND NOT ([c].[Region] LIKE N'')");
         }
 
         public override async Task IsNullOrEmpty_negated_in_projection(bool async)
@@ -1684,7 +1684,7 @@ WHERE [c].[Region] IS NOT NULL AND NOT ([c].[Region] LIKE N'')");
 
             AssertSql(
                 @"SELECT [c].[CustomerID] AS [Id], CASE
-    WHEN [c].[Region] IS NOT NULL AND NOT ([c].[Region] LIKE N'') THEN CAST(1 AS bit)
+    WHEN ([c].[Region] IS NOT NULL) AND NOT ([c].[Region] LIKE N'') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Value]
 FROM [Customers] AS [c]");
@@ -1697,7 +1697,7 @@ FROM [Customers] AS [c]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[Region] IS NULL OR ([c].[Region] = N'')");
+WHERE ([c].[Region] IS NULL) OR ([c].[Region] = N'')");
         }
 
         public override async Task IsNullOrWhiteSpace_in_predicate_on_non_nullable_column(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1293,7 +1293,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o0]
     GROUP BY [o0].[CustomerID]
-    HAVING (COUNT(*) > 30) AND (([o0].[CustomerID] = [o].[CustomerID]) OR ([o0].[CustomerID] IS NULL AND [o].[CustomerID] IS NULL)))");
+    HAVING (COUNT(*) > 30) AND (([o0].[CustomerID] = [o].[CustomerID]) OR (([o0].[CustomerID] IS NULL) AND ([o].[CustomerID] IS NULL))))");
         }
 
         public override async Task GroupBy_aggregate_Pushdown(bool async)
@@ -1648,7 +1648,7 @@ OUTER APPLY (
     FROM [Products] AS [p0]
     GROUP BY [p0].[ProductID]
 ) AS [t0]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')
 ORDER BY [o].[OrderID], [t].[ProductID]");
         }
 
@@ -1662,7 +1662,7 @@ ORDER BY [o].[OrderID], [t].[ProductID]");
         SELECT 1
         FROM [Orders] AS [o]
         GROUP BY [o].[CustomerID]
-        HAVING ([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL) THEN CAST(1 AS bit)
+        HAVING ([o].[CustomerID] <> N'ALFKI') OR ([o].[CustomerID] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -1745,7 +1745,7 @@ GROUP BY [o].[CustomerID]");
 
             AssertSql(
                 @"SELECT COUNT(CASE
-    WHEN (([o].[OrderID] < 10300) AND [o].[OrderDate] IS NOT NULL) AND (DATEPART(year, [o].[OrderDate]) = 1997) THEN 1
+    WHEN (([o].[OrderID] < 10300) AND ([o].[OrderDate] IS NOT NULL)) AND (DATEPART(year, [o].[OrderDate]) = 1997) THEN 1
 END)
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
@@ -1757,7 +1757,7 @@ GROUP BY [o].[CustomerID]");
 
             AssertSql(
                 @"SELECT COUNT(CASE
-    WHEN (([o].[OrderID] < 10300) AND [o].[OrderDate] IS NOT NULL) AND (DATEPART(year, [o].[OrderDate]) = 1997) THEN 1
+    WHEN (([o].[OrderID] < 10300) AND ([o].[OrderDate] IS NOT NULL)) AND (DATEPART(year, [o].[OrderDate]) = 1997) THEN 1
 END)
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
@@ -1769,7 +1769,7 @@ GROUP BY [o].[CustomerID]");
 
             AssertSql(
                 @"SELECT COUNT(CASE
-    WHEN (([o].[OrderID] < 10300) AND [o].[OrderDate] IS NOT NULL) AND (DATEPART(year, [o].[OrderDate]) = 1997) THEN 1
+    WHEN (([o].[OrderID] < 10300) AND ([o].[OrderDate] IS NOT NULL)) AND (DATEPART(year, [o].[OrderDate]) = 1997) THEN 1
 END)
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
@@ -1781,7 +1781,7 @@ GROUP BY [o].[CustomerID]");
 
             AssertSql(
                 @"SELECT MIN(CASE
-    WHEN (([o].[OrderID] < 10300) AND [o].[OrderDate] IS NOT NULL) AND (DATEPART(year, [o].[OrderDate]) = 1997) THEN [o].[OrderID]
+    WHEN (([o].[OrderID] < 10300) AND ([o].[OrderDate] IS NOT NULL)) AND (DATEPART(year, [o].[OrderDate]) = 1997) THEN [o].[OrderID]
 END)
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
@@ -1872,7 +1872,7 @@ GROUP BY [o].[EmployeeID]");
                 @"SELECT (
     SELECT TOP(1) [e0].[Title]
     FROM [Employees] AS [e0]
-    WHERE (([e0].[Title] = N'Sales Representative') AND ([e0].[EmployeeID] = 1)) AND (([e].[Title] = [e0].[Title]) OR ([e].[Title] IS NULL AND [e0].[Title] IS NULL)))
+    WHERE (([e0].[Title] = N'Sales Representative') AND ([e0].[EmployeeID] = 1)) AND (([e].[Title] = [e0].[Title]) OR (([e].[Title] IS NULL) AND ([e0].[Title] IS NULL))))
 FROM [Employees] AS [e]
 WHERE ([e].[Title] = N'Sales Representative') AND ([e].[EmployeeID] = 1)
 GROUP BY [e].[Title]");
@@ -1960,7 +1960,7 @@ LEFT JOIN (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'A%'
-) AS [t0] ON ([t].[City] = [t0].[City]) OR ([t].[City] IS NULL AND [t0].[City] IS NULL)
+) AS [t0] ON ([t].[City] = [t0].[City]) OR (([t].[City] IS NULL) AND ([t0].[City] IS NULL))
 ORDER BY [t].[City]");
         }
 
@@ -2039,7 +2039,7 @@ GROUP BY [o].[CustomerID]");
     FROM (
         SELECT DISTINCT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
         FROM [Orders] AS [o0]
-        WHERE ([o].[CustomerID] = [o0].[CustomerID]) OR ([o].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL)
+        WHERE ([o].[CustomerID] = [o0].[CustomerID]) OR (([o].[CustomerID] IS NULL) AND ([o0].[CustomerID] IS NULL))
     ) AS [t]) AS [Max]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
@@ -2487,7 +2487,7 @@ FROM (
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
 ) AS [t]
-INNER JOIN [Orders] AS [o0] ON (([t].[Key] = [o0].[CustomerID]) OR ([t].[Key] IS NULL AND [o0].[CustomerID] IS NULL)) AND (([t].[LastOrderDate] = [o0].[OrderDate]) OR ([t].[LastOrderDate] IS NULL AND [o0].[OrderDate] IS NULL))");
+INNER JOIN [Orders] AS [o0] ON (([t].[Key] = [o0].[CustomerID]) OR (([t].[Key] IS NULL) AND ([o0].[CustomerID] IS NULL))) AND (([t].[LastOrderDate] = [o0].[OrderDate]) OR (([t].[LastOrderDate] IS NULL) AND ([o0].[OrderDate] IS NULL)))");
         }
 
         public override async Task GroupBy_aggregate_from_right_side_of_join(bool async)
@@ -2688,7 +2688,7 @@ END), 0) AS [Sum1], COALESCE(SUM(CASE
     ELSE 0
 END), 0) AS [Sum2]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')
 GROUP BY [o].[CustomerID]");
         }
 
@@ -2793,7 +2793,7 @@ FROM (
     SELECT DISTINCT [c].[City]
     FROM [Orders] AS [o]
     LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')
 ) AS [t]
 OUTER APPLY (
     SELECT [p].[ProductID]
@@ -2834,7 +2834,7 @@ FROM (
     SELECT [o].[CustomerID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
-    HAVING [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+    HAVING ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
 ORDER BY [t].[CustomerID]");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
@@ -49,7 +49,7 @@ ORDER BY [p].[ProductID], [t].[OrderID], [t].[ProductID]");
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')");
         }
 
         public override async Task Include_when_result_operator(bool async)
@@ -154,7 +154,7 @@ ORDER BY [t].[CustomerID]");
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
         }
 
@@ -269,7 +269,7 @@ ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[ProductID]");
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Orders] AS [o]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ORDER BY [o].[OrderID], [o0].[OrderID]");
         }
 
@@ -677,7 +677,7 @@ FROM [Customers] AS [c]
 OUTER APPLY (
     SELECT TOP(5) [o].[OrderID]
     FROM [Orders] AS [o]
-    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR [o].[CustomerID] IS NULL
+    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR ([o].[CustomerID] IS NULL)
     ORDER BY [c].[CustomerID]
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -244,7 +244,7 @@ INNER JOIN [Customers] AS [c1] ON [c].[CustomerID] = [c1].[CustomerID]");
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')");
         }
 
         public override async Task GroupJoin_simple(bool async)
@@ -339,7 +339,7 @@ FROM [Employees] AS [e]
 LEFT JOIN (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ) AS [t] ON [e].[EmployeeID] = [t].[EmployeeID]");
         }
 
@@ -483,7 +483,7 @@ INNER JOIN (
         FROM [Orders] AS [o]
         ORDER BY [o].[OrderID]
     ) AS [t]
-    WHERE [t].[CustomerID] IS NOT NULL AND ([t].[CustomerID] LIKE N'A%')
+    WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CustomerID] LIKE N'A%')
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]");
         }
 
@@ -734,7 +734,7 @@ FROM (
 ) AS [t]
 OUTER APPLY (
     SELECT CASE
-        WHEN ([t1].[CustomerID] = [c0].[City]) OR ([t1].[CustomerID] IS NULL AND [c0].[City] IS NULL) THEN N'A'
+        WHEN ([t1].[CustomerID] = [c0].[City]) OR (([t1].[CustomerID] IS NULL) AND ([c0].[City] IS NULL)) THEN N'A'
         ELSE N'B'
     END AS [Title], [t1].[OrderID], [c0].[CustomerID], [t1].[OrderDate]
     FROM (

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
@@ -124,7 +124,7 @@ LEFT JOIN [Customers] AS [c] ON [m].[CustomerID] = [c].[CustomerID]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] IS NOT NULL AND ([c].[CustomerID] = [o].[CustomerID]))");
+    WHERE ([c].[CustomerID] IS NOT NULL) AND ([c].[CustomerID] = [o].[CustomerID]))");
         }
 
         [ConditionalFact]
@@ -172,7 +172,7 @@ FROM (
 WHERE EXISTS (
     SELECT 1
     FROM [Customers] AS [c]
-    WHERE ([c].[City] = [m].[City]) OR ([c].[City] IS NULL AND [m].[City] IS NULL))
+    WHERE ([c].[City] = [m].[City]) OR (([c].[City] IS NULL) AND ([m].[City] IS NULL)))
 ORDER BY [m].[ContactName]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -431,10 +431,10 @@ FROM [Employees] AS [e]
 WHERE ([e].[FirstName] = (
     SELECT TOP(1) [e0].[FirstName]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID])) OR ([e].[FirstName] IS NULL AND (
+    ORDER BY [e0].[EmployeeID])) OR (([e].[FirstName] IS NULL) AND ((
     SELECT TOP(1) [e0].[FirstName]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID]) IS NULL)");
+    ORDER BY [e0].[EmployeeID]) IS NULL))");
         }
 
         public override async Task Where_query_composition_is_null(bool async)
@@ -593,7 +593,7 @@ FROM [Employees] AS [e]
 WHERE (
     SELECT TOP(1) [e0].[EmployeeID]
     FROM [Employees] AS [e0]
-    WHERE ([e0].[EmployeeID] <> [e].[ReportsTo]) OR [e].[ReportsTo] IS NULL) = 0");
+    WHERE ([e0].[EmployeeID] <> [e].[ReportsTo]) OR ([e].[ReportsTo] IS NULL)) = 0");
         }
 
         public override async Task Where_query_composition_entity_equality_multiple_elements_Single(bool async)
@@ -606,7 +606,7 @@ FROM [Employees] AS [e]
 WHERE (
     SELECT TOP(1) [e0].[EmployeeID]
     FROM [Employees] AS [e0]
-    WHERE ([e0].[EmployeeID] <> [e].[ReportsTo]) OR [e].[ReportsTo] IS NULL) = 0");
+    WHERE ([e0].[EmployeeID] <> [e].[ReportsTo]) OR ([e].[ReportsTo] IS NULL)) = 0");
         }
 
         public override async Task Where_query_composition_entity_equality_multiple_elements_FirstOrDefault(bool async)
@@ -619,7 +619,7 @@ FROM [Employees] AS [e]
 WHERE (
     SELECT TOP(1) [e0].[EmployeeID]
     FROM [Employees] AS [e0]
-    WHERE ([e0].[EmployeeID] <> [e].[ReportsTo]) OR [e].[ReportsTo] IS NULL) = 0");
+    WHERE ([e0].[EmployeeID] <> [e].[ReportsTo]) OR ([e].[ReportsTo] IS NULL)) = 0");
         }
 
         public override async Task Where_query_composition_entity_equality_multiple_elements_First(bool async)
@@ -632,7 +632,7 @@ FROM [Employees] AS [e]
 WHERE (
     SELECT TOP(1) [e0].[EmployeeID]
     FROM [Employees] AS [e0]
-    WHERE ([e0].[EmployeeID] <> [e].[ReportsTo]) OR [e].[ReportsTo] IS NULL) = 0");
+    WHERE ([e0].[EmployeeID] <> [e].[ReportsTo]) OR ([e].[ReportsTo] IS NULL)) = 0");
         }
 
         public override async Task Where_query_composition2(bool async)
@@ -650,10 +650,10 @@ FROM (
 WHERE ([t].[FirstName] = (
     SELECT TOP(1) [e0].[FirstName]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID])) OR ([t].[FirstName] IS NULL AND (
+    ORDER BY [e0].[EmployeeID])) OR (([t].[FirstName] IS NULL) AND ((
     SELECT TOP(1) [e0].[FirstName]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID]) IS NULL)");
+    ORDER BY [e0].[EmployeeID]) IS NULL))");
         }
 
         public override async Task Where_query_composition2_FirstOrDefault(bool async)
@@ -671,10 +671,10 @@ FROM (
 WHERE ([t].[FirstName] = (
     SELECT TOP(1) [e0].[FirstName]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID])) OR ([t].[FirstName] IS NULL AND (
+    ORDER BY [e0].[EmployeeID])) OR (([t].[FirstName] IS NULL) AND ((
     SELECT TOP(1) [e0].[FirstName]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID]) IS NULL)");
+    ORDER BY [e0].[EmployeeID]) IS NULL))");
         }
 
         public override async Task Where_query_composition2_FirstOrDefault_with_anonymous(bool async)
@@ -692,10 +692,10 @@ FROM (
 WHERE ([t].[FirstName] = (
     SELECT TOP(1) [e0].[FirstName]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID])) OR ([t].[FirstName] IS NULL AND (
+    ORDER BY [e0].[EmployeeID])) OR (([t].[FirstName] IS NULL) AND ((
     SELECT TOP(1) [e0].[FirstName]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID]) IS NULL)");
+    ORDER BY [e0].[EmployeeID]) IS NULL))");
         }
 
         public override void Select_Subquery_Single()
@@ -787,16 +787,16 @@ WHERE (
         FROM [Orders] AS [o1]
         INNER JOIN [Customers] AS [c0] ON [o1].[CustomerID] = [c0].[CustomerID]
         WHERE [o1].[OrderID] = [t0].[OrderID]
-        ORDER BY [o1].[OrderID], [c0].[CustomerID])) OR ((
+        ORDER BY [o1].[OrderID], [c0].[CustomerID])) OR (((
         SELECT TOP(1) [c].[Country]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] = [t].[CustomerID]
-        ORDER BY [c].[CustomerID]) IS NULL AND (
+        ORDER BY [c].[CustomerID]) IS NULL) AND ((
         SELECT TOP(1) [c0].[Country]
         FROM [Orders] AS [o1]
         INNER JOIN [Customers] AS [c0] ON [o1].[CustomerID] = [c0].[CustomerID]
         WHERE [o1].[OrderID] = [t0].[OrderID]
-        ORDER BY [o1].[OrderID], [c0].[CustomerID]) IS NULL)) > 0
+        ORDER BY [o1].[OrderID], [c0].[CustomerID]) IS NULL))) > 0
 ORDER BY [t].[OrderID]");
         }
 
@@ -1329,7 +1329,7 @@ END");
     WHEN EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'A%')) THEN CAST(1 AS bit)
+        WHERE ([c].[ContactName] IS NOT NULL) AND ([c].[ContactName] LIKE N'A%')) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -1344,7 +1344,7 @@ FROM [Customers] AS [c]
 WHERE NOT (EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')))");
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')))");
         }
 
         public override async Task Any_nested_negated2(bool async)
@@ -1354,10 +1354,10 @@ WHERE NOT (EXISTS (
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND NOT (EXISTS (
+WHERE (([c].[City] <> N'London') OR ([c].[City] IS NULL)) AND NOT (EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')))");
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')))");
         }
 
         public override async Task Any_nested_negated3(bool async)
@@ -1370,7 +1370,7 @@ FROM [Customers] AS [c]
 WHERE NOT (EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%'))) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)");
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%'))) AND (([c].[City] <> N'London') OR ([c].[City] IS NULL))");
         }
 
         public override async Task Any_nested(bool async)
@@ -1383,7 +1383,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%'))");
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%'))");
         }
 
         public override async Task Any_nested2(bool async)
@@ -1393,10 +1393,10 @@ WHERE EXISTS (
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND EXISTS (
+WHERE (([c].[City] <> N'London') OR ([c].[City] IS NULL)) AND EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%'))");
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%'))");
         }
 
         public override async Task Any_nested3(bool async)
@@ -1409,7 +1409,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)");
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')) AND (([c].[City] <> N'London') OR ([c].[City] IS NULL))");
         }
 
         public override void Any_with_multiple_conditions_still_uses_exists()
@@ -1434,7 +1434,7 @@ WHERE ([c].[City] = N'London') AND EXISTS (
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE [c].[ContactName] IS NULL OR NOT ([c].[ContactName] LIKE N'A%')) THEN CAST(1 AS bit)
+        WHERE ([c].[ContactName] IS NULL) OR NOT ([c].[ContactName] LIKE N'A%')) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -1448,7 +1448,7 @@ END");
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE (([c].[ContactName] <> N'') OR [c].[ContactName] IS NULL) AND ([c].[ContactName] IS NULL OR (LEFT([c].[ContactName], LEN([c].[ContactName])) <> [c].[ContactName]))) THEN CAST(1 AS bit)
+        WHERE (([c].[ContactName] <> N'') OR ([c].[ContactName] IS NULL)) AND (([c].[ContactName] IS NULL) OR (LEFT([c].[ContactName], LEN([c].[ContactName])) <> [c].[ContactName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -1823,7 +1823,7 @@ ORDER BY [c].[CustomerID]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE ([c].[City] = [e].[City]) OR ([c].[City] IS NULL AND [e].[City] IS NULL)
+WHERE ([c].[City] = [e].[City]) OR (([c].[City] IS NULL) AND ([e].[City] IS NULL))
 ORDER BY [e].[City], [c].[CustomerID] DESC");
         }
 
@@ -2235,7 +2235,7 @@ WHERE ([o].[OrderID] <= 10250) AND (((
             FROM [Customers] AS [c0]
             WHERE [c0].[CustomerID] = N'ALFKI') THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END) <> N'Nowhere') OR (
+    END) <> N'Nowhere') OR ((
     SELECT TOP(1) [c].[City]
     FROM [Customers] AS [c]
     ORDER BY CASE
@@ -2244,7 +2244,7 @@ WHERE ([o].[OrderID] <= 10250) AND (((
             FROM [Customers] AS [c0]
             WHERE [c0].[CustomerID] = N'ALFKI') THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
-    END) IS NULL)");
+    END) IS NULL))");
         }
 
         public override async Task Where_subquery_recursive_trivial(bool async)
@@ -2520,7 +2520,7 @@ ORDER BY [c].[City]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY CASE
-    WHEN ([c].[Region] = N'ASK') AND [c].[Region] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([c].[Region] = N'ASK') AND ([c].[Region] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -2989,7 +2989,7 @@ ORDER BY [c].[CustomerID]");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
+WHERE ([o].[OrderID] < 10400) AND ((([o].[OrderDate] IS NOT NULL) AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -3006,7 +3006,7 @@ WHERE [o].[OrderID] < 10400");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
+WHERE ([o].[OrderID] < 10400) AND ((([o].[OrderDate] IS NOT NULL) AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -3023,7 +3023,7 @@ WHERE 0 = 1");
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) OR (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
+WHERE ([o].[OrderID] < 10400) OR ((([o].[OrderDate] IS NOT NULL) AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]");
@@ -3080,7 +3080,7 @@ ORDER BY (
             AssertSql(
                 @"SELECT [o].[CustomerID]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] IS NOT NULL AND (CONVERT(varchar(10), [o].[EmployeeID]) LIKE N'%10%')");
+WHERE ([o].[OrderDate] IS NOT NULL) AND (CONVERT(varchar(10), [o].[EmployeeID]) LIKE N'%10%')");
         }
 
         public override async Task Select_expression_long_to_string(bool async)
@@ -3229,7 +3229,7 @@ ORDER BY [o].[OrderID]");
 
 SELECT DISTINCT DATEPART(year, [o].[OrderDate])
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] IS NOT NULL AND (DATEPART(year, [o].[OrderDate]) < @__nextYear_0)");
+WHERE ([o].[OrderDate] IS NOT NULL) AND (DATEPART(year, [o].[OrderDate]) < @__nextYear_0)");
         }
 
         public override async Task DefaultIfEmpty_without_group_join(bool async)
@@ -3299,7 +3299,7 @@ CROSS JOIN (
     ) AS [t] ON 1 = 1
 ) AS [t0]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE ([c].[City] = N'Seattle') AND ([t0].[OrderID] IS NOT NULL AND [o0].[OrderID] IS NOT NULL)
+WHERE ([c].[City] = N'Seattle') AND (([t0].[OrderID] IS NOT NULL) AND ([o0].[OrderID] IS NOT NULL))
 ORDER BY [t0].[OrderID], [o0].[OrderDate]");
         }
 
@@ -3326,7 +3326,7 @@ OUTER APPLY (
     FROM [Orders] AS [o0]
     WHERE [o0].[OrderID] <= CAST(LEN([c].[CustomerID]) AS int)
 ) AS [t1]
-WHERE ([c].[City] = N'Seattle') AND ([t0].[OrderID] IS NOT NULL AND [t1].[OrderID] IS NOT NULL)
+WHERE ([c].[City] = N'Seattle') AND (([t0].[OrderID] IS NOT NULL) AND ([t1].[OrderID] IS NOT NULL))
 ORDER BY [t0].[OrderID], [t1].[OrderDate]");
         }
 
@@ -3712,7 +3712,7 @@ FROM (
     SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [A]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[A] IS NOT NULL AND ([t].[A] LIKE N'A%')");
+WHERE ([t].[A] IS NOT NULL) AND ([t].[A] LIKE N'A%')");
         }
 
         public override async Task Anonymous_complex_orderby(bool async)
@@ -3816,7 +3816,7 @@ FROM (
     SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [Property]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[Property] IS NOT NULL AND ([t].[Property] LIKE N'A%')");
+WHERE ([t].[Property] IS NOT NULL) AND ([t].[Property] LIKE N'A%')");
         }
 
         public override async Task DTO_complex_orderby(bool async)
@@ -4282,7 +4282,7 @@ FROM [Orders] AS [o]
 CROSS JOIN [Orders] AS [o0]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-WHERE ([o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')) AND (([c].[CustomerID] = [c0].[CustomerID]) OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))
+WHERE (([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')) AND (([c].[CustomerID] = [c0].[CustomerID]) OR (([c].[CustomerID] IS NULL) AND ([c0].[CustomerID] IS NULL)))
 ORDER BY [o].[OrderID], [o0].[OrderID]");
         }
 
@@ -4296,7 +4296,7 @@ FROM [Orders] AS [o]
 CROSS JOIN [Orders] AS [o0]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-WHERE ([o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')) AND (([c].[CustomerID] = [c0].[CustomerID]) OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))
+WHERE (([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')) AND (([c].[CustomerID] = [c0].[CustomerID]) OR (([c].[CustomerID] IS NULL) AND ([c0].[CustomerID] IS NULL)))
 ORDER BY [o].[OrderID], [o0].[OrderID]");
         }
 
@@ -4341,7 +4341,7 @@ WHERE 0 = 1");
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-WHERE ([o].[OrderID] < 10250) AND [c].[CustomerID] IS NOT NULL
+WHERE ([o].[OrderID] < 10250) AND ([c].[CustomerID] IS NOT NULL)
 ORDER BY [o].[OrderID], [o].[ProductID]");
         }
 
@@ -4573,11 +4573,11 @@ WHERE ([c].[CustomerID] LIKE N'A%') AND (((
     SELECT TOP(1) [o].[OrderID]
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-    ORDER BY [o].[OrderDate]) <> 0) OR (
+    ORDER BY [o].[OrderDate]) <> 0) OR ((
     SELECT TOP(1) [o].[OrderID]
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-    ORDER BY [o].[OrderDate]) IS NULL)");
+    ORDER BY [o].[OrderDate]) IS NULL))");
         }
 
         public override async Task Collection_navigation_equal_to_null_for_subquery(bool async)
@@ -5137,12 +5137,12 @@ ORDER BY [c].[CustomerID]");
             FROM [Orders] AS [o1]
             LEFT JOIN [Customers] AS [c1] ON [o1].[CustomerID] = [c1].[CustomerID]
             WHERE [c].[CustomerID] = [o1].[CustomerID]
-            ORDER BY [o1].[OrderDate]) = [o].[CustomerID]) OR ((
+            ORDER BY [o1].[OrderDate]) = [o].[CustomerID]) OR (((
             SELECT TOP(1) [c1].[CustomerID]
             FROM [Orders] AS [o1]
             LEFT JOIN [Customers] AS [c1] ON [o1].[CustomerID] = [c1].[CustomerID]
             WHERE [c].[CustomerID] = [o1].[CustomerID]
-            ORDER BY [o1].[OrderDate]) IS NULL AND [o].[CustomerID] IS NULL))) AND ([o].[OrderID] < 11000)) THEN CAST(1 AS bit)
+            ORDER BY [o1].[OrderDate]) IS NULL) AND ([o].[CustomerID] IS NULL)))) AND ([o].[OrderID] < 11000)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Complex]
 FROM [Customers] AS [c]
@@ -5277,12 +5277,12 @@ FROM (
 CROSS APPLY (
     SELECT TOP(9) [e].[City], [t0].[City] AS [c1]
     FROM [Employees] AS [e]
-    WHERE ([t0].[City] = [e].[City]) OR ([t0].[City] IS NULL AND [e].[City] IS NULL)
+    WHERE ([t0].[City] = [e].[City]) OR (([t0].[City] IS NULL) AND ([e].[City] IS NULL))
 ) AS [t1]
 CROSS APPLY (
     SELECT TOP(9) [t0].[City], [e0].[EmployeeID]
     FROM [Employees] AS [e0]
-    WHERE ([t1].[City] = [e0].[City]) OR ([t1].[City] IS NULL AND [e0].[City] IS NULL)
+    WHERE ([t1].[City] = [e0].[City]) OR (([t1].[City] IS NULL) AND ([e0].[City] IS NULL))
 ) AS [t2]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
@@ -264,7 +264,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR [c].[Phone] IS NULL)");
+WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR ([c].[Phone] IS NULL))");
         }
 
         public override async Task Select_Navigations_Where_Navigations(bool async)
@@ -275,7 +275,7 @@ WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR [c].[Ph
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR [c].[Phone] IS NULL)");
+WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR ([c].[Phone] IS NULL))");
         }
 
         public override async Task Select_Singleton_Navigation_With_Member_Access(bool async)
@@ -286,7 +286,7 @@ WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR [c].[Ph
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR [c].[Phone] IS NULL)");
+WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR ([c].[Phone] IS NULL))");
         }
 
         public override async Task Select_count_plus_sum(bool async)
@@ -312,7 +312,7 @@ FROM [Orders] AS [o]");
                 @"SELECT [c].[City] AS [B]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR [c].[Phone] IS NULL)");
+WHERE ([c].[City] = N'Seattle') AND (([c].[Phone] <> N'555 555 5555') OR ([c].[Phone] IS NULL))");
         }
 
         public override async Task Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected(bool async)
@@ -329,7 +329,7 @@ CROSS JOIN (
 ) AS [t]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Customers] AS [c0] ON [t].[CustomerID] = [c0].[CustomerID]
-WHERE ([o].[OrderID] < 10300) AND (([c].[City] = [c0].[City]) OR ([c].[City] IS NULL AND [c0].[City] IS NULL))");
+WHERE ([o].[OrderID] < 10300) AND (([c].[City] = [c0].[City]) OR (([c].[City] IS NULL) AND ([c0].[City] IS NULL)))");
         }
 
         public override async Task Select_Where_Navigation_Equals_Navigation(bool async)
@@ -342,7 +342,7 @@ FROM [Orders] AS [o]
 CROSS JOIN [Orders] AS [o0]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-WHERE (([o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')) AND ([o0].[CustomerID] IS NOT NULL AND ([o0].[CustomerID] LIKE N'A%'))) AND (([c].[CustomerID] = [c0].[CustomerID]) OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))");
+WHERE ((([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')) AND (([o0].[CustomerID] IS NOT NULL) AND ([o0].[CustomerID] LIKE N'A%'))) AND (([c].[CustomerID] = [c0].[CustomerID]) OR (([c].[CustomerID] IS NULL) AND ([c0].[CustomerID] IS NULL)))");
         }
 
         public override async Task Select_Where_Navigation_Null(bool async)
@@ -509,7 +509,7 @@ WHERE EXISTS (
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Orders] AS [o]
-        WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL)) THEN CAST(1 AS bit)
+        WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[CustomerID] <> N'ALFKI') OR ([o].[CustomerID] IS NULL))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [All]
 FROM [Customers] AS [c]");
@@ -525,7 +525,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL))");
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[CustomerID] <> N'ALFKI') OR ([o].[CustomerID] IS NULL)))");
         }
 
         public override async Task Collection_select_nav_prop_count(bool async)
@@ -619,7 +619,7 @@ END AS [all], (
     FROM [Order Details] AS [o3]
     WHERE [o].[OrderID] = [o3].[OrderID]) AS [collection2]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')");
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'A%')");
         }
 
         public override async Task Collection_select_nav_prop_sum(bool async)
@@ -857,7 +857,7 @@ WHERE ((
     FROM [Order Details] AS [o0]
     INNER JOIN [Orders] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
     LEFT JOIN [Customers] AS [c0] ON [o1].[CustomerID] = [c0].[CustomerID]
-    WHERE ([c].[Country] = [c0].[Country]) OR ([c].[Country] IS NULL AND [c0].[Country] IS NULL)) > 0) AND [o].[OrderID] IN (10643, 10692)");
+    WHERE ([c].[Country] = [c0].[Country]) OR (([c].[Country] IS NULL) AND ([c0].[Country] IS NULL))) > 0) AND [o].[OrderID] IN (10643, 10692)");
         }
 
         public override async Task Project_single_scalar_value_subquery_is_properly_inlined(bool async)
@@ -954,7 +954,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE (
     SELECT COUNT(*)
     FROM [Orders] AS [o0]
-    WHERE ([c].[CustomerID] IS NOT NULL AND ([c].[CustomerID] = [o0].[CustomerID])) AND ([o0].[OrderID] > 10260)) > 30");
+    WHERE (([c].[CustomerID] IS NOT NULL) AND ([c].[CustomerID] = [o0].[CustomerID])) AND ([o0].[OrderID] > 10260)) > 30");
         }
 
         public override async Task Multiple_include_with_multiple_optional_navigations(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
         }
 
         public override async Task Materialized_query(bool async)
@@ -42,7 +42,7 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
         }
 
         public override async Task Find(bool async)
@@ -55,7 +55,7 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))) AND ([c].[CustomerID] = @__p_0)");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))) AND ([c].[CustomerID] = @__p_0)");
         }
 
         public override async Task Materialized_query_parameter(bool async)
@@ -67,7 +67,7 @@ WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AN
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
         }
 
         public override async Task Materialized_query_parameter_new_context(bool async)
@@ -79,13 +79,13 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))",
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))",
                 //
                 @"@__ef_filter__TenantPrefix_0='T' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
         }
 
         public override async Task Projection_query_parameter(bool async)
@@ -97,7 +97,7 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
         }
 
         public override async Task Projection_query(bool async)
@@ -109,7 +109,7 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
         }
 
         public override async Task Include_query(bool async)
@@ -127,11 +127,11 @@ LEFT JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c0].[CompanyName] IS NOT NULL AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
+        WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c0].[CompanyName] IS NOT NULL) AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL
-) AS [t0] ON [t0].[CompanyName] IS NOT NULL AND ([c].[CustomerID] = [t0].[CustomerID])
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
+) AS [t0] ON ([t0].[CompanyName] IS NOT NULL) AND ([c].[CustomerID] = [t0].[CustomerID])
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
 ORDER BY [c].[CustomerID], [t0].[OrderID]");
         }
 
@@ -158,9 +158,9 @@ FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
+    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
-WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
+WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)");
         }
 
         public override async Task Project_reference_that_itself_has_query_filter_with_another_reference(bool async)
@@ -179,9 +179,9 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c].[CustomerID], [c].[CompanyName]
         FROM [Customers] AS [c]
-        WHERE (@__ef_filter__TenantPrefix_1 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1))
+        WHERE (@__ef_filter__TenantPrefix_1 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1)) = @__ef_filter__TenantPrefix_1))
     ) AS [t] ON [o0].[CustomerID] = [t].[CustomerID]
-    WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
+    WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 ) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
 WHERE [o].[Quantity] > @__ef_filter___quantity_0");
         }
@@ -202,10 +202,10 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c0].[CompanyName] IS NOT NULL AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
+        WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c0].[CompanyName] IS NOT NULL) AND (LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL
-) AS [t0] ON [t0].[CompanyName] IS NOT NULL AND ([c].[CustomerID] = [t0].[CustomerID])
+) AS [t0] ON ([t0].[CompanyName] IS NOT NULL) AND ([c].[CustomerID] = [t0].[CustomerID])
 INNER JOIN (
     SELECT [o0].[OrderID], [o0].[Discount]
     FROM [Order Details] AS [o0]
@@ -215,13 +215,13 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [c1].[CustomerID], [c1].[CompanyName]
             FROM [Customers] AS [c1]
-            WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c1].[CompanyName] IS NOT NULL AND (LEFT([c1].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
+            WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c1].[CompanyName] IS NOT NULL) AND (LEFT([c1].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
         ) AS [t3] ON [o1].[CustomerID] = [t3].[CustomerID]
-        WHERE [t3].[CustomerID] IS NOT NULL AND [t3].[CompanyName] IS NOT NULL
+        WHERE ([t3].[CustomerID] IS NOT NULL) AND ([t3].[CompanyName] IS NOT NULL)
     ) AS [t2] ON [o0].[OrderID] = [t2].[OrderID]
     WHERE [o0].[Quantity] > @__ef_filter___quantity_1
 ) AS [t1] ON [t0].[OrderID] = [t1].[OrderID]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))) AND ([t1].[Discount] < CAST(10 AS real))");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))) AND ([t1].[Discount] < CAST(10 AS real))");
         }
 
         [ConditionalFact]
@@ -241,7 +241,7 @@ SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[Cont
 FROM (
     select * from Customers
 ) AS [m]
-WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([m].[CompanyName] IS NOT NULL AND (LEFT([m].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
+WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([m].[CompanyName] IS NOT NULL) AND (LEFT([m].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))");
         }
 
         [ConditionalFact]
@@ -264,9 +264,9 @@ FROM (
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
+    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
 ) AS [t] ON [m].[CustomerID] = [t].[CustomerID]
-WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
+WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)");
         }
 
         public override void Compiled_query()
@@ -279,14 +279,14 @@ WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))) AND ([c].[CustomerID] = @__customerID)",
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))) AND ([c].[CustomerID] = @__customerID)",
                 //
                 @"@__ef_filter__TenantPrefix_0='B' (Size = 4000)
 @__customerID='BLAUS' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))) AND ([c].[CustomerID] = @__customerID)");
+WHERE ((@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))) AND ([c].[CustomerID] = @__customerID)");
         }
 
         public override async Task Entity_Equality(bool async)
@@ -301,9 +301,9 @@ FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
+    WHERE (@__ef_filter__TenantPrefix_0 = N'') OR (([c].[CompanyName] IS NOT NULL) AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
-WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
+WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -364,10 +364,10 @@ WHERE [c].[CustomerID] LIKE N'A%'");
         WHERE ([o].[OrderID] = [o0].[OrderID]) AND (([o0].[OrderID] <> (
             SELECT COUNT(*)
             FROM [Orders] AS [o1]
-            WHERE [c].[CustomerID] = [o1].[CustomerID])) OR (
+            WHERE [c].[CustomerID] = [o1].[CustomerID])) OR ((
             SELECT COUNT(*)
             FROM [Orders] AS [o1]
-            WHERE [c].[CustomerID] = [o1].[CustomerID]) IS NULL)), 0)
+            WHERE [c].[CustomerID] = [o1].[CustomerID]) IS NULL))), 0)
     FROM [Orders] AS [o]
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND ([o].[OrderID] < 10500)), 0) AS [Order]
 FROM [Customers] AS [c]
@@ -952,7 +952,7 @@ FROM [Orders] AS [o]");
 
             AssertSql(
                 @"SELECT [o].[CustomerID], CASE
-    WHEN ([o].[CustomerID] = N'ALFKI') AND [o].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([o].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [o].[OrderID], CAST(LEN([o].[CustomerID]) AS int)
 FROM [Orders] AS [o]");
@@ -1058,7 +1058,7 @@ FROM [Customers] AS [c]
 OUTER APPLY (
     SELECT [c].[City]
     FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] <> [o].[CustomerID]) OR [o].[CustomerID] IS NULL
+    WHERE ([c].[CustomerID] <> [o].[CustomerID]) OR ([o].[CustomerID] IS NULL)
 ) AS [t]");
         }
 
@@ -1072,7 +1072,7 @@ FROM [Customers] AS [c]
 OUTER APPLY (
     SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] <> [o].[CustomerID]) OR [o].[CustomerID] IS NULL
+    WHERE ([c].[CustomerID] <> [o].[CustomerID]) OR ([o].[CustomerID] IS NULL)
     ORDER BY [c].[City], [o].[OrderID]
 ) AS [t]");
         }
@@ -1406,7 +1406,7 @@ ORDER BY [c].[CustomerID]");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN ([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([c].[City] = N'Seattle') AND ([c].[City] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Customers] AS [c]
@@ -1604,7 +1604,7 @@ FROM (
 OUTER APPLY (
     SELECT [t].[CustomerID], [o0].[OrderID], [o0].[OrderDate]
     FROM [Orders] AS [o0]
-    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
+    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR (([t].[CustomerID] IS NULL) AND ([o0].[CustomerID] IS NULL)))
 ) AS [t0]
 ORDER BY [t].[CustomerID], [t0].[OrderID]");
         }
@@ -1640,7 +1640,7 @@ FROM (
 OUTER APPLY (
     SELECT [t].[OrderDate] AS [Outer1], [t].[CustomerID] AS [Outer2], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
     FROM [Orders] AS [o0]
-    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
+    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR (([t].[CustomerID] IS NULL) AND ([o0].[CustomerID] IS NULL)))
 ) AS [t0]
 ORDER BY [t].[OrderDate], [t].[CustomerID]");
         }
@@ -1719,12 +1719,12 @@ OUTER APPLY (
     FROM (
         SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
         FROM [Orders] AS [o]
-        WHERE (([o].[CustomerID] = [t].[City]) OR ([o].[CustomerID] IS NULL AND [t].[City] IS NULL)) AND (DATEPART(year, [o].[OrderDate]) = 1997)
+        WHERE (([o].[CustomerID] = [t].[City]) OR (([o].[CustomerID] IS NULL) AND ([t].[City] IS NULL))) AND (DATEPART(year, [o].[OrderDate]) = 1997)
     ) AS [t0]
     OUTER APPLY (
         SELECT [t0].[OrderID], [o0].[OrderID] AS [OrderID0]
         FROM [Orders] AS [o0]
-        WHERE ([t0].[CustomerID] = [t].[City]) OR ([t0].[CustomerID] IS NULL AND [t].[City] IS NULL)
+        WHERE ([t0].[CustomerID] = [t].[City]) OR (([t0].[CustomerID] IS NULL) AND ([t].[City] IS NULL))
     ) AS [t2]
 ) AS [t1]
 ORDER BY [t].[City], [t1].[OrderID], [t1].[OrderID00]");
@@ -1791,7 +1791,7 @@ ORDER BY [t].[CustomerID], [t0].[OrderID]");
 FROM (
     SELECT TOP(1) [o].[OrderID], [o].[OrderDate]
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+    WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ) AS [t]
 OUTER APPLY (
     SELECT [t1].[OrderID], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [t1].[UnitPrice] AS [UnitPrice0], [t1].[ProductID] AS [ProductID0]
@@ -1821,7 +1821,7 @@ FROM (
 ) AS [t]
 OUTER APPLY (
     SELECT CASE
-        WHEN ([t1].[CustomerID] = [c0].[CustomerID]) OR ([t1].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL) THEN N'A'
+        WHEN ([t1].[CustomerID] = [c0].[CustomerID]) OR (([t1].[CustomerID] IS NULL) AND ([c0].[CustomerID] IS NULL)) THEN N'A'
         ELSE N'B'
     END AS [Title], [t1].[OrderID], [c0].[CustomerID], [t1].[OrderDate]
     FROM (

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -274,11 +274,11 @@ FROM (
 FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] IS NOT NULL AND ([c].[CompanyName] LIKE N'A%')
+    WHERE ([c].[CompanyName] IS NOT NULL) AND ([c].[CompanyName] LIKE N'A%')
     UNION
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CompanyName] IS NOT NULL AND ([c0].[CompanyName] LIKE N'B%')
+    WHERE ([c0].[CompanyName] IS NOT NULL) AND ([c0].[CompanyName] LIKE N'B%')
 ) AS [t]");
         }
 
@@ -295,7 +295,7 @@ FROM (
     SELECT [p].[ProductName] AS [ContactName]
     FROM [Products] AS [p]
 ) AS [t]
-WHERE [t].[ContactName] IS NOT NULL AND ([t].[ContactName] LIKE N'C%')
+WHERE ([t].[ContactName] IS NOT NULL) AND ([t].[ContactName] LIKE N'C%')
 ORDER BY [t].[ContactName]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
@@ -52,7 +52,7 @@ ORDER BY [p].[ProductID]");
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')");
         }
 
         public override async Task Include_when_result_operator(bool async)
@@ -173,14 +173,14 @@ ORDER BY [t].[CustomerID], [o].[OrderID]");
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ORDER BY [o].[OrderID], [c].[CustomerID]",
                 //
                 @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID], [c].[CustomerID]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ORDER BY [o].[OrderID], [c].[CustomerID]");
         }
 
@@ -313,13 +313,13 @@ ORDER BY [t].[OrderID]");
             AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ORDER BY [o].[OrderID]",
                 //
                 @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID]
 FROM [Orders] AS [o]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+WHERE ([o].[CustomerID] IS NOT NULL) AND ([o].[CustomerID] LIKE N'F%')
 ORDER BY [o].[OrderID]");
         }
 
@@ -948,7 +948,7 @@ FROM [Customers] AS [c]
 OUTER APPLY (
     SELECT TOP(5) [o].[OrderID]
     FROM [Orders] AS [o]
-    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR [o].[CustomerID] IS NULL
+    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR ([o].[CustomerID] IS NULL)
     ORDER BY [c].[CustomerID]
 ) AS [t]
 WHERE [c].[CustomerID] LIKE N'F%'
@@ -959,7 +959,7 @@ FROM [Customers] AS [c]
 OUTER APPLY (
     SELECT TOP(5) [o].[OrderID]
     FROM [Orders] AS [o]
-    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR [o].[CustomerID] IS NULL
+    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR ([o].[CustomerID] IS NULL)
     ORDER BY [c].[CustomerID]
 ) AS [t]
 INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -483,10 +483,10 @@ FROM [Employees] AS [e]
 WHERE ([e].[Title] = (
     SELECT TOP(1) [e0].[Title]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[Title])) OR ([e].[Title] IS NULL AND (
+    ORDER BY [e0].[Title])) OR (([e].[Title] IS NULL) AND ((
     SELECT TOP(1) [e0].[Title]
     FROM [Employees] AS [e0]
-    ORDER BY [e0].[Title]) IS NULL)");
+    ORDER BY [e0].[Title]) IS NULL))");
         }
 
         public override async Task Where_subquery_correlated(bool async)
@@ -680,10 +680,10 @@ FROM [Customers] AS [c]
 WHERE (CASE
     WHEN N'Sea' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'Sea', [c].[City]) AS int) - 1
-END <> -1) OR CASE
+END <> -1) OR (CASE
     WHEN N'Sea' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'Sea', [c].[City]) AS int) - 1
-END IS NULL");
+END IS NULL)");
         }
 
         public override async Task Where_string_replace(bool async)
@@ -949,7 +949,7 @@ FROM [Customers] AS [c]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[City] = [c].[City]) OR [c].[City] IS NULL");
+WHERE ([c].[City] = [c].[City]) OR ([c].[City] IS NULL)");
         }
 
         public override async Task Where_in_optimization_multiple(bool async)
@@ -971,7 +971,7 @@ WHERE ([c].[City] IN (N'London', N'Berlin') OR ([c].[CustomerID] = N'ALFKI')) OR
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND (([e].[City] <> N'London') OR [e].[City] IS NULL)");
+WHERE (([c].[City] <> N'London') OR ([c].[City] IS NULL)) AND (([e].[City] <> N'London') OR ([e].[City] IS NULL))");
         }
 
         public override async Task Where_not_in_optimization2(bool async)
@@ -982,7 +982,7 @@ WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND (([e].[City] <> N'Lo
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] NOT IN (N'London', N'Berlin') OR [c].[City] IS NULL");
+WHERE [c].[City] NOT IN (N'London', N'Berlin') OR ([c].[City] IS NULL)");
         }
 
         public override async Task Where_not_in_optimization3(bool async)
@@ -993,7 +993,7 @@ WHERE [c].[City] NOT IN (N'London', N'Berlin') OR [c].[City] IS NULL");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] NOT IN (N'London', N'Berlin', N'Seattle') OR [c].[City] IS NULL");
+WHERE [c].[City] NOT IN (N'London', N'Berlin', N'Seattle') OR ([c].[City] IS NULL)");
         }
 
         public override async Task Where_not_in_optimization4(bool async)
@@ -1004,7 +1004,7 @@ WHERE [c].[City] NOT IN (N'London', N'Berlin', N'Seattle') OR [c].[City] IS NULL
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] NOT IN (N'London', N'Berlin', N'Seattle', N'Lisboa') OR [c].[City] IS NULL");
+WHERE [c].[City] NOT IN (N'London', N'Berlin', N'Seattle', N'Lisboa') OR ([c].[City] IS NULL)");
         }
 
         public override async Task Where_select_many_and(bool async)
@@ -1547,7 +1547,7 @@ FROM [Customers] AS [c]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] IS NULL AND ([c].[Country] = N'UK')");
+WHERE ([c].[City] IS NULL) AND ([c].[Country] = N'UK')");
         }
 
         public override async Task Where_compare_null_with_cast_to_object(bool async)
@@ -2145,7 +2145,7 @@ WHERE [c].[CustomerID] IN (N'ALFKI', N'ANATR', N'ANTON')");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[Region] IN (N'WA', N'OR', N'BC') OR [c].[Region] IS NULL");
+WHERE [c].[Region] IN (N'WA', N'OR', N'BC') OR ([c].[Region] IS NULL)");
         }
 
         public override async Task Constant_array_Contains_OrElse_comparison_with_constant_gets_combined_to_one_in(bool async)
@@ -2222,7 +2222,7 @@ WHERE [c].[CustomerID] IN (N'ALFKI', N'ANATR') OR ([c].[CustomerID] = N'ANTON')"
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[Region] IN (N'WA', N'OR') OR [c].[Region] IS NULL) OR ([c].[Region] = N'BC')");
+WHERE ([c].[Region] IN (N'WA', N'OR') OR ([c].[Region] IS NULL)) OR ([c].[Region] = N'BC')");
         }
 
         public override async Task Parameter_array_Contains_OrElse_comparison_with_constant(bool async)
@@ -2265,7 +2265,7 @@ WHERE [c].[CustomerID] = N'ANATR'");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[Region] <> N'WA') AND [c].[Region] IS NOT NULL");
+WHERE ([c].[Region] <> N'WA') AND ([c].[Region] IS NOT NULL)");
         }
 
         public override async Task Filter_with_EF_Property_using_closure_for_property_name(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -479,7 +479,7 @@ WHERE CASE
     WHEN ([e].[NullableBoolA] = [e].[BoolB]) AND ([e].[NullableBoolA] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CASE
-    WHEN ([e].[IntA] = [e].[NullableIntB]) AND [e].[NullableIntB] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([e].[IntA] = [e].[NullableIntB]) AND ([e].[NullableIntB] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END",
                 //
@@ -489,7 +489,7 @@ WHERE CASE
     WHEN (([e].[NullableBoolA] = [e].[NullableBoolB]) AND (([e].[NullableBoolA] IS NOT NULL) AND ([e].[NullableBoolB] IS NOT NULL))) OR (([e].[NullableBoolA] IS NULL) AND ([e].[NullableBoolB] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CASE
-    WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL)) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL) THEN CAST(1 AS bit)
+    WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND (([e].[NullableIntA] IS NOT NULL) AND ([e].[NullableIntB] IS NOT NULL))) OR (([e].[NullableIntA] IS NULL) AND ([e].[NullableIntB] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -515,7 +515,7 @@ WHERE CASE
     WHEN ([e].[NullableBoolA] = [e].[BoolB]) AND ([e].[NullableBoolA] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> CASE
-    WHEN ([e].[IntA] = [e].[NullableIntB]) AND [e].[NullableIntB] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([e].[IntA] = [e].[NullableIntB]) AND ([e].[NullableIntB] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END",
                 //
@@ -525,7 +525,7 @@ WHERE CASE
     WHEN (([e].[NullableBoolA] = [e].[NullableBoolB]) AND (([e].[NullableBoolA] IS NOT NULL) AND ([e].[NullableBoolB] IS NOT NULL))) OR (([e].[NullableBoolA] IS NULL) AND ([e].[NullableBoolB] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> CASE
-    WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL)) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL) THEN CAST(1 AS bit)
+    WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND (([e].[NullableIntA] IS NOT NULL) AND ([e].[NullableIntB] IS NOT NULL))) OR (([e].[NullableIntA] IS NULL) AND ([e].[NullableIntB] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -551,7 +551,7 @@ WHERE CASE
     WHEN ([e].[NullableBoolA] <> [e].[BoolB]) OR ([e].[NullableBoolA] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CASE
-    WHEN ([e].[IntA] = [e].[NullableIntB]) AND [e].[NullableIntB] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([e].[IntA] = [e].[NullableIntB]) AND ([e].[NullableIntB] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END",
                 //
@@ -561,7 +561,7 @@ WHERE CASE
     WHEN (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR (([e].[NullableBoolA] IS NULL) OR ([e].[NullableBoolB] IS NULL))) AND (([e].[NullableBoolA] IS NOT NULL) OR ([e].[NullableBoolB] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CASE
-    WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL)) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL) THEN CAST(1 AS bit)
+    WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND (([e].[NullableIntA] IS NOT NULL) AND ([e].[NullableIntB] IS NOT NULL))) OR (([e].[NullableIntA] IS NULL) AND ([e].[NullableIntB] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -587,7 +587,7 @@ WHERE CASE
     WHEN ([e].[NullableBoolA] <> [e].[BoolB]) OR ([e].[NullableBoolA] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> CASE
-    WHEN ([e].[IntA] = [e].[NullableIntB]) AND [e].[NullableIntB] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([e].[IntA] = [e].[NullableIntB]) AND ([e].[NullableIntB] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END",
                 //
@@ -597,7 +597,7 @@ WHERE CASE
     WHEN (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR (([e].[NullableBoolA] IS NULL) OR ([e].[NullableBoolB] IS NULL))) AND (([e].[NullableBoolA] IS NOT NULL) OR ([e].[NullableBoolB] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> CASE
-    WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL)) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL) THEN CAST(1 AS bit)
+    WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND (([e].[NullableIntA] IS NOT NULL) AND ([e].[NullableIntB] IS NOT NULL))) OR (([e].[NullableIntA] IS NULL) AND ([e].[NullableIntB] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -623,7 +623,7 @@ WHERE CASE
     WHEN ([e].[NullableBoolA] <> [e].[BoolB]) OR ([e].[NullableBoolA] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CASE
-    WHEN ([e].[IntA] <> [e].[NullableIntB]) OR [e].[NullableIntB] IS NULL THEN CAST(1 AS bit)
+    WHEN ([e].[IntA] <> [e].[NullableIntB]) OR ([e].[NullableIntB] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END",
                 //
@@ -633,7 +633,7 @@ WHERE CASE
     WHEN (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR (([e].[NullableBoolA] IS NULL) OR ([e].[NullableBoolB] IS NULL))) AND (([e].[NullableBoolA] IS NOT NULL) OR ([e].[NullableBoolB] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CASE
-    WHEN (([e].[NullableIntA] <> [e].[NullableIntB]) OR ([e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL)) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL) THEN CAST(1 AS bit)
+    WHEN (([e].[NullableIntA] <> [e].[NullableIntB]) OR (([e].[NullableIntA] IS NULL) OR ([e].[NullableIntB] IS NULL))) AND (([e].[NullableIntA] IS NOT NULL) OR ([e].[NullableIntB] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -659,7 +659,7 @@ WHERE CASE
     WHEN ([e].[NullableBoolA] <> [e].[BoolB]) OR ([e].[NullableBoolA] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> CASE
-    WHEN ([e].[IntA] <> [e].[NullableIntB]) OR [e].[NullableIntB] IS NULL THEN CAST(1 AS bit)
+    WHEN ([e].[IntA] <> [e].[NullableIntB]) OR ([e].[NullableIntB] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END",
                 //
@@ -669,7 +669,7 @@ WHERE CASE
     WHEN (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR (([e].[NullableBoolA] IS NULL) OR ([e].[NullableBoolB] IS NULL))) AND (([e].[NullableBoolA] IS NOT NULL) OR ([e].[NullableBoolB] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> CASE
-    WHEN (([e].[NullableIntA] <> [e].[NullableIntB]) OR ([e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL)) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL) THEN CAST(1 AS bit)
+    WHEN (([e].[NullableIntA] <> [e].[NullableIntB]) OR (([e].[NullableIntA] IS NULL) OR ([e].[NullableIntB] IS NULL))) AND (([e].[NullableIntA] IS NOT NULL) OR ([e].[NullableIntB] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -713,7 +713,7 @@ INNER JOIN [Entities2] AS [e0] ON [e].[NullableIntA] = [e0].[NullableIntB]");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] = N'Foo') OR [e].[NullableStringA] IS NULL");
+WHERE ([e].[NullableStringA] = N'Foo') OR ([e].[NullableStringA] IS NULL)");
         }
 
         public override async Task Contains_with_local_array_closure_false_with_null(bool async)
@@ -723,7 +723,7 @@ WHERE ([e].[NullableStringA] = N'Foo') OR [e].[NullableStringA] IS NULL");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] <> N'Foo') AND [e].[NullableStringA] IS NOT NULL");
+WHERE ([e].[NullableStringA] <> N'Foo') AND ([e].[NullableStringA] IS NOT NULL)");
         }
 
         public override async Task Contains_with_local_nullable_array_closure_negated(bool async)
@@ -733,7 +733,7 @@ WHERE ([e].[NullableStringA] <> N'Foo') AND [e].[NullableStringA] IS NOT NULL");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL");
+WHERE ([e].[NullableStringA] <> N'Foo') OR ([e].[NullableStringA] IS NULL)");
         }
 
         public override async Task Contains_with_local_array_closure_with_multiple_nulls(bool async)
@@ -743,7 +743,7 @@ WHERE ([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] = N'Foo') OR [e].[NullableStringA] IS NULL");
+WHERE ([e].[NullableStringA] = N'Foo') OR ([e].[NullableStringA] IS NULL)");
         }
 
         public override async Task Where_multiple_ors_with_null(bool async)
@@ -753,7 +753,7 @@ WHERE ([e].[NullableStringA] = N'Foo') OR [e].[NullableStringA] IS NULL");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableStringA] IN (N'Foo', N'Blah') OR [e].[NullableStringA] IS NULL");
+WHERE [e].[NullableStringA] IN (N'Foo', N'Blah') OR ([e].[NullableStringA] IS NULL)");
         }
 
         public override async Task Where_multiple_ands_with_null(bool async)
@@ -763,7 +763,7 @@ WHERE [e].[NullableStringA] IN (N'Foo', N'Blah') OR [e].[NullableStringA] IS NUL
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableStringA] NOT IN (N'Foo', N'Blah') AND [e].[NullableStringA] IS NOT NULL");
+WHERE [e].[NullableStringA] NOT IN (N'Foo', N'Blah') AND ([e].[NullableStringA] IS NOT NULL)");
         }
 
         public override async Task Where_multiple_ors_with_nullable_parameter(bool async)
@@ -773,7 +773,7 @@ WHERE [e].[NullableStringA] NOT IN (N'Foo', N'Blah') AND [e].[NullableStringA] I
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] = N'Foo') OR [e].[NullableStringA] IS NULL");
+WHERE ([e].[NullableStringA] = N'Foo') OR ([e].[NullableStringA] IS NULL)");
         }
 
         public override async Task Where_multiple_ands_with_nullable_parameter_and_constant(bool async)
@@ -785,7 +785,7 @@ WHERE ([e].[NullableStringA] = N'Foo') OR [e].[NullableStringA] IS NULL");
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ((([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL) AND [e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringA] <> @__prm3_2)");
+WHERE ((([e].[NullableStringA] <> N'Foo') OR ([e].[NullableStringA] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL)) AND ([e].[NullableStringA] <> @__prm3_2)");
         }
 
         public override async Task Where_multiple_ands_with_nullable_parameter_and_constant_not_optimized(bool async)
@@ -797,7 +797,7 @@ WHERE ((([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL) AND 
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringB] IS NOT NULL AND (([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL)) AND [e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringA] <> @__prm3_2)");
+WHERE ((([e].[NullableStringB] IS NOT NULL) AND (([e].[NullableStringA] <> N'Foo') OR ([e].[NullableStringA] IS NULL))) AND ([e].[NullableStringA] IS NOT NULL)) AND ([e].[NullableStringA] <> @__prm3_2)");
         }
 
         public override async Task Where_coalesce(bool async)
@@ -837,7 +837,7 @@ WHERE [e].[NullableStringA] IS NOT NULL");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (COALESCE([e].[NullableStringA], [e].[NullableStringB]) = [e].[NullableStringC]) OR (([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) AND [e].[NullableStringC] IS NULL)");
+WHERE (COALESCE([e].[NullableStringA], [e].[NullableStringB]) = [e].[NullableStringC]) OR ((([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) AND ([e].[NullableStringC] IS NULL))");
         }
 
         public override async Task Where_not_equal_with_coalesce(bool async)
@@ -847,7 +847,7 @@ WHERE (COALESCE([e].[NullableStringA], [e].[NullableStringB]) = [e].[NullableStr
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ((COALESCE([e].[NullableStringA], [e].[NullableStringB]) <> [e].[NullableStringC]) OR (([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) OR [e].[NullableStringC] IS NULL)) AND (([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) OR [e].[NullableStringC] IS NOT NULL)");
+WHERE ((COALESCE([e].[NullableStringA], [e].[NullableStringB]) <> [e].[NullableStringC]) OR ((([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) OR ([e].[NullableStringC] IS NULL))) AND ((([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL)) OR ([e].[NullableStringC] IS NOT NULL))");
         }
 
         public override async Task Where_equal_with_coalesce_both_sides(bool async)
@@ -867,7 +867,7 @@ WHERE COALESCE([e].[NullableStringA], [e].[NullableStringB]) = COALESCE([e].[Str
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ((COALESCE([e].[NullableIntA], [e].[NullableIntB]) <> COALESCE([e].[NullableIntC], [e].[NullableIntB])) OR (([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL) OR ([e].[NullableIntC] IS NULL AND [e].[NullableIntB] IS NULL))) AND (([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL) OR ([e].[NullableIntC] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL))");
+WHERE ((COALESCE([e].[NullableIntA], [e].[NullableIntB]) <> COALESCE([e].[NullableIntC], [e].[NullableIntB])) OR ((([e].[NullableIntA] IS NULL) AND ([e].[NullableIntB] IS NULL)) OR (([e].[NullableIntC] IS NULL) AND ([e].[NullableIntB] IS NULL)))) AND ((([e].[NullableIntA] IS NOT NULL) OR ([e].[NullableIntB] IS NOT NULL)) OR (([e].[NullableIntC] IS NOT NULL) OR ([e].[NullableIntB] IS NOT NULL)))");
         }
 
         public override async Task Where_equal_with_conditional(bool async)
@@ -878,12 +878,12 @@ WHERE ((COALESCE([e].[NullableIntA], [e].[NullableIntB]) <> COALESCE([e].[Nullab
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE (CASE
-    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
+    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) THEN [e].[NullableStringA]
     ELSE [e].[NullableStringB]
-END = [e].[NullableStringC]) OR (CASE
-    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
+END = [e].[NullableStringC]) OR ((CASE
+    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) THEN [e].[NullableStringA]
     ELSE [e].[NullableStringB]
-END IS NULL AND [e].[NullableStringC] IS NULL)");
+END IS NULL) AND ([e].[NullableStringC] IS NULL))");
         }
 
         public override async Task Where_not_equal_with_conditional(bool async)
@@ -894,15 +894,15 @@ END IS NULL AND [e].[NullableStringC] IS NULL)");
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE (([e].[NullableStringC] <> CASE
-    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
+    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) THEN [e].[NullableStringA]
     ELSE [e].[NullableStringB]
-END) OR ([e].[NullableStringC] IS NULL OR CASE
-    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
+END) OR (([e].[NullableStringC] IS NULL) OR (CASE
+    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) THEN [e].[NullableStringA]
     ELSE [e].[NullableStringB]
-END IS NULL)) AND ([e].[NullableStringC] IS NOT NULL OR CASE
-    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[NullableStringA]
+END IS NULL))) AND (([e].[NullableStringC] IS NOT NULL) OR (CASE
+    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) THEN [e].[NullableStringA]
     ELSE [e].[NullableStringB]
-END IS NOT NULL)");
+END IS NOT NULL))");
         }
 
         public override async Task Where_equal_with_conditional_non_nullable(bool async)
@@ -913,9 +913,9 @@ END IS NOT NULL)");
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE ([e].[NullableStringC] <> CASE
-    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN [e].[StringA]
+    WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) THEN [e].[StringA]
     ELSE [e].[StringB]
-END) OR [e].[NullableStringC] IS NULL");
+END) OR ([e].[NullableStringC] IS NULL)");
         }
 
         public override async Task Where_equal_with_and_and_contains(bool async)
@@ -934,7 +934,7 @@ WHERE (([e].[NullableStringB] LIKE N'') OR (CHARINDEX([e].[NullableStringB], [e]
 
             AssertSql(
                 @"SELECT CASE
-    WHEN ([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL THEN CAST(1 AS bit)
+    WHEN ([e].[NullableStringA] <> N'Foo') OR ([e].[NullableStringA] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Entities1] AS [e]");
@@ -948,10 +948,10 @@ FROM [Entities1] AS [e]");
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
 ORDER BY CASE
-    WHEN ([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL THEN CAST(1 AS bit)
+    WHEN ([e].[NullableStringA] <> N'Foo') OR ([e].[NullableStringA] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, CASE
-    WHEN ([e].[NullableIntB] <> 10) OR [e].[NullableIntB] IS NULL THEN CAST(1 AS bit)
+    WHEN ([e].[NullableIntB] <> 10) OR ([e].[NullableIntB] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -1251,33 +1251,33 @@ FROM [Entities1] AS [e]
 WHERE (CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END = [e].[NullableIntA]) OR (CASE
+END = [e].[NullableIntA]) OR ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL AND [e].[NullableIntA] IS NULL)",
+END IS NULL) AND ([e].[NullableIntA] IS NULL))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE (CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END = [e].[NullableIntA]) OR (CASE
+END = [e].[NullableIntA]) OR ((CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END IS NULL AND [e].[NullableIntA] IS NULL)",
+END IS NULL) AND ([e].[NullableIntA] IS NULL))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END <> [e].[NullableIntB]) OR (CASE
+END <> [e].[NullableIntB]) OR ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL OR [e].[NullableIntB] IS NULL)) AND (CASE
+END IS NULL) OR ([e].[NullableIntB] IS NULL))) AND ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)");
+END IS NOT NULL) OR ([e].[NullableIntB] IS NOT NULL))");
             // issue #18773
             //            AssertSql(
             //                @"SELECT [e].[Id]
@@ -1327,13 +1327,13 @@ WHERE (CASE
 END = CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END) OR (CASE
+END) OR ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL AND CASE
+END IS NULL) AND (CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END IS NULL)",
+END IS NULL))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
@@ -1343,19 +1343,19 @@ WHERE ((CASE
 END <> CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END) OR (CASE
+END) OR ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL OR CASE
+END IS NULL) OR (CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END IS NULL)) AND (CASE
+END IS NULL))) AND ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NOT NULL OR CASE
+END IS NOT NULL) OR (CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END IS NOT NULL)",
+END IS NOT NULL))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
@@ -1365,19 +1365,19 @@ WHERE ((CASE
 END <> CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END) OR (CASE
+END) OR ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL OR CASE
+END IS NULL) OR (CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END IS NULL)) AND (CASE
+END IS NULL))) AND ((CASE
     WHEN N'oo' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NOT NULL OR CASE
+END IS NOT NULL) OR (CASE
     WHEN N'ar' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END IS NOT NULL)");
+END IS NOT NULL))");
             // issue #18773
             //            AssertSql(
             //                @"SELECT [e].[Id]
@@ -1400,11 +1400,11 @@ END IS NOT NULL)");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) = [e].[NullableStringA]) OR ((([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) OR [e].[NullableStringC] IS NULL) AND [e].[NullableStringA] IS NULL)",
+WHERE (REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) = [e].[NullableStringA]) OR (((([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL)) OR ([e].[NullableStringC] IS NULL)) AND ([e].[NullableStringA] IS NULL))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ((REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) <> [e].[NullableStringA]) OR ((([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) OR [e].[NullableStringC] IS NULL) OR [e].[NullableStringA] IS NULL)) AND ((([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL) AND [e].[NullableStringC] IS NOT NULL) OR [e].[NullableStringA] IS NOT NULL)");
+WHERE ((REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) <> [e].[NullableStringA]) OR (((([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL)) OR ([e].[NullableStringC] IS NULL)) OR ([e].[NullableStringA] IS NULL))) AND (((([e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringB] IS NOT NULL)) AND ([e].[NullableStringC] IS NOT NULL)) OR ([e].[NullableStringA] IS NOT NULL))");
         }
 
         public override async Task Null_semantics_coalesce(bool async)
@@ -1472,7 +1472,7 @@ END = CAST(1 AS bit)");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ((SUBSTRING([e].[NullableStringA], 0 + 1, [e].[IntA]) <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)");
+WHERE ((SUBSTRING([e].[NullableStringA], 0 + 1, [e].[IntA]) <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL))");
         }
 
         public override async Task Null_semantics_join_with_composite_key(bool async)
@@ -1482,8 +1482,8 @@ WHERE ((SUBSTRING([e].[NullableStringA], 0 + 1, [e].[IntA]) <> [e].[NullableStri
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC], [e0].[Id], [e0].[BoolA], [e0].[BoolB], [e0].[BoolC], [e0].[IntA], [e0].[IntB], [e0].[IntC], [e0].[NullableBoolA], [e0].[NullableBoolB], [e0].[NullableBoolC], [e0].[NullableIntA], [e0].[NullableIntB], [e0].[NullableIntC], [e0].[NullableStringA], [e0].[NullableStringB], [e0].[NullableStringC], [e0].[StringA], [e0].[StringB], [e0].[StringC]
 FROM [Entities1] AS [e]
-INNER JOIN [Entities2] AS [e0] ON (([e].[NullableStringA] = [e0].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e0].[NullableStringB] IS NULL)) AND (CASE
-    WHEN (([e].[NullableStringB] <> [e].[NullableStringC]) OR ([e].[NullableStringB] IS NULL OR [e].[NullableStringC] IS NULL)) AND ([e].[NullableStringB] IS NOT NULL OR [e].[NullableStringC] IS NOT NULL) THEN CAST(1 AS bit)
+INNER JOIN [Entities2] AS [e0] ON (([e].[NullableStringA] = [e0].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e0].[NullableStringB] IS NULL))) AND (CASE
+    WHEN (([e].[NullableStringB] <> [e].[NullableStringC]) OR (([e].[NullableStringB] IS NULL) OR ([e].[NullableStringC] IS NULL))) AND (([e].[NullableStringB] IS NOT NULL) OR ([e].[NullableStringC] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = COALESCE([e0].[NullableBoolA], [e0].[BoolC]))");
         }
@@ -1499,15 +1499,15 @@ WHERE [e].[NullableIntA] IN (1, 2)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] NOT IN (1, 2) OR [e].[NullableIntA] IS NULL",
+WHERE [e].[NullableIntA] NOT IN (1, 2) OR ([e].[NullableIntA] IS NULL)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL",
+WHERE [e].[NullableIntA] IN (1, 2) OR ([e].[NullableIntA] IS NULL)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL",
+WHERE [e].[NullableIntA] NOT IN (1, 2) AND ([e].[NullableIntA] IS NOT NULL)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
@@ -1515,15 +1515,15 @@ WHERE [e].[NullableIntA] IN (1, 2)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] NOT IN (1, 2) OR [e].[NullableIntA] IS NULL",
+WHERE [e].[NullableIntA] NOT IN (1, 2) OR ([e].[NullableIntA] IS NULL)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL",
+WHERE [e].[NullableIntA] IN (1, 2) OR ([e].[NullableIntA] IS NULL)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL");
+WHERE [e].[NullableIntA] NOT IN (1, 2) AND ([e].[NullableIntA] IS NOT NULL)");
         }
 
         public override async Task Null_semantics_contains_array_with_no_values(bool async)
@@ -1605,23 +1605,23 @@ FROM [Entities1] AS [e]");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NOT NULL AND ([e].[NullableIntA] = [e].[NullableIntB])",
+WHERE ([e].[NullableIntA] IS NOT NULL) AND ([e].[NullableIntA] = [e].[NullableIntB])",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NOT NULL AND (([e].[NullableIntA] <> [e].[NullableIntB]) OR [e].[NullableIntB] IS NULL)",
+WHERE ([e].[NullableIntA] IS NOT NULL) AND (([e].[NullableIntA] <> [e].[NullableIntB]) OR ([e].[NullableIntB] IS NULL))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NOT NULL AND ([e].[NullableIntA] = [e].[IntC])",
+WHERE ([e].[NullableIntA] IS NOT NULL) AND ([e].[NullableIntA] = [e].[IntC])",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL) AND ([e].[NullableIntA] = [e].[NullableIntB])",
+WHERE (([e].[NullableIntA] IS NOT NULL) AND ([e].[NullableIntB] IS NOT NULL)) AND ([e].[NullableIntA] = [e].[NullableIntB])",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL) AND ([e].[NullableIntA] <> [e].[NullableIntB])");
+WHERE (([e].[NullableIntA] IS NOT NULL) AND ([e].[NullableIntB] IS NOT NULL)) AND ([e].[NullableIntA] <> [e].[NullableIntB])");
         }
 
         public override async Task Null_semantics_with_null_check_complex(bool async)
@@ -1631,15 +1631,15 @@ WHERE ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL) AND ([
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NOT NULL AND ((([e].[NullableIntC] <> [e].[NullableIntA]) OR [e].[NullableIntC] IS NULL) OR ([e].[NullableIntB] IS NOT NULL AND ([e].[NullableIntA] <> [e].[NullableIntB])))",
+WHERE ([e].[NullableIntA] IS NOT NULL) AND ((([e].[NullableIntC] <> [e].[NullableIntA]) OR ([e].[NullableIntC] IS NULL)) OR (([e].[NullableIntB] IS NOT NULL) AND ([e].[NullableIntA] <> [e].[NullableIntB])))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NOT NULL AND ((([e].[NullableIntC] <> [e].[NullableIntA]) OR [e].[NullableIntC] IS NULL) OR (([e].[NullableIntA] <> [e].[NullableIntB]) OR [e].[NullableIntB] IS NULL))",
+WHERE ([e].[NullableIntA] IS NOT NULL) AND ((([e].[NullableIntC] <> [e].[NullableIntA]) OR ([e].[NullableIntC] IS NULL)) OR (([e].[NullableIntA] <> [e].[NullableIntB]) OR ([e].[NullableIntB] IS NULL)))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL) AND (([e].[NullableIntA] = [e].[NullableIntC]) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntC] IS NULL))");
+WHERE (([e].[NullableIntA] IS NOT NULL) OR ([e].[NullableIntB] IS NOT NULL)) AND (([e].[NullableIntA] = [e].[NullableIntC]) OR (([e].[NullableIntA] IS NULL) AND ([e].[NullableIntC] IS NULL)))");
         }
 
         public override async Task Null_semantics_with_null_check_complex2(bool async)
@@ -1667,15 +1667,15 @@ WHERE [e].[NullableIntA] IS NOT NULL",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL",
+WHERE ([e].[NullableIntA] IS NULL) OR ([e].[NullableIntB] IS NULL)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL",
+WHERE ([e].[NullableIntA] IS NULL) AND ([e].[NullableIntB] IS NULL)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL");
+WHERE ([e].[NullableIntA] IS NOT NULL) OR ([e].[NullableIntB] IS NOT NULL)");
         }
 
         public override async Task Coalesce_not_equal(bool async)
@@ -1733,7 +1733,7 @@ WHERE [e].[IntA] > @__i_0");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL) AND ([e].[NullableStringA] <> [e].[NullableStringB])");
+WHERE (([e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringB] IS NOT NULL)) AND ([e].[NullableStringA] <> [e].[NullableStringB])");
         }
 
         public override async Task Nullable_column_info_doesnt_propagate_inside_binary_OrElse(bool async)
@@ -1743,7 +1743,7 @@ WHERE ([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL) 
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) AND ((([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL))");
+WHERE (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL)) AND ((([e].[NullableStringA] <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL)))");
         }
 
         public override async Task Nullable_column_info_propagates_inside_binary_OrElse_when_info_is_duplicated(bool async)
@@ -1753,11 +1753,11 @@ WHERE ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) A
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL) OR [e].[NullableStringA] IS NOT NULL) AND (([e].[NullableStringA] <> [e].[NullableStringB]) OR [e].[NullableStringB] IS NULL)",
+WHERE ((([e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringB] IS NOT NULL)) OR ([e].[NullableStringA] IS NOT NULL)) AND (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringB] IS NULL))",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL AND [e].[NullableStringA] IS NOT NULL)) AND ([e].[NullableStringA] <> [e].[NullableStringB])");
+WHERE ((([e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringB] IS NOT NULL)) OR (([e].[NullableStringB] IS NOT NULL) AND ([e].[NullableStringA] IS NOT NULL))) AND ([e].[NullableStringA] <> [e].[NullableStringB])");
         }
 
         public override async Task Nullable_column_info_propagates_inside_conditional(bool async)
@@ -1784,7 +1784,7 @@ FROM [Entities1] AS [e]");
     WHEN [e].[NullableStringA] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Foo], CASE
-    WHEN ([e].[NullableStringA] <> [e].[StringA]) OR [e].[NullableStringA] IS NULL THEN CAST(1 AS bit)
+    WHEN ([e].[NullableStringA] <> [e].[StringA]) OR ([e].[NullableStringA] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Bar]
 FROM [Entities1] AS [e]");
@@ -1808,7 +1808,7 @@ WHERE (([e].[NullableBoolA] <> [e0].[NullableBoolB]) OR (([e].[NullableBoolA] IS
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] IS NOT NULL AND ([e].[NullableBoolB] IS NOT NULL)) AND [e].[NullableStringC] IS NOT NULL) AND (([e].[NullableBoolB] <> [e].[NullableBoolC]) OR ([e].[NullableBoolC] IS NULL))");
+WHERE ((([e].[NullableStringA] IS NOT NULL) AND ([e].[NullableBoolB] IS NOT NULL)) AND ([e].[NullableStringC] IS NOT NULL)) AND (([e].[NullableBoolB] <> [e].[NullableBoolC]) OR ([e].[NullableBoolC] IS NULL))");
         }
 
         public override async Task Empty_subquery_with_contains_returns_false(bool async)
@@ -1837,7 +1837,7 @@ FROM [Entities1] AS [e]");
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE (SUBSTRING([e].[NullableStringA], 1, 1) = SUBSTRING([e].[NullableStringB], LEN([e].[NullableStringB]), 1)) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)");
+WHERE (SUBSTRING([e].[NullableStringA], 1, 1) = SUBSTRING([e].[NullableStringB], LEN([e].[NullableStringB]), 1)) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL))");
         }
 
         public override async Task Null_semantics_applied_to_CompareTo_equality(bool async)
@@ -1847,19 +1847,19 @@ WHERE (SUBSTRING([e].[NullableStringA], 1, 1) = SUBSTRING([e].[NullableStringB],
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)",
+WHERE ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL))",
                 //
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)",
+WHERE ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL))",
                 //
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)",
+WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL))",
                 //
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)");
+WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL))");
         }
 
         public override async Task Nested_CompareTo_optimized(bool async)
@@ -1869,19 +1869,19 @@ WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)",
+WHERE ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL))",
                 //
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)",
+WHERE ([e].[NullableStringA] = [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL))",
                 //
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)",
+WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL))",
                 //
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)");
+WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL))");
         }
 
         public override async Task False_compared_to_negated_is_null(bool async)
@@ -1901,7 +1901,7 @@ WHERE [e].[NullableStringA] IS NULL");
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL");
+WHERE [e].[NullableIntA] NOT IN (1, 2) AND ([e].[NullableIntA] IS NOT NULL)");
         }
 
         public override async Task Multiple_non_equality_comparisons_including_null_comparison_work_for_relational_null_semantics(bool async)
@@ -1911,7 +1911,7 @@ WHERE [e].[NullableIntA] NOT IN (1, 2) AND [e].[NullableIntA] IS NOT NULL");
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableIntA] <> 1) AND [e].[NullableIntA] IS NOT NULL");
+WHERE ([e].[NullableIntA] <> 1) AND ([e].[NullableIntA] IS NOT NULL)");
         }
 
         public override async Task Multiple_non_equality_comparisons_without_null_comparison_work_for_relational_null_semantics(bool async)
@@ -1931,7 +1931,7 @@ WHERE [e].[NullableIntA] NOT IN (1, 2)");
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableIntA] = 1) OR [e].[NullableIntA] IS NULL");
+WHERE ([e].[NullableIntA] = 1) OR ([e].[NullableIntA] IS NULL)");
         }
 
         public override async Task Multiple_contains_calls_get_combined_into_one_for_relational_null_semantics(bool async)
@@ -1961,7 +1961,7 @@ WHERE [e].[NullableIntA] NOT IN (1, NULL, 2, 3)");
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL");
+WHERE [e].[NullableIntA] IN (1, 2) OR ([e].[NullableIntA] IS NULL)");
         }
 
         public override async Task Negated_contains_with_comparison_dont_get_combined_for_relational_null_semantics(bool async)
@@ -1971,7 +1971,7 @@ WHERE [e].[NullableIntA] IN (1, 2) OR [e].[NullableIntA] IS NULL");
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableIntA] IS NOT NULL AND [e].[NullableIntA] NOT IN (1, 2)");
+WHERE ([e].[NullableIntA] IS NOT NULL) AND [e].[NullableIntA] NOT IN (1, 2)");
         }
 
         public override async Task Negated_contains_with_comparison_without_null_get_combined_for_relational_null_semantics(bool async)
@@ -2055,6 +2055,32 @@ WHERE [e].[BoolB] <> CASE
 END");
         }
 
+        public override async Task Bool_not_equal_nullable_int_HasValue(bool async)
+        {
+            await base.Bool_not_equal_nullable_int_HasValue(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableIntA] IS NULL",
+                //
+                @"@__prm_0='False'
+
+SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE @__prm_0 <> CASE
+    WHEN [e].[NullableIntA] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END",
+                //
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[BoolB] <> CASE
+    WHEN [e].[NullableIntA] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+        }
+
         public override async Task Bool_not_equal_nullable_bool_compared_to_null(bool async)
         {
             await base.Bool_not_equal_nullable_bool_compared_to_null(async);
@@ -2127,7 +2153,7 @@ END");
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableStringA] IS NOT NULL AND ([e].[NullableStringA] = N'Foo')");
+WHERE ([e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringA] = N'Foo')");
         }
 
         public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_negative(bool async)
@@ -2137,7 +2163,7 @@ WHERE [e].[NullableStringA] IS NOT NULL AND ([e].[NullableStringA] = N'Foo')");
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableStringA] IS NOT NULL OR (([e].[NullableStringA] = N'Foo') AND [e].[NullableStringA] IS NOT NULL)");
+WHERE ([e].[NullableStringA] IS NOT NULL) OR (([e].[NullableStringA] = N'Foo') AND ([e].[NullableStringA] IS NOT NULL))");
         }
 
         public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_nested(bool async)
@@ -2147,7 +2173,7 @@ WHERE [e].[NullableStringA] IS NOT NULL OR (([e].[NullableStringA] = N'Foo') AND
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) OR ([e].[NullableStringA] <> [e].[NullableStringB])");
+WHERE (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL)) OR ([e].[NullableStringA] <> [e].[NullableStringB])");
         }
 
         public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_intersection(bool async)
@@ -2157,7 +2183,7 @@ WHERE ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) OR ([e].[
             AssertSql(
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] IS NULL AND ((([e].[StringA] = N'Foo') OR [e].[NullableStringA] IS NULL) OR [e].[NullableStringB] IS NULL)) OR (([e].[NullableStringA] <> [e].[NullableStringB]) OR [e].[NullableStringB] IS NULL)");
+WHERE (([e].[NullableStringA] IS NULL) AND ((([e].[StringA] = N'Foo') OR ([e].[NullableStringA] IS NULL)) OR ([e].[NullableStringB] IS NULL))) OR (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringB] IS NULL))");
         }
 
         public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional(bool async)
@@ -2170,11 +2196,11 @@ WHERE ([e].[NullableStringA] IS NULL AND ((([e].[StringA] = N'Foo') OR [e].[Null
 FROM [Entities1] AS [e]
 WHERE CASE
     WHEN [e].[NullableStringA] IS NULL THEN CASE
-        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) THEN CAST(1 AS bit)
+        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL)) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE CASE
-        WHEN (([e].[NullableStringA] <> [e].[NullableStringC]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringC] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringC] IS NOT NULL) THEN CAST(1 AS bit)
+        WHEN (([e].[NullableStringA] <> [e].[NullableStringC]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringC] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringC] IS NOT NULL)) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)");
@@ -2189,12 +2215,12 @@ END = CAST(1 AS bit)");
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
 WHERE CASE
-    WHEN [e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL THEN CASE
-        WHEN (([e].[NullableStringA] = [e].[NullableStringB]) AND ([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN CAST(1 AS bit)
+    WHEN ([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL) THEN CASE
+        WHEN (([e].[NullableStringA] = [e].[NullableStringB]) AND (([e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringB] IS NOT NULL))) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE CASE
-        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) THEN CAST(1 AS bit)
+        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL)) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)");
@@ -2208,12 +2234,12 @@ END = CAST(1 AS bit)");
                 @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
 FROM [Entities1] AS [e]
 WHERE CASE
-    WHEN ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) AND ([e].[NullableBoolC] IS NULL) THEN CASE
-        WHEN (([e].[NullableStringA] = [e].[NullableStringB]) AND ([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN CAST(1 AS bit)
+    WHEN (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL)) AND ([e].[NullableBoolC] IS NULL) THEN CASE
+        WHEN (([e].[NullableStringA] = [e].[NullableStringB]) AND (([e].[NullableStringA] IS NOT NULL) AND ([e].[NullableStringB] IS NOT NULL))) OR (([e].[NullableStringA] IS NULL) AND ([e].[NullableStringB] IS NULL)) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE CASE
-        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) THEN CAST(1 AS bit)
+        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR (([e].[NullableStringA] IS NULL) OR ([e].[NullableStringB] IS NULL))) AND (([e].[NullableStringA] IS NOT NULL) OR ([e].[NullableStringB] IS NOT NULL)) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -247,7 +247,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
-WHERE ([p].[Id] <> 42) OR [p].[Id] IS NULL
+WHERE ([p].[Id] <> 42) OR ([p].[Id] IS NULL)
 ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
@@ -278,7 +278,7 @@ ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].
     LEFT JOIN [OwnedPerson] AS [o1] ON [o0].[ClientId] = [o1].[Id]
     LEFT JOIN [Planet] AS [p0] ON [o1].[PersonAddress_Country_PlanetId] = [p0].[Id]
     LEFT JOIN [Star] AS [s] ON [p0].[StarId] = [s].[Id]
-    WHERE ([o].[Id] = [o0].[ClientId]) AND (([s].[Id] <> 42) OR [s].[Id] IS NULL)) AS [Count], [p].[Id], [p].[StarId]
+    WHERE ([o].[Id] = [o0].[ClientId]) AND (([s].[Id] <> 42) OR ([s].[Id] IS NULL))) AS [Count], [p].[Id], [p].[StarId]
 FROM [OwnedPerson] AS [o]
 LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 ORDER BY [o].[Id]");
@@ -297,7 +297,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
-WHERE ([p].[Id] <> 7) OR [p].[Id] IS NULL
+WHERE ([p].[Id] <> 7) OR ([p].[Id] IS NULL)
 ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
@@ -1169,7 +1169,7 @@ ORDER BY [m].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0], [t2].[Id], [t2].[
                 @"SELECT [b].[Throned_Value], [f].[Id], [b].[Id], [p].[Id], [p].[StarId]
 FROM [Fink] AS [f]
 LEFT JOIN [Barton] AS [b] ON [f].[BartonId] = [b].[Id]
-LEFT JOIN [Planet] AS [p] ON ([b].[Throned_Value] <> [p].[Id]) OR [b].[Throned_Value] IS NULL
+LEFT JOIN [Planet] AS [p] ON ([b].[Throned_Value] <> [p].[Id]) OR ([b].[Throned_Value] IS NULL)
 ORDER BY [f].[Id], [b].[Id]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2989,7 +2989,7 @@ FROM [Factions] AS [f]
 WHERE EXISTS (
     SELECT 1
     FROM [Leaders] AS [l]
-    WHERE ([l].[Name] IS NOT NULL AND ([l].[Name] LIKE N'Bran%')) AND ([l].[Name] = N'Crach an Craite'))");
+    WHERE (([l].[Name] IS NOT NULL) AND ([l].[Name] LIKE N'Bran%')) AND ([l].[Name] = N'Crach an Craite'))");
             }
         }
 
@@ -4736,7 +4736,7 @@ FROM [Posts] AS [p]");
 FROM [EntitiesWithQueryFilterSelfReference] AS [e]
 WHERE EXISTS (
     SELECT 1
-    FROM [EntitiesWithQueryFilterSelfReference] AS [e0]) AND (([e].[Name] <> N'Foo') OR [e].[Name] IS NULL)");
+    FROM [EntitiesWithQueryFilterSelfReference] AS [e0]) AND (([e].[Name] <> N'Foo') OR ([e].[Name] IS NULL))");
             }
 
             using (var context = contextFactory.CreateContext())
@@ -4753,7 +4753,7 @@ WHERE EXISTS (
     FROM [EntitiesWithQueryFilterSelfReference] AS [e0]
     WHERE EXISTS (
         SELECT 1
-        FROM [EntitiesWithQueryFilterSelfReference] AS [e1])) AND (([e].[Name] <> N'Foo') OR [e].[Name] IS NULL)");
+        FROM [EntitiesWithQueryFilterSelfReference] AS [e1])) AND (([e].[Name] <> N'Foo') OR ([e].[Name] IS NULL))");
             }
         }
 
@@ -5354,10 +5354,10 @@ OUTER APPLY (
         WHERE [e].[Id] = [v].[Entity11023Id]) AND (((
         SELECT TOP(1) [v0].[Id]
         FROM [Values] AS [v0]
-        WHERE [e].[Id] = [v0].[Entity11023Id]) = [t].[Value11023Id]) OR ((
+        WHERE [e].[Id] = [v0].[Entity11023Id]) = [t].[Value11023Id]) OR (((
         SELECT TOP(1) [v0].[Id]
         FROM [Values] AS [v0]
-        WHERE [e].[Id] = [v0].[Entity11023Id]) IS NULL AND [t].[Value11023Id] IS NULL))
+        WHERE [e].[Id] = [v0].[Entity11023Id]) IS NULL) AND ([t].[Value11023Id] IS NULL)))
 ) AS [t0]
 ORDER BY [e].[Id], [t0].[Id]");
             }
@@ -5753,7 +5753,7 @@ LEFT JOIN (
         WHEN COALESCE((
             SELECT MAX([d2].[GameNumber])
             FROM [DbGame] AS [d2]
-            WHERE [d1].[Id] IS NOT NULL AND ([d1].[Id] = [d2].[SeasonId])), 0) > 10 THEN CAST(1 AS bit)
+            WHERE ([d1].[Id] IS NOT NULL) AND ([d1].[Id] = [d2].[SeasonId])), 0) > 10 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [IsPastTradeDeadline], [d].[DbTradeId]
     FROM [DbTradeAsset] AS [d]
@@ -6250,7 +6250,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [Customers] AS [c0]
     LEFT JOIN [CustomerMemberships] AS [c1] ON [c0].[Id] = [c1].[CustomerId]
-    WHERE [c1].[Id] IS NOT NULL AND ([c0].[Id] = [c].[CustomerId])) > 0");
+    WHERE ([c1].[Id] IS NOT NULL) AND ([c0].[Id] = [c].[CustomerId])) > 0");
             }
 
             using (var context = contextFactory.CreateContext())
@@ -7310,13 +7310,13 @@ CROSS JOIN (
 
 SELECT [e].[Id], [e].[Name], [e].[TenantId]
 FROM [Entities] AS [e]
-WHERE (([e].[Name] <> N'Foo') OR [e].[Name] IS NULL) AND ([e].[TenantId] = @__ef_filter__p_0)",
+WHERE (([e].[Name] <> N'Foo') OR ([e].[Name] IS NULL)) AND ([e].[TenantId] = @__ef_filter__p_0)",
                     //
                     @"@__ef_filter__p_0='2'
 
 SELECT [e].[Id], [e].[Name], [e].[TenantId]
 FROM [Entities] AS [e]
-WHERE (([e].[Name] <> N'Foo') OR [e].[Name] IS NULL) AND ([e].[TenantId] = @__ef_filter__p_0)");
+WHERE (([e].[Name] <> N'Foo') OR ([e].[Name] IS NULL)) AND ([e].[TenantId] = @__ef_filter__p_0)");
             }
         }
 
@@ -9445,12 +9445,12 @@ OUTER APPLY (
     SELECT [m0].[Id], [m0].[Budget], [m0].[Description], [m0].[DurationInMins], [m0].[Name], [m0].[PosterUrl], [m0].[Rating], [m0].[ReleaseDate], [m0].[Revenue]
     FROM [MovieActorEntity] AS [m]
     INNER JOIN [MovieEntity] AS [m0] ON [m].[MovieId] = [m0].[Id]
-    WHERE [t].[Id0] IS NOT NULL AND ([t].[Id0] = [m].[ActorId])
+    WHERE ([t].[Id0] IS NOT NULL) AND ([t].[Id0] = [m].[ActorId])
     UNION
     SELECT [m2].[Id], [m2].[Budget], [m2].[Description], [m2].[DurationInMins], [m2].[Name], [m2].[PosterUrl], [m2].[Rating], [m2].[ReleaseDate], [m2].[Revenue]
     FROM [MovieDirectorEntity] AS [m1]
     INNER JOIN [MovieEntity] AS [m2] ON [m1].[MovieId] = [m2].[Id]
-    WHERE [t].[Id1] IS NOT NULL AND ([t].[Id1] = [m1].[DirectorId])
+    WHERE ([t].[Id1] IS NOT NULL) AND ([t].[Id1] = [m1].[DirectorId])
 ) AS [t0]
 ORDER BY [t].[Id], [t].[Id0], [t].[Id1], [p0].[Id]");
         }
@@ -9584,7 +9584,7 @@ FROM (
         SELECT COUNT(*)
         FROM [Cars] AS [c]
         INNER JOIN [Taxis] AS [t0] ON [c].[Id] = [t0].[CarId]
-        WHERE ([u].[Id] = [c].[EUserId]) AND (([t0].[ReportText] <> N'') OR [t0].[ReportText] IS NULL)) AS [c], [u].[Id]
+        WHERE ([u].[Id] = [c].[EUserId]) AND (([t0].[ReportText] <> N'') OR ([t0].[ReportText] IS NULL))) AS [c], [u].[Id]
     FROM [Users] AS [u]
 ) AS [t]
 OUTER APPLY (

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SharedTypeQuerySqlServerTest.cs
@@ -20,7 +20,7 @@ FROM [ViewQuery24601] AS [v]
 WHERE EXISTS (
     SELECT 1
     FROM [STET] AS [s]
-    WHERE ([s].[Value] = [v].[Value]) OR ([s].[Value] IS NULL AND [v].[Value] IS NULL))");
+    WHERE ([s].[Value] = [v].[Value]) OR (([s].[Value] IS NULL) AND ([v].[Value] IS NULL)))");
         }
 
         public override async Task Can_use_shared_type_entity_type_in_query_filter_with_from_sql(bool async)
@@ -35,7 +35,7 @@ WHERE EXISTS (
     FROM (
         Select * from STET
     ) AS [s]
-    WHERE ([s].[Value] = [v].[Value]) OR ([s].[Value] IS NULL AND [v].[Value] IS NULL))");
+    WHERE ([s].[Value] = [v].[Value]) OR (([s].[Value] IS NULL) AND ([v].[Value] IS NULL)))");
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTFiltersInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTFiltersInheritanceQuerySqlServerTest.cs
@@ -47,7 +47,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE ([a].[CountryId] = 1) AND [k].[Species] IS NOT NULL");
+WHERE ([a].[CountryId] = 1) AND ([k].[Species] IS NOT NULL)");
         }
 
         public override async Task Can_use_is_kiwi_with_other_predicate(bool async)
@@ -63,7 +63,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE ([a].[CountryId] = 1) AND ([k].[Species] IS NOT NULL AND ([a].[CountryId] = 1))");
+WHERE ([a].[CountryId] = 1) AND (([k].[Species] IS NOT NULL) AND ([a].[CountryId] = 1))");
         }
 
         public override async Task Can_use_is_kiwi_in_projection(bool async)
@@ -93,7 +93,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE ([a].[CountryId] = 1) AND ([k].[Species] IS NOT NULL OR [e].[Species] IS NOT NULL)
+WHERE ([a].[CountryId] = 1) AND (([k].[Species] IS NOT NULL) OR ([e].[Species] IS NOT NULL))
 ORDER BY [a].[Species]");
         }
 
@@ -110,7 +110,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE (([a].[CountryId] = 1) AND ([a].[CountryId] = 1)) AND ([k].[Species] IS NOT NULL OR [e].[Species] IS NOT NULL)
+WHERE (([a].[CountryId] = 1) AND ([a].[CountryId] = 1)) AND (([k].[Species] IS NOT NULL) OR ([e].[Species] IS NOT NULL))
 ORDER BY [a].[Species]");
         }
 
@@ -124,7 +124,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE ([a].[CountryId] = 1) AND ([k].[Species] IS NOT NULL OR [e].[Species] IS NOT NULL)");
+WHERE ([a].[CountryId] = 1) AND (([k].[Species] IS NOT NULL) OR ([e].[Species] IS NOT NULL))");
         }
 
         public override async Task Can_use_of_type_bird_first(bool async)
@@ -140,7 +140,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE ([a].[CountryId] = 1) AND ([k].[Species] IS NOT NULL OR [e].[Species] IS NOT NULL)
+WHERE ([a].[CountryId] = 1) AND (([k].[Species] IS NOT NULL) OR ([e].[Species] IS NOT NULL))
 ORDER BY [a].[Species]");
         }
 
@@ -155,7 +155,7 @@ END AS [Discriminator]
 FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE ([a].[CountryId] = 1) AND [k].[Species] IS NOT NULL");
+WHERE ([a].[CountryId] = 1) AND ([k].[Species] IS NOT NULL)");
         }
 
         public override async Task Can_use_derived_set(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -50,7 +50,7 @@ WHERE [s].[Id] = -[s].[Id]");
             AssertSql(
                 @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-WHERE [s].[Name] IS NOT NULL AND NOT ([s].[Name] LIKE N'us%')");
+WHERE ([s].[Name] IS NOT NULL) AND NOT ([s].[Name] LIKE N'us%')");
         }
 
         public override async Task Entity_equality_empty(bool async)
@@ -296,7 +296,7 @@ END AS [Discriminator], [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Is
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
+WHERE ([t].[Id] IS NOT NULL) AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
         }
 
         public override async Task Include_where_list_contains_navigation2(bool async)
@@ -314,7 +314,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE [c].[Location] IS NOT NULL AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
+WHERE ([c].[Location] IS NOT NULL) AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
         }
 
         public override async Task Navigation_accessed_twice_outside_and_inside_subquery(bool async)
@@ -331,7 +331,7 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE [t].[Id] IS NOT NULL AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
+WHERE ([t].[Id] IS NOT NULL) AND [t].[Id] IN ('34c8d86e-a4ac-4be5-827f-584dda348a07', 'df36f493-463f-4123-83f9-6b135deeb7ba', 'a8ad98f9-e023-4e2a-9a70-c2728455bd34', '70534e05-782c-4052-8720-c2c54481ce5f', 'a7be028a-0cf2-448f-ab55-ce8bc5d8cf69', 'b39a6fba-9026-4d69-828e-fd7068673e57')");
         }
 
         public override async Task Include_with_join_multi_level(bool async)
@@ -455,7 +455,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 ) AS [t] ON [w].[OwnerFullName] = [t].[FullName]
 LEFT JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
-WHERE ([t].[Nickname] <> N'Paduk') OR [t].[Nickname] IS NULL
+WHERE ([t].[Nickname] <> N'Paduk') OR ([t].[Nickname] IS NULL)
 ORDER BY [c].[Name], [w].[Id]");
         }
 
@@ -739,15 +739,15 @@ WHERE (([g].[Rank] & (
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL AND (
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL) AND ((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)",
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL))",
                 //
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -762,15 +762,15 @@ WHERE ((2 & (
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL AND (
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL) AND ((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)");
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL))");
         }
 
         public override async Task Where_enum_has_flag_subquery_client_eval(bool async)
@@ -791,15 +791,15 @@ WHERE (([g].[Rank] & (
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL AND (
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL) AND ((
     SELECT TOP(1) [g0].[Rank]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)");
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL))");
         }
 
         public override async Task Where_enum_has_flag_with_non_nullable_parameter(bool async)
@@ -901,7 +901,7 @@ WHERE [w].[IsAutomatic] = CAST(1 AS bit)");
                 @"@__ammunitionType_0='1' (Nullable = true)
 
 SELECT [w].[Id], CASE
-    WHEN ([w].[AmmunitionType] = @__ammunitionType_0) AND [w].[AmmunitionType] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([w].[AmmunitionType] = @__ammunitionType_0) AND ([w].[AmmunitionType] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Cartridge]
 FROM [Weapons] AS [w]
@@ -967,11 +967,11 @@ FROM [Weapons] AS [w]");
 
             AssertSql(
                 @"SELECT [w].[Id], CASE
-    WHEN [w].[AmmunitionType] IS NOT NULL AND ([w].[AmmunitionType] = 1) THEN N'Yes'
+    WHEN ([w].[AmmunitionType] IS NOT NULL) AND ([w].[AmmunitionType] = 1) THEN N'Yes'
     ELSE N'No'
 END AS [IsCartridge]
 FROM [Weapons] AS [w]
-WHERE [w].[AmmunitionType] IS NOT NULL AND ([w].[AmmunitionType] = 1)");
+WHERE ([w].[AmmunitionType] IS NOT NULL) AND ([w].[AmmunitionType] = 1)");
         }
 
         public override async Task Select_ternary_operation_multiple_conditions(bool async)
@@ -1004,7 +1004,7 @@ FROM [Weapons] AS [w]");
 
             AssertSql(
                 @"SELECT [w].[Id], CASE
-    WHEN ([w].[IsAutomatic] = CAST(0 AS bit)) AND (([w].[SynergyWithId] = 1) AND [w].[SynergyWithId] IS NOT NULL) THEN CAST(1 AS bit)
+    WHEN ([w].[IsAutomatic] = CAST(0 AS bit)) AND (([w].[SynergyWithId] = 1) AND ([w].[SynergyWithId] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsCartridge]
 FROM [Weapons] AS [w]");
@@ -1035,7 +1035,7 @@ FROM [Weapons] AS [w]");
 END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
-WHERE ([g].[LeaderNickname] = N'Marcus') AND [g].[LeaderNickname] IS NOT NULL");
+WHERE ([g].[LeaderNickname] = N'Marcus') AND ([g].[LeaderNickname] IS NOT NULL)");
         }
 
         public override async Task Null_propagation_optimization2(bool async)
@@ -1052,7 +1052,7 @@ LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[Squad
 WHERE CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CASE
-        WHEN [g].[LeaderNickname] IS NOT NULL AND ([g].[LeaderNickname] LIKE N'%us') THEN CAST(1 AS bit)
+        WHEN ([g].[LeaderNickname] IS NOT NULL) AND ([g].[LeaderNickname] LIKE N'%us') THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)");
@@ -1092,10 +1092,10 @@ LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[Squad
 WHERE (CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CAST(LEN([g].[LeaderNickname]) AS int)
-END = 5) AND CASE
+END = 5) AND (CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CAST(LEN([g].[LeaderNickname]) AS int)
-END IS NOT NULL");
+END IS NOT NULL)");
         }
 
         public override async Task Null_propagation_optimization5(bool async)
@@ -1112,10 +1112,10 @@ LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[Squad
 WHERE (CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
     ELSE NULL
-END = 5) AND CASE
+END = 5) AND (CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
     ELSE NULL
-END IS NOT NULL");
+END IS NOT NULL)");
         }
 
         public override async Task Null_propagation_optimization6(bool async)
@@ -1132,10 +1132,10 @@ LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[Squad
 WHERE (CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
     ELSE NULL
-END = 5) AND CASE
+END = 5) AND (CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CAST(LEN([g].[LeaderNickname]) AS int)
     ELSE NULL
-END IS NOT NULL");
+END IS NOT NULL)");
         }
 
         public override async Task Select_null_propagation_optimization7(bool async)
@@ -1206,7 +1206,7 @@ CROSS JOIN (
 
             AssertSql(
                 @"SELECT [t].[Nickname], CASE
-    WHEN [t].[Nickname] IS NOT NULL AND [t].[SquadId] IS NOT NULL THEN CASE
+    WHEN ([t].[Nickname] IS NOT NULL) AND ([t].[SquadId] IS NOT NULL) THEN CASE
         WHEN [t].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
@@ -1226,7 +1226,7 @@ ORDER BY [t].[Nickname]");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [t].[Nickname] IS NOT NULL AND [t].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([t].[Nickname] IS NOT NULL) AND ([t].[SquadId] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [t].[Nickname]
 FROM [Gears] AS [g]
@@ -1243,7 +1243,7 @@ ORDER BY [t].[Nickname]");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [t].[Nickname] IS NOT NULL AND [t].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([t].[Nickname] IS NOT NULL) AND ([t].[SquadId] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [t].[Nickname]
 FROM [Gears] AS [g]
@@ -1341,7 +1341,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-LEFT JOIN [Tags] AS [t1] ON (([t0].[Nickname] = [t1].[GearNickName]) OR ([t0].[Nickname] IS NULL AND [t1].[GearNickName] IS NULL)) AND (([t0].[SquadId] = [t1].[GearSquadId]) OR ([t0].[SquadId] IS NULL AND [t1].[GearSquadId] IS NULL))
+LEFT JOIN [Tags] AS [t1] ON (([t0].[Nickname] = [t1].[GearNickName]) OR (([t0].[Nickname] IS NULL) AND ([t1].[GearNickName] IS NULL))) AND (([t0].[SquadId] = [t1].[GearSquadId]) OR (([t0].[SquadId] IS NULL) AND ([t1].[GearSquadId] IS NULL)))
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName]
     FROM [Gears] AS [g0]
@@ -1461,7 +1461,7 @@ LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
 ) AS [t2] ON ([t0].[GearNickName] = [t2].[Nickname]) AND ([t0].[GearSquadId] = [t2].[SquadId])
-WHERE ([t1].[Nickname] = [t2].[Nickname]) OR ([t1].[Nickname] IS NULL AND [t2].[Nickname] IS NULL)");
+WHERE ([t1].[Nickname] = [t2].[Nickname]) OR (([t1].[Nickname] IS NULL) AND ([t2].[Nickname] IS NULL))");
         }
 
         public override async Task Select_Singleton_Navigation_With_Member_Access(bool async)
@@ -1478,7 +1478,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE ([t0].[Nickname] = N'Marcus') AND (([t0].[CityOfBirthName] <> N'Ephyra') OR [t0].[CityOfBirthName] IS NULL)");
+WHERE ([t0].[Nickname] = N'Marcus') AND (([t0].[CityOfBirthName] <> N'Ephyra') OR ([t0].[CityOfBirthName] IS NULL))");
         }
 
         public override async Task Select_Where_Navigation(bool async)
@@ -1511,7 +1511,7 @@ LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
 ) AS [t2] ON ([t0].[GearNickName] = [t2].[Nickname]) AND ([t0].[GearSquadId] = [t2].[SquadId])
-WHERE (([t1].[Nickname] = [t2].[Nickname]) OR ([t1].[Nickname] IS NULL AND [t2].[Nickname] IS NULL)) AND (([t1].[SquadId] = [t2].[SquadId]) OR ([t1].[SquadId] IS NULL AND [t2].[SquadId] IS NULL))");
+WHERE (([t1].[Nickname] = [t2].[Nickname]) OR (([t1].[Nickname] IS NULL) AND ([t2].[Nickname] IS NULL))) AND (([t1].[SquadId] = [t2].[SquadId]) OR (([t1].[SquadId] IS NULL) AND ([t2].[SquadId] IS NULL)))");
         }
 
         public override async Task Select_Where_Navigation_Null(bool async)
@@ -1525,7 +1525,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE [t0].[Nickname] IS NULL OR [t0].[SquadId] IS NULL");
+WHERE ([t0].[Nickname] IS NULL) OR ([t0].[SquadId] IS NULL)");
         }
 
         public override async Task Select_Where_Navigation_Null_Reverse(bool async)
@@ -1539,7 +1539,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE [t0].[Nickname] IS NULL OR [t0].[SquadId] IS NULL");
+WHERE ([t0].[Nickname] IS NULL) OR ([t0].[SquadId] IS NULL)");
         }
 
         public override async Task Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected(bool async)
@@ -1558,7 +1558,7 @@ LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
 ) AS [t2] ON ([t0].[GearNickName] = [t2].[Nickname]) AND ([t0].[GearSquadId] = [t2].[SquadId])
-WHERE ([t1].[Nickname] = [t2].[Nickname]) OR ([t1].[Nickname] IS NULL AND [t2].[Nickname] IS NULL)");
+WHERE ([t1].[Nickname] = [t2].[Nickname]) OR (([t1].[Nickname] IS NULL) AND ([t2].[Nickname] IS NULL))");
         }
 
         public override async Task Optional_Navigation_Null_Coalesce_To_Clr_Type(bool async)
@@ -2073,7 +2073,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[CityOfBirthName]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE ([t0].[Nickname] = N'Marcus') AND (([t0].[CityOfBirthName] <> N'Ephyra') OR [t0].[CityOfBirthName] IS NULL)");
+WHERE ([t0].[Nickname] = N'Marcus') AND (([t0].[CityOfBirthName] <> N'Ephyra') OR ([t0].[CityOfBirthName] IS NULL))");
         }
 
         public override async Task GroupJoin_Composite_Key(bool async)
@@ -2502,7 +2502,7 @@ WHERE ([w].[AmmunitionType] = 1) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)
 
             AssertSql(
                 @"SELECT CASE
-    WHEN (([w].[AmmunitionType] = 1) AND [w].[AmmunitionType] IS NOT NULL) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)) = CAST(1 AS bit)) THEN CAST(1 AS bit)
+    WHEN (([w].[AmmunitionType] = 1) AND ([w].[AmmunitionType] IS NOT NULL)) AND (COALESCE([w].[IsAutomatic], CAST(0 AS bit)) = CAST(1 AS bit)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Weapons] AS [w]");
@@ -2519,7 +2519,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND ([t0].[HasSoulPatch] = CAST(1 AS bit))");
+WHERE (([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)) AND ([t0].[HasSoulPatch] = CAST(1 AS bit))");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_predicate2(bool async)
@@ -2642,7 +2642,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_projection_into_anonymous_type(bool async)
@@ -2656,7 +2656,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_DTOs(bool async)
@@ -2670,7 +2670,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_list_initializers(bool async)
@@ -2684,7 +2684,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)
 ORDER BY [t].[Note]");
         }
 
@@ -2699,7 +2699,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_orderby(bool async)
@@ -2713,7 +2713,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
+WHERE ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)
 ORDER BY [t0].[SquadId]");
         }
 
@@ -2733,7 +2733,7 @@ ORDER BY [t0].[SquadId]");
             FROM [Gears] AS [g]
             LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
         ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-        WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND ([t0].[HasSoulPatch] = CAST(0 AS bit))) THEN CAST(1 AS bit)
+        WHERE (([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)) AND ([t0].[HasSoulPatch] = CAST(0 AS bit))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -2749,7 +2749,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND ([t0].[HasSoulPatch] = CAST(0 AS bit))");
+WHERE (([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)) AND ([t0].[HasSoulPatch] = CAST(0 AS bit))");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_contains(bool async)
@@ -2763,7 +2763,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND EXISTS (
+WHERE (([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL)) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
@@ -2888,7 +2888,7 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL
+    WHERE ([w].[Name] <> N'Lancer') OR ([w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [c].[Name] IN (N'Ephyra', N'Hanover')
 ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name]");
@@ -3223,7 +3223,7 @@ WHERE ([w].[Id] <> 50) AND ([t].[HasSoulPatch] = CAST(0 AS bit))");
                 @"SELECT DISTINCT [g].[HasSoulPatch]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Sum_with_optional_navigation_is_translated_to_sql(bool async)
@@ -3234,7 +3234,7 @@ WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
                 @"SELECT COALESCE(SUM([g].[SquadId]), 0)
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task Count_with_optional_navigation_is_translated_to_sql(bool async)
@@ -3245,7 +3245,7 @@ WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
                 @"SELECT COUNT(*)
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE ([t].[Note] <> N'Foo') OR [t].[Note] IS NULL");
+WHERE ([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)");
         }
 
         public override async Task FirstOrDefault_with_manually_created_groupjoin_is_translated_to_sql(bool async)
@@ -3291,7 +3291,7 @@ WHERE NOT (EXISTS (
         FROM [Gears] AS [g]
         LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
         LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-        WHERE ([t].[Note] = N'Foo') AND [t].[Note] IS NOT NULL) THEN CAST(1 AS bit)
+        WHERE ([t].[Note] = N'Foo') AND ([t].[Note] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -3412,7 +3412,7 @@ ORDER BY [g].[Nickname]");
 FROM [Gears] AS [g]
 INNER JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName]
 INNER JOIN [Tags] AS [t0] ON [g].[Nickname] = [t0].[GearNickName]
-WHERE ([t].[GearNickName] <> N'Cole Train') OR [t].[GearNickName] IS NULL
+WHERE ([t].[GearNickName] <> N'Cole Train') OR ([t].[GearNickName] IS NULL)
 ORDER BY [g].[Nickname], [t0].[Id]");
         }
 
@@ -3838,7 +3838,7 @@ LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId]
     FROM [Gears] AS [g0]
 ) AS [t1] ON ([t0].[DefeatedByNickname] = [t1].[Nickname]) AND ([t0].[DefeatedBySquadId] = [t1].[SquadId])
-WHERE ([l].[Id] IS NOT NULL AND ([t].[HasSoulPatch] = CAST(1 AS bit))) AND (([t1].[Nickname] = [t].[Nickname]) AND ([t1].[SquadId] = [t].[SquadId]))");
+WHERE (([l].[Id] IS NOT NULL) AND ([t].[HasSoulPatch] = CAST(1 AS bit))) AND (([t1].[Nickname] = [t].[Nickname]) AND ([t1].[SquadId] = [t].[SquadId]))");
         }
 
         public override async Task Comparing_entities_using_Equals_inheritance(bool async)
@@ -3869,7 +3869,7 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
-WHERE ([g].[SquadId] < 2) AND (([c].[Name] = N'Ephyra') OR [c].[Name] IS NULL)");
+WHERE ([g].[SquadId] < 2) AND (([c].[Name] = N'Ephyra') OR ([c].[Name] IS NULL))");
         }
 
         public override async Task Optional_navigation_with_collection_composite_key(bool async)
@@ -3890,7 +3890,7 @@ WHERE ([t0].[Discriminator] = N'Officer') AND ((
     SELECT COUNT(*)
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-    WHERE (([t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL) AND (([t0].[Nickname] = [g0].[LeaderNickname]) AND ([t0].[SquadId] = [g0].[LeaderSquadId]))) AND ([g0].[Nickname] = N'Dom')) > 0)");
+    WHERE ((([t0].[Nickname] IS NOT NULL) AND ([t0].[SquadId] IS NOT NULL)) AND (([t0].[Nickname] = [g0].[LeaderNickname]) AND ([t0].[SquadId] = [g0].[LeaderSquadId]))) AND ([g0].[Nickname] = N'Dom')) > 0)");
         }
 
         public override async Task Select_null_conditional_with_inheritance(bool async)
@@ -3973,7 +3973,7 @@ LEFT JOIN (
     END AS [Discriminator]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
+) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR (([t0].[Nickname] IS NULL) AND ([t1].[LeaderNickname] IS NULL))) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 WHERE [l].[Id] IS NOT NULL
 ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
@@ -4001,7 +4001,7 @@ LEFT JOIN (
     END AS [Discriminator]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
+) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR (([t0].[Nickname] IS NULL) AND ([t1].[LeaderNickname] IS NULL))) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 WHERE [l].[Id] IS NOT NULL
 ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
@@ -4069,7 +4069,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
     INNER JOIN [Cities] AS [c] ON [g0].[CityOfBirthName] = [c].[Name]
-) AS [t0] ON (([t].[Nickname] = [t0].[LeaderNickname]) OR ([t].[Nickname] IS NULL AND [t0].[LeaderNickname] IS NULL)) AND ([t].[SquadId] = [t0].[LeaderSquadId])
+) AS [t0] ON (([t].[Nickname] = [t0].[LeaderNickname]) OR (([t].[Nickname] IS NULL) AND ([t0].[LeaderNickname] IS NULL))) AND ([t].[SquadId] = [t0].[LeaderSquadId])
 ORDER BY [l].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]");
         }
 
@@ -4251,7 +4251,7 @@ LEFT JOIN (
     END AS [Discriminator]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
+) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR (([t0].[Nickname] IS NULL) AND ([t1].[LeaderNickname] IS NULL))) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
@@ -4337,7 +4337,7 @@ LEFT JOIN (
     END AS [Discriminator]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
+) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR (([t0].[Nickname] IS NULL) AND ([t1].[LeaderNickname] IS NULL))) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
@@ -4369,7 +4369,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Id],
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN [t0].[HasSoulPatch]
+    WHEN ([t0].[Nickname] IS NOT NULL) AND ([t0].[SquadId] IS NOT NULL) THEN [t0].[HasSoulPatch]
     ELSE CAST(0 AS bit)
 END AS [Prop]
 FROM [Tags] AS [t]
@@ -4437,7 +4437,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -4453,7 +4453,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -4469,7 +4469,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -4485,7 +4485,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name] DESC");
@@ -4504,7 +4504,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     WHERE [g0].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
-WHERE [o].[Nickname] IS NOT NULL AND ([g].[Nickname] <> N'Foo')
+WHERE ([o].[Nickname] IS NOT NULL) AND ([g].[Nickname] <> N'Foo')
 ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
@@ -4518,7 +4518,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT [w].[Name], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -4534,7 +4534,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT N'BFG' AS [c], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -4550,7 +4550,7 @@ FROM [Gears] AS [g]
 LEFT JOIN (
     SELECT CAST(1 AS bit) AS [c], [w].[Id], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
 ORDER BY [g].[Nickname], [g].[SquadId]");
@@ -4665,7 +4665,7 @@ LEFT JOIN (
     LEFT JOIN (
         SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE ([w].[Name] <> N'Bar') OR [w].[Name] IS NULL
+        WHERE ([w].[Name] <> N'Bar') OR ([w].[Name] IS NULL)
     ) AS [t] ON [g0].[FullName] = [t].[OwnerFullName]
     WHERE [g0].[FullName] <> N'Foo'
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
@@ -4743,7 +4743,7 @@ ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[FullName
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
+WHERE ([o].[Nickname] IS NOT NULL) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
@@ -4772,7 +4772,7 @@ LEFT JOIN (
         FROM [Gears] AS [g2]
     ) AS [t2] ON [w].[OwnerFullName] = [t2].[FullName]
 ) AS [t1] ON [t0].[FullName] = [t1].[OwnerFullName]
-WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
+WHERE ([o].[Nickname] IS NOT NULL) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
@@ -4802,7 +4802,7 @@ LEFT JOIN (
         FROM [Gears] AS [g2]
     ) AS [t2] ON [w].[OwnerFullName] = [t2].[FullName]
 ) AS [t1] ON [t0].[FullName] = [t1].[OwnerFullName]
-WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
+WHERE ([o].[Nickname] IS NOT NULL) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
@@ -4828,14 +4828,14 @@ LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [t2].[Nickname], [t2].[SquadId], (
         SELECT COUNT(*)
         FROM [Weapons] AS [w0]
-        WHERE [t2].[FullName] IS NOT NULL AND ([t2].[FullName] = [w0].[OwnerFullName])) AS [c]
+        WHERE ([t2].[FullName] IS NOT NULL) AND ([t2].[FullName] = [w0].[OwnerFullName])) AS [c]
     FROM [Weapons] AS [w]
     LEFT JOIN (
         SELECT [g2].[Nickname], [g2].[SquadId], [g2].[FullName]
         FROM [Gears] AS [g2]
     ) AS [t2] ON [w].[OwnerFullName] = [t2].[FullName]
 ) AS [t1] ON [t0].[FullName] = [t1].[OwnerFullName]
-WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
+WHERE ([o].[Nickname] IS NOT NULL) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
@@ -4872,7 +4872,7 @@ LEFT JOIN (
             SELECT [g4].[Nickname], [g4].[HasSoulPatch], [g4].[SquadId]
             FROM [Gears] AS [g4]
         ) AS [t4] ON [s].[Id] = [t4].[SquadId]
-        WHERE ([w].[Name] <> N'Bar') OR [w].[Name] IS NULL
+        WHERE ([w].[Name] <> N'Bar') OR ([w].[Name] IS NULL)
     ) AS [t1] ON [g2].[FullName] = [t1].[OwnerFullName]
     WHERE [g2].[FullName] <> N'Foo'
 ) AS [t2] ON ([g].[Nickname] = [t2].[LeaderNickname]) AND ([g].[SquadId] = [t2].[LeaderSquadId])
@@ -4884,7 +4884,7 @@ LEFT JOIN (
         FROM [Gears] AS [g5]
     ) AS [t6] ON [w1].[OwnerFullName] = [t6].[FullName]
 ) AS [t5] ON [t0].[FullName] = [t5].[OwnerFullName]
-WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
+WHERE ([o].[Nickname] IS NOT NULL) AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
@@ -4940,7 +4940,7 @@ LEFT JOIN (
     OUTER APPLY (
         SELECT [w].[Name], [g0].[Nickname], [w].[Id]
         FROM [Weapons] AS [w]
-        WHERE (([w].[Name] <> N'Bar') OR [w].[Name] IS NULL) AND ([g0].[FullName] = [w].[OwnerFullName])
+        WHERE (([w].[Name] <> N'Bar') OR ([w].[Name] IS NULL)) AND ([g0].[FullName] = [w].[OwnerFullName])
     ) AS [t]
     WHERE [g0].[FullName] <> N'Foo'
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
@@ -4962,7 +4962,7 @@ OUTER APPLY (
     LEFT JOIN (
         SELECT [w].[Name], [g].[Nickname], [w].[Id], [w].[OwnerFullName]
         FROM [Weapons] AS [w]
-        WHERE ([w].[Name] <> N'Bar') OR [w].[Name] IS NULL
+        WHERE ([w].[Name] <> N'Bar') OR ([w].[Name] IS NULL)
     ) AS [t] ON [g0].[FullName] = [t].[OwnerFullName]
     WHERE ([g0].[FullName] <> N'Foo') AND (([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
 ) AS [t0]
@@ -4981,7 +4981,7 @@ CROSS JOIN [Squads] AS [s]
 LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
+    WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR ([w].[Name] IS NULL))
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 LEFT JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], CASE
@@ -5130,7 +5130,7 @@ LEFT JOIN (
 LEFT JOIN (
     SELECT [g0].[FullName], [g0].[Nickname], [g0].[SquadId], [g0].[LeaderNickname], [g0].[LeaderSquadId]
     FROM [Gears] AS [g0]
-) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
+) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR (([t0].[Nickname] IS NULL) AND ([t1].[LeaderNickname] IS NULL))) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
@@ -5357,7 +5357,7 @@ INNER JOIN (
     END AS [Discriminator]
     FROM [Factions] AS [f]
     LEFT JOIN [LocustHordes] AS [l1] ON [f].[Id] = [l1].[Id]
-    WHERE [l1].[Id] IS NOT NULL AND ([f].[Name] = N'Swarm')
+    WHERE ([l1].[Id] IS NOT NULL) AND ([f].[Name] = N'Swarm')
 ) AS [t] ON [l].[Name] = [t].[CommanderName]
 WHERE ([t].[Eradicated] <> CAST(1 AS bit)) OR ([t].[Eradicated] IS NULL)");
         }
@@ -5375,7 +5375,7 @@ LEFT JOIN (
     END AS [Discriminator]
     FROM [Factions] AS [f]
     LEFT JOIN [LocustHordes] AS [l1] ON [f].[Id] = [l1].[Id]
-    WHERE [l1].[Id] IS NOT NULL AND ([f].[Name] = N'Swarm')
+    WHERE ([l1].[Id] IS NOT NULL) AND ([f].[Name] = N'Swarm')
 ) AS [t] ON [l].[Name] = [t].[CommanderName]
 WHERE ([t].[Eradicated] <> CAST(1 AS bit)) OR ([t].[Eradicated] IS NULL)");
         }
@@ -5401,7 +5401,7 @@ FROM (
         FROM [Gears] AS [g]
         LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
     ) AS [t] ON ([l0].[DefeatedByNickname] = [t].[Nickname]) AND ([l0].[DefeatedBySquadId] = [t].[SquadId])
-    LEFT JOIN [Tags] AS [t0] ON (([t].[Nickname] = [t0].[GearNickName]) OR ([t].[Nickname] IS NULL AND [t0].[GearNickName] IS NULL)) AND (([t].[SquadId] = [t0].[GearSquadId]) OR ([t].[SquadId] IS NULL AND [t0].[GearSquadId] IS NULL))
+    LEFT JOIN [Tags] AS [t0] ON (([t].[Nickname] = [t0].[GearNickName]) OR (([t].[Nickname] IS NULL) AND ([t0].[GearNickName] IS NULL))) AND (([t].[SquadId] = [t0].[GearSquadId]) OR (([t].[SquadId] IS NULL) AND ([t0].[GearSquadId] IS NULL)))
     ORDER BY [t0].[Note]
 ) AS [t1]
 LEFT JOIN [Weapons] AS [w] ON [t1].[FullName] = [w].[OwnerFullName]
@@ -6344,7 +6344,7 @@ END");
                 @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 ORDER BY CASE
-    WHEN ([w].[Name] = N'Marcus'' Lancer') AND [w].[Name] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([w].[Name] = N'Marcus'' Lancer') AND ([w].[Name] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [w].[Id]");
         }
@@ -6368,7 +6368,7 @@ ORDER BY [w].[Id] + 2");
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN ([w0].[Name] = N'Marcus'' Lancer') AND [w0].[Name] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([w0].[Name] = N'Marcus'' Lancer') AND ([w0].[Name] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -6382,7 +6382,7 @@ END");
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN (N'Marcus'' Lancer' = [w0].[Name]) AND [w0].[Name] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN (N'Marcus'' Lancer' = [w0].[Name]) AND ([w0].[Name] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }
@@ -6748,7 +6748,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
 LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-WHERE (SUBSTRING([t].[Note], 0 + 1, CAST(LEN([s].[Name]) AS int)) = [t].[GearNickName]) OR (([t].[Note] IS NULL OR [s].[Name] IS NULL) AND [t].[GearNickName] IS NULL)");
+WHERE (SUBSTRING([t].[Note], 0 + 1, CAST(LEN([s].[Name]) AS int)) = [t].[GearNickName]) OR ((([t].[Note] IS NULL) OR ([s].[Name] IS NULL)) AND ([t].[GearNickName] IS NULL))");
         }
 
         public override async Task Filter_with_new_Guid(bool async)
@@ -6791,7 +6791,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
 LEFT JOIN [Tags] AS [t0] ON ([g].[Nickname] = [t0].[GearNickName]) AND ([g].[SquadId] = [t0].[GearSquadId])
-WHERE ((([t].[Note] <> N'Foo') OR [t].[Note] IS NULL) AND [o].[Nickname] IS NOT NULL) AND (([t0].[Note] <> N'Bar') OR [t0].[Note] IS NULL)");
+WHERE ((([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)) AND ([o].[Nickname] IS NOT NULL)) AND (([t0].[Note] <> N'Bar') OR ([t0].[Note] IS NULL))");
         }
 
         public override async Task OfTypeNav2(bool async)
@@ -6806,7 +6806,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
-WHERE ((([t].[Note] <> N'Foo') OR [t].[Note] IS NULL) AND [o].[Nickname] IS NOT NULL) AND (([c].[Location] <> 'Bar') OR [c].[Location] IS NULL)");
+WHERE ((([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)) AND ([o].[Nickname] IS NOT NULL)) AND (([c].[Location] <> 'Bar') OR ([c].[Location] IS NULL))");
         }
 
         public override async Task OfTypeNav3(bool async)
@@ -6822,7 +6822,7 @@ LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[Squad
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
 INNER JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 LEFT JOIN [Tags] AS [t0] ON ([g].[Nickname] = [t0].[GearNickName]) AND ([g].[SquadId] = [t0].[GearSquadId])
-WHERE ((([t].[Note] <> N'Foo') OR [t].[Note] IS NULL) AND [o].[Nickname] IS NOT NULL) AND (([t0].[Note] <> N'Bar') OR [t0].[Note] IS NULL)");
+WHERE ((([t].[Note] <> N'Foo') OR ([t].[Note] IS NULL)) AND ([o].[Nickname] IS NOT NULL)) AND (([t0].[Note] <> N'Bar') OR ([t0].[Note] IS NULL))");
         }
 
         public override void Nav_rewrite_Distinct_with_convert()
@@ -6855,7 +6855,7 @@ LEFT JOIN (
     FROM [LocustLeaders] AS [l0]
     INNER JOIN [LocustCommanders] AS [l1] ON [l0].[Name] = [l1].[Name]
 ) AS [t] ON [l].[CommanderName] = [t].[Name]
-WHERE ([c].[Name] <> N'Foo') OR [c].[Name] IS NULL");
+WHERE ([c].[Name] <> N'Foo') OR ([c].[Name] IS NULL)");
         }
 
         public override async Task Nav_rewrite_with_convert2(bool async)
@@ -6874,7 +6874,7 @@ LEFT JOIN (
     FROM [LocustLeaders] AS [l0]
     INNER JOIN [LocustCommanders] AS [l1] ON [l0].[Name] = [l1].[Name]
 ) AS [t] ON [l].[CommanderName] = [t].[Name]
-WHERE (([c].[Name] <> N'Foo') OR [c].[Name] IS NULL) AND (([t].[Name] <> N'Bar') OR [t].[Name] IS NULL)");
+WHERE (([c].[Name] <> N'Foo') OR ([c].[Name] IS NULL)) AND (([t].[Name] <> N'Bar') OR ([t].[Name] IS NULL))");
         }
 
         public override async Task Nav_rewrite_with_convert3(bool async)
@@ -6893,7 +6893,7 @@ LEFT JOIN (
     FROM [LocustLeaders] AS [l0]
     INNER JOIN [LocustCommanders] AS [l1] ON [l0].[Name] = [l1].[Name]
 ) AS [t] ON [l].[CommanderName] = [t].[Name]
-WHERE (([c].[Name] <> N'Foo') OR [c].[Name] IS NULL) AND (([t].[Name] <> N'Bar') OR [t].[Name] IS NULL)");
+WHERE (([c].[Name] <> N'Foo') OR ([c].[Name] IS NULL)) AND (([t].[Name] <> N'Bar') OR ([t].[Name] IS NULL))");
         }
 
         public override async Task Where_contains_on_navigation_with_composite_keys(bool async)
@@ -7002,7 +7002,7 @@ LEFT JOIN (
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [t].[Nickname] IS NULL OR [t].[SquadId] IS NULL THEN CAST(1 AS bit)
+    WHEN ([t].[Nickname] IS NULL) OR ([t].[SquadId] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -7042,7 +7042,7 @@ LEFT JOIN (
         LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
     ) AS [t2]
     WHERE [t2].[row] <= 50
-) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
+) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR (([t0].[Nickname] IS NULL) AND ([t1].[LeaderNickname] IS NULL))) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 WHERE [t0].[Discriminator] = N'Officer'
 ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Nickname], [t1].[SquadId]");
         }
@@ -7067,7 +7067,7 @@ LEFT JOIN (
     END AS [Discriminator]
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
+) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR (([t0].[Nickname] IS NULL) AND ([t1].[LeaderNickname] IS NULL))) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 WHERE [t0].[Discriminator] = N'Officer'
 ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
@@ -7163,7 +7163,7 @@ LEFT JOIN (
     FROM [LocustLeaders] AS [l0]
     INNER JOIN [LocustCommanders] AS [l1] ON [l0].[Name] = [l1].[Name]
 ) AS [t] ON [l].[CommanderName] = [t].[Name]
-WHERE [l].[Id] IS NOT NULL AND [t].[Name] IS NOT NULL");
+WHERE ([l].[Id] IS NOT NULL) AND ([t].[Name] IS NOT NULL)");
         }
 
         public override async Task Navigation_based_on_complex_expression3(bool async)
@@ -7299,7 +7299,7 @@ ORDER BY [t].[Note]");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [t0].[Nickname] IS NOT NULL AND [t0].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([t0].[Nickname] IS NOT NULL) AND ([t0].[SquadId] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[Id], [t1].[SquadId]
 FROM [Tags] AS [t]
@@ -7329,7 +7329,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
-    WHERE (([c].[Name] = [g].[CityOfBirthName]) AND [o].[Nickname] IS NOT NULL) AND ([g].[Nickname] = N'Marcus'))");
+    WHERE (([c].[Name] = [g].[CityOfBirthName]) AND ([o].[Nickname] IS NOT NULL)) AND ([g].[Nickname] = N'Marcus'))");
         }
 
         public override async Task Query_reusing_parameter_doesnt_declare_duplicate_parameter(bool async)
@@ -7662,12 +7662,12 @@ WHERE ([c].[Name] = (
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
     INNER JOIN [Cities] AS [c0] ON [g].[CityOfBirthName] = [c0].[Name]
-    ORDER BY [g].[Nickname])) OR ([c].[Name] IS NULL AND (
+    ORDER BY [g].[Nickname])) OR (([c].[Name] IS NULL) AND ((
     SELECT TOP(1) [c0].[Name]
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
     INNER JOIN [Cities] AS [c0] ON [g].[CityOfBirthName] = [c0].[Name]
-    ORDER BY [g].[Nickname]) IS NULL)");
+    ORDER BY [g].[Nickname]) IS NULL))");
         }
 
         public override async Task Bitwise_operation_with_non_null_parameter_optimizes_null_checks(bool async)
@@ -7725,7 +7725,7 @@ FROM [Weapons] AS [w]",
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
-WHERE (([w].[AmmunitionType] & @__prm_0) <> 0) OR [w].[AmmunitionType] IS NULL",
+WHERE (([w].[AmmunitionType] & @__prm_0) <> 0) OR ([w].[AmmunitionType] IS NULL)",
                 //
                 @"@__prm_0='1' (Nullable = true)
 
@@ -7896,10 +7896,10 @@ WHERE CASE
         WHEN ((
             SELECT TOP(1) [w].[Name]
             FROM [Weapons] AS [w]
-            WHERE [w].[Id] = [g].[SquadId]) = @__prm2_1) AND (
+            WHERE [w].[Id] = [g].[SquadId]) = @__prm2_1) AND ((
             SELECT TOP(1) [w].[Name]
             FROM [Weapons] AS [w]
-            WHERE [w].[Id] = [g].[SquadId]) IS NOT NULL THEN CAST(1 AS bit)
+            WHERE [w].[Id] = [g].[SquadId]) IS NOT NULL) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE CAST(0 AS bit)
@@ -8130,7 +8130,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [LocustLeaders] AS [l1]
     LEFT JOIN [LocustCommanders] AS [l2] ON [l1].[Name] = [l2].[Name]
-    WHERE ([l1].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR ([l1].[ThreatLevelNullableByte] IS NULL AND [l].[ThreatLevelNullableByte] IS NULL))");
+    WHERE ([l1].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR (([l1].[ThreatLevelNullableByte] IS NULL) AND ([l].[ThreatLevelNullableByte] IS NULL)))");
         }
 
         public override async Task Contains_on_collection_of_nullable_byte_subquery_null_constant(bool async)
@@ -8245,7 +8245,7 @@ CROSS APPLY (
         SELECT 1
         FROM [LocustLeaders] AS [l1]
         LEFT JOIN [LocustCommanders] AS [l2] ON [l1].[Name] = [l2].[Name]
-        WHERE ([l1].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR ([l1].[ThreatLevelNullableByte] IS NULL AND [l].[ThreatLevelNullableByte] IS NULL))
+        WHERE ([l1].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR (([l1].[ThreatLevelNullableByte] IS NULL) AND ([l].[ThreatLevelNullableByte] IS NULL)))
 ) AS [t]");
         }
 
@@ -8266,7 +8266,7 @@ CROSS APPLY (
         SELECT 1
         FROM [LocustLeaders] AS [l1]
         LEFT JOIN [LocustCommanders] AS [l2] ON [l1].[Name] = [l2].[Name]
-        WHERE ([l1].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR ([l1].[ThreatLevelNullableByte] IS NULL AND [l].[ThreatLevelNullableByte] IS NULL)))
+        WHERE ([l1].[ThreatLevelNullableByte] = [l].[ThreatLevelNullableByte]) OR (([l1].[ThreatLevelNullableByte] IS NULL) AND ([l].[ThreatLevelNullableByte] IS NULL))))
 ) AS [t]");
         }
 
@@ -8332,7 +8332,7 @@ ORDER BY [g].[Nickname]");
                 @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-WHERE [w0].[Id] IS NOT NULL AND (([w0].[AmmunitionType] = 1) OR [w0].[AmmunitionType] IS NULL)");
+WHERE ([w0].[Id] IS NOT NULL) AND (([w0].[AmmunitionType] = 1) OR ([w0].[AmmunitionType] IS NULL))");
         }
 
         [ConditionalTheory]
@@ -8394,7 +8394,7 @@ ORDER BY [c].[Location]");
 END AS [Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
-INNER JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL
+INNER JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR ([w].[OwnerFullName] IS NULL)
 ORDER BY [g].[Nickname], [w].[Id]");
         }
 
@@ -8408,7 +8408,7 @@ ORDER BY [g].[Nickname], [w].[Id]");
 END AS [Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
-LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR ([w].[OwnerFullName] IS NULL)
 ORDER BY [g].[Nickname], [w].[Id]");
         }
 
@@ -8427,7 +8427,7 @@ LEFT JOIN (
     SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
     FROM [Weapons] AS [w]
     LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
-) AS [t] ON ([g].[FullName] <> [t].[OwnerFullName]) OR [t].[OwnerFullName] IS NULL
+) AS [t] ON ([g].[FullName] <> [t].[OwnerFullName]) OR ([t].[OwnerFullName] IS NULL)
 ORDER BY [g].[Nickname], [t].[Id]");
         }
 
@@ -8438,7 +8438,7 @@ ORDER BY [g].[Nickname], [t].[Id]");
             AssertSql(
                 @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
-LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL");
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR ([w].[OwnerFullName] IS NULL)");
         }
 
         public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join(bool async)
@@ -8487,7 +8487,7 @@ LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[Squad
 CROSS APPLY (
     SELECT TOP(3) [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
-    WHERE ([w].[OwnerFullName] <> [g].[FullName]) OR [w].[OwnerFullName] IS NULL
+    WHERE ([w].[OwnerFullName] <> [g].[FullName]) OR ([w].[OwnerFullName] IS NULL)
     ORDER BY [w].[Id]
 ) AS [t]
 ORDER BY [g].[Nickname], [t].[Id]");
@@ -8534,14 +8534,14 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
 END AS [Discriminator]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[Name] = [l0].[Name]
-WHERE [l0].[Name] IS NOT NULL AND (([l0].[HighCommandId] <> 0) OR [l0].[HighCommandId] IS NULL)",
+WHERE ([l0].[Name] IS NOT NULL) AND (([l0].[HighCommandId] <> 0) OR ([l0].[HighCommandId] IS NULL))",
                 //
                 @"SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], CASE
     WHEN [l0].[Name] IS NOT NULL THEN N'LocustCommander'
 END AS [Discriminator]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN [LocustCommanders] AS [l0] ON [l].[Name] = [l0].[Name]
-WHERE [l0].[Name] IS NOT NULL AND (([l0].[HighCommandId] <> 0) OR [l0].[HighCommandId] IS NULL)");
+WHERE ([l0].[Name] IS NOT NULL) AND (([l0].[HighCommandId] <> 0) OR ([l0].[HighCommandId] IS NULL))");
         }
 
         public override async Task Cast_to_derived_followed_by_include_and_FirstOrDefault(bool async)
@@ -8666,7 +8666,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t] ON ([l0].[DefeatedByNickname] = [t].[Nickname]) AND ([l0].[DefeatedBySquadId] = [t].[SquadId])
-WHERE [l0].[Name] IS NOT NULL AND ([t].[Nickname] IS NULL OR [t].[SquadId] IS NULL)");
+WHERE ([l0].[Name] IS NOT NULL) AND (([t].[Nickname] IS NULL) OR ([t].[SquadId] IS NULL))");
         }
 
         public override async Task Composite_key_entity_not_equal_null(bool async)
@@ -8683,7 +8683,7 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId]
     FROM [Gears] AS [g]
 ) AS [t] ON ([l0].[DefeatedByNickname] = [t].[Nickname]) AND ([l0].[DefeatedBySquadId] = [t].[SquadId])
-WHERE [l0].[Name] IS NOT NULL AND ([t].[Nickname] IS NOT NULL AND [t].[SquadId] IS NOT NULL)");
+WHERE ([l0].[Name] IS NOT NULL) AND (([t].[Nickname] IS NOT NULL) AND ([t].[SquadId] IS NOT NULL))");
         }
 
         public override async Task Projecting_property_converted_to_nullable_with_comparison(bool async)
@@ -8752,7 +8752,7 @@ END IS NOT NULL");
 
             AssertSql(
                 @"SELECT CASE
-    WHEN ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL THEN CASE
+    WHEN ([t].[Note] <> N'K.I.A.') OR ([t].[Note] IS NULL) THEN CASE
         WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[SquadId]
         ELSE NULL
     END
@@ -8887,10 +8887,10 @@ LEFT JOIN (
     SELECT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
-WHERE CASE
+WHERE (CASE
     WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[Nickname]
     ELSE NULL
-END IS NOT NULL AND (CASE
+END IS NOT NULL) AND (CASE
     WHEN [t].[GearNickName] IS NOT NULL THEN [t0].[HasSoulPatch]
     ELSE NULL
 END = CAST(0 AS bit))
@@ -8905,7 +8905,7 @@ ORDER BY [t].[Note]");
                 @"SELECT [g].[Nickname]
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-WHERE (DATEPART(month, [t].[IssueDate]) <> 5) OR [t].[IssueDate] IS NULL
+WHERE (DATEPART(month, [t].[IssueDate]) <> 5) OR ([t].[IssueDate] IS NULL)
 ORDER BY [g].[Nickname]");
         }
 
@@ -9118,7 +9118,7 @@ LEFT JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]");
                 @"SELECT [l].[Name], [l].[LocustHordeId], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l0].[DefeatedByNickname], [l0].[DefeatedBySquadId], [l0].[HighCommandId], CASE
     WHEN [l0].[Name] IS NOT NULL THEN N'LocustCommander'
 END AS [Discriminator], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOfBirthName], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t].[Discriminator], CASE
-    WHEN [t].[Nickname] IS NULL OR [t].[SquadId] IS NULL THEN CAST(1 AS bit)
+    WHEN ([t].[Nickname] IS NULL) OR ([t].[SquadId] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [IsNull], [t0].[Id], [t0].[CapitalName], [t0].[Name], [t0].[ServerAddress], [t0].[CommanderName], [t0].[Eradicated], CASE
     WHEN [t0].[Id] IS NULL THEN CAST(1 AS bit)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
@@ -352,7 +352,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE [k].[Species] IS NOT NULL AND ([a].[CountryId] = 1)");
+WHERE ([k].[Species] IS NOT NULL) AND ([a].[CountryId] = 1)");
         }
 
         public override async Task Can_use_of_type_animal(bool async)
@@ -384,7 +384,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE [k].[Species] IS NOT NULL OR [e].[Species] IS NOT NULL
+WHERE ([k].[Species] IS NOT NULL) OR ([e].[Species] IS NOT NULL)
 ORDER BY [a].[Species]");
         }
 
@@ -401,7 +401,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE [k].[Species] IS NOT NULL OR [e].[Species] IS NOT NULL
+WHERE ([k].[Species] IS NOT NULL) OR ([e].[Species] IS NOT NULL)
 ORDER BY [a].[Species]");
         }
 
@@ -418,7 +418,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE ([a].[CountryId] = 1) AND ([k].[Species] IS NOT NULL OR [e].[Species] IS NOT NULL)
+WHERE ([a].[CountryId] = 1) AND (([k].[Species] IS NOT NULL) OR ([e].[Species] IS NOT NULL))
 ORDER BY [a].[Species]");
         }
 
@@ -432,7 +432,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE [k].[Species] IS NOT NULL OR [e].[Species] IS NOT NULL");
+WHERE ([k].[Species] IS NOT NULL) OR ([e].[Species] IS NOT NULL)");
         }
 
         public override async Task Can_use_of_type_kiwi(bool async)
@@ -460,7 +460,7 @@ END AS [Discriminator]
 FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE [k].[Species] IS NOT NULL AND ([k].[FoundOn] = CAST(0 AS tinyint))");
+WHERE ([k].[Species] IS NOT NULL) AND ([k].[FoundOn] = CAST(0 AS tinyint))");
         }
 
         public override async Task Can_use_of_type_kiwi_where_south_on_derived_property(bool async)
@@ -474,7 +474,7 @@ END AS [Discriminator]
 FROM [Animals] AS [a]
 LEFT JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
 LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
-WHERE [k].[Species] IS NOT NULL AND ([k].[FoundOn] = CAST(1 AS tinyint))");
+WHERE ([k].[Species] IS NOT NULL) AND ([k].[FoundOn] = CAST(1 AS tinyint))");
         }
 
         public override async Task Can_use_of_type_rose(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
@@ -107,7 +107,7 @@ ORDER BY (
         INNER JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE ([e].[Id] = [j].[EntityOneId]) AND ([t].[Name] IS NOT NULL AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
+    WHERE ([e].[Id] = [j].[EntityOneId]) AND (([t].[Name] IS NOT NULL) AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
         }
 
         public override async Task Skip_navigation_long_count_without_predicate(bool async)
@@ -135,7 +135,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND (([e1].[Name] IS NOT NULL) AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
@@ -106,7 +106,7 @@ ORDER BY (
         INNER JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE ([e].[Id] = [j].[EntityOneId]) AND ([t].[Name] IS NOT NULL AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
+    WHERE ([e].[Id] = [j].[EntityOneId]) AND (([t].[Name] IS NOT NULL) AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
         }
 
         public override async Task Skip_navigation_long_count_without_predicate(bool async)
@@ -134,7 +134,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND (([e1].[Name] IS NOT NULL) AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTRelationshipsQuerySqlServerTest.cs
@@ -92,7 +92,7 @@ LEFT JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
@@ -112,7 +112,7 @@ LEFT JOIN (
 ) AS [t] ON [c].[ParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [t].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
+WHERE ([c].[Name] <> N'Bar') OR ([c].[Name] IS NULL)
 ORDER BY [c].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -257,7 +257,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnBase] AS [b1]
     LEFT JOIN [DerivedCollectionsOnBase] AS [d1] ON [b1].[Id] = [d1].[Id]
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
@@ -280,7 +280,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -377,7 +377,7 @@ LEFT JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
 LEFT JOIN [ReferencesOnBase] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -397,7 +397,7 @@ LEFT JOIN (
 ) AS [t] ON [r].[ParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [t].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([r].[Name] <> N'Bar') OR [r].[Name] IS NULL
+WHERE ([r].[Name] <> N'Bar') OR ([r].[Name] IS NULL)
 ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -518,7 +518,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -539,7 +539,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -558,7 +558,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -579,7 +579,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -624,7 +624,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -647,7 +647,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
@@ -1116,19 +1116,19 @@ ORDER BY [b].[Id], [t].[Id]");
 END AS [Discriminator], [b].[OwnedReferenceOnBase_Id], [b].[OwnedReferenceOnBase_Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name]
 FROM [BaseEntities] AS [b]
 LEFT JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [b].[Id]
@@ -1140,7 +1140,7 @@ INNER JOIN (
     FROM [BaseCollectionsOnBase] AS [b0]
     LEFT JOIN [DerivedCollectionsOnBase] AS [d0] ON [b0].[Id] = [d0].[Id]
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]");
         }
 
@@ -1161,7 +1161,7 @@ LEFT JOIN (
     FROM [BaseEntities] AS [b0]
     LEFT JOIN [DerivedEntities] AS [d0] ON [b0].[Id] = [d0].[Id]
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id]",
                 //
                 @"SELECT [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b1].[Name], [b].[Id], [t].[Id]
@@ -1171,7 +1171,7 @@ LEFT JOIN (
     FROM [BaseEntities] AS [b0]
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 INNER JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id]",
                 //
                 @"SELECT [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [b].[Id], [t].[Id]
@@ -1181,7 +1181,7 @@ LEFT JOIN (
     FROM [BaseEntities] AS [b0]
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id], [t].[Id]");
         }
 
@@ -1258,25 +1258,25 @@ ORDER BY [c].[Id], [t].[Id]");
 END AS [Discriminator], [b].[OwnedReferenceOnBase_Id], [b].[OwnedReferenceOnBase_Name], [d].[Id], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name]
 FROM [BaseEntities] AS [b]
 LEFT JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]",
                 //
                 @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [b].[Id]
 FROM [BaseEntities] AS [b]
 INNER JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
-WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
+WHERE ([b].[Name] <> N'Bar') OR ([b].[Name] IS NULL)
 ORDER BY [b].[Id]");
         }
 
@@ -1294,7 +1294,7 @@ LEFT JOIN (
     FROM [BaseEntities] AS [b]
     LEFT JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
 ) AS [t] ON [c].[ParentId] = [t].[Id]
-WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
+WHERE ([c].[Name] <> N'Bar') OR ([c].[Name] IS NULL)
 ORDER BY [c].[Id], [t].[Id]",
                 //
                 @"SELECT [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b0].[Name], [c].[Id], [t].[Id]
@@ -1304,7 +1304,7 @@ LEFT JOIN (
     FROM [BaseEntities] AS [b]
 ) AS [t] ON [c].[ParentId] = [t].[Id]
 INNER JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
-WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
+WHERE ([c].[Name] <> N'Bar') OR ([c].[Name] IS NULL)
 ORDER BY [c].[Id], [t].[Id]",
                 //
                 @"SELECT [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [c].[Id], [t].[Id]
@@ -1314,7 +1314,7 @@ LEFT JOIN (
     FROM [BaseEntities] AS [b]
 ) AS [t] ON [c].[ParentId] = [t].[Id]
 INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [t].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
+WHERE ([c].[Name] <> N'Bar') OR ([c].[Name] IS NULL)
 ORDER BY [c].[Id], [t].[Id]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -250,11 +250,11 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]");
             AssertSql(
                 @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[PeriodEnd], [l].[PeriodStart], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
 FROM [LocustLeaders] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
-WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0) OR [l].[HighCommandId] IS NULL)",
+WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0) OR ([l].[HighCommandId] IS NULL))",
                 //
                 @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[PeriodEnd], [l].[PeriodStart], [l].[ThreatLevel], [l].[ThreatLevelByte], [l].[ThreatLevelNullableByte], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId]
 FROM [LocustLeaders] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
-WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0) OR [l].[HighCommandId] IS NULL)");
+WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0) OR ([l].[HighCommandId] IS NULL))");
         }
 
         public override async Task Accessing_property_of_optional_navigation_in_child_projection_works(bool async)
@@ -263,7 +263,7 @@ WHERE ([l].[Discriminator] = N'LocustCommander') AND (([l].[HighCommandId] <> 0)
 
             AssertSql(
                 @"SELECT CASE
-    WHEN [g].[Nickname] IS NOT NULL AND [g].[SquadId] IS NOT NULL THEN CAST(1 AS bit)
+    WHEN ([g].[Nickname] IS NOT NULL) AND ([g].[SquadId] IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [t].[Id], [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[Id], [t0].[SquadId]
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
@@ -301,7 +301,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         SELECT 1
         FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
         LEFT JOIN [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
-        WHERE ([t].[Note] = N'Foo') AND [t].[Note] IS NOT NULL) THEN CAST(1 AS bit)
+        WHERE ([t].[Note] = N'Foo') AND ([t].[Note] IS NOT NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerTest.cs
@@ -125,7 +125,7 @@ ORDER BY (
         FROM [EntityRoots] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0]
         WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE ([e].[Id] = [j].[EntityOneId]) AND ([t].[Name] IS NOT NULL AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
+    WHERE ([e].[Id] = [j].[EntityOneId]) AND (([t].[Name] IS NOT NULL) AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
         }
 
         public override async Task Skip_navigation_long_count_without_predicate(bool async)
@@ -153,7 +153,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0]
     INNER JOIN [EntityTwos] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND ([e1].[Name] IS NOT NULL AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
+    WHERE ([e].[Id] = [e0].[SelfSkipSharedRightId]) AND (([e1].[Name] IS NOT NULL) AND ([e1].[Name] LIKE N'L%'))) DESC, [e].[Id]");
         }
 
         public override async Task Skip_navigation_select_many_average(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -258,7 +258,7 @@ ORDER BY [c].[Id]");
             AssertSql(
                 @"SELECT [c].[Id], [c].[FirstName], [c].[LastName]
 FROM [Customers] AS [c]
-WHERE (([dbo].[StringLength]([c].[FirstName]) <> [dbo].[StringLength]([c].[LastName])) OR ([c].[FirstName] IS NULL OR [c].[LastName] IS NULL)) AND ([c].[FirstName] IS NOT NULL OR [c].[LastName] IS NOT NULL)
+WHERE (([dbo].[StringLength]([c].[FirstName]) <> [dbo].[StringLength]([c].[LastName])) OR (([c].[FirstName] IS NULL) OR ([c].[LastName] IS NULL))) AND (([c].[FirstName] IS NOT NULL) OR ([c].[LastName] IS NOT NULL))
 ORDER BY [c].[Id]");
         }
 
@@ -290,7 +290,7 @@ WHERE SUBSTRING([c].[FirstName], 0 + 1, 1) IN (N'A', N'B', N'C')");
                 @"SELECT [c].[Id], [c].[FirstName], [c].[LastName]
 FROM [Customers] AS [c]
 WHERE CASE
-    WHEN SUBSTRING([c].[FirstName], 0 + 1, 1) IN (N'A', N'B', N'C') AND SUBSTRING([c].[FirstName], 0 + 1, 1) IS NOT NULL THEN CAST(1 AS bit)
+    WHEN SUBSTRING([c].[FirstName], 0 + 1, 1) IN (N'A', N'B', N'C') AND (SUBSTRING([c].[FirstName], 0 + 1, 1) IS NOT NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END IN (CAST(1 AS bit), CAST(0 AS bit))");
         }
@@ -804,7 +804,7 @@ ORDER BY [g].[Year]");
                 @"SELECT [g].[Count], [g].[CustomerId], [g].[Year]
 FROM [Addresses] AS [a]
 CROSS APPLY [dbo].[GetCustomerOrderCountByYearOnlyFrom2000](1, CASE
-    WHEN (([a].[City] = [a].[State]) AND ([a].[City] IS NOT NULL AND [a].[State] IS NOT NULL)) OR ([a].[City] IS NULL AND [a].[State] IS NULL) THEN CAST(1 AS bit)
+    WHEN (([a].[City] = [a].[State]) AND (([a].[City] IS NOT NULL) AND ([a].[State] IS NOT NULL))) OR (([a].[City] IS NULL) AND ([a].[State] IS NULL)) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END) AS [g]
 ORDER BY [a].[Id], [g].[Year]");

--- a/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
@@ -181,7 +181,7 @@ INNER JOIN (
     FROM [PoweredVehicles] AS [p]
     INNER JOIN [CombustionEngines] AS [c0] ON [p].[Name] = [c0].[VehicleName]
 ) AS [t] ON [c].[VehicleName] = [t].[Name]
-WHERE [c].[Capacity] IS NOT NULL AND [c].[FuelType] IS NOT NULL");
+WHERE ([c].[Capacity] IS NOT NULL) AND ([c].[FuelType] IS NOT NULL)");
         }
 
         public override async Task Can_change_dependent_instance_non_derived()

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -51,9 +51,9 @@ LEFT JOIN (
         FROM [Vehicles] AS [v6]
         WHERE [v6].[Discriminator] IN (N'PoweredVehicle', N'CompositeVehicle')
     ) AS [t3] ON [v5].[Name] = [t3].[Name]
-    WHERE [v5].[Computed] IS NOT NULL AND [v5].[Engine_Discriminator] IS NOT NULL
+    WHERE ([v5].[Computed] IS NOT NULL) AND ([v5].[Engine_Discriminator] IS NOT NULL)
 ) AS [t2] ON [v].[Name] = CASE
-    WHEN [t2].[Computed] IS NOT NULL AND [t2].[Engine_Discriminator] IS NOT NULL THEN [t2].[Name]
+    WHEN ([t2].[Computed] IS NOT NULL) AND ([t2].[Engine_Discriminator] IS NOT NULL) THEN [t2].[Name]
 END
 LEFT JOIN (
     SELECT [v7].[Name], [v7].[Capacity], [v7].[FuelTank_Discriminator], [v7].[FuelType], [v7].[GrainGeometry]
@@ -63,7 +63,7 @@ LEFT JOIN (
         FROM [Vehicles] AS [v8]
         WHERE [v8].[Discriminator] IN (N'PoweredVehicle', N'CompositeVehicle')
     ) AS [t5] ON [v7].[Name] = [t5].[Name]
-    WHERE [v7].[Capacity] IS NOT NULL AND [v7].[FuelTank_Discriminator] IS NOT NULL
+    WHERE ([v7].[Capacity] IS NOT NULL) AND ([v7].[FuelTank_Discriminator] IS NOT NULL)
     UNION
     SELECT [v9].[Name], [v9].[Capacity], [v9].[FuelTank_Discriminator], [v9].[FuelType], [v9].[GrainGeometry]
     FROM [Vehicles] AS [v9]
@@ -77,11 +77,11 @@ LEFT JOIN (
         ) AS [t7] ON [v10].[Name] = [t7].[Name]
         WHERE [v10].[Engine_Discriminator] IN (N'ContinuousCombustionEngine', N'IntermittentCombustionEngine', N'SolidRocket')
     ) AS [t6] ON [v9].[Name] = [t6].[Name]
-    WHERE [v9].[Capacity] IS NOT NULL AND [v9].[FuelTank_Discriminator] IS NOT NULL
+    WHERE ([v9].[Capacity] IS NOT NULL) AND ([v9].[FuelTank_Discriminator] IS NOT NULL)
 ) AS [t4] ON CASE
-    WHEN [t2].[Computed] IS NOT NULL AND [t2].[Engine_Discriminator] IS NOT NULL THEN [t2].[Name]
+    WHEN ([t2].[Computed] IS NOT NULL) AND ([t2].[Engine_Discriminator] IS NOT NULL) THEN [t2].[Name]
 END = CASE
-    WHEN [t4].[Capacity] IS NOT NULL AND [t4].[FuelTank_Discriminator] IS NOT NULL THEN [t4].[Name]
+    WHEN ([t4].[Capacity] IS NOT NULL) AND ([t4].[FuelTank_Discriminator] IS NOT NULL) THEN [t4].[Name]
 END
 ORDER BY [v].[Name]");
         }
@@ -128,7 +128,7 @@ INNER JOIN (
     FROM [Vehicles] AS [v0]
     WHERE [v0].[Discriminator] IN (N'PoweredVehicle', N'CompositeVehicle')
 ) AS [t] ON [v].[Name] = [t].[Name]
-WHERE [v].[Capacity] IS NOT NULL AND [v].[FuelTank_Discriminator] IS NOT NULL
+WHERE ([v].[Capacity] IS NOT NULL) AND ([v].[FuelTank_Discriminator] IS NOT NULL)
 UNION
 SELECT [v1].[Name], [v1].[Capacity], [v1].[FuelTank_Discriminator], [v1].[FuelType], [v1].[GrainGeometry]
 FROM [Vehicles] AS [v1]
@@ -142,7 +142,7 @@ INNER JOIN (
     ) AS [t2] ON [v2].[Name] = [t2].[Name]
     WHERE [v2].[Engine_Discriminator] IN (N'ContinuousCombustionEngine', N'IntermittentCombustionEngine', N'SolidRocket')
 ) AS [t1] ON [v1].[Name] = [t1].[Name]
-WHERE [v1].[Capacity] IS NOT NULL AND [v1].[FuelTank_Discriminator] IS NOT NULL");
+WHERE ([v1].[Capacity] IS NOT NULL) AND ([v1].[FuelTank_Discriminator] IS NOT NULL)");
         }
 
         public override async Task Can_query_shared_derived_nonhierarchy()
@@ -186,7 +186,7 @@ INNER JOIN (
     FROM [Vehicles] AS [v0]
     WHERE [v0].[Discriminator] IN (N'PoweredVehicle', N'CompositeVehicle')
 ) AS [t] ON [v].[Name] = [t].[Name]
-WHERE [v].[Capacity] IS NOT NULL AND [v].[FuelType] IS NOT NULL
+WHERE ([v].[Capacity] IS NOT NULL) AND ([v].[FuelType] IS NOT NULL)
 UNION
 SELECT [v1].[Name], [v1].[Capacity], [v1].[FuelType]
 FROM [Vehicles] AS [v1]
@@ -200,7 +200,7 @@ INNER JOIN (
     ) AS [t2] ON [v2].[Name] = [t2].[Name]
     WHERE [v2].[Engine_Discriminator] IN (N'ContinuousCombustionEngine', N'IntermittentCombustionEngine', N'SolidRocket')
 ) AS [t1] ON [v1].[Name] = [t1].[Name]
-WHERE [v1].[Capacity] IS NOT NULL AND [v1].[FuelType] IS NOT NULL");
+WHERE ([v1].[Capacity] IS NOT NULL) AND ([v1].[FuelType] IS NOT NULL)");
         }
 
         public override async Task Can_change_dependent_instance_non_derived()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -217,7 +217,7 @@ WHERE ""s"".""Id"" = -""s"".""Id""");
             AssertSql(
                 @"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
 FROM ""Squads"" AS ""s""
-WHERE ""s"".""Name"" IS NOT NULL AND NOT (""s"".""Name"" LIKE 'us%')");
+WHERE (""s"".""Name"" IS NOT NULL) AND NOT (""s"".""Name"" LIKE 'us%')");
         }
 
         public override async Task Select_datetimeoffset_comparison_in_projection(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -184,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""ContactName"" IS NOT NULL AND (""c"".""ContactName"" LIKE 'M%')");
+WHERE (""c"".""ContactName"" IS NOT NULL) AND (""c"".""ContactName"" LIKE 'M%')");
         }
 
         public override async Task String_StartsWith_Identity(bool async)
@@ -194,7 +194,7 @@ WHERE ""c"".""ContactName"" IS NOT NULL AND (""c"".""ContactName"" LIKE 'M%')");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (""c"".""ContactName"" = '') OR (""c"".""ContactName"" IS NOT NULL AND (((""c"".""ContactName"" LIKE ""c"".""ContactName"" || '%') AND (substr(""c"".""ContactName"", 1, length(""c"".""ContactName"")) = ""c"".""ContactName"")) OR (""c"".""ContactName"" = '')))");
+WHERE (""c"".""ContactName"" = '') OR ((""c"".""ContactName"" IS NOT NULL) AND (((""c"".""ContactName"" LIKE ""c"".""ContactName"" || '%') AND (substr(""c"".""ContactName"", 1, length(""c"".""ContactName"")) = ""c"".""ContactName"")) OR (""c"".""ContactName"" = '')))");
         }
 
         public override async Task String_StartsWith_Column(bool async)
@@ -204,7 +204,7 @@ WHERE (""c"".""ContactName"" = '') OR (""c"".""ContactName"" IS NOT NULL AND (((
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (""c"".""ContactName"" = '') OR (""c"".""ContactName"" IS NOT NULL AND (((""c"".""ContactName"" LIKE ""c"".""ContactName"" || '%') AND (substr(""c"".""ContactName"", 1, length(""c"".""ContactName"")) = ""c"".""ContactName"")) OR (""c"".""ContactName"" = '')))");
+WHERE (""c"".""ContactName"" = '') OR ((""c"".""ContactName"" IS NOT NULL) AND (((""c"".""ContactName"" LIKE ""c"".""ContactName"" || '%') AND (substr(""c"".""ContactName"", 1, length(""c"".""ContactName"")) = ""c"".""ContactName"")) OR (""c"".""ContactName"" = '')))");
         }
 
         public override async Task String_StartsWith_MethodCall(bool async)
@@ -214,7 +214,7 @@ WHERE (""c"".""ContactName"" = '') OR (""c"".""ContactName"" IS NOT NULL AND (((
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""ContactName"" IS NOT NULL AND (""c"".""ContactName"" LIKE 'M%')");
+WHERE (""c"".""ContactName"" IS NOT NULL) AND (""c"".""ContactName"" LIKE 'M%')");
         }
 
         public override async Task String_EndsWith_Literal(bool async)
@@ -224,7 +224,7 @@ WHERE ""c"".""ContactName"" IS NOT NULL AND (""c"".""ContactName"" LIKE 'M%')");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""ContactName"" IS NOT NULL AND (""c"".""ContactName"" LIKE '%b')");
+WHERE (""c"".""ContactName"" IS NOT NULL) AND (""c"".""ContactName"" LIKE '%b')");
         }
 
         public override async Task String_EndsWith_Identity(bool async)
@@ -234,7 +234,7 @@ WHERE ""c"".""ContactName"" IS NOT NULL AND (""c"".""ContactName"" LIKE '%b')");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (""c"".""ContactName"" = '') OR (""c"".""ContactName"" IS NOT NULL AND ((substr(""c"".""ContactName"", -length(""c"".""ContactName"")) = ""c"".""ContactName"") OR (""c"".""ContactName"" = '')))");
+WHERE (""c"".""ContactName"" = '') OR ((""c"".""ContactName"" IS NOT NULL) AND ((substr(""c"".""ContactName"", -length(""c"".""ContactName"")) = ""c"".""ContactName"") OR (""c"".""ContactName"" = '')))");
         }
 
         public override async Task String_EndsWith_Column(bool async)
@@ -244,7 +244,7 @@ WHERE (""c"".""ContactName"" = '') OR (""c"".""ContactName"" IS NOT NULL AND ((s
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (""c"".""ContactName"" = '') OR (""c"".""ContactName"" IS NOT NULL AND ((substr(""c"".""ContactName"", -length(""c"".""ContactName"")) = ""c"".""ContactName"") OR (""c"".""ContactName"" = '')))");
+WHERE (""c"".""ContactName"" = '') OR ((""c"".""ContactName"" IS NOT NULL) AND ((substr(""c"".""ContactName"", -length(""c"".""ContactName"")) = ""c"".""ContactName"") OR (""c"".""ContactName"" = '')))");
         }
 
         public override async Task String_EndsWith_MethodCall(bool async)
@@ -254,7 +254,7 @@ WHERE (""c"".""ContactName"" = '') OR (""c"".""ContactName"" IS NOT NULL AND ((s
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""ContactName"" IS NOT NULL AND (""c"".""ContactName"" LIKE '%m')");
+WHERE (""c"".""ContactName"" IS NOT NULL) AND (""c"".""ContactName"" LIKE '%m')");
         }
 
         public override async Task String_Contains_Literal(bool async)
@@ -322,7 +322,7 @@ WHERE ('M' = '') OR (instr(""c"".""ContactName"", 'M') > 0)");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""Region"" IS NULL OR (trim(""c"".""Region"") = '')");
+WHERE (""c"".""Region"" IS NULL) OR (trim(""c"".""Region"") = '')");
         }
 
         public override async Task Indexof_with_emptystring(bool async)
@@ -624,7 +624,7 @@ WHERE regexp(""c"".""CustomerID"", 'ALFKI')");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""Region"" IS NULL OR (""c"".""Region"" = '')");
+WHERE (""c"".""Region"" IS NULL) OR (""c"".""Region"" = '')");
         }
 
         public override async Task IsNullOrEmpty_in_projection(bool async)
@@ -632,7 +632,7 @@ WHERE ""c"".""Region"" IS NULL OR (""c"".""Region"" = '')");
             await base.IsNullOrEmpty_in_projection(async);
 
             AssertSql(
-                @"SELECT ""c"".""CustomerID"" AS ""Id"", ""c"".""Region"" IS NULL OR (""c"".""Region"" = '') AS ""Value""
+                @"SELECT ""c"".""CustomerID"" AS ""Id"", (""c"".""Region"" IS NULL) OR (""c"".""Region"" = '') AS ""Value""
 FROM ""Customers"" AS ""c""");
         }
 
@@ -643,7 +643,7 @@ FROM ""Customers"" AS ""c""");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""Region"" IS NOT NULL AND (""c"".""Region"" <> '')");
+WHERE (""c"".""Region"" IS NOT NULL) AND (""c"".""Region"" <> '')");
         }
 
         public override Task Datetime_subtraction_TotalDays(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql(
                 @"SELECT ""o"".""CustomerID""
 FROM ""Orders"" AS ""o""
-WHERE ""o"".""OrderDate"" IS NOT NULL AND (('10' = '') OR (instr(CAST(""o"".""EmployeeID"" AS TEXT), '10') > 0))");
+WHERE (""o"".""OrderDate"" IS NOT NULL) AND (('10' = '') OR (instr(CAST(""o"".""EmployeeID"" AS TEXT), '10') > 0))");
         }
 
         public override async Task Take_Skip(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQueryFiltersQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQueryFiltersQuerySqliteTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
 SELECT COUNT(*)
 FROM ""Customers"" AS ""c""
-WHERE (@__ef_filter__TenantPrefix_0 = '') OR (""c"".""CompanyName"" IS NOT NULL AND (((""c"".""CompanyName"" LIKE @__ef_filter__TenantPrefix_0 || '%') AND (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = '')))");
+WHERE (@__ef_filter__TenantPrefix_0 = '') OR ((""c"".""CompanyName"" IS NOT NULL) AND (((""c"".""CompanyName"" LIKE @__ef_filter__TenantPrefix_0 || '%') AND (substr(""c"".""CompanyName"", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = '')))");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
@@ -191,7 +191,7 @@ WHERE length(""c"".""City"") = 6");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ((instr(""c"".""City"", 'Sea') - 1) <> -1) OR ""c"".""City"" IS NULL");
+WHERE ((instr(""c"".""City"", 'Sea') - 1) <> -1) OR (""c"".""City"" IS NULL)");
         }
 
         public override async Task Where_string_replace(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteTest.cs
@@ -71,6 +71,26 @@ FROM ""Entities1"" AS ""e""
 WHERE ""e"".""BoolB"" <> (""e"".""NullableBoolA"" IS NOT NULL)");
         }
 
+        public override async Task Bool_not_equal_nullable_int_HasValue(bool async)
+        {
+            await base.Bool_not_equal_nullable_int_HasValue(async);
+
+            AssertSql(
+                @"SELECT ""e"".""Id"", ""e"".""BoolA"", ""e"".""BoolB"", ""e"".""BoolC"", ""e"".""IntA"", ""e"".""IntB"", ""e"".""IntC"", ""e"".""NullableBoolA"", ""e"".""NullableBoolB"", ""e"".""NullableBoolC"", ""e"".""NullableIntA"", ""e"".""NullableIntB"", ""e"".""NullableIntC"", ""e"".""NullableStringA"", ""e"".""NullableStringB"", ""e"".""NullableStringC"", ""e"".""StringA"", ""e"".""StringB"", ""e"".""StringC""
+FROM ""Entities1"" AS ""e""
+WHERE ""e"".""NullableIntA"" IS NULL",
+                //
+                @"@__prm_0='False'
+
+SELECT ""e"".""Id"", ""e"".""BoolA"", ""e"".""BoolB"", ""e"".""BoolC"", ""e"".""IntA"", ""e"".""IntB"", ""e"".""IntC"", ""e"".""NullableBoolA"", ""e"".""NullableBoolB"", ""e"".""NullableBoolC"", ""e"".""NullableIntA"", ""e"".""NullableIntB"", ""e"".""NullableIntC"", ""e"".""NullableStringA"", ""e"".""NullableStringB"", ""e"".""NullableStringC"", ""e"".""StringA"", ""e"".""StringB"", ""e"".""StringC""
+FROM ""Entities1"" AS ""e""
+WHERE @__prm_0 <> (""e"".""NullableIntA"" IS NOT NULL)",
+                //
+                @"SELECT ""e"".""Id"", ""e"".""BoolA"", ""e"".""BoolB"", ""e"".""BoolC"", ""e"".""IntA"", ""e"".""IntB"", ""e"".""IntC"", ""e"".""NullableBoolA"", ""e"".""NullableBoolB"", ""e"".""NullableBoolC"", ""e"".""NullableIntA"", ""e"".""NullableIntB"", ""e"".""NullableIntC"", ""e"".""NullableStringA"", ""e"".""NullableStringB"", ""e"".""NullableStringC"", ""e"".""StringA"", ""e"".""StringB"", ""e"".""StringC""
+FROM ""Entities1"" AS ""e""
+WHERE ""e"".""BoolB"" <> (""e"".""NullableIntA"" IS NOT NULL)");
+        }
+
         public override async Task Bool_not_equal_nullable_bool_compared_to_null(bool async)
         {
             await base.Bool_not_equal_nullable_bool_compared_to_null(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
@@ -218,7 +218,7 @@ WHERE ""s"".""Id"" = -""s"".""Id""");
             AssertSql(
                 @"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
 FROM ""Squads"" AS ""s""
-WHERE ""s"".""Name"" IS NOT NULL AND NOT (""s"".""Name"" LIKE 'us%')");
+WHERE (""s"".""Name"" IS NOT NULL) AND NOT (""s"".""Name"" LIKE 'us%')");
         }
 
         public override async Task Select_datetimeoffset_comparison_in_projection(bool async)


### PR DESCRIPTION
Fixes #26652

**Description**

EF Core's SQL generation currently omits parentheses around SQL `IS (NOT) NULL`, in some cases where these are required.

**Customer impact**

When using database providers other than SQL Server, the LINQ expression `Where(b => b.SomeBool = b.SomeNonBoolColumn.HasValue)` returns incorrect results.

**How found**

Customer reported (originally in https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1309)

**Regression**

No

**Testing**

Added test for this scenario.

**Risk**

Very low, the fix simply adds parentheses around all occurrences of `IS (NOT) NULL`.

