### PR TITLE
[6.0.x] Query: Update table references in pushdown after moving table referen…

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2817,6 +2817,18 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             _tables.Add(subquery);
             _tableReferences.Add(subqueryTableReferenceExpression);
 
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26587", out var enabled)
+                && enabled;
+
+            if (!useOldBehavior)
+            {
+                // Remap tableReferences in inner so that all components follow referential integrity.
+                foreach (var tableReference in subquery._tableReferences)
+                {
+                    tableReference.UpdateTableReference(this, subquery);
+                }
+            }
+
             var projectionMap = new Dictionary<SqlExpression, ColumnExpression>(ReferenceEqualityComparer.Instance);
 
             if (_projection.Count > 0)
@@ -2953,10 +2965,13 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 subquery.ClearOrdering();
             }
 
-            // Remap tableReferences in inner
-            foreach (var tableReference in subquery._tableReferences)
+            if (useOldBehavior)
             {
-                tableReference.UpdateTableReference(this, subquery);
+                // Remap tableReferences in inner
+                foreach (var tableReference in subquery._tableReferences)
+                {
+                    tableReference.UpdateTableReference(this, subquery);
+                }
             }
 
             var tableReferenceUpdatingExpressionVisitor = new TableReferenceUpdatingExpressionVisitor(this, subquery);

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -1812,6 +1812,20 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_aggregate_using_grouping_key_Pushdown(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().GroupBy(e => e.CustomerID)
+                    .Where(g => g.Count() > 10)
+                    .Select(g => new { g.Key, Max = g.Max(e => g.Key) })
+                    .OrderBy(t => t.Key)
+                    .Take(20)
+                    .Skip(4));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_aggregate_Pushdown_followed_by_projecting_Length(bool async)
         {
             return AssertQueryScalar(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1316,6 +1316,26 @@ ORDER BY [t].[CustomerID]
 OFFSET @__p_1 ROWS");
         }
 
+        public override async Task GroupBy_aggregate_using_grouping_key_Pushdown(bool async)
+        {
+            await base.GroupBy_aggregate_using_grouping_key_Pushdown(async);
+
+            AssertSql(
+                @"@__p_0='20'
+@__p_1='4'
+
+SELECT [t].[Key], [t].[Max]
+FROM (
+    SELECT TOP(@__p_0) [o].[CustomerID] AS [Key], MAX([o].[CustomerID]) AS [Max]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    HAVING COUNT(*) > 10
+    ORDER BY [o].[CustomerID]
+) AS [t]
+ORDER BY [t].[Key]
+OFFSET @__p_1 ROWS");
+        }
+
         public override async Task GroupBy_aggregate_Pushdown_followed_by_projecting_Length(bool async)
         {
             await base.GroupBy_aggregate_Pushdown_followed_by_projecting_Length(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -128,5 +128,24 @@ SELECT CASE
 END AS [HasAccess]
 FROM [Users] AS [u]");
         }
+
+        public override async Task GroupBy_aggregate_on_right_side_of_join(bool async)
+        {
+            await base.GroupBy_aggregate_on_right_side_of_join(async);
+
+            AssertSql(
+                @"@__orderId_0='123456'
+
+SELECT [o].[Id], [o].[CancellationDate], [o].[OrderId], [o].[ShippingDate]
+FROM [OrderItems] AS [o]
+INNER JOIN (
+    SELECT [o0].[OrderId] AS [Key]
+    FROM [OrderItems] AS [o0]
+    WHERE [o0].[OrderId] = @__orderId_0
+    GROUP BY [o0].[OrderId]
+) AS [t] ON [o].[OrderId] = [t].[Key]
+WHERE [o].[OrderId] = @__orderId_0
+ORDER BY [o].[OrderId]");
+        }
     }
 }


### PR DESCRIPTION
…ces to subquery

Doing so causes all table references to maintain referential integrity again, which is required in processing projections in certain scenarios

Resolves #26587

**Description**
Pushing down a select expression in subquery causes it to transfer table references to subquery which causes intermediate phase where the referential integrity of select expression graph is violated. Processing of projection requires the graph to be consistent. We made the graph consistent again but after processing the projection so this can cause exception if projection runs some code which requires consistent graph.

**Customer impact**
Customer queries involving GroupBy which has aggregate applied on it and using grouping key in aggregate, if it gets pushed down (which can happen due to Skip/Take operators, joining it with other queries or other kind of composition), then it will throw exception.

**How found**
Customer reported on RTM package

**Regression**
Yes. 

**Testing**
Added tests for the root cause scenario and also for the customer scenario.

**Risk**
Low. We are doing same processing as before just little early. Also added quirk to revert to previous behavior.