### PR TITLE
Call sync connection close instead of async (7.0)

### DIFF
--- a/benchmark/Directory.Build.props
+++ b/benchmark/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.test.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rulesets/EFCore.test.ruleset
+++ b/rulesets/EFCore.test.ruleset
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="EFCore" ToolsVersion="15.0">
+  <Include Path="StyleCop.noxmldocs.ruleset" Action="Default" />
+  <Include Path="FxCop.test.ruleset" Action="Default" />
+  <Include Path="Documentation.ruleset" Action="Default" />
+</RuleSet>

--- a/rulesets/FxCop.test.ruleset
+++ b/rulesets/FxCop.test.ruleset
@@ -51,7 +51,7 @@
       <Rule Id="CA1305" Action="None" />             <!-- Specify IFormatProvider -->
       <Rule Id="CA1307" Action="None" />             <!-- Specify StringComparison -->
       <Rule Id="CA1308" Action="None" />             <!-- Normalize strings to uppercase -->
-      <Rule Id="CA1309" Action="Error" />            <!-- Use ordinal stringcomparison -->
+      <Rule Id="CA1309" Action="None" />             <!-- Use ordinal stringcomparison -->
       <Rule Id="CA1401" Action="None" />             <!-- P/Invokes should not be visible -->
       <Rule Id="CA1501" Action="None" />             <!-- Avoid excessive inheritance -->
       <Rule Id="CA1502" Action="None" />             <!-- Avoid excessive complexity -->
@@ -95,7 +95,7 @@
       <Rule Id="CA1829" Action="None" />             <!-- Use Length/Count property instead of Count() when available -->
       <Rule Id="CA2000" Action="None" />             <!-- Dispose objects before losing scope -->
       <Rule Id="CA2002" Action="None" />             <!-- Do not lock on objects with weak identity -->
-      <Rule Id="CA2007" Action="Error" />            <!-- Consider calling ConfigureAwait on the awaited task -->
+      <Rule Id="CA2007" Action="None" />             <!-- Consider calling ConfigureAwait on the awaited task -->
       <Rule Id="CA2008" Action="Error" />            <!-- Do not create tasks without passing a TaskScheduler -->
       <Rule Id="CA2009" Action="Error" />            <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
       <Rule Id="CA2010" Action="None" />             <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -240,9 +240,11 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         (string ContainerId, JToken Document, IUpdateEntry Entry, CosmosClientWrapper Wrapper) parameters,
         CancellationToken cancellationToken = default)
     {
-        using var stream = new MemoryStream();
+        var stream = new MemoryStream();
+        await using var __ = stream.ConfigureAwait(false);
         var writer = new StreamWriter(stream, new UTF8Encoding(), bufferSize: 1024, leaveOpen: false);
-        await using var __ = writer.ConfigureAwait(false);
+        await using var ___ = writer.ConfigureAwait(false);
+
         using var jsonWriter = new JsonTextWriter(writer);
         Serializer.Serialize(jsonWriter, parameters.Document);
         await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -311,8 +313,10 @@ public class CosmosClientWrapper : ICosmosClientWrapper
         (string ContainerId, string ResourceId, JObject Document, IUpdateEntry Entry, CosmosClientWrapper Wrapper) parameters,
         CancellationToken cancellationToken = default)
     {
-        await using var stream = new MemoryStream();
-        await using var writer = new StreamWriter(stream, new UTF8Encoding(), bufferSize: 1024, leaveOpen: false);
+        var stream = new MemoryStream();
+        await using var __ = stream.ConfigureAwait(false);
+        var writer = new StreamWriter(stream, new UTF8Encoding(), bufferSize: 1024, leaveOpen: false);
+        await using var ___ = writer.ConfigureAwait(false);
         using var jsonWriter = new JsonTextWriter(writer);
         Serializer.Serialize(jsonWriter, parameters.Document);
         await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -3026,7 +3026,8 @@ public sealed partial class SelectExpression : TableExpressionBase
     {
         Check.DebugAssert(_tables.Count == _tableReferences.Count, "All the tables should have their associated TableReferences.");
         Check.DebugAssert(
-            string.Equals(GetAliasFromTableExpressionBase(tableExpressionBase), tableReferenceExpression.Alias),
+            string.Equals(
+                GetAliasFromTableExpressionBase(tableExpressionBase), tableReferenceExpression.Alias, StringComparison.Ordinal),
             "Alias of table and table reference should be the same.");
 
         var uniqueAlias = GenerateUniqueAlias(_usedAliases, tableReferenceExpression.Alias);

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -880,7 +880,7 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
                     }
                     else
                     {
-                        CloseDbConnectionAsync();
+                        CloseDbConnection();
                     }
 
                     wasClosed = true;

--- a/src/EFCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransaction.cs
@@ -314,7 +314,8 @@ public class RelationalTransaction : IDbContextTransaction, IInfrastructure<DbTr
 
             if (!interceptionResult.IsSuppressed)
             {
-                await using var command = Connection.DbConnection.CreateCommand();
+                var command = Connection.DbConnection.CreateCommand();
+                await using var _ = command.ConfigureAwait(false);
                 command.Transaction = _dbTransaction;
                 command.CommandText = _sqlGenerationHelper.GenerateCreateSavepointStatement(name);
                 await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -403,7 +404,8 @@ public class RelationalTransaction : IDbContextTransaction, IInfrastructure<DbTr
 
             if (!interceptionResult.IsSuppressed)
             {
-                await using var command = Connection.DbConnection.CreateCommand();
+                var command = Connection.DbConnection.CreateCommand();
+                await using var _ = command.ConfigureAwait(false);
                 command.Transaction = _dbTransaction;
                 command.CommandText = _sqlGenerationHelper.GenerateRollbackToSavepointStatement(name);
                 await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -492,7 +494,8 @@ public class RelationalTransaction : IDbContextTransaction, IInfrastructure<DbTr
 
             if (!interceptionResult.IsSuppressed)
             {
-                await using var command = Connection.DbConnection.CreateCommand();
+                var command = Connection.DbConnection.CreateCommand();
+                await using var _ = command.ConfigureAwait(false);
                 command.Transaction = _dbTransaction;
                 command.CommandText = _sqlGenerationHelper.GenerateReleaseSavepointStatement(name);
                 await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -77,7 +77,8 @@ public class SqlServerDatabaseCreator : RelationalDatabaseCreator
     /// </summary>
     public override async Task CreateAsync(CancellationToken cancellationToken = default)
     {
-        await using (var masterConnection = _connection.CreateMasterConnection())
+        var masterConnection = _connection.CreateMasterConnection();
+        await using (masterConnection.ConfigureAwait(false))
         {
             await Dependencies.MigrationCommandExecutor
                 .ExecuteNonQueryAsync(CreateCreateOperations(), masterConnection, cancellationToken)
@@ -360,7 +361,8 @@ SELECT 1 ELSE SELECT 0");
     {
         ClearAllPools();
 
-        await using var masterConnection = _connection.CreateMasterConnection();
+        var masterConnection = _connection.CreateMasterConnection();
+        await using var _ = masterConnection.ConfigureAwait(false);
         await Dependencies.MigrationCommandExecutor
             .ExecuteNonQueryAsync(CreateDropCommands(), masterConnection, cancellationToken)
             .ConfigureAwait(false);

--- a/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
@@ -85,8 +85,8 @@ public class ForeignKeyAttributeConvention :
 
         foreach (var inverse in inverses)
         {
-            unconfiguredNavigations.RemoveAll(n => string.Equals(n.GetSimpleMemberName(), inverse));
-            foreignKeyNavigations.RemoveAll(n => string.Equals(n.GetSimpleMemberName(), inverse));
+            unconfiguredNavigations.RemoveAll(n => string.Equals(n.GetSimpleMemberName(), inverse, StringComparison.Ordinal));
+            foreignKeyNavigations.RemoveAll(n => string.Equals(n.GetSimpleMemberName(), inverse, StringComparison.Ordinal));
         }
 
         if (unconfiguredNavigations.Count == 1)

--- a/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
@@ -72,7 +72,7 @@ public class InversePropertyAttributeConvention :
         var targetEntityType = targetEntityTypeBuilder.Metadata;
         var targetClrType = targetEntityType.ClrType;
         var inverseNavigationPropertyInfo = targetEntityType.GetRuntimeProperties().Values
-                .FirstOrDefault(p => string.Equals(p.GetSimpleMemberName(), attribute.Property))
+                .FirstOrDefault(p => string.Equals(p.GetSimpleMemberName(), attribute.Property, StringComparison.Ordinal))
             ?? targetEntityType.GetRuntimeProperties().Values
                 .FirstOrDefault(p => string.Equals(p.GetSimpleMemberName(), attribute.Property, StringComparison.OrdinalIgnoreCase));
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1707;1591;xUnit1000;xUnit1003;xUnit1004;xUnit1010;xUnit1013;xUnit1026</NoWarn>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.test.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Also add missing ConfigureAwait(false) and StringComparison.Ordinal, because of a configuration mismatch between FxCop and the built-in diagnostics analyzers.

Fixes #26790
