### PR TITLE
Static analysis: minor small changes

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
@@ -110,7 +110,7 @@ public class CosmosProjectionBindingExpressionVisitor : ExpressionVisitor
         {
             switch (expression)
             {
-                case ConstantExpression _:
+                case ConstantExpression:
                     return expression;
 
                 case ParameterExpression parameterExpression:
@@ -130,7 +130,7 @@ public class CosmosProjectionBindingExpressionVisitor : ExpressionVisitor
 
                     throw new InvalidOperationException(CoreStrings.TranslationFailed(parameterExpression.Print()));
 
-                case MaterializeCollectionNavigationExpression _:
+                case MaterializeCollectionNavigationExpression:
                     return base.Visit(expression);
             }
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -113,7 +113,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                                     _ownerMappings[accessExpression] =
                                         (innerObjectAccessExpression.Navigation.DeclaringEntityType, innerAccessExpression);
                                     break;
-                                case RootReferenceExpression _:
+                                case RootReferenceExpression:
                                     innerAccessExpression = _jObjectParameter;
                                     break;
                                 default:

--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -253,9 +253,9 @@ public class CosmosSqlTranslatingExpressionVisitor : ExpressionVisitor
     {
         switch (extensionExpression)
         {
-            case EntityProjectionExpression _:
-            case EntityReferenceExpression _:
-            case SqlExpression _:
+            case EntityProjectionExpression:
+            case EntityReferenceExpression:
+            case SqlExpression:
                 return extensionExpression;
 
             case EntityShaperExpression entityShaperExpression:
@@ -380,7 +380,7 @@ public class CosmosSqlTranslatingExpressionVisitor : ExpressionVisitor
                 && right is SqlExpression rightSql)
             {
                 sqlObject = leftSql;
-                arguments = new SqlExpression[1] { rightSql };
+                arguments = new[] { rightSql };
             }
             else
             {
@@ -407,7 +407,7 @@ public class CosmosSqlTranslatingExpressionVisitor : ExpressionVisitor
             if (left is SqlExpression leftSql
                 && right is SqlExpression rightSql)
             {
-                arguments = new SqlExpression[2] { leftSql, rightSql };
+                arguments = new[] { leftSql, rightSql };
             }
             else
             {
@@ -428,7 +428,7 @@ public class CosmosSqlTranslatingExpressionVisitor : ExpressionVisitor
             if (enumerable is SqlExpression sqlEnumerable
                 && item is SqlExpression sqlItem)
             {
-                arguments = new SqlExpression[2] { sqlEnumerable, sqlItem };
+                arguments = new[] { sqlEnumerable, sqlItem };
             }
             else
             {
@@ -450,7 +450,7 @@ public class CosmosSqlTranslatingExpressionVisitor : ExpressionVisitor
                 && item is SqlExpression sqlItem)
             {
                 sqlObject = sqlEnumerable;
-                arguments = new SqlExpression[1] { sqlItem };
+                arguments = new[] { sqlItem };
             }
             else
             {

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -20,7 +20,6 @@ public class MigrationsOperations
     private readonly string? _language;
     private readonly DesignTimeServicesBuilder _servicesBuilder;
     private readonly DbContextOperations _contextOperations;
-    private readonly string[] _args;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -43,7 +42,7 @@ public class MigrationsOperations
         _projectDir = projectDir;
         _rootNamespace = rootNamespace;
         _language = language;
-        _args = args ?? Array.Empty<string>();
+        args ??= Array.Empty<string>();
         _contextOperations = new DbContextOperations(
             reporter,
             assembly,
@@ -52,9 +51,9 @@ public class MigrationsOperations
             rootNamespace,
             language,
             nullable,
-            _args);
+            args);
 
-        _servicesBuilder = new DesignTimeServicesBuilder(assembly, startupAssembly, reporter, _args);
+        _servicesBuilder = new DesignTimeServicesBuilder(assembly, startupAssembly, reporter, args);
     }
 
     /// <summary>

--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -715,8 +715,6 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                     .AppendLine()
                     .Append("oldCollation: ")
                     .Append(Code.Literal(operation.OldDatabase.Collation));
-
-                needComma = true;
             }
 
             builder.Append(")");

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -1053,7 +1053,7 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
 
         using (mainBuilder.Indent())
         {
-            var foreignKeyVariable = "runtimeForeignKey";
+            const string foreignKeyVariable = "runtimeForeignKey";
             var variables = new HashSet<string>
             {
                 declaringEntityType,

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -247,8 +247,8 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
     {
         switch (extensionExpression)
         {
-            case EntityProjectionExpression _:
-            case EntityReferenceExpression _:
+            case EntityProjectionExpression:
+            case EntityReferenceExpression:
                 return extensionExpression;
 
             case EntityShaperExpression entityShaperExpression:
@@ -527,7 +527,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
             }
 
             @object = left;
-            arguments = new Expression[1] { right };
+            arguments = new[] { right };
         }
         else if (method.Name == nameof(object.Equals)
                  && methodCallExpression.Object == null
@@ -560,7 +560,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
                 return QueryCompilationContext.NotTranslatedExpression;
             }
 
-            arguments = new Expression[2] { left, right };
+            arguments = new[] { left, right };
         }
         else if (method.IsGenericMethod
                  && method.GetGenericMethodDefinition().Equals(EnumerableMethods.Contains))
@@ -582,7 +582,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
                 return QueryCompilationContext.NotTranslatedExpression;
             }
 
-            arguments = new Expression[2] { enumerable, item };
+            arguments = new[] { enumerable, item };
         }
         else if (methodCallExpression.Arguments.Count == 1
                  && method.IsContainsMethod())
@@ -605,7 +605,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
             }
 
             @object = enumerable;
-            arguments = new Expression[1] { item };
+            arguments = new[] { item };
         }
         else
         {

--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -110,7 +110,7 @@ public class InMemoryProjectionBindingExpressionVisitor : ExpressionVisitor
             {
                 switch (expression)
                 {
-                    case ConstantExpression _:
+                    case ConstantExpression:
                         return expression;
 
                     case ProjectionBindingExpression projectionBindingExpression:

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
@@ -557,7 +557,7 @@ public partial class InMemoryQueryExpression : Expression, IPrintableExpression
         bool defaultElementSelector)
     {
         var source = ServerQueryExpression;
-        Expression? selector = null;
+        Expression? selector;
         if (defaultElementSelector)
         {
             selector = Lambda(

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -747,13 +747,13 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
             => value == null ? null : long.Parse(value, CultureInfo.InvariantCulture);
 
         private static Type AsType(string value)
-            => value == typeof(long).Name
+            => value == nameof(Int64)
                 ? typeof(long)
-                : value == typeof(int).Name
+                : value == nameof(Int32)
                     ? typeof(int)
-                    : value == typeof(short).Name
+                    : value == nameof(Int16)
                         ? typeof(short)
-                        : value == typeof(decimal).Name
+                        : value == nameof(Decimal)
                             ? typeof(decimal)
                             : typeof(byte);
 

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1863,7 +1863,7 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
                     }
 
                     var targetTable = diffContext.FindTarget(sourceTable);
-                    bool removedMapping = !(targetTable != null
+                    var removedMapping = !(targetTable != null
                         && targetKeyMap.Keys.Any(
                             k => k.Item2 == targetTable
                                 && k.Item1.DeclaringEntityType.GetTableMappings().First().Table == firstTargetTable));

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -118,7 +118,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
             {
                 switch (expression)
                 {
-                    case ConstantExpression _:
+                    case ConstantExpression:
                         return expression;
 
                     case ParameterExpression parameterExpression:
@@ -306,7 +306,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
                     new ProjectionBindingExpression(_selectExpression, _projectionMembers.Peek(), typeof(ValueBuffer)));
             }
 
-            case IncludeExpression _:
+            case IncludeExpression:
                 return _indexBasedBinding ? base.VisitExtension(extensionExpression) : QueryCompilationContext.NotTranslatedExpression;
 
             case CollectionResultExpression collectionResultExpression:
@@ -544,7 +544,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
     /// </summary>
     protected override Expression VisitUnary(UnaryExpression unaryExpression)
     {
-        var operand = Visit(unaryExpression.Operand)!;
+        var operand = Visit(unaryExpression.Operand);
 
         return (unaryExpression.NodeType == ExpressionType.Convert
                 || unaryExpression.NodeType == ExpressionType.ConvertChecked)

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -86,7 +86,8 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     /// <summary>
     ///     The default alias separator.
     /// </summary>
-    protected virtual string AliasSeparator { get; } = " AS ";
+    protected virtual string AliasSeparator
+        => " AS ";
 
     /// <summary>
     ///     The current SQL command builder.
@@ -838,7 +839,7 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     {
         switch (innerExpression)
         {
-            case LikeExpression _:
+            case LikeExpression:
                 return true;
 
             case SqlUnaryExpression sqlUnaryExpression:
@@ -1069,9 +1070,9 @@ public class QuerySqlGenerator : SqlExpressionVisitor
         static string GetSetOperation(SetOperationBase operation)
             => operation switch
             {
-                ExceptExpression _ => "EXCEPT",
-                IntersectExpression _ => "INTERSECT",
-                UnionExpression _ => "UNION",
+                ExceptExpression => "EXCEPT",
+                IntersectExpression => "INTERSECT",
+                UnionExpression => "UNION",
                 _ => throw new InvalidOperationException(CoreStrings.UnknownEntity("SetOperationType"))
             };
     }

--- a/src/EFCore.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryCompilationContext.cs
@@ -37,7 +37,8 @@ public class RelationalQueryCompilationContext : QueryCompilationContext
 
     /// <summary>
     ///     A value indicating the <see cref="EntityFrameworkCore.QuerySplittingBehavior" /> configured for the query.
-    ///     If no value has been configured then <see cref="QuerySplittingBehavior.SingleQuery" /> will be used.
+    ///     If no value has been configured then <see cref="Microsoft.EntityFrameworkCore.QuerySplittingBehavior.SingleQuery" />
+    ///     will be used.
     /// </summary>
     public virtual QuerySplittingBehavior? QuerySplittingBehavior { get; internal set; }
 }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1308,7 +1308,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                 {
                     DeferredOwnedExpansionExpression doee => UnwrapDeferredEntityProjectionExpression(doee),
                     // For the source entity shaper or owned collection expansion
-                    EntityShaperExpression _ or ShapedQueryExpression _ => expression,
+                    EntityShaperExpression or ShapedQueryExpression => expression,
                     _ => base.Visit(expression)
                 };
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -852,7 +852,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     return accessor;
                 }
 
-                case GroupByShaperExpression _:
+                case GroupByShaperExpression:
                     throw new InvalidOperationException(RelationalStrings.ClientGroupByNotSupported);
             }
 

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -358,9 +358,9 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
     {
         switch (extensionExpression)
         {
-            case EntityProjectionExpression _:
-            case EntityReferenceExpression _:
-            case SqlExpression _:
+            case EntityProjectionExpression:
+            case EntityReferenceExpression:
+            case SqlExpression:
                 return extensionExpression;
 
             case EntityShaperExpression entityShaperExpression:
@@ -530,7 +530,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                 && right is SqlExpression rightSql)
             {
                 sqlObject = leftSql;
-                arguments = new SqlExpression[1] { rightSql };
+                arguments = new[] { rightSql };
             }
             else
             {
@@ -565,7 +565,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             if (left is SqlExpression leftSql
                 && right is SqlExpression rightSql)
             {
-                arguments = new SqlExpression[2] { leftSql, rightSql };
+                arguments = new[] { leftSql, rightSql };
             }
             else
             {
@@ -588,7 +588,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             if (enumerable is SqlExpression sqlEnumerable
                 && item is SqlExpression sqlItem)
             {
-                arguments = new SqlExpression[2] { sqlEnumerable, sqlItem };
+                arguments = new[] { sqlEnumerable, sqlItem };
             }
             else
             {
@@ -612,7 +612,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                 && item is SqlExpression sqlItem)
             {
                 sqlObject = sqlEnumerable;
-                arguments = new SqlExpression[1] { sqlItem };
+                arguments = new[] { sqlItem };
             }
             else
             {

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -217,7 +217,7 @@ public sealed partial class SelectExpression : TableExpressionBase
         {
             TableExpression tableExpression => tableExpression.Table,
             TableValuedFunctionExpression tableValuedFunctionExpression => tableValuedFunctionExpression.StoreFunction,
-            _ => entityType.GetDefaultMappings().Single().Table,
+            _ => entityType.GetDefaultMappings().Single().Table
         };
 
         var tableReferenceExpression = new TableReferenceExpression(this, tableExpressionBase.Alias!);
@@ -1158,7 +1158,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                 newGroupByTerms.Add(newItem);
             }
 
-            keySelector = new ReplacingExpressionVisitor(groupByTerms, newGroupByTerms).Visit(keySelector);
+            new ReplacingExpressionVisitor(groupByTerms, newGroupByTerms).Visit(keySelector);
             groupByTerms = newGroupByTerms;
         }
 
@@ -1706,7 +1706,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             {
                 ColumnExpression columnExpression => columnExpression.IsNullable,
                 SqlConstantExpression sqlConstantExpression => sqlConstantExpression.Value == null,
-                _ => true,
+                _ => true
             };
     }
 

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -976,7 +976,7 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
     }
 
     /// <summary>
-    ///     Template method that by default calls <see cref="DbConnection.CloseAsync" /> but can be overridden
+    ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.CloseAsync" /> but can be overridden
     ///     by providers to make a different call instead.
     /// </summary>
     protected virtual Task CloseDbConnectionAsync()
@@ -1073,7 +1073,7 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
         => DbConnection.Dispose();
 
     /// <summary>
-    ///     Template method that by default calls <see cref="DbConnection.DisposeAsync" /> but can be overridden by
+    ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.DisposeAsync" /> but can be overridden by
     ///     providers to make a different call instead.
     /// </summary>
     protected virtual ValueTask DisposeDbConnectionAsync()

--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data.Common;
+
 namespace Microsoft.EntityFrameworkCore.Storage;
 
 /// <summary>
@@ -68,7 +70,7 @@ public class RelationalDataReader : IDisposable, IAsyncDisposable
         => _command;
 
     /// <summary>
-    ///     Calls <see cref="DbDataReader.Read()" /> on the underlying <see cref="System.Data.Common.DbDataReader" />.
+    ///     Calls <see cref="System.Data.Common.DbDataReader.Read" /> on the underlying <see cref="System.Data.Common.DbDataReader" />.
     /// </summary>
     /// <returns><see langword="true" /> if there are more rows; otherwise <see langword="false" />.</returns>
     public virtual bool Read()
@@ -79,7 +81,7 @@ public class RelationalDataReader : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    ///     Calls <see cref="DbDataReader.ReadAsync(CancellationToken)" /> on the underlying
+    ///     Calls <see cref="System.Data.Common.DbDataReader.ReadAsync(CancellationToken)" /> on the underlying
     ///     <see cref="System.Data.Common.DbDataReader" />.
     /// </summary>
     /// <returns><see langword="true" /> if there are more rows; otherwise <see langword="false" />.</returns>

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -454,7 +454,8 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
     /// <summary>
     ///     Gets the string format to be used to generate SQL literals of this type.
     /// </summary>
-    protected virtual string SqlLiteralFormatString { get; } = "{0}";
+    protected virtual string SqlLiteralFormatString
+        => "{0}";
 
     /// <summary>
     ///     Creates a <see cref="DbParameter" /> with the appropriate type information configured.

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -570,7 +570,7 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             }
 
             var historyTableName = operation[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
-            var historyTable = default(string);
+            string historyTable;
             if (needsExec)
             {
                 historyTable = Dependencies.SqlGenerationHelper.DelimitIdentifier(historyTableName!);
@@ -1684,10 +1684,9 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
     /// <param name="builder">The command builder to use to add the SQL fragment.</param>
     protected override void IndexTraits(MigrationOperation operation, IModel? model, MigrationCommandListBuilder builder)
     {
-        var clustered = operation[SqlServerAnnotationNames.Clustered] as bool?;
-        if (clustered.HasValue)
+        if (operation[SqlServerAnnotationNames.Clustered] is bool clustered)
         {
-            builder.Append(clustered.Value ? "CLUSTERED " : "NONCLUSTERED ");
+            builder.Append(clustered ? "CLUSTERED " : "NONCLUSTERED ");
         }
     }
 

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
@@ -136,7 +136,7 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
                         .Append(")");
                     break;
 
-                case TemporalAllTableExpression _:
+                case TemporalAllTableExpression:
                     Sql.Append("ALL");
                     break;
 

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -60,7 +60,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
             var table = queryRootExpression.EntityType.GetTableMappings().Single().Table;
             var temporalTableExpression = queryRootExpression switch
             {
-                TemporalAllQueryRootExpression _ => (TemporalTableExpression)new TemporalAllTableExpression(table),
+                TemporalAllQueryRootExpression => (TemporalTableExpression)new TemporalAllTableExpression(table),
                 TemporalAsOfQueryRootExpression asOf => new TemporalAsOfTableExpression(table, asOf.PointInTime),
                 TemporalBetweenQueryRootExpression between => new TemporalBetweenTableExpression(table, between.From, between.To),
                 TemporalContainedInQueryRootExpression containedIn => new TemporalContainedInTableExpression(

--- a/src/EFCore.Sqlite.Core/Infrastructure/SpatialiteLoader.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SpatialiteLoader.cs
@@ -149,7 +149,7 @@ public static class SpatialiteLoader
                 .Select(p => p.Key).FirstOrDefault();
             if (assetPath != default)
             {
-                string? assetDirectory = null;
+                string? assetDirectory;
                 if (File.Exists(Path.Combine(AppContext.BaseDirectory, assetPath.Item2)))
                 {
                     // NB: This enables framework-dependent deployments

--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -70,14 +70,14 @@ public class SqliteMigrationsSqlGenerator : MigrationsSqlGenerator
         {
             switch (operation)
             {
-                case AddPrimaryKeyOperation _:
-                case AddUniqueConstraintOperation _:
-                case AddCheckConstraintOperation _:
-                case AlterTableOperation _:
-                case DropCheckConstraintOperation _:
-                case DropForeignKeyOperation _:
-                case DropPrimaryKeyOperation _:
-                case DropUniqueConstraintOperation _:
+                case AddPrimaryKeyOperation:
+                case AddUniqueConstraintOperation:
+                case AddCheckConstraintOperation:
+                case AlterTableOperation:
+                case DropCheckConstraintOperation:
+                case DropForeignKeyOperation:
+                case DropPrimaryKeyOperation:
+                case DropUniqueConstraintOperation:
                 {
                     var tableOperation = (ITableMigrationOperation)operation;
                     var rebuild = rebuilds.GetOrAddNew((tableOperation.Table, tableOperation.Schema));
@@ -220,25 +220,25 @@ public class SqliteMigrationsSqlGenerator : MigrationsSqlGenerator
                     break;
                 }
 
-                case AlterSequenceOperation _:
-                case CreateSequenceOperation _:
-                case CreateTableOperation _:
-                case DropIndexOperation _:
-                case DropSchemaOperation _:
-                case DropSequenceOperation _:
-                case DropTableOperation _:
-                case EnsureSchemaOperation _:
-                case RenameSequenceOperation _:
-                case RestartSequenceOperation _:
+                case AlterSequenceOperation:
+                case CreateSequenceOperation:
+                case CreateTableOperation:
+                case DropIndexOperation:
+                case DropSchemaOperation:
+                case DropSequenceOperation:
+                case DropTableOperation:
+                case EnsureSchemaOperation:
+                case RenameSequenceOperation:
+                case RestartSequenceOperation:
                 {
                     operations.Add(operation);
 
                     break;
                 }
 
-                case DeleteDataOperation _:
-                case InsertDataOperation _:
-                case UpdateDataOperation _:
+                case DeleteDataOperation:
+                case InsertDataOperation:
+                case UpdateDataOperation:
                 {
                     var tableOperation = (ITableMigrationOperation)operation;
                     if (rebuilds.TryGetValue((tableOperation.Table, tableOperation.Schema), out var rebuild))

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -91,8 +91,8 @@ public class ChangeTracker : IResettableService
     ///         and <see cref="EntityFrameworkQueryableExtensions.AsTracking{TEntity}(IQueryable{TEntity})" /> methods.
     ///     </para>
     ///     <para>
-    ///         The default value is <see cref="QueryTrackingBehavior.TrackAll" />. This means the change tracker will
-    ///         keep track of changes for all entities that are returned from a LINQ query.
+    ///         The default value is <see cref="Microsoft.EntityFrameworkCore.QueryTrackingBehavior.TrackAll" />. This means
+    ///         the change tracker will keep track of changes for all entities that are returned from a LINQ query.
     ///     </para>
     /// </remarks>
     public virtual QueryTrackingBehavior QueryTrackingBehavior

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1686,9 +1686,9 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
         var equals = ValuesEqualFunc(property);
 
         return (!_storeGeneratedValues.TryGetValue(storeGeneratedIndex, out var generatedValue)
-                || @equals(defaultValue, generatedValue))
+                || equals(defaultValue, generatedValue))
             && (!_temporaryValues.TryGetValue(storeGeneratedIndex, out generatedValue)
-                || @equals(defaultValue, generatedValue));
+                || equals(defaultValue, generatedValue));
     }
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -148,7 +148,7 @@ public abstract class NavigationEntry : MemberEntry
     ///         Loading entities from the database using
     ///         <see cref="EntityFrameworkQueryableExtensions.Include{TEntity,TProperty}" /> or
     ///         <see
-    ///             cref="EntityFrameworkQueryableExtensions.ThenInclude{TEntity,TPreviousProperty,TProperty}(Query.IIncludableQueryable{TEntity,IEnumerable{TPreviousProperty}},System.Linq.Expressions.Expression{Func{TPreviousProperty,TProperty}})" />
+    ///             cref="EntityFrameworkQueryableExtensions.ThenInclude{TEntity,TPreviousProperty,TProperty}(Microsoft.EntityFrameworkCore.Query.IIncludableQueryable{TEntity,System.Collections.Generic.IEnumerable{TPreviousProperty}},System.Linq.Expressions.Expression{System.Func{TPreviousProperty,TProperty}})" />
     ///         , <see cref="Load" />, or <see cref="LoadAsync" /> will set this flag. Subsequent calls to <see cref="Load" />
     ///         or <see cref="LoadAsync" /> will then be a no-op.
     ///     </para>

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -515,9 +515,9 @@ public class DbContext :
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any
-    ///         changes to entity instances before saving to the underlying database. This can be disabled via
-    ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+    ///         This method will automatically call <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.DetectChanges" />
+    ///         to discover any changes to entity instances before saving to the underlying database. This can be disabled via
+    ///         <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.AutoDetectChangesEnabled" />.
     ///     </para>
     ///     <para>
     ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
@@ -549,9 +549,9 @@ public class DbContext :
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any
-    ///         changes to entity instances before saving to the underlying database. This can be disabled via
-    ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+    ///         This method will automatically call <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.DetectChanges" />
+    ///         to discover any changes to entity instances before saving to the underlying database. This can be disabled via
+    ///         <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.AutoDetectChangesEnabled" />.
     ///     </para>
     ///     <para>
     ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
@@ -565,8 +565,8 @@ public class DbContext :
     ///     </para>
     /// </remarks>
     /// <param name="acceptAllChangesOnSuccess">
-    ///     Indicates whether <see cref="ChangeTracker.AcceptAllChanges" /> is called after the changes have
-    ///     been sent successfully to the database.
+    ///     Indicates whether <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.AcceptAllChanges" />
+    ///     is called after the changes have been sent successfully to the database.
     /// </param>
     /// <returns>
     ///     The number of state entries written to the database.
@@ -642,16 +642,16 @@ public class DbContext :
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any
-    ///         changes to entity instances before saving to the underlying database. This can be disabled via
-    ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+    ///         This method will automatically call <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.DetectChanges" />
+    ///         to discover any changes to entity instances before saving to the underlying database. This can be disabled via
+    ///         <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.AutoDetectChangesEnabled" />.
     ///     </para>
     ///     <para>
     ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
     ///         includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
     ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
-    ///         in parallel. See <see href="https://aka.ms/efcore-docs-threading">Avoiding DbContext threading issues</see> for more information
-    ///         and examples.
+    ///         in parallel. See <see href="https://aka.ms/efcore-docs-threading">Avoiding DbContext threading issues</see> for more
+    ///         information and examples.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-saving-data">Saving data in EF Core</see> for more information and examples.
@@ -679,24 +679,24 @@ public class DbContext :
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any
-    ///         changes to entity instances before saving to the underlying database. This can be disabled via
-    ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+    ///         This method will automatically call <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.DetectChanges" />
+    ///         to discover any changes to entity instances before saving to the underlying database. This can be disabled via
+    ///         <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.AutoDetectChangesEnabled" />.
     ///     </para>
     ///     <para>
     ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
     ///         includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
     ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
-    ///         in parallel. See <see href="https://aka.ms/efcore-docs-threading">Avoiding DbContext threading issues</see> for more information
-    ///         and examples.
+    ///         in parallel. See <see href="https://aka.ms/efcore-docs-threading">Avoiding DbContext threading issues</see> for more
+    ///         information and examples.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-saving-data">Saving data in EF Core</see> for more information and examples.
     ///     </para>
     /// </remarks>
     /// <param name="acceptAllChangesOnSuccess">
-    ///     Indicates whether <see cref="ChangeTracker.AcceptAllChanges" /> is called after the changes have
-    ///     been sent successfully to the database.
+    ///     Indicates whether <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker.AcceptAllChanges" /> is called after
+    ///     the changes have been sent successfully to the database.
     /// </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>

--- a/src/ef/CommandLineUtils/CommandLineApplication.cs
+++ b/src/ef/CommandLineUtils/CommandLineApplication.cs
@@ -91,9 +91,7 @@ internal class CommandLineApplication
         var lastArg = Arguments.LastOrDefault();
         if (lastArg?.MultipleValues == true)
         {
-            var message = string.Format(
-                "The last argument '{0}' accepts multiple values. No more argument can be added.",
-                lastArg.Name);
+            var message = $"The last argument '{lastArg.Name}' accepts multiple values. No more argument can be added.";
             throw new InvalidOperationException(message);
         }
 
@@ -414,7 +412,7 @@ internal class CommandLineApplication
             optionsBuilder.AppendLine();
             optionsBuilder.AppendLine("Options:");
             var maxOptLen = MaxOptionTemplateLength(target.Options);
-            var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxOptLen + 2);
+            var outputFormat = $"  {{0, -{maxOptLen + 2}}}{{1}}";
             foreach (var opt in target.Options)
             {
                 optionsBuilder.AppendFormat(outputFormat, opt.Template, opt.Description);
@@ -429,7 +427,7 @@ internal class CommandLineApplication
             commandsBuilder.AppendLine();
             commandsBuilder.AppendLine("Commands:");
             var maxCmdLen = MaxCommandLength(target.Commands);
-            var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxCmdLen + 2);
+            var outputFormat = $"  {{0, -{maxCmdLen + 2}}}{{1}}";
             foreach (var cmd in target.Commands.OrderBy(c => c.Name))
             {
                 commandsBuilder.AppendFormat(outputFormat, cmd.Name, cmd.Description);

--- a/src/ef/Commands/CommandBase.cs
+++ b/src/ef/Commands/CommandBase.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             command.HandleResponseFiles = true;
 
             command.OnExecute(
-                (args) =>
+                args =>
                 {
                     Reporter.IsVerbose = verbose.HasValue();
                     Reporter.NoColor = noColor.HasValue();

--- a/tools/Resources.tt
+++ b/tools/Resources.tt
@@ -278,10 +278,9 @@ namespace <#= model.Namespace.EndsWith(".Internal", StringComparison.Ordinal) ? 
         using (var reader = new ResXResourceReader(resourceFile))
         {
             reader.UseResXDataNodes = true;
-            sortedResources = Enumerable.ToList(
-                from DictionaryEntry r in reader
-                orderby r.Key
-                select (ResXDataNode)r.Value);
+            sortedResources = (from DictionaryEntry r in reader
+                               orderby r.Key
+                               select (ResXDataNode)r.Value).ToList();
 
             result.Resources = sortedResources
                 .Select(r => new Resource(r))
@@ -367,7 +366,7 @@ namespace <#= model.Namespace.EndsWith(".Internal", StringComparison.Ordinal) ? 
         public string EventId { get; }
         public string Level { get; }
         public bool Obsolete { get; }
-        public bool ForLogging => Name.StartsWith("Log");
+        public bool ForLogging => Name.StartsWith("Log", StringComparison.Ordinal);
         public IEnumerable<(string NameOfString, string ParamString)> Parameters { get; }
         public IEnumerable<string> Types { get; }
     }


### PR DESCRIPTION
Part of #26805

For example:
- Assignment is not used
- Redundant discard
- Redundant explicit size in array creation
- Convert field to local
- Redundant verbatim prefix
- Redundant lambda parens


