### PR TITLE
Add AtTimeZoneExpression and some relevant translations

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -285,6 +285,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=composability/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=composable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Constructible/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=datetimeoffset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=doesnt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=efcore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=evaluatable/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -895,6 +895,42 @@ public class QuerySqlGenerator : SqlExpressionVisitor
         return inExpression;
     }
 
+    /// <inheritdoc />
+    protected override Expression VisitAtTimeZone(AtTimeZoneExpression atTimeZoneExpression)
+    {
+        var requiresBrackets = RequiresParentheses(atTimeZoneExpression, atTimeZoneExpression.Operand);
+
+        if (requiresBrackets)
+        {
+            _relationalCommandBuilder.Append("(");
+        }
+
+        Visit(atTimeZoneExpression.Operand);
+
+        if (requiresBrackets)
+        {
+            _relationalCommandBuilder.Append(")");
+        }
+
+        _relationalCommandBuilder.Append(" AT TIME ZONE ");
+
+        requiresBrackets = RequiresParentheses(atTimeZoneExpression, atTimeZoneExpression.TimeZone);
+
+        if (requiresBrackets)
+        {
+            _relationalCommandBuilder.Append("(");
+        }
+
+        Visit(atTimeZoneExpression.TimeZone);
+
+        if (requiresBrackets)
+        {
+            _relationalCommandBuilder.Append(")");
+        }
+
+        return atTimeZoneExpression;
+    }
+
     /// <summary>
     ///     Gets a SQL operator for a SQL binary operation.
     /// </summary>
@@ -914,7 +950,7 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     {
         switch (innerExpression)
         {
-            case LikeExpression:
+            case AtTimeZoneExpression or LikeExpression:
                 return true;
 
             case SqlUnaryExpression sqlUnaryExpression:

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -54,6 +54,7 @@ public class SqlExpressionFactory : ISqlExpressionFactory
 
         return sqlExpression switch
         {
+            AtTimeZoneExpression e => ApplyTypeMappingOnAtTimeZone(e, typeMapping),
             CaseExpression e => ApplyTypeMappingOnCase(e, typeMapping),
             CollateExpression e => ApplyTypeMappingOnCollate(e, typeMapping),
             DistinctExpression e => ApplyTypeMappingOnDistinct(e, typeMapping),
@@ -68,6 +69,9 @@ public class SqlExpressionFactory : ISqlExpressionFactory
             _ => sqlExpression
         };
     }
+
+    private SqlExpression ApplyTypeMappingOnAtTimeZone(AtTimeZoneExpression atTimeZoneExpression, RelationalTypeMapping? typeMapping)
+        => new AtTimeZoneExpression(atTimeZoneExpression.Operand, atTimeZoneExpression.TimeZone, atTimeZoneExpression.Type, typeMapping);
 
     private SqlExpression ApplyTypeMappingOnLike(LikeExpression likeExpression)
     {

--- a/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionVisitor.cs
@@ -24,6 +24,9 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
             case ShapedQueryExpression shapedQueryExpression:
                 return shapedQueryExpression.UpdateQueryExpression(Visit(shapedQueryExpression.QueryExpression));
 
+            case AtTimeZoneExpression atTimeZoneExpression:
+                return VisitAtTimeZone(atTimeZoneExpression);
+
             case CaseExpression caseExpression:
                 return VisitCase(caseExpression);
 
@@ -114,6 +117,14 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
 
         return base.VisitExtension(extensionExpression);
     }
+
+
+    /// <summary>
+    ///     Visits the children of the sql "at time zone" expression.
+    /// </summary>
+    /// <param name="atTimeZoneExpression">The expression to visit.</param>
+    /// <returns>The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.</returns>
+    protected abstract Expression VisitAtTimeZone(AtTimeZoneExpression atTimeZoneExpression);
 
     /// <summary>
     ///     Visits the children of the case expression.
@@ -277,7 +288,7 @@ public abstract class SqlExpressionVisitor : ExpressionVisitor
     protected abstract Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression);
 
     /// <summary>
-    ///     Visits the children of the sql fragent expression.
+    ///     Visits the children of the sql fragment expression.
     /// </summary>
     /// <param name="sqlFragmentExpression">The expression to visit.</param>
     /// <returns>The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.</returns>

--- a/src/EFCore.Relational/Query/SqlExpressions/AtTimeZoneExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/AtTimeZoneExpression.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+/// <summary>
+///     <para>
+///         An expression that represents an AT TIME ZONE operation in a SQL tree.
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+public class AtTimeZoneExpression : SqlExpression
+{
+    /// <summary>
+    ///     Creates a new instance of the <see cref="AtTimeZoneExpression" /> class.
+    /// </summary>
+    /// <param name="operand">The operand on which to perform the time zone conversion.</param>
+    /// <param name="timeZone">The time zone to convert to.</param>
+    /// <param name="type">The <see cref="Type" /> of the expression.</param>
+    /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
+    public AtTimeZoneExpression(
+        SqlExpression operand,
+        SqlExpression timeZone,
+        Type type,
+        RelationalTypeMapping? typeMapping)
+        : base(type, typeMapping)
+    {
+        Operand = operand;
+        TimeZone = timeZone;
+    }
+
+    /// <summary>
+    ///     The input operand on which to apply the time zone.
+    /// </summary>
+    public virtual SqlExpression Operand { get; }
+
+    /// <summary>
+    ///     The time zone to be applied.
+    /// </summary>
+    public virtual SqlExpression TimeZone { get; }
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var operand = (SqlExpression)visitor.Visit(Operand);
+        var timeZone = (SqlExpression)visitor.Visit(TimeZone);
+
+        return Update(operand, timeZone);
+    }
+
+    /// <summary>
+    ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will
+    ///     return this expression.
+    /// </summary>
+    /// <param name="operand">The <see cref="Operand" /> property of the result.</param>
+    /// <param name="timeZone">The <see cref="TimeZone" /> property of the result.</param>
+    /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
+    public virtual AtTimeZoneExpression Update(SqlExpression operand, SqlExpression timeZone)
+        => operand != Operand || timeZone != TimeZone
+            ? new AtTimeZoneExpression(operand, timeZone, Type, TypeMapping)
+            : this;
+
+    /// <inheritdoc />
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Visit(Operand);
+
+        expressionPrinter.Append(" AT TIME ZONE ");
+
+        expressionPrinter.Visit(TimeZone);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is AtTimeZoneExpression atTimeZoneExpression
+                && Equals(atTimeZoneExpression));
+
+    private bool Equals(AtTimeZoneExpression atTimeZoneExpression)
+        => base.Equals(atTimeZoneExpression)
+            && Operand.Equals(atTimeZoneExpression.Operand)
+            && TimeZone.Equals(atTimeZoneExpression.TimeZone);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(base.GetHashCode(), Operand, TimeZone);
+}

--- a/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
@@ -1438,4 +1438,50 @@ public static class SqlServerDbFunctionsExtensions
         this DbFunctions _,
         string expression)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(IsNumeric)));
+
+    /// <summary>
+    ///     Converts <paramref name="dateTime" /> to the corresponding <c>datetimeoffset</c> in the target <paramref name="timeZone" />.
+    ///     Corresponds to the SQL Server's <c>AT TIME ZONE</c> construct.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Note that the <see cref="DateTime.Kind" /> of <paramref name="dateTime" /> is not taken into account when performing the
+    ///         conversion; the offset for the provided time zone is simply applied as-is.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see>, and
+    ///         <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///         for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="dateTime">The value to convert to <c>datetimeoffset</c>.</param>
+    /// <param name="timeZone">A valid SQL Server time zone ID.</param>
+    /// <returns>The <c>datetimeoffset</c> resulting from the conversion.</returns>
+    /// <seealso href="https://docs.microsoft.com/sql/t-sql/queries/at-time-zone-transact-sql">SQL Server documentation for <c>AT TIME ZONE</c>.</seealso>
+    public static DateTimeOffset AtTimeZone(
+        this DbFunctions _,
+        DateTime dateTime,
+        string timeZone)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(AtTimeZone)));
+
+    /// <summary>
+    ///     Converts <paramref name="dateTimeOffset" /> to the time zone specified by <paramref name="timeZone"/>.
+    ///     Corresponds to the SQL Server's <c>AT TIME ZONE</c> construct.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="dateTimeOffset">The value on which to perform the time zone conversion.</param>
+    /// <param name="timeZone">A valid SQL Server time zone ID.</param>
+    /// <returns>The <c>datetimeoffset</c> resulting from the conversion.</returns>
+    /// <seealso href="https://docs.microsoft.com/sql/t-sql/queries/at-time-zone-transact-sql">SQL Server documentation for <c>AT TIME ZONE</c>.</seealso>
+    public static DateTimeOffset AtTimeZone(
+        this DbFunctions _,
+        DateTimeOffset dateTimeOffset,
+        string timeZone)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(AtTimeZone)));
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -123,6 +123,7 @@ public static class SqlServerServiceCollectionExtensions
             .TryAdd<IMemberTranslatorProvider, SqlServerMemberTranslatorProvider>()
             .TryAdd<IQuerySqlGeneratorFactory, SqlServerQuerySqlGeneratorFactory>()
             .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, SqlServerSqlTranslatingExpressionVisitorFactory>()
+            .TryAdd<ISqlExpressionFactory, SqlServerSqlExpressionFactory>()
             .TryAdd<IRelationalParameterBasedSqlProcessorFactory, SqlServerParameterBasedSqlProcessorFactory>()
             .TryAdd<INavigationExpansionExtensibilityHelper, SqlServerNavigationExpansionExtensibilityHelper>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, SqlServerQueryableMethodTranslatingExpressionVisitorFactory>()

--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -312,6 +312,23 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    protected override Expression VisitAtTimeZone(AtTimeZoneExpression atTimeZoneExpression)
+    {
+        var parentSearchCondition = _isSearchCondition;
+        _isSearchCondition = false;
+        var operand = (SqlExpression)Visit(atTimeZoneExpression.Operand);
+        var timeZone = (SqlExpression)Visit(atTimeZoneExpression.TimeZone);
+        _isSearchCondition = parentSearchCondition;
+
+        return atTimeZoneExpression.Update(operand, timeZone);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     protected override Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression)
     {
         var parentIsSearchCondition = _isSearchCondition;

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlExpressionFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlExpressionFactory.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqlServerSqlExpressionFactory : SqlExpressionFactory
+{
+    private IRelationalTypeMappingSource _typeMappingSource;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlServerSqlExpressionFactory(SqlExpressionFactoryDependencies dependencies)
+        : base(dependencies)
+        => _typeMappingSource = dependencies.TypeMappingSource;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [return: NotNullIfNotNull("sqlExpression")]
+    public override SqlExpression? ApplyTypeMapping(SqlExpression? sqlExpression, RelationalTypeMapping? typeMapping)
+    {
+#pragma warning disable IDE0046 // Convert to conditional expression
+        if (sqlExpression == null
+#pragma warning restore IDE0046 // Convert to conditional expression
+            || sqlExpression.TypeMapping != null)
+        {
+            return sqlExpression;
+        }
+
+        return sqlExpression is AtTimeZoneExpression atTimeZoneExpression
+            ? ApplyTypeMappingOnAtTimeZone(atTimeZoneExpression, typeMapping)
+            : base.ApplyTypeMapping(sqlExpression, typeMapping);
+    }
+
+    private SqlExpression ApplyTypeMappingOnAtTimeZone(AtTimeZoneExpression atTimeZoneExpression, RelationalTypeMapping? typeMapping)
+    {
+        var operandTypeMapping = typeMapping is null
+            ? null
+            : atTimeZoneExpression.Operand.Type == typeof(DateTimeOffset)
+                ? typeMapping
+                : atTimeZoneExpression.Operand.Type == typeof(DateTime)
+                    ? _typeMappingSource.FindMapping(typeof(DateTime), "datetime2", precision: typeMapping.Precision)
+                    : null;
+
+        return new AtTimeZoneExpression(
+            operandTypeMapping is null ? atTimeZoneExpression.Operand : ApplyTypeMapping(atTimeZoneExpression.Operand, operandTypeMapping),
+            atTimeZoneExpression.TimeZone,
+            atTimeZoneExpression.Type,
+            typeMapping);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2534,6 +2534,145 @@ FROM [Missions] AS [m]
 WHERE [m].[Timeline] = '1902-01-02T10:00:00.1234567+01:30'");
     }
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Where_AtTimeZone_datetimeoffset_constant(bool async)
+    {
+        using var context = CreateContext();
+
+        var query = context.Set<Mission>().Where(
+            m => EF.Functions.AtTimeZone(m.Timeline, "UTC") == new DateTimeOffset(2, 3, 1, 13, 0, 0, TimeSpan.Zero));
+
+        var missions = async
+            ? await query.ToListAsync()
+            : query.ToList();
+
+        var mission = Assert.Single(missions);
+        Assert.Equal(2, mission.Id);
+
+        AssertSql(
+            @"SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Duration], [m].[Rating], [m].[Timeline]
+FROM [Missions] AS [m]
+WHERE ([m].[Timeline] AT TIME ZONE 'UTC') = '0002-03-01T13:00:00.0000000+00:00'");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Where_AtTimeZone_datetimeoffset_parameter(bool async)
+    {
+        using var context = CreateContext();
+
+        var dateTime = new DateTimeOffset(2, 3, 1, 13, 0, 0, TimeSpan.Zero);
+        var timeZone = "UTC";
+        var query = context.Set<Mission>().Where(m => m.Timeline == EF.Functions.AtTimeZone(dateTime, timeZone));
+
+        var missions = async
+            ? await query.ToListAsync()
+            : query.ToList();
+
+        var mission = Assert.Single(missions);
+        Assert.Equal(2, mission.Id);
+
+        AssertSql(
+                @"@__dateTime_1='0002-03-01T13:00:00.0000000+00:00'
+@__timeZone_2='UTC' (Size = 8000) (DbType = AnsiString)
+
+SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Duration], [m].[Rating], [m].[Timeline]
+FROM [Missions] AS [m]
+WHERE [m].[Timeline] = (@__dateTime_1 AT TIME ZONE @__timeZone_2)");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Where_AtTimeZone_datetimeoffset_column(bool async)
+    {
+        using var context = CreateContext();
+
+        var query = context.Set<Mission>()
+            .Where(m => EF.Functions.AtTimeZone(m.Timeline, "UTC") == new DateTimeOffset(2, 3, 1, 13, 0, 0, TimeSpan.Zero));
+
+        var missions = async
+            ? await query.ToListAsync()
+            : query.ToList();
+
+        var mission = Assert.Single(missions);
+        Assert.Equal(2, mission.Id);
+
+        AssertSql(
+                @"SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Duration], [m].[Rating], [m].[Timeline]
+FROM [Missions] AS [m]
+WHERE ([m].[Timeline] AT TIME ZONE 'UTC') = '0002-03-01T13:00:00.0000000+00:00'");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Where_AtTimeZone_datetime_constant(bool async)
+    {
+        using var context = CreateContext();
+
+        var query = context.Set<Mission>().Where(m => m.Timeline == EF.Functions.AtTimeZone(new DateTime(10, 5, 3, 12, 0, 0), "UTC"));
+
+        var missions = async
+            ? await query.ToListAsync()
+            : query.ToList();
+
+        var mission = Assert.Single(missions);
+        Assert.Equal(3, mission.Id);
+
+        AssertSql(
+            @"SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Duration], [m].[Rating], [m].[Timeline]
+FROM [Missions] AS [m]
+WHERE [m].[Timeline] = (CAST('0010-05-03T12:00:00.0000000' AS datetime2) AT TIME ZONE 'UTC')");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Where_AtTimeZone_datetime_parameter(bool async)
+    {
+        using var context = CreateContext();
+
+        var dateTime = new DateTime(10, 5, 3, 12, 0, 0);
+        var timeZone = "UTC";
+        var query = context.Set<Mission>().Where(m => m.Timeline == EF.Functions.AtTimeZone(dateTime, timeZone));
+
+        var missions = async
+            ? await query.ToListAsync()
+            : query.ToList();
+
+        var mission = Assert.Single(missions);
+        Assert.Equal(3, mission.Id);
+
+        AssertSql(
+                @"@__dateTime_1='0010-05-03T12:00:00.0000000'
+@__timeZone_2='UTC' (Size = 8000) (DbType = AnsiString)
+
+SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Duration], [m].[Rating], [m].[Timeline]
+FROM [Missions] AS [m]
+WHERE [m].[Timeline] = (@__dateTime_1 AT TIME ZONE @__timeZone_2)");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Where_AtTimeZone_datetime_column(bool async)
+    {
+        using var context = CreateContext();
+
+        var query = context.Set<CogTag>()
+            .Where(ct => EF.Functions.AtTimeZone(ct.IssueDate, "UTC") == new DateTimeOffset(15, 3, 7, 0, 0, 0, TimeSpan.Zero));
+
+        var missions = async
+            ? await query.ToListAsync()
+            : query.ToList();
+
+        var mission = Assert.Single(missions);
+        Assert.Equal(Guid.Parse("A7BE028A-0CF2-448F-AB55-CE8BC5D8CF69"), mission.Id);
+
+        AssertSql(
+            @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
+FROM [Tags] AS [t]
+WHERE ([t].[IssueDate] AT TIME ZONE 'UTC') = '0015-03-07T00:00:00.0000000+00:00'");
+    }
+
     public override async Task Orderby_added_for_client_side_GroupJoin_composite_dependent_to_principal_LOJ_when_incomplete_key_is_used(
         bool async)
     {


### PR DESCRIPTION
* Adds AtTimeZoneExpression support to relational, along with support in QuerySqlGenerator, SqlNullabilityProcessor.
* Adds SQL Server-specific EF.Functions.AtTimeZone for datetimeoffset -> datetimeoffset and for datetime/datetime2 -> datetimeoffset

Closes #26199
Closes #26971
