### PR TITLE
Use a unique identifier for variables during insert

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31521.260
-MinimumVisualStudioVersion = 16.0.28418.106
+MinimumVisualStudioVersion = 17.0.31521.260
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B9E4CC99-199C-4E3B-9EC5-D1FDFCD6C27B}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -65,7 +65,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Update.Internal
                         modificationCommands[0],
                         modificationCommands[0].ColumnModifications.Where(o => o.IsKey).ToList(),
                         modificationCommands[0].ColumnModifications.Where(o => o.IsRead).ToList(),
-                        commandPosition);
+                        (!AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26632", out var enabled) || !enabled)
+                            ? commandPosition
+                            : 0);
             }
 
             var readOperations = modificationCommands[0].ColumnModifications.Where(o => o.IsRead).ToList();

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Update.Internal
                         modificationCommands[0],
                         modificationCommands[0].ColumnModifications.Where(o => o.IsKey).ToList(),
                         modificationCommands[0].ColumnModifications.Where(o => o.IsRead).ToList(),
-                        0);
+                        commandPosition);
             }
 
             var readOperations = modificationCommands[0].ColumnModifications.Where(o => o.IsRead).ToList();


### PR DESCRIPTION
Fixes #26632

**Description**

When the entity types have store-generated primary keys invalid SQL is produced when a single entity of one type as well as 3 or more (or the amount specified in `MinBatchSize`) are inserted together.

**Customer impact**

`SaveChanges` produces invalid SQL that results in an exception. The workaround would be to call `SaveChanges` after each batch of specific entity type is added, but this isn't always practical.

**How found**

Customer reported on 6.0

**Regression**

Yes, this worked in 5.0. Introduced in #25718

**Testing**

Added test for this scenario.

**Risk**

Low, the change has very predictable impact. Also added a quirk mode.
