### PR TITLE
Return null schema for unmapped entity types.

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -135,6 +135,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>The database schema that contains the mapped table.</returns>
         public static string? GetSchema(this IReadOnlyEntityType entityType)
         {
+            if (entityType.GetTableName() == null
+                && !(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26651", out var enabled) && enabled))
+            {
+                return null;
+            }
+
             var schemaAnnotation = entityType.FindAnnotation(RelationalAnnotationNames.Schema);
             if (schemaAnnotation != null)
             {

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -564,6 +564,37 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 o => Assert.Equal("EntityWithOneProperty", o.GetEntityTypes().Single().GetViewName()));
         }
 
+        [ConditionalFact]
+        public void Unmapped_entity_types_are_stored_in_the_model_snapshot()
+        {
+            Test(
+                builder => {
+                    builder.HasDefaultSchema("default");
+                    builder.Entity<EntityWithOneProperty>().Ignore(e => e.EntityWithTwoProperties).ToTable((string)null);
+                },
+                AddBoilerPlate(@"
+            modelBuilder
+                .HasDefaultSchema(""default"")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
+
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable((string)null);
+                });"),
+                o => {
+                    Assert.Null(o.GetEntityTypes().Single().GetTableName());
+                    Assert.Null(o.GetEntityTypes().Single().GetSchema());
+                });
+        }
+
         private class TestKeylessType
         {
             public string Something { get; set; }

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -101,7 +101,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     Assert.Equal("People", peopleTable.Name);
                     if (AssertSchemaNames)
+                    {
                         Assert.Equal("dbo2", peopleTable.Schema);
+                    }
 
                     Assert.Collection(
                         peopleTable.Columns.OrderBy(c => c.Name),


### PR DESCRIPTION
Fixes #26651

**Description**

We started including the default schema in each `ToTable` call in the model snapshot, even if it was to mark an entity type as not mapped - `ToTable(null, "schema")`, which doesn't work.

**Customer impact**

If the model has a default schema and unmapped entity types the model snapshot in the generated migration throws an exception when used.

**How found**

Customer reported on 6.0

**Regression**

Yes, this worked in 5.0

**Testing**

Added test for this scenario.

**Risk**

Low, the fix just affects models with unmapped entity types. Also added a quirk mode.

