### PR TITLE
Replace our nullability decoding with the new BCL API

### DIFF
--- a/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
@@ -49,37 +49,14 @@ public abstract class NonNullableConventionBase : IModelFinalizingConvention
 
         var nullabilityInfoContext = (NullabilityInfoContext)annotation.Value!;
 
-        if (memberInfo is PropertyInfo propertyInfo)
+        var nullabilityInfo = memberInfo switch
         {
-            var nullabilityInfo = nullabilityInfoContext.Create(propertyInfo);
+            PropertyInfo propertyInfo => nullabilityInfoContext.Create(propertyInfo),
+            FieldInfo fieldInfo => nullabilityInfoContext.Create(fieldInfo),
+            _ => null
+        };
 
-            if (nullabilityInfo.ReadState == NullabilityState.NotNull)
-            {
-                return true;
-            }
-
-            // In order for us to configure a property as non-nullable, it must be:
-            // 1. Non-nullable for both read and write, or
-            // 2. Non-nullable for read and read-only, or
-            // 3. Non-nullable for write and write-only
-            // if (nullabilityInfo.ReadState == NullabilityState.NotNull
-            //     && (nullabilityInfo.WriteState == NullabilityState.NotNull || !propertyInfo.CanWrite)
-            //     || nullabilityInfo.WriteState == NullabilityState.NotNull && !propertyInfo.CanRead)
-            // {
-            //     return true;
-            // }
-        }
-        else if (memberInfo is FieldInfo fieldInfo)
-        {
-            var nullabilityInfo = nullabilityInfoContext.Create(fieldInfo);
-
-            if (nullabilityInfo.ReadState == NullabilityState.NotNull /* && nullabilityInfo.WriteState == NullabilityState.NotNull */)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return nullabilityInfo?.ReadState == NullabilityState.NotNull;
     }
 
     /// <inheritdoc />

--- a/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
@@ -14,12 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 /// </remarks>
 public abstract class NonNullableConventionBase : IModelFinalizingConvention
 {
-    // For the interpretation of nullability metadata, see
-    // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md
-
     private const string StateAnnotationName = "NonNullableConventionState";
-    private const string NullableAttributeFullName = "System.Runtime.CompilerServices.NullableAttribute";
-    private const string NullableContextAttributeFullName = "System.Runtime.CompilerServices.NullableContextAttribute";
 
     /// <summary>
     ///     Creates a new instance of <see cref="NonNullableConventionBase" />.
@@ -50,118 +43,48 @@ public abstract class NonNullableConventionBase : IModelFinalizingConvention
             return false;
         }
 
-        var state = GetOrInitializeState(modelBuilder);
+        var annotation =
+            modelBuilder.Metadata.FindAnnotation(StateAnnotationName)
+            ?? modelBuilder.Metadata.AddAnnotation(StateAnnotationName, new NullabilityInfoContext());
 
-        // First check for [MaybeNull] on the return value. If it exists, the member is nullable.
-        // Note: avoid using GetCustomAttribute<> below because of https://github.com/mono/mono/issues/17477
-        var isMaybeNull = memberInfo switch
-        {
-            FieldInfo f
-                => f.CustomAttributes.Any(a => a.AttributeType == typeof(MaybeNullAttribute)),
-            PropertyInfo p
-                => p.GetMethod?.ReturnParameter?.CustomAttributes?.Any(a => a.AttributeType == typeof(MaybeNullAttribute)) == true,
-            _ => false
-        };
+        var nullabilityInfoContext = (NullabilityInfoContext)annotation.Value!;
 
-        if (isMaybeNull)
+        if (memberInfo is PropertyInfo propertyInfo)
         {
-            return false;
+            var nullabilityInfo = nullabilityInfoContext.Create(propertyInfo);
+
+            if (nullabilityInfo.ReadState == NullabilityState.NotNull)
+            {
+                return true;
+            }
+
+            // In order for us to configure a property as non-nullable, it must be:
+            // 1. Non-nullable for both read and write, or
+            // 2. Non-nullable for read and read-only, or
+            // 3. Non-nullable for write and write-only
+            // if (nullabilityInfo.ReadState == NullabilityState.NotNull
+            //     && (nullabilityInfo.WriteState == NullabilityState.NotNull || !propertyInfo.CanWrite)
+            //     || nullabilityInfo.WriteState == NullabilityState.NotNull && !propertyInfo.CanRead)
+            // {
+            //     return true;
+            // }
         }
-
-        // For C# 8.0 nullable types, the C# compiler currently synthesizes a NullableAttribute that expresses nullability into
-        // assemblies it produces. If the model is spread across more than one assembly, there will be multiple versions of this
-        // attribute, so look for it by name, caching to avoid reflection on every check.
-        // Note that this may change - if https://github.com/dotnet/corefx/issues/36222 is done we can remove all of this.
-
-        // First look for NullableAttribute on the member itself
-        if (Attribute.GetCustomAttributes(memberInfo)
-                .FirstOrDefault(a => a.GetType().FullName == NullableAttributeFullName) is Attribute attribute)
+        else if (memberInfo is FieldInfo fieldInfo)
         {
-            var attributeType = attribute.GetType();
+            var nullabilityInfo = nullabilityInfoContext.Create(fieldInfo);
 
-            if (attributeType != state.NullableAttrType)
+            if (nullabilityInfo.ReadState == NullabilityState.NotNull /* && nullabilityInfo.WriteState == NullabilityState.NotNull */)
             {
-                state.NullableFlagsFieldInfo = attributeType.GetField("NullableFlags");
-                state.NullableAttrType = attributeType;
+                return true;
             }
-
-            if (state.NullableFlagsFieldInfo?.GetValue(attribute) is byte[] flags)
-            {
-                return flags.FirstOrDefault() == 1;
-            }
-        }
-
-        // No attribute on the member, try to find a NullableContextAttribute on the declaring type
-        var type = memberInfo.DeclaringType;
-        if (type is not null)
-        {
-            // We currently don't calculate support nullability for generic properties, since calculating that is complex
-            // (depends on the nullability of generic type argument).
-            // However, we special case Dictionary as it's used for property bags, and specifically don't identify its indexer
-            // as non-nullable.
-            if (memberInfo is PropertyInfo property
-                && property.IsIndexerProperty()
-                && type.IsGenericType
-                && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
-            {
-                return false;
-            }
-
-            return DoesTypeHaveNonNullableContext(type, state);
         }
 
         return false;
     }
-
-    private static bool DoesTypeHaveNonNullableContext(Type type, NonNullabilityConventionState state)
-    {
-        if (state.TypeCache.TryGetValue(type, out var cachedTypeNonNullable))
-        {
-            return cachedTypeNonNullable;
-        }
-
-        if (Attribute.GetCustomAttributes(type)
-                .FirstOrDefault(a => a.GetType().FullName == NullableContextAttributeFullName) is Attribute contextAttr)
-        {
-            var attributeType = contextAttr.GetType();
-
-            if (attributeType != state.NullableContextAttrType)
-            {
-                state.NullableContextFlagFieldInfo = attributeType.GetField("Flag");
-                state.NullableContextAttrType = attributeType;
-            }
-
-            if (state.NullableContextFlagFieldInfo?.GetValue(contextAttr) is byte flag)
-            {
-                return state.TypeCache[type] = flag == 1;
-            }
-        }
-        else if (type.IsNested)
-        {
-            return state.TypeCache[type] = DoesTypeHaveNonNullableContext(type.DeclaringType!, state);
-        }
-
-        return state.TypeCache[type] = false;
-    }
-
-    private static NonNullabilityConventionState GetOrInitializeState(IConventionModelBuilder modelBuilder)
-        => (NonNullabilityConventionState)(
-            modelBuilder.Metadata.FindAnnotation(StateAnnotationName)
-            ?? modelBuilder.Metadata.AddAnnotation(StateAnnotationName, new NonNullabilityConventionState())
-        ).Value!;
 
     /// <inheritdoc />
     public virtual void ProcessModelFinalizing(
         IConventionModelBuilder modelBuilder,
         IConventionContext<IConventionModelBuilder> context)
         => modelBuilder.Metadata.RemoveAnnotation(StateAnnotationName);
-
-    private sealed class NonNullabilityConventionState
-    {
-        public Type? NullableAttrType;
-        public Type? NullableContextAttrType;
-        public FieldInfo? NullableFlagsFieldInfo;
-        public FieldInfo? NullableContextFlagFieldInfo;
-        public Dictionary<Type, bool> TypeCache { get; } = new();
-    }
 }

--- a/src/EFCore/Metadata/Conventions/NonNullableReferencePropertyConvention.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableReferencePropertyConvention.cs
@@ -15,6 +15,8 @@ public class NonNullableReferencePropertyConvention : NonNullableConventionBase,
     IPropertyAddedConvention,
     IPropertyFieldChangedConvention
 {
+    private readonly NullabilityInfoContext _nullabilityInfoContext = new();
+
     /// <summary>
     ///     Creates a new instance of <see cref="NonNullableReferencePropertyConvention" />.
     /// </summary>
@@ -26,8 +28,6 @@ public class NonNullableReferencePropertyConvention : NonNullableConventionBase,
 
     private void Process(IConventionPropertyBuilder propertyBuilder)
     {
-        // If the model is spread across multiple assemblies, it may contain different NullableAttribute types as
-        // the compiler synthesizes them for each assembly.
         if (propertyBuilder.Metadata.GetIdentifyingMemberInfo() is MemberInfo memberInfo
             && IsNonNullableReferenceType(propertyBuilder.ModelBuilder, memberInfo))
         {

--- a/src/EFCore/Metadata/Conventions/NonNullableReferencePropertyConvention.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableReferencePropertyConvention.cs
@@ -15,8 +15,6 @@ public class NonNullableReferencePropertyConvention : NonNullableConventionBase,
     IPropertyAddedConvention,
     IPropertyFieldChangedConvention
 {
-    private readonly NullabilityInfoContext _nullabilityInfoContext = new();
-
     /// <summary>
     ///     Creates a new instance of <see cref="NonNullableReferencePropertyConvention" />.
     /// </summary>

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
@@ -8,21 +8,23 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
+#nullable enable
+
 public class NonNullableNavigationConventionTest
 {
     [ConditionalFact]
     public void Non_nullability_does_not_override_configuration_from_explicit_source()
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Post>();
-        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention);
+        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             nameof(Post.Blog),
             nameof(Blog.Posts),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Post.Blog));
+        var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Post.Blog))!;
 
         relationshipBuilder.IsRequired(false, ConfigurationSource.Explicit);
 
@@ -39,15 +41,15 @@ public class NonNullableNavigationConventionTest
     public void Non_nullability_does_not_override_configuration_from_data_annotation()
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Post>();
-        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention);
+        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             nameof(Post.Blog),
             nameof(Blog.Posts),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Post.Blog));
+        var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Post.Blog))!;
 
         relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
 
@@ -65,15 +67,15 @@ public class NonNullableNavigationConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = principalEntityTypeBuilder.HasRelationship(
             dependentEntityTypeBuilder.Metadata,
             nameof(Principal.Dependents),
             nameof(Dependent.Principal),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependents));
+        var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependents))!;
 
         Assert.False(relationshipBuilder.Metadata.IsRequired);
 
@@ -89,17 +91,17 @@ public class NonNullableNavigationConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 nameof(Dependent.Principal),
                 nameof(Principal.Dependent),
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasEntityTypes
-                (principalEntityTypeBuilder.Metadata, dependentEntityTypeBuilder.Metadata, ConfigurationSource.Explicit);
+                (principalEntityTypeBuilder.Metadata, dependentEntityTypeBuilder.Metadata, ConfigurationSource.Explicit)!;
 
-        var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependent));
+        var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependent))!;
 
         Assert.False(relationshipBuilder.Metadata.IsRequired);
 
@@ -116,7 +118,7 @@ public class NonNullableNavigationConventionTest
         modelBuilder.Entity<BlogDetails>();
 
         Assert.True(
-            model.FindEntityType(typeof(BlogDetails)).GetForeignKeys().Single(fk => fk.PrincipalEntityType?.ClrType == typeof(Blog))
+            model.FindEntityType(typeof(BlogDetails))!.GetForeignKeys().Single(fk => fk.PrincipalEntityType?.ClrType == typeof(Blog))
                 .IsRequired);
     }
 
@@ -125,7 +127,7 @@ public class NonNullableNavigationConventionTest
         var context = new ConventionContext<IConventionNavigationBuilder>(
             relationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
         CreateNotNullNavigationConvention().ProcessNavigationAdded(navigation.Builder, context);
-        return context.ShouldStopProcessing() ? (Navigation)context.Result?.Metadata : navigation;
+        return context.ShouldStopProcessing() ? (Navigation)context.Result?.Metadata! : navigation;
     }
 
     private NonNullableNavigationConvention CreateNotNullNavigationConvention()
@@ -146,15 +148,15 @@ public class NonNullableNavigationConventionTest
 
         var modelBuilder = new Model(conventionSet).Builder;
 
-        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit)!;
     }
 
     private ModelBuilder CreateModelBuilder()
     {
         var serviceProvider = CreateServiceProvider();
         return new ModelBuilder(
-            serviceProvider.GetService<IConventionSetBuilder>().CreateConventionSet(),
-            serviceProvider.GetService<ModelDependencies>());
+            serviceProvider.GetRequiredService<IConventionSetBuilder>().CreateConventionSet(),
+            serviceProvider.GetRequiredService<ModelDependencies>());
     }
 
     private ProviderConventionSetBuilderDependencies CreateDependencies()
@@ -179,9 +181,9 @@ public class NonNullableNavigationConventionTest
         return modelLogger;
     }
 
-#nullable enable
 #pragma warning disable CS8618
-
+    // ReSharper disable UnusedMember.Local
+    // ReSharper disable ClassNeverInstantiated.Local
     private class Blog
     {
         public int Id { get; set; }
@@ -245,6 +247,7 @@ public class NonNullableNavigationConventionTest
         [ForeignKey("PrincipalId, PrincipalFk")]
         public Principal? CompositePrincipal { get; set; }
     }
+    // ReSharper restore ClassNeverInstantiated.Local
+    // ReSharper restore UnusedMember.Local
 #pragma warning restore CS8618
-#nullable disable
 }

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableReferencePropertyConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableReferencePropertyConventionTest.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
+#nullable enable
+
 public class NonNullableReferencePropertyConventionTest
 {
     [ConditionalFact]
@@ -15,7 +17,7 @@ public class NonNullableReferencePropertyConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit)!;
 
         propertyBuilder.IsRequired(false, ConfigurationSource.Explicit);
 
@@ -29,7 +31,7 @@ public class NonNullableReferencePropertyConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit)!;
 
         propertyBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
 
@@ -77,7 +79,7 @@ public class NonNullableReferencePropertyConventionTest
     }
 
     [ConditionalFact]
-    public void Non_nullability_ignores_context_on_generic_types()
+    public void Dictionary_indexer_is_not_configured_as_non_nullable()
     {
         var modelBuilder = CreateModelBuilder();
         var entityTypeBuilder = modelBuilder.SharedTypeEntity<Dictionary<string, object>>("SomeBag");
@@ -102,30 +104,31 @@ public class NonNullableReferencePropertyConventionTest
 
         var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 
-        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit)!;
     }
 
     private ProviderConventionSetBuilderDependencies CreateDependencies()
         => InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
 
+    // ReSharper disable PropertyCanBeMadeInitOnly.Local
     private class A
     {
+        // ReSharper disable once UnusedMember.Local
         public int Id { get; set; }
 
-#nullable enable
-        public string NonNullable { get; } = "";
+        public string NonNullable => "";
         public string? Nullable { get; set; }
 
         [MaybeNull]
-        public string NonNullablePropertyMaybeNull { get; } = "";
+        public string NonNullablePropertyMaybeNull { get; set; } = "";
 
         [AllowNull]
-        public string NonNullablePropertyAllowNull { get; } = "";
+        public string NonNullablePropertyAllowNull { get; set; } = "";
 
-        public string? NullablePropertyNotNull { get; } = "";
+        public string? NullablePropertyNotNull { get; set; } = "";
 
         [DisallowNull]
-        public string? NullablePropertyDisallowNull { get; } = "";
+        public string? NullablePropertyDisallowNull { get; set; } = "";
 
         [MaybeNull]
         public string NonNullableFieldMaybeNull = "";
@@ -140,15 +143,15 @@ public class NonNullableReferencePropertyConventionTest
 
         [Required]
         public string? RequiredAndNullable { get; set; }
-#nullable disable
 
+#nullable disable
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' context.
         public string NullObliviousNonNullable { get; set; }
         public string? NullObliviousNullable { get; set; }
 #pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' context.
+#nullable enable
     }
 
-#nullable enable
     public class B
     {
         [Key]
@@ -168,7 +171,7 @@ public class NonNullableReferencePropertyConventionTest
     {
         public string? Nullable { get; set; }
     }
-#nullable disable
+    // ReSharper restore PropertyCanBeMadeInitOnly.Local
 
     private static ModelBuilder CreateModelBuilder()
         => InMemoryTestHelpers.Instance.CreateConventionBuilder();


### PR DESCRIPTION
One possible design question...

* NRT nullability is computed in a convention, but not value type nullability; that's just hard-coded in [Property.DefaultIsNullable](https://github.com/dotnet/efcore/blob/main/src/EFCore/Metadata/Internal/Property.cs#L187).
  * We want NRT computation to be in a convention, since there's a [NullabilityInfoContext](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.nullabilityinfocontext?view=net-6.0) which caches stuff for perf.
  * We could have a single convention setting IsRequired for both NRTs and value types (NullabilityInfoContext detects for those too), but this could possibly be heavier perf-wise. Also not sure it's worth it, /cc @AndriySvyryd.

Also see #26966 which was discovered as part of this.

Closes #24744

