### PR TITLE
Fixup navigations to/from join entity when new many-to-many relationship is created

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -17,7 +17,6 @@ public class ChangeDetector : IChangeDetector
 {
     private readonly IDiagnosticsLogger<DbLoggerCategory.ChangeTracking> _logger;
     private readonly ILoggingOptions _loggingOptions;
-    private bool _suspended;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -39,28 +38,9 @@ public class ChangeDetector : IChangeDetector
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void Suspend()
-        => _suspended = true;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual void Resume()
-        => _suspended = false;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public virtual void PropertyChanged(InternalEntityEntry entry, IPropertyBase propertyBase, bool setModified)
     {
-        if (_suspended
-            || entry.EntityState == EntityState.Detached
+        if (entry.EntityState == EntityState.Detached
             || propertyBase is IServiceProperty)
         {
             return;
@@ -103,8 +83,7 @@ public class ChangeDetector : IChangeDetector
     /// </summary>
     public virtual void PropertyChanging(InternalEntityEntry entry, IPropertyBase propertyBase)
     {
-        if (_suspended
-            || entry.EntityState == EntityState.Detached
+        if (entry.EntityState == EntityState.Detached
             || propertyBase is IServiceProperty)
         {
             return;

--- a/src/EFCore/ChangeTracking/Internal/IChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/IChangeDetector.cs
@@ -48,20 +48,4 @@ public interface IChangeDetector
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     void DetectChanges(InternalEntityEntry entry);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    void Suspend();
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    void Resume();
 }

--- a/src/EFCore/ChangeTracking/Internal/INavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/INavigationFixer.cs
@@ -23,7 +23,7 @@ public interface INavigationFixer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void BeginAttachGraph();
+    bool BeginDelayedFixup();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -31,7 +31,7 @@ public interface INavigationFixer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void CompleteAttachGraph();
+    void CompleteDelayedFixup();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -39,7 +39,7 @@ public interface INavigationFixer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void AbortAttachGraph();
+    void AbortDelayedFixup();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -15,7 +15,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 public class NavigationFixer : INavigationFixer
 {
     private IList<Action>? _danglingJoinEntities;
-    private readonly IChangeDetector _changeDetector;
     private readonly IEntityGraphAttacher _attacher;
     private bool _inFixup;
     private bool _inAttachGraph;
@@ -26,11 +25,8 @@ public class NavigationFixer : INavigationFixer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public NavigationFixer(
-        IChangeDetector changeDetector,
-        IEntityGraphAttacher attacher)
+    public NavigationFixer(IEntityGraphAttacher attacher)
     {
-        _changeDetector = changeDetector;
         _attacher = attacher;
     }
 
@@ -40,10 +36,17 @@ public class NavigationFixer : INavigationFixer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void BeginAttachGraph()
+    public virtual bool BeginDelayedFixup()
     {
+        if (_inAttachGraph)
+        {
+            return false;
+        }
+
         _danglingJoinEntities?.Clear();
         _inAttachGraph = true;
+
+        return true;
     }
 
     /// <summary>
@@ -52,22 +55,17 @@ public class NavigationFixer : INavigationFixer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void CompleteAttachGraph()
+    public virtual void CompleteDelayedFixup()
     {
         _inAttachGraph = false;
-        try
+        if (_danglingJoinEntities != null)
         {
-            if (_danglingJoinEntities != null)
+            var dangles = _danglingJoinEntities.ToList();
+            _danglingJoinEntities.Clear();
+            foreach (var synthesize in dangles)
             {
-                foreach (var synthesize in _danglingJoinEntities)
-                {
-                    synthesize();
-                }
+                synthesize();
             }
-        }
-        finally
-        {
-            _danglingJoinEntities?.Clear();
         }
     }
 
@@ -77,7 +75,7 @@ public class NavigationFixer : INavigationFixer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void AbortAttachGraph()
+    public virtual void AbortDelayedFixup()
     {
         _inAttachGraph = false;
         _danglingJoinEntities?.Clear();
@@ -120,10 +118,9 @@ public class NavigationFixer : INavigationFixer
             newTargetEntry = null;
         }
 
+        var delayingFixup = BeginDelayedFixup();
         try
         {
-            _inFixup = true;
-
             if (navigation.IsOnDependent)
             {
                 if (newValue != null)
@@ -226,7 +223,10 @@ public class NavigationFixer : INavigationFixer
         }
         finally
         {
-            _inFixup = false;
+            if (delayingFixup)
+            {
+                CompleteDelayedFixup();
+            }
         }
 
         if (newValue != null
@@ -273,13 +273,17 @@ public class NavigationFixer : INavigationFixer
             if (oldTargetEntry != null
                 && oldTargetEntry.EntityState != EntityState.Detached)
             {
+                var delayingFixup = BeginDelayedFixup();
                 try
                 {
-                    _inFixup = true;
-
                     if (navigationBase is ISkipNavigation skipNavigation)
                     {
-                        FindJoinEntry(entry, oldTargetEntry, skipNavigation)?.SetEntityState(EntityState.Deleted);
+                        var joinEntry = FindJoinEntry(entry, oldTargetEntry, skipNavigation);
+
+                        joinEntry?.SetEntityState(
+                            joinEntry.EntityState != EntityState.Added
+                                ? EntityState.Deleted
+                                : EntityState.Detached);
 
                         Check.DebugAssert(
                             skipNavigation.Inverse.IsCollection,
@@ -309,7 +313,10 @@ public class NavigationFixer : INavigationFixer
                 }
                 finally
                 {
-                    _inFixup = false;
+                    if (delayingFixup)
+                    {
+                        CompleteDelayedFixup();
+                    }
                 }
             }
         }
@@ -319,10 +326,9 @@ public class NavigationFixer : INavigationFixer
             var newTargetEntry = stateManager.GetOrCreateEntry(newValue, targetEntityType);
             if (newTargetEntry.EntityState != EntityState.Detached)
             {
+                var delayingFixup = BeginDelayedFixup();
                 try
                 {
-                    _inFixup = true;
-
                     if (navigationBase is ISkipNavigation skipNavigation)
                     {
                         FindOrCreateJoinEntry(
@@ -357,7 +363,10 @@ public class NavigationFixer : INavigationFixer
                 }
                 finally
                 {
-                    _inFixup = false;
+                    if (delayingFixup)
+                    {
+                        CompleteDelayedFixup();
+                    }
                 }
             }
             else
@@ -394,10 +403,9 @@ public class NavigationFixer : INavigationFixer
             return;
         }
 
+        var delayingFixup = BeginDelayedFixup();
         try
         {
-            _inFixup = true;
-
             var stateManager = entry.StateManager;
 
             foreach (var foreignKey in containingForeignKeys)
@@ -538,7 +546,10 @@ public class NavigationFixer : INavigationFixer
         }
         finally
         {
-            _inFixup = false;
+            if (delayingFixup)
+            {
+                CompleteDelayedFixup();
+            }
         }
     }
 
@@ -558,20 +569,8 @@ public class NavigationFixer : INavigationFixer
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void TrackedFromQuery(
-        InternalEntityEntry entry)
-    {
-        try
-        {
-            _inFixup = true;
-
-            InitialFixup(entry, fromQuery: true);
-        }
-        finally
-        {
-            _inFixup = false;
-        }
-    }
+    public virtual void TrackedFromQuery(InternalEntityEntry entry)
+        => InitialFixup(entry, fromQuery: true);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -584,20 +583,15 @@ public class NavigationFixer : INavigationFixer
         EntityState oldState,
         bool fromQuery)
     {
-        if (fromQuery || _inFixup)
-        {
-            return;
-        }
-
+        var delayingFixup = BeginDelayedFixup();
         try
         {
-            _inFixup = true;
-
             if (oldState == EntityState.Detached)
             {
-                InitialFixup(entry, fromQuery: false);
+                InitialFixup(entry, fromQuery);
             }
-            else if (oldState == EntityState.Deleted
+            else if ((oldState == EntityState.Deleted
+                         || oldState == EntityState.Added)
                      && entry.EntityState == EntityState.Detached)
             {
                 DeleteFixup(entry);
@@ -605,7 +599,10 @@ public class NavigationFixer : INavigationFixer
         }
         finally
         {
-            _inFixup = false;
+            if (delayingFixup)
+            {
+                CompleteDelayedFixup();
+            }
         }
     }
 
@@ -1314,18 +1311,26 @@ public class NavigationFixer : INavigationFixer
             && hasOnlyKeyProperties
             && dependentEntry.EntityState != EntityState.Detached)
         {
-            switch (dependentEntry.EntityState)
+            try
             {
-                case EntityState.Added:
-                    dependentEntry.SetEntityState(EntityState.Detached);
-                    DeleteFixup(dependentEntry);
-                    break;
-                case EntityState.Unchanged:
-                case EntityState.Modified:
-                    dependentEntry.SetEntityState(
-                        dependentEntry.SharedIdentityEntry != null ? EntityState.Detached : EntityState.Deleted);
-                    DeleteFixup(dependentEntry);
-                    break;
+                _inFixup = true;
+                switch (dependentEntry.EntityState)
+                {
+                    case EntityState.Added:
+                        dependentEntry.SetEntityState(EntityState.Detached);
+                        DeleteFixup(dependentEntry);
+                        break;
+                    case EntityState.Unchanged:
+                    case EntityState.Modified:
+                        dependentEntry.SetEntityState(
+                            dependentEntry.SharedIdentityEntry != null ? EntityState.Detached : EntityState.Deleted);
+                        DeleteFixup(dependentEntry);
+                        break;
+                }
+            }
+            finally
+            {
+                _inFixup = false;
             }
         }
     }
@@ -1350,7 +1355,7 @@ public class NavigationFixer : INavigationFixer
     {
         if (navigation != null)
         {
-            _changeDetector.Suspend();
+            _inFixup = true;
             var entity = value?.Entity;
             try
             {
@@ -1358,7 +1363,7 @@ public class NavigationFixer : INavigationFixer
             }
             finally
             {
-                _changeDetector.Resume();
+                _inFixup = false;
             }
 
             entry.SetRelationshipSnapshotValue(navigation, entity);
@@ -1369,7 +1374,7 @@ public class NavigationFixer : INavigationFixer
     {
         if (navigation != null)
         {
-            _changeDetector.Suspend();
+            _inFixup = true;
             try
             {
                 if (entry.AddToCollection(navigation, value, fromQuery))
@@ -1379,14 +1384,14 @@ public class NavigationFixer : INavigationFixer
             }
             finally
             {
-                _changeDetector.Resume();
+                _inFixup = false;
             }
         }
     }
 
     private void RemoveFromCollection(InternalEntityEntry entry, INavigationBase navigation, InternalEntityEntry value)
     {
-        _changeDetector.Suspend();
+        _inFixup = true;
         try
         {
             if (entry.RemoveFromCollection(navigation, value))
@@ -1396,7 +1401,7 @@ public class NavigationFixer : INavigationFixer
         }
         finally
         {
-            _changeDetector.Resume();
+            _inFixup = false;
         }
     }
 

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -49,7 +49,8 @@ public class NavigationFixer : INavigationFixer
             return false;
         }
 
-        if (_danglingJoinEntities != null)
+        if (_danglingJoinEntities != null
+            && _danglingJoinEntities.Any())
         {
             throw new InvalidOperationException(CoreStrings.InvalidDbContext);
         }
@@ -68,10 +69,11 @@ public class NavigationFixer : INavigationFixer
     public virtual void CompleteDelayedFixup()
     {
         _inAttachGraph = false;
-        if (_danglingJoinEntities != null)
+        if (_danglingJoinEntities != null
+            && _danglingJoinEntities.Any())
         {
             var dangles = _danglingJoinEntities.ToList();
-            _danglingJoinEntities = null;
+            _danglingJoinEntities.Clear();
             foreach (var arguments in dangles)
             {
                 FindOrCreateJoinEntry(arguments);

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -638,7 +638,7 @@ public class StateManager : IStateManager
     public virtual void ResetState()
     {
         Clear();
-        Dependencies.NavigationFixer.AbortAttachGraph();
+        Dependencies.NavigationFixer.AbortDelayedFixup();
 
         Tracked = null;
         StateChanged = null;
@@ -688,7 +688,7 @@ public class StateManager : IStateManager
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual void BeginAttachGraph()
-        => Dependencies.NavigationFixer.BeginAttachGraph();
+        => Dependencies.NavigationFixer.BeginDelayedFixup();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -697,7 +697,7 @@ public class StateManager : IStateManager
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual void CompleteAttachGraph()
-        => Dependencies.NavigationFixer.CompleteAttachGraph();
+        => Dependencies.NavigationFixer.CompleteDelayedFixup();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -706,7 +706,7 @@ public class StateManager : IStateManager
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual void AbortAttachGraph()
-        => Dependencies.NavigationFixer.AbortAttachGraph();
+        => Dependencies.NavigationFixer.AbortDelayedFixup();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1150,6 +1150,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, keyProperty);
 
         /// <summary>
+        ///     A previous error has left the DbContext in an invalid state. Applications should not continue to use a DbContext instance after an InvalidOperationException has been thrown.
+        /// </summary>
+        public static string InvalidDbContext
+            => GetString("InvalidDbContext");
+
+        /// <summary>
         ///     The specified type '{type}' must be a non-interface reference type to be used as an entity type.
         /// </summary>
         public static string InvalidEntityType(object? type)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -547,6 +547,9 @@
   <data name="InvalidAlternateKeyValue" xml:space="preserve">
     <value>Unable to track an entity of type '{entityType}' because alternate key property '{keyProperty}' is null. If the alternate key is not used in a relationship, then consider using a unique index instead. Unique indexes may contain nulls, while alternate keys may not.</value>
   </data>
+  <data name="InvalidDbContext" xml:space="preserve">
+    <value>A previous error has left the DbContext in an invalid state. Applications should not continue to use a DbContext instance after an InvalidOperationException has been thrown.</value>
+  </data>
   <data name="InvalidEntityType" xml:space="preserve">
     <value>The specified type '{type}' must be a non-interface reference type to be used as an entity type.</value>
   </data>

--- a/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -909,8 +909,13 @@ public class ChangeDetectorTest
         Assert.Equal(new[] { product3 }, testListener.CollectionChange.Item3);
         Assert.Empty(testListener.CollectionChange.Item4);
 
+        var productEntry = stateManager.GetOrCreateEntry(product3);
+        Assert.Same(productEntry, testListener.ReferenceChange.Item1);
+        Assert.Same(productEntry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Null(testListener.ReferenceChange.Item3);
+        Assert.Equal(category, testListener.ReferenceChange.Item4);
+
         Assert.Null(testListener.KeyChange);
-        Assert.Null(testListener.ReferenceChange);
     }
 
     [ConditionalFact]
@@ -1076,8 +1081,13 @@ public class ChangeDetectorTest
         Assert.Equal(new[] { product3 }, testListener.CollectionChange.Item3);
         Assert.Empty(testListener.CollectionChange.Item4);
 
+        var productEntry = stateManager.GetOrCreateEntry(product3);
+        Assert.Same(productEntry, testListener.ReferenceChange.Item1);
+        Assert.Same(productEntry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Null(testListener.ReferenceChange.Item3);
+        Assert.Equal(category, testListener.ReferenceChange.Item4);
+
         Assert.Null(testListener.KeyChange);
-        Assert.Null(testListener.ReferenceChange);
     }
 
     [ConditionalFact]
@@ -1548,7 +1558,12 @@ public class ChangeDetectorTest
         Assert.Equal(new[] { product3 }, testListener.CollectionChange.Item3);
         Assert.Empty(testListener.CollectionChange.Item4);
 
-        Assert.Null(testListener.ReferenceChange);
+        var productEntry = stateManager.GetOrCreateEntry(product3);
+        Assert.Same(productEntry, testListener.ReferenceChange.Item1);
+        Assert.Same(productEntry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Null(testListener.ReferenceChange.Item3);
+        Assert.Equal(category, testListener.ReferenceChange.Item4);
+
         Assert.Null(testListener.KeyChange);
     }
 
@@ -2112,8 +2127,8 @@ public class ChangeDetectorTest
 
     private class TestRelationshipListener : NavigationFixer
     {
-        public TestRelationshipListener(IChangeDetector changeDetector, IEntityGraphAttacher attacher)
-            : base(changeDetector, attacher)
+        public TestRelationshipListener(IEntityGraphAttacher attacher)
+            : base(attacher)
         {
         }
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -504,15 +504,14 @@ public class InternalEntryEntrySubscriberTest
         public List<Tuple<InternalEntityEntry, INavigationBase, IEnumerable<object>, IEnumerable<object>>> CollectionChanged { get; }
             = new();
 
-        public void BeginAttachGraph()
+        public bool BeginDelayedFixup()
+            => false;
+
+        public void CompleteDelayedFixup()
         {
         }
 
-        public void CompleteAttachGraph()
-        {
-        }
-
-        public void AbortAttachGraph()
+        public void AbortDelayedFixup()
         {
         }
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -627,15 +627,14 @@ public class StateManagerTest
         public EntityState ChangingState;
         public EntityState ChangedState;
 
-        public void BeginAttachGraph()
+        public bool BeginDelayedFixup()
+            => false;
+
+        public void CompleteDelayedFixup()
         {
         }
 
-        public void CompleteAttachGraph()
-        {
-        }
-
-        public void AbortAttachGraph()
+        public void AbortDelayedFixup()
         {
         }
 

--- a/test/EFCore.Tests/DbContextServicesTest.cs
+++ b/test/EFCore.Tests/DbContextServicesTest.cs
@@ -386,15 +386,14 @@ namespace Microsoft.EntityFrameworkCore
             public void StateChanged(InternalEntityEntry entry, EntityState oldState, bool fromQuery)
                 => throw new NotImplementedException();
 
-            public void BeginAttachGraph()
+            public bool BeginDelayedFixup()
+                => false;
+
+            public void CompleteDelayedFixup()
             {
             }
 
-            public void CompleteAttachGraph()
-            {
-            }
-
-            public void AbortAttachGraph()
+            public void AbortDelayedFixup()
             {
             }
 


### PR DESCRIPTION
Fixes #26779

Also cleanup of delay-fixup/suspended detection logic, and tests for #26074.