### PR TITLE
SQL row value comparison syntax

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
@@ -36,4 +36,72 @@ public static class RelationalDbFunctionsExtensions
         TProperty operand,
         [NotParameterized] string collation)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Collate)));
+
+    /// <summary>
+    ///     A DbFunction method stub that can be used in LINQ queries to target SQL row value comparisons.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="columns">The columns on which the comparison will be performed.</param>
+    /// <param name="values">The values to compare with.</param>
+    public static bool LessThan(
+        this DbFunctions _,
+        object[] columns,
+        object[] values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(LessThan)));
+
+    /// <summary>
+    ///     A DbFunction method stub that can be used in LINQ queries to target SQL row value comparisons.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="columns">The columns on which the comparison will be performed.</param>
+    /// <param name="values">The values to compare with.</param>
+    public static bool LessThanOrEqual(
+        this DbFunctions _,
+        object[] columns,
+        object[] values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(LessThanOrEqual)));
+
+    /// <summary>
+    ///     A DbFunction method stub that can be used in LINQ queries to target SQL row value comparisons.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="columns">The columns on which the comparison will be performed.</param>
+    /// <param name="values">The values to compare with.</param>
+    public static bool GreaterThan(
+        this DbFunctions _,
+        object[] columns,
+        object[] values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(GreaterThan)));
+
+    /// <summary>
+    ///     A DbFunction method stub that can be used in LINQ queries to target SQL row value comparisons.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="columns">The columns on which the comparison will be performed.</param>
+    /// <param name="values">The values to compare with.</param>
+    public static bool GreaterThanOrEqual(
+        this DbFunctions _,
+        object[] columns,
+        object[] values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(GreaterThanOrEqual)));
 }

--- a/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
@@ -51,7 +51,7 @@ public static class RelationalDbFunctionsExtensions
     public static bool LessThan(
         this DbFunctions _,
         object[] columns,
-        object[] values)
+        [NotParameterized] object[] values)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(LessThan)));
 
     /// <summary>
@@ -68,7 +68,7 @@ public static class RelationalDbFunctionsExtensions
     public static bool LessThanOrEqual(
         this DbFunctions _,
         object[] columns,
-        object[] values)
+        [NotParameterized] object[] values)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(LessThanOrEqual)));
 
     /// <summary>
@@ -85,7 +85,7 @@ public static class RelationalDbFunctionsExtensions
     public static bool GreaterThan(
         this DbFunctions _,
         object[] columns,
-        object[] values)
+        [NotParameterized] object[] values)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(GreaterThan)));
 
     /// <summary>
@@ -102,6 +102,6 @@ public static class RelationalDbFunctionsExtensions
     public static bool GreaterThanOrEqual(
         this DbFunctions _,
         object[] columns,
-        object[] values)
+        [NotParameterized] object[] values)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(GreaterThanOrEqual)));
 }

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -760,6 +760,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 value);
 
         /// <summary>
+        ///     Columns count and values count should be equal.
+        /// </summary>
+        public static string InvalidRowValueArgumentsCount
+            => GetString("InvalidRowValueArgumentsCount");
+
+        /// <summary>
         ///     Queries performing '{method}' operation must have a deterministic sort order. Rewrite the query to apply an 'OrderBy' operation on the sequence before calling '{method}'.
         /// </summary>
         public static string LastUsedWithoutOrderBy(object? method)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -400,6 +400,9 @@
   <data name="InvalidMinBatchSize" xml:space="preserve">
     <value>The specified 'MinBatchSize' value '{value}' is not valid. It must be a positive number.</value>
   </data>
+  <data name="InvalidRowValueArgumentsCount" xml:space="preserve">
+    <value>Columns count and values count should be equal.</value>
+  </data>
   <data name="LastUsedWithoutOrderBy" xml:space="preserve">
     <value>Queries performing '{method}' operation must have a deterministic sort order. Rewrite the query to apply an 'OrderBy' operation on the sequence before calling '{method}'.</value>
   </data>

--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -469,4 +469,16 @@ public interface ISqlExpressionFactory
     /// <param name="tableExpressionBase">A table source to project from.</param>
     /// <returns>An expression representing a SELECT in a SQL tree.</returns>
     SelectExpression Select(IEntityType entityType, TableExpressionBase tableExpressionBase);
+
+    /// <summary>
+    ///     Creates a new <see cref="RowValueExpression" /> which represents a row value comparison in a SQL tree.
+    /// </summary>
+    /// <param name="operatorType">The operator to apply.</param>
+    /// <param name="columns">The columns on which the comparison will be performed..</param>
+    /// <param name="values">The values to compare with.</param>
+    /// <returns>An expression representing a row value comparison in a SQL tree.</returns>
+    RowValueExpression RowValue(
+        ExpressionType operatorType,
+        IReadOnlyList<SqlExpression> columns,
+        IReadOnlyList<SqlExpression> values);
 }

--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -480,5 +480,5 @@ public interface ISqlExpressionFactory
     RowValueExpression RowValue(
         ExpressionType operatorType,
         IReadOnlyList<SqlExpression> columns,
-        IReadOnlyList<SqlExpression> values);
+        IReadOnlyList<object> values);
 }

--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -474,10 +474,22 @@ public interface ISqlExpressionFactory
     ///     Creates a new <see cref="RowValueExpression" /> which represents a row value comparison in a SQL tree.
     /// </summary>
     /// <param name="operatorType">The operator to apply.</param>
-    /// <param name="columns">The columns on which the comparison will be performed..</param>
+    /// <param name="columns">The columns on which the comparison will be performed.</param>
     /// <param name="values">The values to compare with.</param>
     /// <returns>An expression representing a row value comparison in a SQL tree.</returns>
     RowValueExpression RowValue(
+        ExpressionType operatorType,
+        IReadOnlyList<SqlExpression> columns,
+        IReadOnlyList<object> values);
+
+    /// <summary>
+    ///     Creates a <see cref="SqlBinaryExpression" /> which represents a row value expanded comparison in a SQL tree.
+    /// </summary>
+    /// <param name="operatorType">The operator to apply.</param>
+    /// <param name="columns">The columns on which the comparison will be performed.</param>
+    /// <param name="values">The values to compare with.</param>
+    /// <returns>An expression representing a row value expanded comparison in a SQL tree.</returns>
+    SqlBinaryExpression RowValueComparison(
         ExpressionType operatorType,
         IReadOnlyList<SqlExpression> columns,
         IReadOnlyList<object> values);

--- a/src/EFCore.Relational/Query/Internal/RowValueComparisonTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/RowValueComparisonTranslator.cs
@@ -29,10 +29,5 @@ public class RowValueComparisonTranslator : RowValueTranslator
         ExpressionType operatorType,
         IReadOnlyList<SqlExpression> columns,
         IReadOnlyList<object> values)
-    {
-        // Create a SqlBinaryExpression
-        //new SqlBinaryExpression(operatorType, , , typeof(bool), null);
-
-        return null;
-    }
+        => SqlExpressionFactory.RowValueComparison(operatorType, columns, values);
 }

--- a/src/EFCore.Relational/Query/Internal/RowValueComparisonTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/RowValueComparisonTranslator.cs
@@ -28,7 +28,7 @@ public class RowValueComparisonTranslator : RowValueTranslator
     protected override SqlExpression? CreateSqlExpression(
         ExpressionType operatorType,
         IReadOnlyList<SqlExpression> columns,
-        IReadOnlyList<SqlExpression> values)
+        IReadOnlyList<object> values)
     {
         // Create a SqlBinaryExpression
         //new SqlBinaryExpression(operatorType, , , typeof(bool), null);

--- a/src/EFCore.Relational/Query/Internal/RowValueComparisonTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/RowValueComparisonTranslator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class RowValueExpandedTranslator : RowValueTranslator
+public class RowValueComparisonTranslator : RowValueTranslator
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -19,7 +19,7 @@ public class RowValueExpandedTranslator : RowValueTranslator
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public RowValueExpandedTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    public RowValueComparisonTranslator(ISqlExpressionFactory sqlExpressionFactory)
         : base(sqlExpressionFactory)
     {
     }

--- a/src/EFCore.Relational/Query/Internal/RowValueExpandedTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/RowValueExpandedTranslator.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class RowValueExpandedTranslator : RowValueTranslator
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public RowValueExpandedTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        : base(sqlExpressionFactory)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override SqlExpression? CreateSqlExpression(
+        ExpressionType operatorType,
+        IReadOnlyList<SqlExpression> columns,
+        IReadOnlyList<SqlExpression> values)
+    {
+        // Create a SqlBinaryExpression
+        //new SqlBinaryExpression(operatorType, , , typeof(bool), null);
+
+        return null;
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/RowValueTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/RowValueTranslator.cs
@@ -42,8 +42,6 @@ public class RowValueTranslator : IMethodCallTranslator
             { _greaterThanOrEqualMethodInfo, ExpressionType.GreaterThanOrEqual },
         };
 
-    private readonly ISqlExpressionFactory _sqlExpressionFactory;
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -52,8 +50,13 @@ public class RowValueTranslator : IMethodCallTranslator
     /// </summary>
     public RowValueTranslator(ISqlExpressionFactory sqlExpressionFactory)
     {
-        _sqlExpressionFactory = sqlExpressionFactory;
+        SqlExpressionFactory = sqlExpressionFactory;
     }
+
+    /// <summary>
+    /// The <see cref="ISqlExpressionFactory"/>.
+    /// </summary>
+    protected ISqlExpressionFactory SqlExpressionFactory { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -69,10 +72,9 @@ public class RowValueTranslator : IMethodCallTranslator
     {
         if (_methodInfoOperatorTypeMap.TryGetValue(method, out var operatorType))
         {
-
             var columns = UnwrapColumns(arguments[1]);
             var values = UnwrapValues(arguments[2]);
-            return _sqlExpressionFactory.RowValue(operatorType, columns, values);
+            return CreateSqlExpression(operatorType, columns, values);
         }
 
         return null;
@@ -99,7 +101,7 @@ public class RowValueTranslator : IMethodCallTranslator
         ExpressionType operatorType,
         IReadOnlyList<SqlExpression> columns,
         IReadOnlyList<object> values)
-        => _sqlExpressionFactory.RowValue(operatorType, columns, values);
+        => SqlExpressionFactory.RowValue(operatorType, columns, values);
 
     private SqlExpression RemoveObjectConvert(SqlExpression expression)
         => expression is SqlUnaryExpression sqlUnaryExpression

--- a/src/EFCore.Relational/Query/Internal/RowValueTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/RowValueTranslator.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class RowValueTranslator : IMethodCallTranslator
+{
+    private static readonly MethodInfo _lessThanMethodInfo =
+        typeof(RelationalDbFunctionsExtensions).GetRequiredRuntimeMethod(
+            nameof(RelationalDbFunctionsExtensions.LessThan),
+            typeof(DbFunctions), typeof(object[]), typeof(object[]));
+
+    private static readonly MethodInfo _lessThanOrEqualMethodInfo =
+        typeof(RelationalDbFunctionsExtensions).GetRequiredRuntimeMethod(
+            nameof(RelationalDbFunctionsExtensions.LessThanOrEqual),
+            typeof(DbFunctions), typeof(object[]), typeof(object[]));
+
+    private static readonly MethodInfo _greaterThanMethodInfo =
+        typeof(RelationalDbFunctionsExtensions).GetRequiredRuntimeMethod(
+            nameof(RelationalDbFunctionsExtensions.GreaterThan),
+            typeof(DbFunctions), typeof(object[]), typeof(object[]));
+
+    private static readonly MethodInfo _greaterThanOrEqualMethodInfo =
+        typeof(RelationalDbFunctionsExtensions).GetRequiredRuntimeMethod(
+            nameof(RelationalDbFunctionsExtensions.GreaterThanOrEqual),
+            typeof(DbFunctions), typeof(object[]), typeof(object[]));
+
+    private static readonly Dictionary<MethodInfo, ExpressionType> _methodInfoOperatorTypeMap =
+        new()
+        {
+            { _lessThanMethodInfo, ExpressionType.LessThan },
+            { _lessThanOrEqualMethodInfo, ExpressionType.LessThanOrEqual },
+            { _greaterThanMethodInfo, ExpressionType.GreaterThan },
+            { _greaterThanOrEqualMethodInfo, ExpressionType.GreaterThanOrEqual },
+        };
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public RowValueTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (_methodInfoOperatorTypeMap.TryGetValue(method, out var operatorType))
+        {
+            var columns = UnwrapColumns(arguments[1]);
+            var values = UnwrapValues(arguments[2]);
+            return _sqlExpressionFactory.RowValue(operatorType, columns, values);
+        }
+
+        return null;
+    }
+
+    private IReadOnlyList<SqlExpression> UnwrapColumns(SqlExpression sqlExpression)
+    {
+        return ((ArrayExpression)sqlExpression).Values;
+    }
+
+    private IReadOnlyList<SqlExpression> UnwrapValues(SqlExpression sqlExpression)
+    {
+        //var c = ((SqlConstantExpression)sqlExpression).Value;
+
+        // ---
+
+        var sqlParamExp = sqlExpression as SqlParameterExpression;
+
+        return new List<SqlExpression>();
+    }
+
+    /// <summary>
+    ///     Creates the sql expression from the row value info.
+    /// </summary>
+    protected virtual SqlExpression? CreateSqlExpression(
+        ExpressionType operatorType,
+        IReadOnlyList<SqlExpression> columns,
+        IReadOnlyList<SqlExpression> values)
+        => _sqlExpressionFactory.RowValue(operatorType, columns, values);
+
+    private bool ValidateValues(SqlExpression values)
+        => values is SqlConstantExpression || values is SqlParameterExpression;
+
+    private SqlExpression RemoveObjectConvert(SqlExpression expression)
+        => expression is SqlUnaryExpression sqlUnaryExpression
+            && sqlUnaryExpression.OperatorType == ExpressionType.Convert
+            && sqlUnaryExpression.Type == typeof(object)
+                ? sqlUnaryExpression.Operand
+                : expression;
+}

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -1163,7 +1163,8 @@ public class QuerySqlGenerator : SqlExpressionVisitor
         _relationalCommandBuilder.Append("(");
         for (var i = 0; i < count; i++)
         {
-            Visit(rowValueExpression.Values[i]);
+            _relationalCommandBuilder.Append(
+                rowValueExpression.ValuesTypeMappings[i].GenerateSqlLiteral(rowValueExpression.Values[i]));
 
             if (i < count - 1)
             {

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -1139,4 +1139,39 @@ public class QuerySqlGenerator : SqlExpressionVisitor
 
         return unionExpression;
     }
+
+    /// <inheritdoc />
+    protected override Expression VisitRowValue(RowValueExpression rowValueExpression)
+    {
+        var count = rowValueExpression.Columns.Count;
+
+        _relationalCommandBuilder.Append("(");
+        for (var i = 0; i < count; i++)
+        {
+            Visit(rowValueExpression.Columns[i]);
+
+            if (i < count - 1)
+            {
+                _relationalCommandBuilder.Append(", ");
+            }
+        }
+        _relationalCommandBuilder.Append(")");
+
+        var @operator = _operatorMap[rowValueExpression.OperatorType];
+        _relationalCommandBuilder.Append(@operator);
+
+        _relationalCommandBuilder.Append("(");
+        for (var i = 0; i < count; i++)
+        {
+            Visit(rowValueExpression.Values[i]);
+
+            if (i < count - 1)
+            {
+                _relationalCommandBuilder.Append(", ");
+            }
+        }
+        _relationalCommandBuilder.Append(")");
+
+        return rowValueExpression;
+    }
 }

--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -46,7 +46,8 @@ public class RelationalMethodCallTranslatorProvider : IMethodCallTranslatorProvi
                 new GetValueOrDefaultTranslator(sqlExpressionFactory),
                 new ComparisonTranslator(sqlExpressionFactory),
                 new ByteArraySequenceEqualTranslator(sqlExpressionFactory),
-                new RandomTranslator(sqlExpressionFactory)
+                new RandomTranslator(sqlExpressionFactory),
+                CreateRowValueTranslator(sqlExpressionFactory),
             });
         _sqlExpressionFactory = sqlExpressionFactory;
     }
@@ -55,6 +56,12 @@ public class RelationalMethodCallTranslatorProvider : IMethodCallTranslatorProvi
     ///     Dependencies for this service.
     /// </summary>
     protected virtual RelationalMethodCallTranslatorProviderDependencies Dependencies { get; }
+
+    /// <summary>
+    ///     Creates the translator that handles row value function calls (LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual).
+    /// </summary>
+    protected virtual IMethodCallTranslator CreateRowValueTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        => new RowValueTranslator(sqlExpressionFactory);
 
     /// <inheritdoc />
     public virtual SqlExpression? Translate(

--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -47,7 +47,7 @@ public class RelationalMethodCallTranslatorProvider : IMethodCallTranslatorProvi
                 new ComparisonTranslator(sqlExpressionFactory),
                 new ByteArraySequenceEqualTranslator(sqlExpressionFactory),
                 new RandomTranslator(sqlExpressionFactory),
-                CreateRowValueTranslator(sqlExpressionFactory),
+                new RowValueTranslator(sqlExpressionFactory),
             });
         _sqlExpressionFactory = sqlExpressionFactory;
     }
@@ -56,12 +56,6 @@ public class RelationalMethodCallTranslatorProvider : IMethodCallTranslatorProvi
     ///     Dependencies for this service.
     /// </summary>
     protected virtual RelationalMethodCallTranslatorProviderDependencies Dependencies { get; }
-
-    /// <summary>
-    ///     Creates the translator that handles row value function calls (LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual).
-    /// </summary>
-    protected virtual IMethodCallTranslator CreateRowValueTranslator(ISqlExpressionFactory sqlExpressionFactory)
-        => new RowValueTranslator(sqlExpressionFactory);
 
     /// <inheritdoc />
     public virtual SqlExpression? Translate(

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -667,7 +667,20 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
     /// <inheritdoc />
     protected override Expression VisitNewArray(NewArrayExpression newArrayExpression)
-        => QueryCompilationContext.NotTranslatedExpression;
+    {
+        var sqlExpressions = new List<SqlExpression>(newArrayExpression.Expressions.Count);
+        foreach (var expression in newArrayExpression.Expressions)
+        {
+            if (TranslationFailed(expression, Visit(expression), out var sqlExpression))
+            {
+                return QueryCompilationContext.NotTranslatedExpression;
+            }
+
+            sqlExpressions.Add(sqlExpression!);
+        }
+
+        return new ArrayExpression(sqlExpressions);
+    }
 
     /// <inheritdoc />
     protected override Expression VisitParameter(ParameterExpression parameterExpression)

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -65,6 +65,7 @@ public class SqlExpressionFactory : ISqlExpressionFactory
             SqlFunctionExpression e => e.ApplyTypeMapping(typeMapping),
             SqlParameterExpression e => e.ApplyTypeMapping(typeMapping),
             InExpression e => ApplyTypeMappingOnIn(e),
+            RowValueExpression e => e,
             _ => sqlExpression
         };
     }
@@ -566,6 +567,13 @@ public class SqlExpressionFactory : ISqlExpressionFactory
     /// <inheritdoc />
     public virtual SqlConstantExpression Constant(object? value, RelationalTypeMapping? typeMapping = null)
         => new(Expression.Constant(value), typeMapping);
+
+    /// <inheritdoc />
+    public virtual RowValueExpression RowValue(
+        ExpressionType operatorType,
+        IReadOnlyList<SqlExpression> columns,
+        IReadOnlyList<SqlExpression> values)
+        => new(operatorType, columns, values, null);
 
     /// <inheritdoc />
     public virtual SelectExpression Select(SqlExpression? projection)

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -572,8 +572,13 @@ public class SqlExpressionFactory : ISqlExpressionFactory
     public virtual RowValueExpression RowValue(
         ExpressionType operatorType,
         IReadOnlyList<SqlExpression> columns,
-        IReadOnlyList<SqlExpression> values)
-        => new(operatorType, columns, values, null);
+        IReadOnlyList<object> values)
+    {
+        var valuesTypeMappings = values
+            .Select(x => Dependencies.TypeMappingSource.FindMapping(x.GetType(), Dependencies.Model)!)
+            .ToList();
+        return new(operatorType, columns, values, valuesTypeMappings, _boolTypeMapping);
+    }
 
     /// <inheritdoc />
     public virtual SelectExpression Select(SqlExpression? projection)

--- a/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
@@ -111,6 +111,9 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
 
             case UnionExpression unionExpression:
                 return VisitUnion(unionExpression);
+
+            case RowValueExpression rowValueExpression:
+                return VisitRowValue(rowValueExpression);
         }
 
         return base.VisitExtension(extensionExpression);
@@ -318,4 +321,11 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     /// <param name="unionExpression">The expression to visit.</param>
     /// <returns>The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.</returns>
     protected abstract Expression VisitUnion(UnionExpression unionExpression);
+
+    /// <summary>
+    ///     Visits the children of the row value expression.
+    /// </summary>
+    /// <param name="rowValueExpression">The expression to visit.</param>
+    /// <returns>The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.</returns>
+    protected abstract Expression VisitRowValue(RowValueExpression rowValueExpression);
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/ArrayExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ArrayExpression.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+/// <summary>
+///     <para>
+///         An expression that represents an array.
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+public class ArrayExpression : SqlExpression
+{
+    /// <summary>
+    ///     Creates a new instance of the <see cref="ArrayExpression" /> class.
+    /// </summary>
+    /// <param name="values">The values to compare with.</param>
+    public ArrayExpression(
+        IReadOnlyList<SqlExpression> values)
+        : base(typeof(bool), null)
+    {
+        Values = values;
+    }
+
+    /// <summary>
+    ///     The values of the array.
+    /// </summary>
+    public IReadOnlyList<SqlExpression> Values { get; }
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+        => this;
+
+    /// <inheritdoc />
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        var count = Values.Count;
+
+        expressionPrinter.Append("new [] {");
+        for (var i = 0; i < count; i++)
+        {
+            expressionPrinter.Visit(Values[i]);
+
+            if (i < count - 1)
+            {
+                expressionPrinter.Append(", ");
+            }
+        }
+        expressionPrinter.Append("}");
+    }
+}

--- a/src/EFCore.Relational/Query/SqlExpressions/ArrayExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ArrayExpression.cs
@@ -28,7 +28,7 @@ public class ArrayExpression : SqlExpression
     /// <summary>
     ///     The values of the array.
     /// </summary>
-    public IReadOnlyList<SqlExpression> Values { get; }
+    public virtual IReadOnlyList<SqlExpression> Values { get; }
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)

--- a/src/EFCore.Relational/Query/SqlExpressions/RowValueExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/RowValueExpression.cs
@@ -49,12 +49,6 @@ public class RowValueExpression : SqlExpression
         {
             throw new InvalidOperationException(RelationalStrings.InvalidRowValueArgumentsCount);
         }
-        if (values.Count != valuesTypeMappings.Count)
-        {
-            throw new InvalidOperationException(RelationalStrings.InvalidRowValueArgumentsCount);
-        }
-
-        // TODO: Validate columns.
 
         OperatorType = operatorType;
         Columns = columns;

--- a/src/EFCore.Relational/Query/SqlExpressions/RowValueExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/RowValueExpression.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+/// <summary>
+///     <para>
+///         An expression that represents a row value in a SQL tree.
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+public class RowValueExpression : SqlExpression
+{
+    private static readonly ISet<ExpressionType> _allowedOperators = new HashSet<ExpressionType>
+    {
+        ExpressionType.LessThan,
+        ExpressionType.LessThanOrEqual,
+        ExpressionType.GreaterThan,
+        ExpressionType.GreaterThanOrEqual,
+    };
+
+    /// <summary>
+    ///     Creates a new instance of the <see cref="RowValueExpression" /> class.
+    /// </summary>
+    /// <param name="operatorType">The operator to apply.</param>
+    /// <param name="columns">The columns on which the comparison will be performed..</param>
+    /// <param name="values">The values to compare with.</param>
+    /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
+    public RowValueExpression(
+        ExpressionType operatorType,
+        IReadOnlyList<SqlExpression> columns,
+        IReadOnlyList<SqlExpression> values,
+        RelationalTypeMapping? typeMapping)
+        : base(typeof(bool), typeMapping)
+    {
+        if (!IsValidOperator(operatorType))
+        {
+            throw new InvalidOperationException(
+                RelationalStrings.UnsupportedOperatorForSqlExpression(
+                    operatorType, typeof(RowValueExpression).ShortDisplayName()));
+        }
+
+        if (columns.Count != values.Count)
+        {
+            throw new InvalidOperationException(RelationalStrings.InvalidRowValueArgumentsCount);
+        }
+
+        // TODO: Validate columns.
+
+        OperatorType = operatorType;
+        Columns = columns;
+        Values = values;
+    }
+
+    /// <summary>
+    ///     The operator of this SQL row value operation.
+    /// </summary>
+    public virtual ExpressionType OperatorType { get; }
+
+    /// <summary>
+    ///     The columns on which the comparison will be performed.
+    /// </summary>
+    public virtual IReadOnlyList<SqlExpression> Columns { get; }
+
+    /// <summary>
+    ///     The values to compare with.
+    /// </summary>
+    public virtual IReadOnlyList<SqlExpression> Values { get; }
+
+    internal static bool IsValidOperator(ExpressionType operatorType)
+        => _allowedOperators.Contains(operatorType);
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+        => this;
+
+    /// <inheritdoc />
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        var count = Columns.Count;
+
+        expressionPrinter.Append("(");
+        for (var i = 0; i < count; i++)
+        {
+            expressionPrinter.Visit(Columns[i]);
+
+            if (i < count - 1)
+            {
+                expressionPrinter.Append(", ");
+            }
+        }
+        expressionPrinter.Append(")");
+
+        expressionPrinter.Append(expressionPrinter.GenerateBinaryOperator(OperatorType));
+
+        expressionPrinter.Append("(");
+        for (var i = 0; i < count; i++)
+        {
+            expressionPrinter.Visit(Values[i]);
+
+            if (i < count - 1)
+            {
+                expressionPrinter.Append(", ");
+            }
+        }
+        expressionPrinter.Append(")");
+    }
+}

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -378,6 +378,8 @@ public class SqlNullabilityProcessor
                 => VisitSqlParameter(sqlParameterExpression, allowOptimizedExpansion, out nullable),
             SqlUnaryExpression sqlUnaryExpression
                 => VisitSqlUnary(sqlUnaryExpression, allowOptimizedExpansion, out nullable),
+            RowValueExpression rowValueExpression
+                => VisitRowValue(rowValueExpression, allowOptimizedExpansion, out nullable),
             _ => VisitCustomSqlExpression(sqlExpression, allowOptimizedExpansion, out nullable)
         };
 
@@ -1092,6 +1094,26 @@ public class SqlNullabilityProcessor
         return !operandNullable && sqlUnaryExpression.OperatorType == ExpressionType.Not
             ? OptimizeNonNullableNotExpression(updated)
             : updated;
+    }
+
+    /// <summary>
+    ///     Visits a <see cref="RowValueExpression" /> and computes its nullability.
+    /// </summary>
+    /// <param name="rowValueExpression">A row value expression to visit.</param>
+    /// <param name="allowOptimizedExpansion">A bool value indicating if optimized expansion which considers null value as false value is allowed.</param>
+    /// <param name="nullable">A bool value indicating whether the sql expression is nullable.</param>
+    /// <returns>An optimized sql expression.</returns>
+    protected virtual SqlExpression VisitRowValue(RowValueExpression rowValueExpression, bool allowOptimizedExpansion, out bool nullable)
+    {
+        nullable = false;
+        return rowValueExpression;
+        //var match = Visit(likeExpression.Match, out var matchNullable);
+        //var pattern = Visit(likeExpression.Pattern, out var patternNullable);
+        //var escapeChar = Visit(likeExpression.EscapeChar, out var escapeCharNullable);
+
+        //nullable = matchNullable || patternNullable || escapeCharNullable;
+
+        //return likeExpression.Update(match, pattern, escapeChar);
     }
 
     private static bool? TryGetBoolConstantValue(SqlExpression? expression)

--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -689,4 +689,15 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
 
         return unionExpression.Update(source1, source2);
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitRowValue(RowValueExpression rowValueExpression)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMethodCallTranslatorProvider.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMethodCallTranslatorProvider.cs
@@ -39,13 +39,10 @@ public class SqlServerMethodCallTranslatorProvider : RelationalMethodCallTransla
                 new SqlServerMathTranslator(sqlExpressionFactory),
                 new SqlServerNewGuidTranslator(sqlExpressionFactory),
                 new SqlServerObjectToStringTranslator(sqlExpressionFactory),
-                new SqlServerStringMethodTranslator(sqlExpressionFactory)
+                new SqlServerStringMethodTranslator(sqlExpressionFactory),
+#pragma warning disable EF1001 // Internal EF Core API usage.
+                new RowValueComparisonTranslator(sqlExpressionFactory),
+#pragma warning restore EF1001 // Internal EF Core API usage.
             });
     }
-
-    /// <inheritdoc/>
-    protected override IMethodCallTranslator CreateRowValueTranslator(ISqlExpressionFactory sqlExpressionFactory)
-#pragma warning disable EF1001 // Internal EF Core API usage.
-        => new RowValueComparisonTranslator(sqlExpressionFactory);
-#pragma warning restore EF1001 // Internal EF Core API usage.
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMethodCallTranslatorProvider.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMethodCallTranslatorProvider.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 
 /// <summary>
@@ -40,4 +42,10 @@ public class SqlServerMethodCallTranslatorProvider : RelationalMethodCallTransla
                 new SqlServerStringMethodTranslator(sqlExpressionFactory)
             });
     }
+
+    /// <inheritdoc/>
+    protected override IMethodCallTranslator CreateRowValueTranslator(ISqlExpressionFactory sqlExpressionFactory)
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        => new RowValueExpandedTranslator(sqlExpressionFactory);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMethodCallTranslatorProvider.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMethodCallTranslatorProvider.cs
@@ -46,6 +46,6 @@ public class SqlServerMethodCallTranslatorProvider : RelationalMethodCallTransla
     /// <inheritdoc/>
     protected override IMethodCallTranslator CreateRowValueTranslator(ISqlExpressionFactory sqlExpressionFactory)
 #pragma warning disable EF1001 // Internal EF Core API usage.
-        => new RowValueExpandedTranslator(sqlExpressionFactory);
+        => new RowValueComparisonTranslator(sqlExpressionFactory);
 #pragma warning restore EF1001 // Internal EF Core API usage.
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
@@ -55,7 +55,7 @@ public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture> : No
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task LessThan(bool async)
+    public virtual Task LessThan_constant(bool async)
     {
         return AssertCount(
             async,
@@ -67,7 +67,7 @@ public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture> : No
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task LessThan2(bool async)
+    public virtual Task LessThan_variables(bool async)
     {
         var a = 2;
         return AssertCount(

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
@@ -52,4 +52,29 @@ public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture> : No
 
     protected abstract string CaseInsensitiveCollation { get; }
     protected abstract string CaseSensitiveCollation { get; }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task LessThan(bool async)
+    {
+        return AssertCount(
+            async,
+            ss => ss.Set<Employee>(),
+            ss => ss.Set<Employee>(),
+            e => EF.Functions.LessThan(new object[] { e.EmployeeID }, new object[] { 2 }),
+            e => e.EmployeeID < 2);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task LessThan2(bool async)
+    {
+        var a = 2;
+        return AssertCount(
+            async,
+            ss => ss.Set<Employee>(),
+            ss => ss.Set<Employee>(),
+            e => EF.Functions.LessThan(new object[] { e.EmployeeID }, new object[] { a }),
+            e => e.EmployeeID < 2);
+    }
 }


### PR DESCRIPTION
- [x] New EF.Functions extensions: `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreatThanOrEqual`.
- [ ] Implement and support a new `RowValueExpression` that translates to SQL row value syntax.
  - [x] `RowValueExpression`
  - [x] `RowValueTranslator`
  - [x] `QuerySqlGenerator`
  - [x] `SqlExpressionFactory`
  - [ ] `SqlNullabilityProcessor`
  - [x] `SearchConditionConvertingExpressionVisitor`
- [x] Override on SQL Server provider and expand to normal comparisons using `RowValueComparisonTranslator`

Closes #26822.
