### PR TITLE
[6.0.2] Restore the ability to break multiple FK cycles

### DIFF
--- a/src/Shared/Multigraph.cs
+++ b/src/Shared/Multigraph.cs
@@ -194,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                         && tryBreakEdge != null)
                     {
                         var candidateVertex = candidateVertices[candidateIndex];
-                        if (predecessorCounts[candidateVertex] != 1)
+                        if (predecessorCounts[candidateVertex] == 0)
                         {
                             candidateIndex++;
                             continue;
@@ -211,9 +211,12 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                             _successorMap[incomingNeighbor].Remove(candidateVertex);
                             _predecessorMap[candidateVertex].Remove(incomingNeighbor);
                             predecessorCounts[candidateVertex]--;
-                            queue.Add(candidateVertex);
-                            broken = true;
-                            break;
+                            if (predecessorCounts[candidateVertex] == 0)
+                            {
+                                queue.Add(candidateVertex);
+                                broken = true;
+                            }
+                            continue;
                         }
 
                         candidateIndex++;

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -341,6 +341,91 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         }
 
         [ConditionalFact]
+        public void Model_differ_breaks_multiple_foreign_key_cycles_in_create_table_operations()
+        {
+            Execute(
+                _ => { },
+                modelBuilder =>
+                {
+                    modelBuilder.Entity<Book>(entity =>
+                    {
+                        entity.HasOne(d => d.Album)
+                            .WithMany(p => p.Books);
+                        entity.HasOne(d => d.User)
+                            .WithMany(p => p.Books);
+                    });
+                    modelBuilder.Entity<Album>(entity =>
+                    {
+                        entity.HasOne(d => d.OwnerUser)
+                            .WithMany(p => p.AlbumOwnerUsers);
+                        entity.HasOne(d => d.Book)
+                            .WithMany(p => p.Albums);
+                    });
+                    modelBuilder.Entity<User>(entity =>
+                    {
+                        entity.HasOne(d => d.Book)
+                            .WithMany(p => p.Users);
+                        entity.HasOne(d => d.ReaderGroup)
+                            .WithMany(p => p.UserReaderGroups);
+                    });
+                    modelBuilder.Entity<Group>(entity =>
+                    {
+                        entity.HasOne(d => d.OwnerAlbum)
+                            .WithMany(p => p.Groups);
+                        entity.HasOne(d => d.OwnerUser)
+                            .WithMany(p => p.Groups);
+                    });
+                },
+                result =>
+                {
+                    Assert.Equal(4, result.OfType<CreateTableOperation>().Count());
+                    Assert.Equal(8, result.OfType<CreateIndexOperation>().Count());
+                    Assert.Equal(8, result.OfType<CreateTableOperation>().SelectMany(t => t.ForeignKeys).Count()
+                        + result.OfType<AddForeignKeyOperation>().Count());
+                });
+        }
+
+        private class Book
+        {
+            public int Id { get; set; }
+
+            public Album Album { get; set; }
+            public User User { get; set; }
+            public ICollection<Album> Albums { get; set; }
+            public ICollection<User> Users { get; set; }
+        }
+
+        private class Album
+        {
+            public int Id { get; set; }
+
+            public User OwnerUser { get; set; }
+            public Book Book { get; set; }
+            public ICollection<Book> Books { get; set; }
+            public ICollection<Group> Groups { get; set; }
+        }
+
+        private class User
+        {
+            public int Id { get; set; }
+
+            public Book Book { get; set; }
+            public Group ReaderGroup { get; set; }
+            public ICollection<Album> AlbumOwnerUsers { get; set; }
+            public ICollection<Book> Books { get; set; }
+            public ICollection<Group> Groups { get; set; }
+        }
+
+        private class Group
+        {
+            public int Id { get; set; }
+
+            public Album OwnerAlbum { get; set; }
+            public User OwnerUser { get; set; }
+            public ICollection<User> UserReaderGroups { get; set; }
+        }
+
+        [ConditionalFact]
         public void Create_table()
         {
             Execute(


### PR DESCRIPTION
Fixes #26834

### Description

Due to a bug fix EF lost the ability to break table cycles where each table participates in multiple cycles.

### Customer impact

An exception is thrown when adding a migration that creates tables linked by multiple foreign key cycles. A workaround would be to add tables without foreign key first, then create another migration for the foreign keys.

### How found

Customer report on 6.0.0.

### Regression

Yes, from 5.0. Regressed by https://github.com/dotnet/efcore/pull/25952

### Testing

This PR adds coverage for this scenario.

### Risk

Low; the fix only affects migrations produced during design-time. Quirk mode not added as there isn't a practical way to access the `AppContext` used by CLI tools.
