### PR TITLE
[6.0.2] Handle duplicate property infos when sorting columns.

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -758,7 +758,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             var leastPriorityPrimaryKeyProperties = new List<IProperty>();
             var primaryKeyPropertyGroups = new Dictionary<PropertyInfo, IProperty>();
             var groups = new Dictionary<PropertyInfo, List<IProperty>>();
-            var unorderedGroups = new Dictionary<PropertyInfo, SortedDictionary<int, IProperty>>();
+            var unorderedGroups = new Dictionary<PropertyInfo, SortedDictionary<(int, string), IProperty>>();
             var types = new Dictionary<Type, SortedDictionary<int, PropertyInfo>>();
 
             foreach (var property in entityType.GetDeclaredProperties())
@@ -786,7 +786,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     clrProperty = foreignKey.DependentToPrincipal!.PropertyInfo!;
                     var groupIndex = foreignKey.Properties.IndexOf(property);
 
-                    unorderedGroups.GetOrAddNew(clrProperty).Add(groupIndex, property);
+                    unorderedGroups.GetOrAddNew(clrProperty).Add((groupIndex, property.Name), property);
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #26405

### Description

If no explicit order is specified we determine the column order partially based on the property declaration order on the CLR types. However for down migrations the snapshot is used and it doesn't have associated CLR types. `Dictionary<string,object>` is used as a stand-in and all properties and navigations are mapped to the indexer. When sorting foreign key properties this causes an exception as the same property info is used as the key multiple times.

### Customer impact

An exception is thrown when creating a migration for a table rename with two or more navigations. There isn't a practical workaround.

### How found

Customer report on RC2. 7 reports so far.

### Regression

Yes, from 5.0

### Testing

This PR adds coverage for this scenario.

### Risk

Low; the fix only affects column order in migrations produced during design-time. Quirk mode not added as there isn't a practical way to access the `AppContext` used by CLI tools.
