### PR TITLE
Update the foreign key builder after IsRequired()

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -973,7 +973,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Metadata.DeclaringEntityType.Model.ScopedModelDependencies?.Logger.AmbiguousEndRequiredWarning(Metadata);
             }
 
-            Metadata.SetIsRequired(required, configurationSource);
+            IConventionForeignKey? foreignKey = Metadata;
+            var result = Metadata.DeclaringEntityType.Model.ConventionDispatcher.Track(
+                () => Metadata.SetIsRequired(required, configurationSource), ref foreignKey);
+            if (foreignKey != null)
+            {
+                return ((ForeignKey)foreignKey).Builder;
+            }
 
             return this;
         }

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -973,6 +973,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Metadata.DeclaringEntityType.Model.ScopedModelDependencies?.Logger.AmbiguousEndRequiredWarning(Metadata);
             }
 
+            if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26611", out var enabled) && enabled)
+            {
+                Metadata.SetIsRequired(required, configurationSource);
+                return this;
+            }
+
             IConventionForeignKey? foreignKey = Metadata;
             var result = Metadata.DeclaringEntityType.Model.ConventionDispatcher.Track(
                 () => Metadata.SetIsRequired(required, configurationSource), ref foreignKey);

--- a/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
@@ -1942,14 +1942,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     {
                         b.HasMany<Beta>()
                             .WithOne(e => e.FirstNav)
-                            .HasForeignKey("ShadowId");
+                            .HasForeignKey("ShadowId")
+                            .IsRequired()
+                            .HasAnnotation("Test", "foo");
                     });
 
-                modelBuilder.FinalizeModel();
+                var model = modelBuilder.FinalizeModel();
 
-                Assert.Equal(
-                    "ShadowId",
-                    modelBuilder.Model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey.Properties.Single().Name);
+                var fk = model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey;
+                Assert.Equal("ShadowId", fk.Properties.Single().Name);
+                Assert.True(fk.IsRequired);
+                Assert.Equal("foo", fk["Test"]);
             }
 
             [ConditionalFact]


### PR DESCRIPTION
Fixes #26611

**Description**

When `IsRequired()` is called for a foreign key specified on a shadow property we replace the property to change in to a non-nullable type. This invalidates the current reference held by the builder.

**Customer impact**

All method calls after `IsRequired()` for a foreign key specified on a shadow property will throw an exception. A workaround would involve separating these calls and repeating some of the setup.

**How found**

Customer reported on 6.0

**Regression**

Yes, this worked in 5.0

**Testing**

Added test for this scenario.

**Risk**

Low, the fix is to update the foreign key reference held by the builder. Also added a quirk mode.