### PR TITLE
[Release/5.0]Fix ValueGenerated, make ValueGeneratedOnUpdate() and ValueGeneratedOnAddOrUpdate() working

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -127,12 +127,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             EntityState? forceStateWhenUnknownKey = null)
         {
             var oldState = _stateData.EntityState;
-            var addingOrUpdating = PrepareForAddOrUpdate(entityState);//Fix ValueGeneration
+            var addingOrUpdating = PrepareForAddOrUpdate(entityState);
 
             entityState = PropagateToUnknownKey(oldState, entityState, addingOrUpdating, forceStateWhenUnknownKey);
 
-            //if (adding || oldState is EntityState.Detached)
-            if (addingOrUpdating)//Fix
+            if (addingOrUpdating)
             {
                 StateManager.ValueGenerationManager.Generate(this, includePrimaryKey: addingOrUpdating);
             }
@@ -154,12 +153,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             CancellationToken cancellationToken = default)
         {
             var oldState = _stateData.EntityState;
-            var addingOrUpdating = PrepareForAddOrUpdate(entityState);//Fix ValueGeneration
+            var addingOrUpdating = PrepareForAddOrUpdate(entityState);
 
             entityState = PropagateToUnknownKey(oldState, entityState, addingOrUpdating, forceStateWhenUnknownKey);
 
-            //if (adding || oldState is EntityState.Detached)
-            if (addingOrUpdating)//Fix
+            if (addingOrUpdating)
             {
                 await StateManager.ValueGenerationManager.GenerateAsync(this, includePrimaryKey: addingOrUpdating, cancellationToken)
                     .ConfigureAwait(false);
@@ -176,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var keyUnknown = IsKeyUnknown;
 
-            if (entityState == EntityState.Added //Fix ValueGeneration
+            if (entityState == EntityState.Added
                 || (oldState == EntityState.Detached
                     && keyUnknown))
             {
@@ -197,7 +195,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             return entityState;
         }
 
-        //Fix For ValueGeneration
         private bool PrepareForAddOrUpdate(EntityState newState)
         {
             switch (newState)
@@ -257,28 +254,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 default:
                     return false;
             }
-        }
-
-        private bool PrepareForAdd(EntityState newState)
-        {
-            if (newState != EntityState.Added
-                || EntityState == EntityState.Added)
-            {
-                return false;
-            }
-
-            if (EntityState == EntityState.Modified)
-            {
-                _stateData.FlagAllProperties(
-                    EntityType.PropertyCount(), PropertyFlag.Modified,
-                    flagged: false);
-            }
-
-            // Temporarily change the internal state to unknown so that key generation, including setting key values
-            // can happen without constraints on changing read-only values kicking in
-            _stateData.EntityState = EntityState.Detached;
-
-            return true;
         }
 
         private void SetEntityState(EntityState oldState, EntityState newState, bool acceptChanges, bool modifyProperties)

--- a/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -94,16 +94,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             foreach (var property in FindCandidateGeneratingProperties(entry))
             {
-                if (entry.EntityState == EntityState.Added || entry.EntityState == EntityState.Detached)//Fix
+                if (entry.EntityState == EntityState.Added || entry.EntityState == EntityState.Detached)
                 {
                     if (!entry.HasDefaultValue(property) || (!includePrimaryKey && property.IsPrimaryKey()))
                     {
                         continue;
                     }
                 }
-                if (entry.EntityState == EntityState.Modified || entry.EntityState == EntityState.Unchanged)//Fix
+                if (entry.EntityState == EntityState.Modified || entry.EntityState == EntityState.Unchanged)
                 {
-                    //Fix,PrimaryKey and ForeignKey was generated or added at EntityState.Added,It need to skip at here.
+                    //Fix,PrimaryKey and ForeignKey was generated or added at EntityState.Added,so it need to skip at here.
                     if (entry.HasDefaultValue(property) || property.IsKey())
                     {
                         continue;
@@ -152,16 +152,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             foreach (var property in FindCandidateGeneratingProperties(entry))
             {
-                if (entry.EntityState == EntityState.Added || entry.EntityState == EntityState.Detached)//Fix
+                if (entry.EntityState == EntityState.Added || entry.EntityState == EntityState.Detached)
                 {
                     if (!entry.HasDefaultValue(property) || (!includePrimaryKey && property.IsPrimaryKey()))
                     {
                         continue;
                     }
                 }
-                if (entry.EntityState == EntityState.Modified || entry.EntityState == EntityState.Unchanged)//Fix
+                if (entry.EntityState == EntityState.Modified || entry.EntityState == EntityState.Unchanged)
                 {
-                    //Fix,PrimaryKey and ForeignKey was generated or added at EntityState.Added,It need to skip at here.
+                    //Fix,PrimaryKey and ForeignKey was generated or added at EntityState.Added, so it need to skip at here.
                     if (entry.HasDefaultValue(property) || property.IsKey())
                     {
                         continue;

--- a/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -94,11 +94,20 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             foreach (var property in FindCandidateGeneratingProperties(entry))
             {
-                if (!entry.HasDefaultValue(property)
-                    || (!includePrimaryKey
-                        && property.IsPrimaryKey()))
+                if (entry.EntityState == EntityState.Added || entry.EntityState == EntityState.Detached)//Fix
                 {
-                    continue;
+                    if (!entry.HasDefaultValue(property) || (!includePrimaryKey && property.IsPrimaryKey()))
+                    {
+                        continue;
+                    }
+                }
+                if (entry.EntityState == EntityState.Modified || entry.EntityState == EntityState.Unchanged)//Fix
+                {
+                    //Fix,PrimaryKey and ForeignKey was generated or added at EntityState.Added,It need to skip at here.
+                    if (entry.HasDefaultValue(property) || property.IsKey())
+                    {
+                        continue;
+                    }
                 }
 
                 var valueGenerator = GetValueGenerator(entry, property);
@@ -143,11 +152,20 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             foreach (var property in FindCandidateGeneratingProperties(entry))
             {
-                if (!entry.HasDefaultValue(property)
-                    || (!includePrimaryKey
-                        && property.IsPrimaryKey()))
+                if (entry.EntityState == EntityState.Added || entry.EntityState == EntityState.Detached)//Fix
                 {
-                    continue;
+                    if (!entry.HasDefaultValue(property) || (!includePrimaryKey && property.IsPrimaryKey()))
+                    {
+                        continue;
+                    }
+                }
+                if (entry.EntityState == EntityState.Modified || entry.EntityState == EntityState.Unchanged)//Fix
+                {
+                    //Fix,PrimaryKey and ForeignKey was generated or added at EntityState.Added,It need to skip at here.
+                    if (entry.HasDefaultValue(property) || property.IsKey())
+                    {
+                        continue;
+                    }
                 }
 
                 var valueGenerator = GetValueGenerator(entry, property);

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -575,6 +575,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             private string _notMapped;
             private ICollection<ChangedOnlyNotificationEntity> _relatedCollection;
 
+            [System.ComponentModel.DataAnnotations.Schema.DatabaseGenerated(System.ComponentModel.DataAnnotations.Schema.DatabaseGeneratedOption.None)]//Fix
             public int Id
             {
                 get => _id;

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -575,7 +576,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             private string _notMapped;
             private ICollection<ChangedOnlyNotificationEntity> _relatedCollection;
 
-            [System.ComponentModel.DataAnnotations.Schema.DatabaseGenerated(System.ComponentModel.DataAnnotations.Schema.DatabaseGeneratedOption.None)]//Fix
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
                 get => _id;

--- a/test/EFCore.Tests/DbContextTrackingTest.cs
+++ b/test/EFCore.Tests/DbContextTrackingTest.cs
@@ -774,7 +774,7 @@ namespace Microsoft.EntityFrameworkCore
             if (attachFirst)
             {
                 context.Entry(gu1).State = EntityState.Unchanged;
-                Assert.Equal(default, gu1.Id);
+                Assert.NotEqual(default, gu1.Id);//Fix
                 Assert.Equal(EntityState.Unchanged, context.Entry(gu1).State);
             }
 
@@ -805,9 +805,9 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Same(gu1, categoryEntry.Entity);
             Assert.Equal(EntityState.Added, categoryEntry.State);
 
-            categoryEntry = context.Entry(gu2);
-            Assert.Same(gu2, categoryEntry.Entity);
-            Assert.Equal(EntityState.Added, categoryEntry.State);
+            var categoryEntry2 = context.Entry(gu2);//Fix
+            Assert.Same(gu2, categoryEntry2.Entity);
+            Assert.Equal(EntityState.Added, categoryEntry2.State);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/DbContextTrackingTest.cs
+++ b/test/EFCore.Tests/DbContextTrackingTest.cs
@@ -774,7 +774,7 @@ namespace Microsoft.EntityFrameworkCore
             if (attachFirst)
             {
                 context.Entry(gu1).State = EntityState.Unchanged;
-                Assert.NotEqual(default, gu1.Id);//Fix
+                Assert.NotEqual(default, gu1.Id);
                 Assert.Equal(EntityState.Unchanged, context.Entry(gu1).State);
             }
 
@@ -805,7 +805,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Same(gu1, categoryEntry.Entity);
             Assert.Equal(EntityState.Added, categoryEntry.State);
 
-            var categoryEntry2 = context.Entry(gu2);//Fix
+            var categoryEntry2 = context.Entry(gu2);
             Assert.Same(gu2, categoryEntry2.Entity);
             Assert.Equal(EntityState.Added, categoryEntry2.State);
         }


### PR DESCRIPTION
Fixes [#6999](https://github.com/dotnet/efcore/issues/6999) and [#19765](https://github.com/dotnet/efcore/issues/19765)

When useing **ValueGeneratedOnUpdate()**, set **PropertyBuilder.Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Save)** for update.

When useing **ValueGeneratedOnAddOrUpdate()**, set **PropertyBuilder.Metadata.SetBeforeSaveBehavior(PropertySaveBehavior.Save)** for add and **PropertyBuilder.Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Save)** for update.