### PR TITLE
[6.0.2] Call sync connection close instead of async

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -264,8 +264,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             (string ContainerId, JToken Document, IUpdateEntry Entry, CosmosClientWrapper Wrapper) parameters,
             CancellationToken cancellationToken = default)
         {
-            await using var stream = new MemoryStream();
-            await using var writer = new StreamWriter(stream, new UTF8Encoding(), bufferSize: 1024, leaveOpen: false);
+            using var stream = new MemoryStream();
+            var writer = new StreamWriter(stream, new UTF8Encoding(), bufferSize: 1024, leaveOpen: false);
+            await using var __ = writer.ConfigureAwait(false);
             using var jsonWriter = new JsonTextWriter(writer);
             Serializer.Serialize(jsonWriter, parameters.Document);
             await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -259,7 +259,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 var command = Dependencies.RawSqlCommandBuilder.Build(GetAppliedMigrationsSql);
 
-                await using var reader = await command.ExecuteReaderAsync(
+                var reader = await command.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
                         Dependencies.Connection,
                         null,
@@ -267,6 +267,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         Dependencies.CurrentContext.Context,
                         Dependencies.CommandLogger, CommandSource.Migrations),
                     cancellationToken).ConfigureAwait(false);
+
+                await using var _ = reader.ConfigureAwait(false);
+
                 while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
                 {
                     rows.Add(new HistoryRow(reader.DbDataReader.GetString(0), reader.DbDataReader.GetString(1)));

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -896,7 +896,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         }
                         else
                         {
-                            CloseDbConnectionAsync();
+                            CloseDbConnection();
                         }
 
                         wasClosed = true;

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -283,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             try
             {
-                await using var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(
+                var dataReader = await storeCommand.RelationalCommand.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
                         connection,
                         storeCommand.ParameterValues,
@@ -291,6 +291,8 @@ namespace Microsoft.EntityFrameworkCore.Update
                         Dependencies.CurrentContext.Context,
                         Dependencies.Logger, CommandSource.SaveChanges),
                     cancellationToken).ConfigureAwait(false);
+
+                await using var _ = dataReader.ConfigureAwait(false);
                 await ConsumeAsync(dataReader, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not DbUpdateException and not OperationCanceledException)

--- a/src/EFCore/ChangeTracking/Internal/EntityGraphAttacher.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityGraphAttacher.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         null,
                         null),
                     PaintActionAsync,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
 
                 rootEntry.StateManager.CompleteAttachGraph();
             }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -990,10 +990,10 @@ namespace Microsoft.EntityFrameworkCore
 
             if (DisposeSync(lease.IsActive, contextShouldBeDisposed))
             {
-                await _serviceScope.DisposeAsyncIfAvailable();
+                await _serviceScope.DisposeAsyncIfAvailable().ConfigureAwait(false);
             }
 
-            await lease.ContextDisposedAsync();
+            await lease.ContextDisposedAsync().ConfigureAwait(false);
         }
 
         private bool DisposeSync(bool leaseActive, bool contextShouldBeDisposed)

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -3127,11 +3127,11 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(source, nameof(source));
 
-            await using (var enumerator = source.AsAsyncEnumerable().GetAsyncEnumerator(cancellationToken))
+            var enumerator = source.AsAsyncEnumerable().GetAsyncEnumerator(cancellationToken);
+            await using var _ = enumerator.ConfigureAwait(false);
+
+            while (await enumerator.MoveNextAsync().ConfigureAwait(false))
             {
-                while (await enumerator.MoveNextAsync().ConfigureAwait(false))
-                {
-                }
             }
         }
 

--- a/src/EFCore/Infrastructure/Internal/LazyLoader.cs
+++ b/src/EFCore/Infrastructure/Internal/LazyLoader.cs
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
             {
                 try
                 {
-                    await entry.LoadAsync(cancellationToken);
+                    await entry.LoadAsync(cancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/src/EFCore/Infrastructure/PooledDbContextFactory.cs
+++ b/src/EFCore/Infrastructure/PooledDbContextFactory.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public virtual async Task<TContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
         {
             var lease = new DbContextLease(_pool, standalone: true);
-            await lease.Context.SetLeaseAsync(lease, cancellationToken);
+            await lease.Context.SetLeaseAsync(lease, cancellationToken).ConfigureAwait(false);
 
             return (TContext)lease.Context;
         }

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -145,7 +145,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             IAsyncEnumerable<TSource> asyncEnumerable,
             CancellationToken cancellationToken = default)
         {
-            await using var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+            var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+            await using var _ = enumerator.ConfigureAwait(false);
+
             if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
             {
                 throw new InvalidOperationException(CoreStrings.SequenceContainsNoElements);
@@ -165,7 +167,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             IAsyncEnumerable<TSource> asyncEnumerable,
             CancellationToken cancellationToken = default)
         {
-            await using var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+            var enumerator = asyncEnumerable.GetAsyncEnumerator(cancellationToken);
+            await using var _ = enumerator.ConfigureAwait(false);
+
             if (!(await enumerator.MoveNextAsync().ConfigureAwait(false)))
             {
                 // TODO: Convert return to Task<TSource?> when changing to C# 9

--- a/src/EFCore/Storage/ExecutionStrategyExtensions.cs
+++ b/src/EFCore/Storage/ExecutionStrategyExtensions.cs
@@ -842,7 +842,8 @@ namespace Microsoft.EntityFrameworkCore
                 async (c, s, ct) =>
                     {
                         Check.NotNull(beginTransaction, nameof(beginTransaction));
-                        await using (var transaction = await beginTransaction(c, cancellationToken).ConfigureAwait(false))
+                        var transaction = await beginTransaction(c, cancellationToken).ConfigureAwait(false);
+                        await using (transaction)
                         {
                             s.CommitFailed = false;
                             s.Result = await s.Operation(s.State, ct).ConfigureAwait(false);

--- a/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
@@ -190,16 +190,15 @@ namespace Microsoft.EntityFrameworkCore
                 return InterceptionResult<DbDataReader>.SuppressWithResult(new FakeDbDataReader());
             }
 
-            public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            public override async ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
                 DbCommand command,
                 CommandEventData eventData,
                 InterceptionResult<DbDataReader> result,
                 CancellationToken cancellationToken = default)
             {
-                base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+                await base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<InterceptionResult<DbDataReader>>(
-                    InterceptionResult<DbDataReader>.SuppressWithResult(new FakeDbDataReader()));
+                return InterceptionResult<DbDataReader>.SuppressWithResult(new FakeDbDataReader());
             }
         }
 
@@ -322,15 +321,15 @@ namespace Microsoft.EntityFrameworkCore
                 return InterceptionResult<object>.SuppressWithResult(InterceptedResult);
             }
 
-            public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            public override async ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
                 DbCommand command,
                 CommandEventData eventData,
                 InterceptionResult<object> result,
                 CancellationToken cancellationToken = default)
             {
-                base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+                await base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<InterceptionResult<object>>(InterceptionResult<object>.SuppressWithResult(InterceptedResult));
+                return InterceptionResult<object>.SuppressWithResult(InterceptedResult);
             }
         }
 
@@ -382,15 +381,15 @@ namespace Microsoft.EntityFrameworkCore
                 return InterceptionResult<int>.SuppressWithResult(2);
             }
 
-            public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            public override async ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
                 DbCommand command,
                 CommandEventData eventData,
                 InterceptionResult<int> result,
                 CancellationToken cancellationToken = default)
             {
-                base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+                await base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<InterceptionResult<int>>(InterceptionResult<int>.SuppressWithResult(2));
+                return InterceptionResult<int>.SuppressWithResult(2);
             }
         }
 
@@ -852,15 +851,15 @@ namespace Microsoft.EntityFrameworkCore
                 return new CompositeFakeDbDataReader(result, new FakeDbDataReader());
             }
 
-            public override ValueTask<DbDataReader> ReaderExecutedAsync(
+            public override async ValueTask<DbDataReader> ReaderExecutedAsync(
                 DbCommand command,
                 CommandExecutedEventData eventData,
                 DbDataReader result,
                 CancellationToken cancellationToken = default)
             {
-                base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+                await base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<DbDataReader>(new CompositeFakeDbDataReader(result, new FakeDbDataReader()));
+                return new CompositeFakeDbDataReader(result, new FakeDbDataReader());
             }
         }
 
@@ -999,15 +998,15 @@ namespace Microsoft.EntityFrameworkCore
                 return InterceptedResult;
             }
 
-            public override ValueTask<object> ScalarExecutedAsync(
+            public override async ValueTask<object> ScalarExecutedAsync(
                 DbCommand command,
                 CommandExecutedEventData eventData,
                 object result,
                 CancellationToken cancellationToken = default)
             {
-                base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
+                await base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
 
-                return new ValueTask<object>(InterceptedResult);
+                return InterceptedResult;
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -10213,8 +10213,8 @@ ORDER BY [t].[Id]");
         public virtual async Task Can_query_with_nav_collection_in_projection_with_split_query_in_parallel_sync()
         {
             var contextFactory = await CreateContext25225Async();
-            var task1 = Task.Factory.StartNew(() => Query(MyContext25225.Parent1Id, MyContext25225.Collection1Id));
-            var task2 = Task.Factory.StartNew(() => Query(MyContext25225.Parent2Id, MyContext25225.Collection2Id));
+            var task1 = Task.Run(() => Query(MyContext25225.Parent1Id, MyContext25225.Collection1Id));
+            var task2 = Task.Run(() => Query(MyContext25225.Parent2Id, MyContext25225.Collection2Id));
             await Task.WhenAll(task1, task2);
 
             void Query(Guid parentId, Guid collectionId)

--- a/test/EFCore.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
             var tasks = new Task[Environment.ProcessorCount];
             for (var i = 0; i < tasks.Length; i++)
             {
-                tasks[i] = Task.Factory.StartNew(() =>
+                tasks[i] = Task.Run(() =>
                 {
                     using (var ctx = new EmptyContext())
                     {

--- a/test/EFCore.Tests/DbSetTest.cs
+++ b/test/EFCore.Tests/DbSetTest.cs
@@ -625,11 +625,11 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public async Task Can_use_Add_to_change_entity_state_async()
         {
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Detached, EntityState.Added);
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Unchanged, EntityState.Added);
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Deleted, EntityState.Added);
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Modified, EntityState.Added);
-            await ChangeStateWithMethod((c, e) => c.Categories.AddAsync(e), EntityState.Added, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Detached, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Unchanged, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Deleted, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Modified, EntityState.Added);
+            await ChangeStateWithMethod(async (c, e) => await c.Categories.AddAsync(e), EntityState.Added, EntityState.Added);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Fixes #26790, replaces #26793

**Description**

As part of logging path optimizations in 6.0, an (unawaited) async connection Close method call was accidentally introduced in a synchronous code path. In addition, while investigating this some cases of missing ConfigureAwait(false) were discovered.

**Customer impact**

In some providers, where pooling isn't used, the unawaited async call causes a race condition with unknown effects, potentially crashing the application. The cases of missing ConfigureAwait(false) could potentially cause EF Core code to run in the user's synchronization context instead of on the thread pool.

**How found**

A customer reported the unawaited async call on 6.0. The other two issues were found as a result of fixing an analyzer issue which suppressed warnings.

**Regression**

Yes, from 5.0.

**Testing**

Verifying that an async method is called instead of a sync one isn't feasible.

**Risk**

Very low - an obvious one line fix to an obvious copy-paste mistake for the unawaited async call, and trivial additions of `ConfigureAwait(false)` where missing.
