### PR TITLE
Use the correct builder when attaching indexes on nested owned entity types

### DIFF
--- a/src/EFCore/Metadata/Internal/PropertiesSnapshot.cs
+++ b/src/EFCore/Metadata/Internal/PropertiesSnapshot.cs
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     var originalEntityType = indexBuilder.Metadata.DeclaringEntityType;
                     var targetEntityTypeBuilder = originalEntityType.Name == entityTypeBuilder.Metadata.Name
-                        || (!originalEntityType.HasSharedClrType && originalEntityType.ClrType == entityTypeBuilder.Metadata.ClrType)
+                        || (!originalEntityType.IsInModel && originalEntityType.ClrType == entityTypeBuilder.Metadata.ClrType)
                             ? entityTypeBuilder
                             : originalEntityType.Builder;
                     indexBuilder.Attach(targetEntityTypeBuilder);

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -1064,7 +1064,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                             l => l.AnotherBookLabel, ab =>
                             {
                                 ab.Ignore(l => l.Book);
-                                ab.OwnsOne(l => l.SpecialBookLabel).Ignore(l => l.Book).Ignore(s => s.BookLabel);
+                                ab.OwnsOne(l => l.SpecialBookLabel)
+                                    .Ignore(l => l.Book)
+                                    .Ignore(s => s.BookLabel)
+                                    .HasIndex(l => l.BookId);
                             });
                         bb.OwnsOne(
                             l => l.SpecialBookLabel, sb =>


### PR DESCRIPTION
Fixes #26659

**Description**

When `OwnsMany()` is called for a navigation of the same CLR type the second type the target entity type is converted to a shared-type entity type. All existing components, like indexes are then reattached to the new entity type, however the incorrect entity type builder was used for nested owned entity types.

**Customer impact**

When a nested owned entity type has a configured index the second `OwnsMany()` call throws an exception. A workaround would be to configure the index after the second `OwnsMany()` call.

**How found**

Customer reported on 6.0

**Regression**

Yes, this worked in 5.0

**Testing**

Added test for this scenario.

**Risk**

Low, the fix is to avoid using an entity type that's no longer in the model.