### PR TITLE
Call sync connection close instead of async

### DIFF
--- a/benchmark/Directory.Build.props
+++ b/benchmark/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.test.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rulesets/EFCore.test.ruleset
+++ b/rulesets/EFCore.test.ruleset
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="EFCore" ToolsVersion="15.0">
+  <Include Path="StyleCop.noxmldocs.ruleset" Action="Default" />
+  <Include Path="FxCop.test.ruleset" Action="Default" />
+  <Include Path="Documentation.ruleset" Action="Default" />
+</RuleSet>

--- a/rulesets/FxCop.test.ruleset
+++ b/rulesets/FxCop.test.ruleset
@@ -51,7 +51,7 @@
       <Rule Id="CA1305" Action="None" />             <!-- Specify IFormatProvider -->
       <Rule Id="CA1307" Action="None" />             <!-- Specify StringComparison -->
       <Rule Id="CA1308" Action="None" />             <!-- Normalize strings to uppercase -->
-      <Rule Id="CA1309" Action="Error" />            <!-- Use ordinal stringcomparison -->
+      <Rule Id="CA1309" Action="None" />             <!-- Use ordinal stringcomparison -->
       <Rule Id="CA1401" Action="None" />             <!-- P/Invokes should not be visible -->
       <Rule Id="CA1501" Action="None" />             <!-- Avoid excessive inheritance -->
       <Rule Id="CA1502" Action="None" />             <!-- Avoid excessive complexity -->
@@ -95,7 +95,7 @@
       <Rule Id="CA1829" Action="None" />             <!-- Use Length/Count property instead of Count() when available -->
       <Rule Id="CA2000" Action="None" />             <!-- Dispose objects before losing scope -->
       <Rule Id="CA2002" Action="None" />             <!-- Do not lock on objects with weak identity -->
-      <Rule Id="CA2007" Action="Error" />            <!-- Consider calling ConfigureAwait on the awaited task -->
+      <Rule Id="CA2007" Action="None" />             <!-- Consider calling ConfigureAwait on the awaited task -->
       <Rule Id="CA2008" Action="Error" />            <!-- Do not create tasks without passing a TaskScheduler -->
       <Rule Id="CA2009" Action="Error" />            <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
       <Rule Id="CA2010" Action="None" />             <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -264,8 +264,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             (string ContainerId, JToken Document, IUpdateEntry Entry, CosmosClientWrapper Wrapper) parameters,
             CancellationToken cancellationToken = default)
         {
-            await using var stream = new MemoryStream();
-            await using var writer = new StreamWriter(stream, new UTF8Encoding(), bufferSize: 1024, leaveOpen: false);
+            using var stream = new MemoryStream();
+            var writer = new StreamWriter(stream, new UTF8Encoding(), bufferSize: 1024, leaveOpen: false);
+            await using var __ = writer.ConfigureAwait(false);
             using var jsonWriter = new JsonTextWriter(writer);
             Serializer.Serialize(jsonWriter, parameters.Document);
             await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -259,7 +259,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 var command = Dependencies.RawSqlCommandBuilder.Build(GetAppliedMigrationsSql);
 
-                await using var reader = await command.ExecuteReaderAsync(
+                var reader = await command.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
                         Dependencies.Connection,
                         null,
@@ -267,6 +267,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         Dependencies.CurrentContext.Context,
                         Dependencies.CommandLogger, CommandSource.Migrations),
                     cancellationToken).ConfigureAwait(false);
+
+                await using var _ = reader.ConfigureAwait(false);
+
                 while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
                 {
                     rows.Add(new HistoryRow(reader.DbDataReader.GetString(0), reader.DbDataReader.GetString(1)));

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -3253,7 +3253,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         {
             Check.DebugAssert(_tables.Count == _tableReferences.Count, "All the tables should have their associated TableReferences.");
             Check.DebugAssert(
-                string.Equals(GetAliasFromTableExpressionBase(tableExpressionBase), tableReferenceExpression.Alias),
+                string.Equals(
+                    GetAliasFromTableExpressionBase(tableExpressionBase), tableReferenceExpression.Alias, StringComparison.Ordinal),
                 "Alias of table and table reference should be the same.");
 
             var uniqueAlias = GenerateUniqueAlias(_usedAliases, tableReferenceExpression.Alias);

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -896,7 +896,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         }
                         else
                         {
-                            CloseDbConnectionAsync();
+                            CloseDbConnection();
                         }
 
                         wasClosed = true;

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -283,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             try
             {
-                await using var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(
+                var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
                         connection,
                         storeCommand.ParameterValues,
@@ -291,6 +291,8 @@ namespace Microsoft.EntityFrameworkCore.Update
                         Dependencies.CurrentContext.Context,
                         Dependencies.Logger, CommandSource.SaveChanges),
                     cancellationToken).ConfigureAwait(false);
+
+                await using var _ = dataReader.ConfigureAwait(false);
                 await ConsumeAsync(dataReader, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException)

--- a/src/EFCore/ChangeTracking/Internal/EntityGraphAttacher.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityGraphAttacher.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         null,
                         null),
                     PaintActionAsync,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
 
                 rootEntry.StateManager.CompleteAttachGraph();
             }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -990,10 +990,10 @@ namespace Microsoft.EntityFrameworkCore
 
             if (DisposeSync(lease.IsActive, contextShouldBeDisposed))
             {
-                await _serviceScope.DisposeAsyncIfAvailable();
+                await _serviceScope.DisposeAsyncIfAvailable().ConfigureAwait(false);
             }
 
-            await lease.ContextDisposedAsync();
+            await lease.ContextDisposedAsync().ConfigureAwait(false);
         }
 
         private bool DisposeSync(bool leaseActive, bool contextShouldBeDisposed)

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -3127,11 +3127,11 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(source, nameof(source));
 
-            await using (var enumerator = source.AsAsyncEnumerable().GetAsyncEnumerator(cancellationToken))
+            var enumerator = source.AsAsyncEnumerable().GetAsyncEnumerator(cancellationToken);
+            await using var _ = enumerator.ConfigureAwait(false);
+
+            while (await enumerator.MoveNextAsync().ConfigureAwait(false))
             {
-                while (await enumerator.MoveNextAsync().ConfigureAwait(false))
-                {
-                }
             }
         }
 

--- a/src/EFCore/Infrastructure/Internal/LazyLoader.cs
+++ b/src/EFCore/Infrastructure/Internal/LazyLoader.cs
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
             {
                 try
                 {
-                    await entry.LoadAsync(cancellationToken);
+                    await entry.LoadAsync(cancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/src/EFCore/Infrastructure/PooledDbContextFactory.cs
+++ b/src/EFCore/Infrastructure/PooledDbContextFactory.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public virtual async Task<TContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
         {
             var lease = new DbContextLease(_pool, standalone: true);
-            await lease.Context.SetLeaseAsync(lease, cancellationToken);
+            await lease.Context.SetLeaseAsync(lease, cancellationToken).ConfigureAwait(false);
 
             return (TContext)lease.Context;
         }

--- a/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
@@ -93,8 +93,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             foreach (var inverse in inverses)
             {
-                unconfiguredNavigations.RemoveAll(n => string.Equals(n.GetSimpleMemberName(), inverse));
-                foreignKeyNavigations.RemoveAll(n => string.Equals(n.GetSimpleMemberName(), inverse));
+                unconfiguredNavigations.RemoveAll(n => string.Equals(n.GetSimpleMemberName(), inverse, StringComparison.Ordinal));
+                foreignKeyNavigations.RemoveAll(n => string.Equals(n.GetSimpleMemberName(), inverse, StringComparison.Ordinal));
             }
 
             if (unconfiguredNavigations.Count == 1)

--- a/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var targetEntityType = targetEntityTypeBuilder.Metadata;
             var targetClrType = targetEntityType.ClrType;
             var inverseNavigationPropertyInfo = targetEntityType.GetRuntimeProperties().Values
-                    .FirstOrDefault(p => string.Equals(p.GetSimpleMemberName(), attribute.Property))
+                    .FirstOrDefault(p => string.Equals(p.GetSimpleMemberName(), attribute.Property, StringComparison.Ordinal))
                 ?? targetEntityType.GetRuntimeProperties().Values
                     .FirstOrDefault(p => string.Equals(p.GetSimpleMemberName(), attribute.Property, StringComparison.OrdinalIgnoreCase));
 

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -145,7 +145,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             IAsyncEnumerable<TSource> asyncEnumerable,
             CancellationToken cancellationToken = default)
         {
-            await using var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+            var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+            await using var _ = enumerator.ConfigureAwait(false);
+
             if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
             {
                 throw new InvalidOperationException(CoreStrings.SequenceContainsNoElements);
@@ -165,7 +167,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             IAsyncEnumerable<TSource> asyncEnumerable,
             CancellationToken cancellationToken = default)
         {
-            await using var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+            var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+            await using var _ = enumerator.ConfigureAwait(false);
+
             if (!(await enumerator.MoveNextAsync().ConfigureAwait(false)))
             {
                 // TODO: Convert return to Task<TSource?> when changing to C# 9

--- a/src/EFCore/Storage/ExecutionStrategyExtensions.cs
+++ b/src/EFCore/Storage/ExecutionStrategyExtensions.cs
@@ -842,7 +842,8 @@ namespace Microsoft.EntityFrameworkCore
                 async (c, s, ct) =>
                     {
                         Check.NotNull(beginTransaction, nameof(beginTransaction));
-                        await using (var transaction = await beginTransaction(c, cancellationToken).ConfigureAwait(false))
+                        var transaction = await beginTransaction(c, cancellationToken).ConfigureAwait(false);
+                        await using (transaction)
                         {
                             s.CommitFailed = false;
                             s.Result = await s.Operation(s.State, ct).ConfigureAwait(false);

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1707;1591;xUnit1000;xUnit1003;xUnit1004;xUnit1010;xUnit1013;xUnit1026</NoWarn>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.test.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
 </Project>

--- a/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
@@ -190,16 +190,15 @@ namespace Microsoft.EntityFrameworkCore
                 return InterceptionResult<DbDataReader>.SuppressWithResult(new FakeDbDataReader());
             }
 
-            public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
                 DbCommand command,
                 CommandEventData eventData,
                 InterceptionResult<DbDataReader> result,
                 CancellationToken cancellationToken = default)
             {
-                base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+                await base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<InterceptionResult<DbDataReader>>(
-                    InterceptionResult<DbDataReader>.SuppressWithResult(new FakeDbDataReader()));
+                return InterceptionResult<DbDataReader>.SuppressWithResult(new FakeDbDataReader());
             }
         }
 
@@ -322,15 +321,15 @@ namespace Microsoft.EntityFrameworkCore
                 return InterceptionResult<object>.SuppressWithResult(InterceptedResult);
             }
 
-            public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            public override async ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
                 DbCommand command,
                 CommandEventData eventData,
                 InterceptionResult<object> result,
                 CancellationToken cancellationToken = default)
             {
-                base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+                await base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<InterceptionResult<object>>(InterceptionResult<object>.SuppressWithResult(InterceptedResult));
+                return InterceptionResult<object>.SuppressWithResult(InterceptedResult);
             }
         }
 
@@ -382,15 +381,15 @@ namespace Microsoft.EntityFrameworkCore
                 return InterceptionResult<int>.SuppressWithResult(2);
             }
 
-            public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            public override async ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
                 DbCommand command,
                 CommandEventData eventData,
                 InterceptionResult<int> result,
                 CancellationToken cancellationToken = default)
             {
-                base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+                await base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<InterceptionResult<int>>(InterceptionResult<int>.SuppressWithResult(2));
+                return InterceptionResult<int>.SuppressWithResult(2);
             }
         }
 
@@ -852,15 +851,15 @@ namespace Microsoft.EntityFrameworkCore
                 return new CompositeFakeDbDataReader(result, new FakeDbDataReader());
             }
 
-            public override ValueTask<DbDataReader> ReaderExecutedAsync(
+            public override async ValueTask<DbDataReader> ReaderExecutedAsync(
                 DbCommand command,
                 CommandExecutedEventData eventData,
                 DbDataReader result,
                 CancellationToken cancellationToken = default)
             {
-                base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+                await base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<DbDataReader>(new CompositeFakeDbDataReader(result, new FakeDbDataReader()));
+                return new CompositeFakeDbDataReader(result, new FakeDbDataReader());
             }
         }
 
@@ -999,15 +998,15 @@ namespace Microsoft.EntityFrameworkCore
                 return InterceptedResult;
             }
 
-            public override ValueTask<object> ScalarExecutedAsync(
+            public override async ValueTask<object> ScalarExecutedAsync(
                 DbCommand command,
                 CommandExecutedEventData eventData,
                 object result,
                 CancellationToken cancellationToken = default)
             {
-                base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
+                await base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<object>(InterceptedResult);
+                return InterceptedResult;
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -10213,8 +10213,8 @@ ORDER BY [t].[Id]");
         public virtual async Task Can_query_with_nav_collection_in_projection_with_split_query_in_parallel_sync()
         {
             var contextFactory = await CreateContext25225Async();
-            var task1 = Task.Factory.StartNew(() => Query(MyContext25225.Parent1Id, MyContext25225.Collection1Id));
-            var task2 = Task.Factory.StartNew(() => Query(MyContext25225.Parent2Id, MyContext25225.Collection2Id));
+            var task1 = Task.Run(() => Query(MyContext25225.Parent1Id, MyContext25225.Collection1Id));
+            var task2 = Task.Run(() => Query(MyContext25225.Parent2Id, MyContext25225.Collection2Id));
             await Task.WhenAll(task1, task2);
 
             void Query(Guid parentId, Guid collectionId)

--- a/test/EFCore.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
             var tasks = new Task[Environment.ProcessorCount];
             for (var i = 0; i < tasks.Length; i++)
             {
-                tasks[i] = Task.Factory.StartNew(() =>
+                tasks[i] = Task.Run(() =>
                 {
                     using (var ctx = new EmptyContext())
                     {

--- a/test/EFCore.Tests/DbSetTest.cs
+++ b/test/EFCore.Tests/DbSetTest.cs
@@ -625,11 +625,11 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public async Task Can_use_Add_to_change_entity_state_async()
         {
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Detached, EntityState.Added);
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Unchanged, EntityState.Added);
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Deleted, EntityState.Added);
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Modified, EntityState.Added);
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Added, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Detached, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Unchanged, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Deleted, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Modified, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Added, EntityState.Added);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Fixes #26790

**Description**

As part of logging path optimizations in 6.0, an (unawaited) async connection Close method call was accidentally introduced in a synchronous code path.

**Customer impact**

In some providers where pooling isn't used, this causes a race condition with unknown effects, potentially crashing the application.

**How found**

Customer reported on 6.0.

**Regression**

Yes, from 5.0.

**Testing**

Verifying that an async method is called instead of a sync one isn't feasible.

**Risk**

Very low - an obvious one line fix to an obvious copy-paste mistake.
