### PR TITLE
Distinguish cancellation from failure

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -112,6 +112,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
             private readonly bool _standAloneStateManager;
             private readonly IConcurrencyDetector _concurrencyDetector;
+            private readonly IExceptionDetector _exceptionDetector;
 
             private IEnumerator<JObject> _enumerator;
 
@@ -125,6 +126,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 _partitionKey = queryingEnumerable._partitionKey;
                 _queryLogger = queryingEnumerable._queryLogger;
                 _standAloneStateManager = queryingEnumerable._standAloneStateManager;
+                _exceptionDetector = _cosmosQueryContext.ExceptionDetector;
 
                 _concurrencyDetector = queryingEnumerable._threadSafetyChecksEnabled
                     ? _cosmosQueryContext.ConcurrencyDetector
@@ -175,7 +177,14 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 }
                 catch (Exception exception)
                 {
-                    _queryLogger.QueryIterationFailed(_contextType, exception);
+                    if (_exceptionDetector.IsCancellation(exception))
+                    {
+                        _queryLogger.QueryCanceled(_contextType);
+                    }
+                    else
+                    {
+                        _queryLogger.QueryIterationFailed(_contextType, exception);
+                    }
 
                     throw;
                 }
@@ -203,6 +212,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             private readonly bool _standAloneStateManager;
             private readonly CancellationToken _cancellationToken;
             private readonly IConcurrencyDetector _concurrencyDetector;
+            private readonly IExceptionDetector _exceptionDetector;
 
             private IAsyncEnumerator<JObject> _enumerator;
 
@@ -216,6 +226,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 _partitionKey = queryingEnumerable._partitionKey;
                 _queryLogger = queryingEnumerable._queryLogger;
                 _standAloneStateManager = queryingEnumerable._standAloneStateManager;
+                _exceptionDetector = _cosmosQueryContext.ExceptionDetector;
                 _cancellationToken = cancellationToken;
 
                 _concurrencyDetector = queryingEnumerable._threadSafetyChecksEnabled
@@ -264,7 +275,14 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 }
                 catch (Exception exception)
                 {
-                    _queryLogger.QueryIterationFailed(_contextType, exception);
+                    if (_exceptionDetector.IsCancellation(exception, _cancellationToken))
+                    {
+                        _queryLogger.QueryCanceled(_contextType);
+                    }
+                    else
+                    {
+                        _queryLogger.QueryIterationFailed(_contextType, exception);
+                    }
 
                     throw;
                 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
@@ -64,7 +64,9 @@ public class InMemoryDatabase : Database, IInMemoryDatabase
     public override Task<int> SaveChangesAsync(
         IList<IUpdateEntry> entries,
         CancellationToken cancellationToken = default)
-        => Task.FromResult(_store.ExecuteTransaction(entries, _updateLogger));
+        => cancellationToken.IsCancellationRequested
+            ? Task.FromCanceled<int>(cancellationToken)
+            : Task.FromResult(_store.ExecuteTransaction(entries, _updateLogger));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Diagnostics/DbCommandInterceptor.cs
+++ b/src/EFCore.Relational/Diagnostics/DbCommandInterceptor.cs
@@ -362,6 +362,31 @@ public abstract class DbCommandInterceptor : IDbCommandInterceptor
         => new(result);
 
     /// <summary>
+    ///     Called when a command was canceled.
+    /// </summary>
+    /// <param name="command">The command.</param>
+    /// <param name="eventData">Contextual information about the command and execution.</param>
+    public virtual void CommandCanceled(
+        DbCommand command,
+        CommandEndEventData eventData)
+    {
+    }
+
+    /// <summary>
+    ///     Called when a command was canceled.
+    /// </summary>
+    /// <param name="command">The command.</param>
+    /// <param name="eventData">Contextual information about the command and execution.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public virtual Task CommandCanceledAsync(
+        DbCommand command,
+        CommandEndEventData eventData,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <summary>
     ///     Called when execution of a command has failed with an exception.
     /// </summary>
     /// <param name="command">The command.</param>

--- a/src/EFCore.Relational/Diagnostics/IDbCommandInterceptor.cs
+++ b/src/EFCore.Relational/Diagnostics/IDbCommandInterceptor.cs
@@ -366,6 +366,28 @@ public interface IDbCommandInterceptor : IInterceptor
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    ///     Called when a command was canceled.
+    /// </summary>
+    /// <param name="command">The command.</param>
+    /// <param name="eventData">Contextual information about the command and execution.</param>
+    void CommandCanceled(
+        DbCommand command,
+        CommandEndEventData eventData);
+
+    /// <summary>
+    ///     Called when a command was canceled.
+    /// </summary>
+    /// <param name="command">The command.</param>
+    /// <param name="eventData">Contextual information about the command and execution.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    Task CommandCanceledAsync(
+        DbCommand command,
+        CommandEndEventData eventData,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Called when execution of a command has failed with an exception.
     /// </summary>
     /// <param name="command">The command.</param>

--- a/src/EFCore.Relational/Diagnostics/IRelationalCommandDiagnosticsLogger.cs
+++ b/src/EFCore.Relational/Diagnostics/IRelationalCommandDiagnosticsLogger.cs
@@ -401,6 +401,56 @@ public interface IRelationalCommandDiagnosticsLogger : IDiagnosticsLogger<DbLogg
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.CommandCanceled" /> event.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="command">The database command object.</param>
+    /// <param name="context">The <see cref="DbContext" /> currently being used, to null if not known.</param>
+    /// <param name="executeMethod">Represents the method that will be called to execute the command.</param>
+    /// <param name="commandId">The correlation ID associated with the given <see cref="DbCommand" />.</param>
+    /// <param name="connectionId">The correlation ID associated with the <see cref="DbConnection" /> being used.</param>
+    /// <param name="startTime">The time that execution began.</param>
+    /// <param name="duration">The amount of time that passed until the exception was raised.</param>
+    /// <param name="commandSource">Source of the command.</param>
+    void CommandCanceled(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbContext? context,
+        DbCommandMethod executeMethod,
+        Guid commandId,
+        Guid connectionId,
+        DateTimeOffset startTime,
+        TimeSpan duration,
+        CommandSource commandSource);
+
+    /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.CommandCanceled" /> event.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="command">The database command object.</param>
+    /// <param name="context">The <see cref="DbContext" /> currently being used, to null if not known.</param>
+    /// <param name="executeMethod">Represents the method that will be called to execute the command.</param>
+    /// <param name="commandId">The correlation ID associated with the given <see cref="DbCommand" />.</param>
+    /// <param name="connectionId">The correlation ID associated with the <see cref="DbConnection" /> being used.</param>
+    /// <param name="startTime">The time that execution began.</param>
+    /// <param name="duration">The amount of time that passed until the exception was raised.</param>
+    /// <param name="commandSource">Source of the command.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task" /> representing the async operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    Task CommandCanceledAsync(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbContext? context,
+        DbCommandMethod executeMethod,
+        Guid commandId,
+        Guid connectionId,
+        DateTimeOffset startTime,
+        TimeSpan duration,
+        CommandSource commandSource,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Logs for the <see cref="RelationalEventId.DataReaderDisposing" /> event.
     /// </summary>
     /// <param name="connection">The connection.</param>

--- a/src/EFCore.Relational/Diagnostics/Internal/DbCommandInterceptorAggregator.cs
+++ b/src/EFCore.Relational/Diagnostics/Internal/DbCommandInterceptorAggregator.cs
@@ -221,6 +221,26 @@ public class DbCommandInterceptorAggregator : InterceptorAggregator<IDbCommandIn
             return result;
         }
 
+        public void CommandCanceled(DbCommand command, CommandEndEventData eventData)
+        {
+            for (var i = 0; i < _interceptors.Length; i++)
+            {
+                _interceptors[i].CommandCanceled(command, eventData);
+            }
+        }
+
+        public async Task CommandCanceledAsync(
+            DbCommand command,
+            CommandEndEventData eventData,
+            CancellationToken cancellationToken = default)
+        {
+            for (var i = 0; i < _interceptors.Length; i++)
+            {
+                await _interceptors[i].CommandCanceledAsync(command, eventData, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
         public void CommandFailed(DbCommand command, CommandErrorEventData eventData)
         {
             for (var i = 0; i < _interceptors.Length; i++)

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -36,6 +36,7 @@ public static class RelationalEventId
         CommandError,
         CommandCreating,
         CommandCreated,
+        CommandCanceled,
 
         // Transaction events
         TransactionStarted = CoreEventId.RelationalBaseId + 200,
@@ -170,6 +171,19 @@ public static class RelationalEventId
 
     private static EventId MakeCommandId(Id id)
         => new((int)id, _sqlPrefix + id);
+
+    /// <summary>
+    ///     A <see cref="DbCommand" /> has been canceled.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="CommandEndEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId CommandCanceled = MakeCommandId(Id.CommandCanceled);
 
     /// <summary>
     ///     A <see cref="DbCommand" /> is being created.

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -320,6 +320,15 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    public EventDefinitionBase? LogCommandCanceled;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     public EventDefinitionBase? LogCommandCreating;
 
     /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1613,6 +1613,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     A DbCommand was canceled ({elapsed}ms) [Parameters=[{parameters}], CommandType='{commandType}', CommandTimeout='{commandTimeout}']{newLine}{commandText}
+        /// </summary>
+        public static EventDefinition<string, string, System.Data.CommandType, int, string, string> LogCommandCanceled(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogCommandCanceled;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogCommandCanceled,
+                    logger,
+                    static logger => new EventDefinition<string, string, System.Data.CommandType, int, string, string>(
+                        logger.Options,
+                        RelationalEventId.CommandCanceled,
+                        LogLevel.Debug,
+                        "RelationalEventId.CommandCanceled",
+                        level => LoggerMessage.Define<string, string, System.Data.CommandType, int, string, string>(
+                            level,
+                            RelationalEventId.CommandCanceled,
+                            _resourceManager.GetString("LogCommandCanceled")!)));
+            }
+
+            return (EventDefinition<string, string, System.Data.CommandType, int, string, string>)definition;
+        }
+
+        /// <summary>
         ///     Created DbCommand for '{executionType}' ({elapsed}ms).
         /// </summary>
         public static EventDefinition<string, int> LogCommandCreated(IDiagnosticsLogger logger)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -455,6 +455,10 @@
     <value>The order of column '{table}.{column}' was ignored. Column orders are only used when the table is first created.</value>
     <comment>Warning RelationalEventId.ColumnOrderIgnoredWarning string string</comment>
   </data>
+  <data name="LogCommandCanceled" xml:space="preserve">
+    <value>A DbCommand was canceled ({elapsed}ms) [Parameters=[{parameters}], CommandType='{commandType}', CommandTimeout='{commandTimeout}']{newLine}{commandText}</value>
+    <comment>Debug RelationalEventId.CommandCanceled string string System.Data.CommandType int string string</comment>
+  </data>
   <data name="LogCommandCreated" xml:space="preserve">
     <value>Created DbCommand for '{executionType}' ({elapsed}ms).</value>
     <comment>Debug RelationalEventId.CommandCreated string int</comment>

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
@@ -151,6 +151,7 @@ public class FromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>,
         private readonly bool _standAloneStateManager;
         private readonly bool _detailedErrorsEnabled;
         private readonly IConcurrencyDetector? _concurrencyDetector;
+        private readonly IExceptionDetector _exceptionDetector;
 
         private IRelationalCommand? _relationalCommand;
         private RelationalDataReader? _dataReader;
@@ -166,6 +167,7 @@ public class FromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>,
             _queryLogger = queryingEnumerable._queryLogger;
             _standAloneStateManager = queryingEnumerable._standAloneStateManager;
             _detailedErrorsEnabled = queryingEnumerable._detailedErrorsEnabled;
+            _exceptionDetector = _relationalQueryContext.ExceptionDetector;
             Current = default!;
 
             _concurrencyDetector = queryingEnumerable._threadSafetyChecksEnabled
@@ -206,7 +208,14 @@ public class FromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>,
             }
             catch (Exception exception)
             {
-                _queryLogger.QueryIterationFailed(_contextType, exception);
+                if (_exceptionDetector.IsCancellation(exception))
+                {
+                    _queryLogger.QueryCanceled(_contextType);
+                }
+                else
+                {
+                    _queryLogger.QueryIterationFailed(_contextType, exception);
+                }
 
                 throw;
             }
@@ -260,6 +269,7 @@ public class FromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>,
         private readonly bool _standAloneStateManager;
         private readonly bool _detailedErrorsEnabled;
         private readonly IConcurrencyDetector? _concurrencyDetector;
+        private readonly IExceptionDetector _exceptionDetector;
 
         private IRelationalCommand? _relationalCommand;
         private RelationalDataReader? _dataReader;
@@ -275,6 +285,7 @@ public class FromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>,
             _queryLogger = queryingEnumerable._queryLogger;
             _standAloneStateManager = queryingEnumerable._standAloneStateManager;
             _detailedErrorsEnabled = queryingEnumerable._detailedErrorsEnabled;
+            _exceptionDetector = _relationalQueryContext.ExceptionDetector;
             Current = default!;
 
             _concurrencyDetector = queryingEnumerable._threadSafetyChecksEnabled
@@ -317,7 +328,14 @@ public class FromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>,
             }
             catch (Exception exception)
             {
-                _queryLogger.QueryIterationFailed(_contextType, exception);
+                if (_exceptionDetector.IsCancellation(exception, _relationalQueryContext.CancellationToken))
+                {
+                    _queryLogger.QueryCanceled(_contextType);
+                }
+                else
+                {
+                    _queryLogger.QueryIterationFailed(_contextType, exception);
+                }
 
                 throw;
             }

--- a/src/EFCore.Relational/Storage/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommand.cs
@@ -120,17 +120,33 @@ public class RelationalCommand : IRelationalCommand
         }
         catch (Exception exception)
         {
-            logger?.CommandError(
-                connection,
-                command,
-                context,
-                DbCommandMethod.ExecuteNonQuery,
-                commandId,
-                connection.ConnectionId,
-                exception,
-                startTime,
-                _stopwatch.Elapsed,
-                parameterObject.CommandSource);
+            if (Dependencies.ExceptionDetector.IsCancellation(exception))
+            {
+                logger?.CommandCanceled(
+                    connection,
+                    command,
+                    context,
+                    DbCommandMethod.ExecuteNonQuery,
+                    commandId,
+                    connection.ConnectionId,
+                    startTime,
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
+            }
+            else
+            {
+                logger?.CommandError(
+                    connection,
+                    command,
+                    context,
+                    DbCommandMethod.ExecuteNonQuery,
+                    commandId,
+                    connection.ConnectionId,
+                    exception,
+                    startTime,
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
+            }
 
             throw;
         }
@@ -217,19 +233,37 @@ public class RelationalCommand : IRelationalCommand
         {
             if (logger != null)
             {
-                await logger.CommandErrorAsync(
-                        connection,
-                        command,
-                        context,
-                        DbCommandMethod.ExecuteNonQuery,
-                        commandId,
-                        connection.ConnectionId,
-                        exception,
-                        startTime,
-                        _stopwatch.Elapsed,
-                        parameterObject.CommandSource,
-                        cancellationToken)
-                    .ConfigureAwait(false);
+                if (Dependencies.ExceptionDetector.IsCancellation(exception, cancellationToken))
+                {
+                    await logger.CommandCanceledAsync(
+                            connection,
+                            command,
+                            context,
+                            DbCommandMethod.ExecuteNonQuery,
+                            commandId,
+                            connection.ConnectionId,
+                            startTime,
+                            _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await logger.CommandErrorAsync(
+                            connection,
+                            command,
+                            context,
+                            DbCommandMethod.ExecuteNonQuery,
+                            commandId,
+                            connection.ConnectionId,
+                            exception,
+                            startTime,
+                            _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
 
             throw;
@@ -300,17 +334,33 @@ public class RelationalCommand : IRelationalCommand
         }
         catch (Exception exception)
         {
-            logger?.CommandError(
-                connection,
-                command,
-                context,
-                DbCommandMethod.ExecuteScalar,
-                commandId,
-                connection.ConnectionId,
-                exception,
-                startTime,
-                _stopwatch.Elapsed,
-                parameterObject.CommandSource);
+            if (Dependencies.ExceptionDetector.IsCancellation(exception))
+            {
+                logger?.CommandCanceled(
+                    connection,
+                    command,
+                    context,
+                    DbCommandMethod.ExecuteScalar,
+                    commandId,
+                    connection.ConnectionId,
+                    startTime,
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
+            }
+            else
+            {
+                logger?.CommandError(
+                    connection,
+                    command,
+                    context,
+                    DbCommandMethod.ExecuteScalar,
+                    commandId,
+                    connection.ConnectionId,
+                    exception,
+                    startTime,
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
+            }
 
             throw;
         }
@@ -396,19 +446,37 @@ public class RelationalCommand : IRelationalCommand
         {
             if (logger != null)
             {
-                await logger.CommandErrorAsync(
-                        connection,
-                        command,
-                        context,
-                        DbCommandMethod.ExecuteScalar,
-                        commandId,
-                        connection.ConnectionId,
-                        exception,
-                        startTime,
-                        _stopwatch.Elapsed,
-                        parameterObject.CommandSource,
-                        cancellationToken)
-                    .ConfigureAwait(false);
+                if (Dependencies.ExceptionDetector.IsCancellation(exception, cancellationToken))
+                {
+                    await logger.CommandCanceledAsync(
+                            connection,
+                            command,
+                            context,
+                            DbCommandMethod.ExecuteScalar,
+                            commandId,
+                            connection.ConnectionId,
+                            startTime,
+                            _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await logger.CommandErrorAsync(
+                            connection,
+                            command,
+                            context,
+                            DbCommandMethod.ExecuteScalar,
+                            commandId,
+                            connection.ConnectionId,
+                            exception,
+                            startTime,
+                            _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
 
             throw;
@@ -484,17 +552,33 @@ public class RelationalCommand : IRelationalCommand
         }
         catch (Exception exception)
         {
-            logger?.CommandError(
-                connection,
-                command,
-                context,
-                DbCommandMethod.ExecuteReader,
-                commandId,
-                connection.ConnectionId,
-                exception,
-                startTime,
-                _stopwatch.Elapsed,
-                parameterObject.CommandSource);
+            if (Dependencies.ExceptionDetector.IsCancellation(exception))
+            {
+                logger?.CommandCanceled(
+                    connection,
+                    command,
+                    context,
+                    DbCommandMethod.ExecuteReader,
+                    commandId,
+                    connection.ConnectionId,
+                    startTime,
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
+            }
+            else
+            {
+                logger?.CommandError(
+                    connection,
+                    command,
+                    context,
+                    DbCommandMethod.ExecuteReader,
+                    commandId,
+                    connection.ConnectionId,
+                    exception,
+                    startTime,
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
+            }
 
             CleanupCommand(command, connection);
 
@@ -602,19 +686,37 @@ public class RelationalCommand : IRelationalCommand
         {
             if (logger != null)
             {
-                await logger.CommandErrorAsync(
-                        connection,
-                        command,
-                        context,
-                        DbCommandMethod.ExecuteReader,
-                        commandId,
-                        connection.ConnectionId,
-                        exception,
-                        startTime,
-                        DateTimeOffset.UtcNow - startTime,
-                        parameterObject.CommandSource,
-                        cancellationToken)
-                    .ConfigureAwait(false);
+                if (Dependencies.ExceptionDetector.IsCancellation(exception, cancellationToken))
+                {
+                    await logger.CommandCanceledAsync(
+                            connection,
+                            command,
+                            context,
+                            DbCommandMethod.ExecuteReader,
+                            commandId,
+                            connection.ConnectionId,
+                            startTime,
+                            _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await logger.CommandErrorAsync(
+                            connection,
+                            command,
+                            context,
+                            DbCommandMethod.ExecuteReader,
+                            commandId,
+                            connection.ConnectionId,
+                            exception,
+                            startTime,
+                            _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
 
             await CleanupCommandAsync(command, connection).ConfigureAwait(false);

--- a/src/EFCore.Relational/Storage/RelationalCommandBuilderDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandBuilderDependencies.cs
@@ -45,12 +45,20 @@ public sealed record RelationalCommandBuilderDependencies
     /// </remarks>
     [EntityFrameworkInternal]
     public RelationalCommandBuilderDependencies(
-        IRelationalTypeMappingSource typeMappingSource)
+        IRelationalTypeMappingSource typeMappingSource,
+        IExceptionDetector exceptionDetector)
     {
+        ExceptionDetector = exceptionDetector;
+
 #pragma warning disable CS0618 // Type or member is obsolete
         TypeMappingSource = typeMappingSource;
 #pragma warning restore CS0618 // Type or member is obsolete
     }
+
+    /// <summary>
+    ///     The exception detector.
+    /// </summary>
+    public IExceptionDetector ExceptionDetector { get; init; }
 
     /// <summary>
     ///     The source for <see cref="RelationalTypeMapping" />s to use.

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -126,6 +126,7 @@ public static class SqlServerServiceCollectionExtensions
             .TryAdd<IRelationalParameterBasedSqlProcessorFactory, SqlServerParameterBasedSqlProcessorFactory>()
             .TryAdd<INavigationExpansionExtensibilityHelper, SqlServerNavigationExpansionExtensibilityHelper>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, SqlServerQueryableMethodTranslatingExpressionVisitorFactory>()
+            .TryAdd<IExceptionDetector, SqlServerExceptionDetector>()
             .TryAddProviderSpecificServices(
                 b => b
                     .TryAddSingleton<ISqlServerValueGeneratorCache, SqlServerValueGeneratorCache>()

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerExceptionDetector.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerExceptionDetector.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqlServerExceptionDetector : IExceptionDetector
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool IsCancellation(Exception exception, CancellationToken cancellationToken = default)
+        => exception is OperationCanceledException || cancellationToken.IsCancellationRequested;
+}

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -55,6 +55,7 @@ public static class CoreEventId
         SaveChangesStarting,
         SaveChangesCompleted,
         OptimisticConcurrencyException,
+        SaveChangesCanceled,
 
         // Query events
         QueryIterationFailed = CoreBaseId + 100,
@@ -72,6 +73,7 @@ public static class CoreEventId
         NavigationBaseIncluded,
         NavigationBaseIncludeIgnored,
         DistinctAfterOrderByWithoutRowLimitingOperatorWarning,
+        QueryCanceled,
 
         // Infrastructure events
         SensitiveDataLoggingEnabledWarning = CoreBaseId + 400,
@@ -145,6 +147,19 @@ public static class CoreEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId SaveChangesFailed = MakeUpdateId(Id.SaveChangesFailed);
+
+    /// <summary>
+    ///     An error occurred while attempting to save changes to the database.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Update" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="DbContextErrorEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId SaveChangesCanceled = MakeUpdateId(Id.SaveChangesCanceled);
 
     /// <summary>
     ///     The same entity is being tracked as a different shared entity entity type.
@@ -296,6 +311,15 @@ public static class CoreEventId
     /// </remarks>
     public static readonly EventId DistinctAfterOrderByWithoutRowLimitingOperatorWarning
         = MakeQueryId(Id.DistinctAfterOrderByWithoutRowLimitingOperatorWarning);
+
+    /// <summary>
+    ///     A query was canceled for context type '{contextType}'.
+    /// </summary>
+    /// <remarks>
+    ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+    /// </remarks>
+    public static readonly EventId QueryCanceled
+        = MakeQueryId(Id.QueryCanceled);
 
     private static readonly string _infraPrefix = DbLoggerCategory.Infrastructure.Name + ".";
 

--- a/src/EFCore/Diagnostics/ISaveChangesInterceptor.cs
+++ b/src/EFCore/Diagnostics/ISaveChangesInterceptor.cs
@@ -136,4 +136,19 @@ public interface ISaveChangesInterceptor : IInterceptor
     Task SaveChangesFailedAsync(
         DbContextErrorEventData eventData,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Called when <see cref="O:DbContext.SaveChanges" /> was canceled.
+    /// </summary>
+    /// <param name="eventData">Contextual information about the failure.</param>
+    void SaveChangesCanceled(DbContextEventData eventData);
+
+    /// <summary>
+    ///     Called when <see cref="O:DbContext.SaveChangesAsync" /> was canceled.
+    /// </summary>
+    /// <param name="eventData">Contextual information about the failure.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    Task SaveChangesCanceledAsync(DbContextEventData eventData, CancellationToken cancellationToken = default);
 }

--- a/src/EFCore/Diagnostics/Internal/SaveChangesInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/SaveChangesInterceptorAggregator.cs
@@ -56,6 +56,14 @@ public class SaveChangesInterceptorAggregator : InterceptorAggregator<ISaveChang
             }
         }
 
+        public void SaveChangesCanceled(DbContextEventData eventData)
+        {
+            for (var i = 0; i < _interceptors.Length; i++)
+            {
+                _interceptors[i].SaveChangesCanceled(eventData);
+            }
+        }
+
         public async ValueTask<InterceptionResult<int>> SavingChangesAsync(
             DbContextEventData eventData,
             InterceptionResult<int> result,
@@ -89,6 +97,16 @@ public class SaveChangesInterceptorAggregator : InterceptorAggregator<ISaveChang
             for (var i = 0; i < _interceptors.Length; i++)
             {
                 await _interceptors[i].SaveChangesFailedAsync(eventData, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public async Task SaveChangesCanceledAsync(
+            DbContextEventData eventData,
+            CancellationToken cancellationToken = default)
+        {
+            for (var i = 0; i < _interceptors.Length; i++)
+            {
+                await _interceptors[i].SaveChangesCanceledAsync(eventData, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/EFCore/Diagnostics/LoggingDefinitions.cs
+++ b/src/EFCore/Diagnostics/LoggingDefinitions.cs
@@ -167,6 +167,15 @@ public abstract class LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    public EventDefinitionBase? LogSaveChangedCanceled;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     public EventDefinitionBase? LogSkipCollectionChangeDetected;
 
     /// <summary>
@@ -339,6 +348,15 @@ public abstract class LoggingDefinitions
     /// </summary>
     [EntityFrameworkInternal]
     public EventDefinitionBase? LogIncludingNavigation;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? LogQueryCanceled;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Diagnostics/SaveChangesInterceptor.cs
+++ b/src/EFCore/Diagnostics/SaveChangesInterceptor.cs
@@ -62,6 +62,14 @@ public abstract class SaveChangesInterceptor : ISaveChangesInterceptor
     }
 
     /// <summary>
+    ///     Called when <see cref="O:DbContext.SaveChanges" /> was canceled.
+    /// </summary>
+    /// <param name="eventData">Contextual information about the failure.</param>
+    public virtual void SaveChangesCanceled(DbContextEventData eventData)
+    {
+    }
+
+    /// <summary>
     ///     Called at the start of <see cref="O:DbContext.SaveChangesAsync" />.
     /// </summary>
     /// <param name="eventData">Contextual information about the <see cref="DbContext" /> being used.</param>
@@ -121,6 +129,18 @@ public abstract class SaveChangesInterceptor : ISaveChangesInterceptor
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     public virtual Task SaveChangesFailedAsync(
         DbContextErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <summary>
+    ///     Called when <see cref="O:DbContext.SaveChanges" /> was canceled.
+    /// </summary>
+    /// <param name="eventData">Contextual information about the cancellation.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public virtual Task SaveChangesCanceledAsync(
+        DbContextEventData eventData,
         CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 }

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -81,6 +81,8 @@ public class EntityFrameworkServicesBuilder
             { typeof(IMemoryCache), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IEvaluatableExpressionFilter), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(INavigationExpansionExtensibilityHelper), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(IExceptionDetector), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+
             { typeof(IProviderConventionSetBuilder), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IConventionSetBuilder), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IDiagnosticsLogger<>), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -295,6 +297,7 @@ public class EntityFrameworkServicesBuilder
         TryAdd<IQueryTranslationPreprocessorFactory, QueryTranslationPreprocessorFactory>();
         TryAdd<IQueryTranslationPostprocessorFactory, QueryTranslationPostprocessorFactory>();
         TryAdd<INavigationExpansionExtensibilityHelper, NavigationExpansionExtensibilityHelper>();
+        TryAdd<IExceptionDetector, ExceptionDetector>();
 
         TryAdd(
             p => p.GetService<IDbContextOptions>()?.FindExtension<CoreOptionsExtension>()?.DbContextLogger

--- a/src/EFCore/Internal/DbContextDependencies.cs
+++ b/src/EFCore/Internal/DbContextDependencies.cs
@@ -38,6 +38,7 @@ public sealed record DbContextDependencies : IDbContextDependencies
         IEntityGraphAttacher entityGraphAttacher,
         IAsyncQueryProvider queryProvider,
         IStateManager stateManager,
+        IExceptionDetector exceptionDetector,
         IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger,
         IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastructureLogger)
     {
@@ -46,6 +47,7 @@ public sealed record DbContextDependencies : IDbContextDependencies
         EntityGraphAttacher = entityGraphAttacher;
         QueryProvider = queryProvider;
         StateManager = stateManager;
+        ExceptionDetector = exceptionDetector;
         UpdateLogger = updateLogger;
         InfrastructureLogger = infrastructureLogger;
         EntityFinderFactory = new EntityFinderFactory(entityFinderSource, stateManager, setSource, currentContext.Context);
@@ -98,6 +100,14 @@ public sealed record DbContextDependencies : IDbContextDependencies
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public IEntityGraphAttacher EntityGraphAttacher { get; init; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IExceptionDetector ExceptionDetector { get; init; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/IDbContextDependencies.cs
+++ b/src/EFCore/Internal/IDbContextDependencies.cs
@@ -73,6 +73,14 @@ public interface IDbContextDependencies
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    IExceptionDetector ExceptionDetector { get;  }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
 
     /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -3910,6 +3910,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     A query was canceled for context type '{contextType}'.
+        /// </summary>
+        public static EventDefinition<Type> LogQueryCanceled(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogQueryCanceled;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).LogQueryCanceled,
+                    logger,
+                    static logger => new EventDefinition<Type>(
+                        logger.Options,
+                        CoreEventId.QueryCanceled,
+                        LogLevel.Debug,
+                        "CoreEventId.QueryCanceled",
+                        level => LoggerMessage.Define<Type>(
+                            level,
+                            CoreEventId.QueryCanceled,
+                            _resourceManager.GetString("LogQueryCanceled")!)));
+            }
+
+            return (EventDefinition<Type>)definition;
+        }
+
+        /// <summary>
         ///     Compiling query expression: {newline}'{queryExpression}'
         /// </summary>
         public static EventDefinition<string, string> LogQueryCompilationStarting(IDiagnosticsLogger logger)
@@ -4157,6 +4182,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             }
 
             return (EventDefinition)definition;
+        }
+
+        /// <summary>
+        ///     A cancellation occurred while saving changes for context type '{contextType}'.
+        /// </summary>
+        public static EventDefinition<Type?> LogSaveChangesCanceled(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogSaveChangedCanceled;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).LogSaveChangedCanceled,
+                    logger,
+                    static logger => new EventDefinition<Type?>(
+                        logger.Options,
+                        CoreEventId.SaveChangesCanceled,
+                        LogLevel.Debug,
+                        "CoreEventId.SaveChangesCanceled",
+                        level => LoggerMessage.Define<Type?>(
+                            level,
+                            CoreEventId.SaveChangesCanceled,
+                            _resourceManager.GetString("LogSaveChangesCanceled")!)));
+            }
+
+            return (EventDefinition<Type?>)definition;
         }
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -837,6 +837,10 @@
     <value>The unchanged property '{entityType}.{property}' was detected as changed from '{oldValue}' to '{newValue}' and will be marked as modified for entity with key '{keyValues}'.</value>
     <comment>Debug CoreEventId.PropertyChangeDetected string string object? object? string</comment>
   </data>
+  <data name="LogQueryCanceled" xml:space="preserve">
+    <value>A query was canceled for context type '{contextType}'.</value>
+    <comment>Debug CoreEventId.QueryCanceled Type</comment>
+  </data>
   <data name="LogQueryCompilationStarting" xml:space="preserve">
     <value>Compiling query expression: {newline}'{queryExpression}'</value>
     <comment>Debug CoreEventId.QueryCompilationStarting string string</comment>
@@ -876,6 +880,10 @@
   <data name="LogRowLimitingOperationWithoutOrderBy" xml:space="preserve">
     <value>The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator. This may lead to unpredictable results. If the 'Distinct' operator is used after 'OrderBy', then make sure to use the 'OrderBy' operator after 'Distinct' as the ordering would otherwise get erased.</value>
     <comment>Warning CoreEventId.RowLimitingOperationWithoutOrderByWarning</comment>
+  </data>
+  <data name="LogSaveChangesCanceled" xml:space="preserve">
+    <value>A cancellation occurred while saving changes for context type '{contextType}'.</value>
+    <comment>Debug CoreEventId.SaveChangesCanceled Type?</comment>
   </data>
   <data name="LogSaveChangesCompleted" xml:space="preserve">
     <value>SaveChanges completed for '{contextType}' with {savedCount} entities written to the database.</value>

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -72,6 +72,12 @@ public abstract class QueryContext : IParameterValues
         => Dependencies.ConcurrencyDetector;
 
     /// <summary>
+    ///     The exception detector to use while executing the query.
+    /// </summary>
+    public virtual IExceptionDetector ExceptionDetector
+        => Dependencies.ExceptionDetector;
+
+    /// <summary>
     ///     The cancellation token to use while executing the query.
     /// </summary>
     public virtual CancellationToken CancellationToken { get; set; }

--- a/src/EFCore/Query/QueryContextDependencies.cs
+++ b/src/EFCore/Query/QueryContextDependencies.cs
@@ -52,12 +52,14 @@ public sealed record QueryContextDependencies
         ICurrentDbContext currentContext,
         IExecutionStrategy executionStrategy,
         IConcurrencyDetector concurrencyDetector,
+        IExceptionDetector exceptionDetector,
         IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
         IDiagnosticsLogger<DbLoggerCategory.Query> queryLogger)
     {
         CurrentContext = currentContext;
         ExecutionStrategy = executionStrategy;
         ConcurrencyDetector = concurrencyDetector;
+        ExceptionDetector = exceptionDetector;
         CommandLogger = commandLogger;
         QueryLogger = queryLogger;
     }
@@ -86,6 +88,11 @@ public sealed record QueryContextDependencies
     ///     Gets the concurrency detector.
     /// </summary>
     public IConcurrencyDetector ConcurrencyDetector { get; init; }
+
+    /// <summary>
+    ///     Gets the exception detector.
+    /// </summary>
+    public IExceptionDetector ExceptionDetector { get; init; }
 
     /// <summary>
     ///     The command logger.

--- a/src/EFCore/Storage/IExceptionDetector.cs
+++ b/src/EFCore/Storage/IExceptionDetector.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Storage;
+
+/// <summary>
+///     Used by EF internal code and database providers to detect various types of exceptions.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
+///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
+///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+///     </para>
+///     <para>
+///         See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
+///         for more information and examples.
+///     </para>
+/// </remarks>
+public interface IExceptionDetector
+{
+    /// <summary>
+    ///     Returns whether the provided exception represents a cancellation event for the current provider.
+    /// </summary>
+    /// <param name="exception">The exception to be checked for cancellation.</param>
+    /// <param name="cancellationToken">
+    ///     If <paramref name="exception" /> is insufficient for identifying a cancellation, this is the cancellation token passed to the
+    ///     asynchronous operation; it can be checked instead as a fallback mechanism.
+    /// </param>
+    public bool IsCancellation(Exception exception, CancellationToken cancellationToken = default);
+}

--- a/src/EFCore/Storage/Internal/ExceptionDetector.cs
+++ b/src/EFCore/Storage/Internal/ExceptionDetector.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class ExceptionDetector : IExceptionDetector
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool IsCancellation(Exception exception, CancellationToken cancellationToken)
+        => exception is OperationCanceledException;
+}

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindQueryInMemoryFixture.cs
@@ -11,4 +11,7 @@ public class NorthwindQueryInMemoryFixture<TModelCustomizer> : NorthwindQueryFix
 
     protected override Type ContextType
         => typeof(NorthwindInMemoryContext);
+
+    protected override bool ShouldLogCategory(string logCategory)
+        => logCategory == DbLoggerCategory.Query.Name;
 }

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 
 namespace Microsoft.EntityFrameworkCore.Migrations;
@@ -400,7 +401,8 @@ public class MigrationCommandExecutorTest
             new RelationalCommandBuilderDependencies(
                 new TestRelationalTypeMappingSource(
                     TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
+                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                new ExceptionDetector()),
             commandText,
             parameters ?? Array.Empty<IRelationalParameter>());
 }

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 
@@ -135,7 +136,8 @@ Statement3
             new MigrationsSqlGeneratorDependencies(
                 new RelationalCommandBuilderFactory(
                     new RelationalCommandBuilderDependencies(
-                        typeMappingSource)),
+                        typeMappingSource,
+                        new ExceptionDetector())),
                 new FakeSqlGenerator(
                     new UpdateSqlGeneratorDependencies(
                         generationHelper,

--- a/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
 public class QuerySqlGeneratorTest
@@ -50,7 +52,8 @@ public class QuerySqlGeneratorTest
                     new RelationalCommandBuilderDependencies(
                         new TestRelationalTypeMappingSource(
                             TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                            TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()))),
+                            TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                        new ExceptionDetector())),
                 new RelationalSqlGenerationHelper(
                     new RelationalSqlGenerationHelperDependencies())));
 

--- a/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
@@ -24,7 +24,8 @@ public class RawSqlCommandBuilderTest
                 new RelationalCommandBuilderDependencies(
                     new TestRelationalTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()))),
+                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                    new ExceptionDetector())),
             new RelationalSqlGenerationHelper(
                 new RelationalSqlGenerationHelperDependencies()),
             new ParameterNameGeneratorFactory(

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage;
 
@@ -41,7 +42,8 @@ public class RelationalCommandBuilderTest
         var dependencies = new RelationalCommandBuilderDependencies(
             new TestRelationalTypeMappingSource(
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()));
+                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+            new ExceptionDetector());
 
         var commandBuilder = new RelationalCommandBuilder(dependencies);
         return commandBuilder;

--- a/test/EFCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
@@ -20,7 +20,8 @@ public class RelationalParameterBuilderTest
 
         var parameterBuilder = new RelationalCommandBuilder(
             new RelationalCommandBuilderDependencies(
-                typeMapper));
+                typeMapper,
+                new ExceptionDetector()));
 
         parameterBuilder.AddParameter(
             "InvariantName",
@@ -57,7 +58,7 @@ public class RelationalParameterBuilderTest
         var property = model.GetEntityTypes().Single().FindProperty("MyProp");
 
         var parameterBuilder = new RelationalCommandBuilder(
-            new RelationalCommandBuilderDependencies(typeMapper));
+            new RelationalCommandBuilderDependencies(typeMapper, new ExceptionDetector()));
 
         parameterBuilder.AddParameter(
             "InvariantName",
@@ -85,7 +86,8 @@ public class RelationalParameterBuilderTest
 
         var parameterBuilder = new RelationalCommandBuilder(
             new RelationalCommandBuilderDependencies(
-                typeMapper));
+                typeMapper,
+                new ExceptionDetector()));
 
         parameterBuilder.AddCompositeParameter(
             "CompositeInvariant",
@@ -121,7 +123,8 @@ public class RelationalParameterBuilderTest
 
         var parameterBuilder = new RelationalCommandBuilder(
             new RelationalCommandBuilderDependencies(
-                typeMapper));
+                typeMapper,
+                new ExceptionDetector()));
 
         parameterBuilder.AddCompositeParameter(
             "CompositeInvariant",

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -40,7 +40,8 @@ public class FakeRelationalConnection : RelationalConnection
                     new RelationalCommandBuilderDependencies(
                         new TestRelationalTypeMappingSource(
                             TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                            TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())))))
+                            TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                        new ExceptionDetector()))))
     {
     }
 

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeRelationalCommandDiagnosticsLogger.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeRelationalCommandDiagnosticsLogger.cs
@@ -50,17 +50,6 @@ public class FakeRelationalCommandDiagnosticsLogger
         CommandSource commandSource)
         => default;
 
-    /// <summary>
-    ///     Logs for the <see cref="RelationalEventId.CommandExecuting" /> event.
-    /// </summary>
-    /// <param name="connection">The connection.</param>
-    /// <param name="command">The database command object.</param>
-    /// <param name="context">The <see cref="DbContext" /> currently being used, to null if not known.</param>
-    /// <param name="commandId">The correlation ID associated with the given <see cref="System.Data.Common.DbCommand" />.</param>
-    /// <param name="connectionId">The correlation ID associated with the <see cref="System.Data.Common.DbConnection" /> being used.</param>
-    /// <param name="startTime">The time that execution began.</param>
-    /// <param name="commandSource">Source of the command.</param>
-    /// <returns>An intercepted result.</returns>
     public InterceptionResult<int> CommandNonQueryExecuting(
         IRelationalConnection connection,
         DbCommand command,
@@ -179,6 +168,34 @@ public class FakeRelationalCommandDiagnosticsLogger
         CancellationToken cancellationToken = default)
         => new(methodResult);
 
+    public void CommandException(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbContext? context,
+        DbCommandMethod executeMethod,
+        Guid commandId,
+        Guid connectionId,
+        Exception exception,
+        DateTimeOffset startTime,
+        TimeSpan duration,
+        CommandSource commandSource)
+    {
+    }
+
+    public Task CommandExceptionAsync(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbContext? context,
+        DbCommandMethod executeMethod,
+        Guid commandId,
+        Guid connectionId,
+        Exception exception,
+        DateTimeOffset startTime,
+        TimeSpan duration,
+        CommandSource commandSource,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
     public void CommandError(
         IRelationalConnection connection,
         DbCommand command,
@@ -201,6 +218,32 @@ public class FakeRelationalCommandDiagnosticsLogger
         Guid commandId,
         Guid connectionId,
         Exception exception,
+        DateTimeOffset startTime,
+        TimeSpan duration,
+        CommandSource commandSource,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public void CommandCanceled(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbContext? context,
+        DbCommandMethod executeMethod,
+        Guid commandId,
+        Guid connectionId,
+        DateTimeOffset startTime,
+        TimeSpan duration,
+        CommandSource commandSource)
+    {
+    }
+
+    public Task CommandCanceledAsync(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbContext? context,
+        DbCommandMethod executeMethod,
+        Guid commandId,
+        Guid connectionId,
         DateTimeOffset startTime,
         TimeSpan duration,
         CommandSource commandSource,

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 
@@ -608,7 +609,8 @@ public class ReaderModificationCommandBatchTest
             return new ModificationCommandBatchFactoryDependencies(
                 new RelationalCommandBuilderFactory(
                     new RelationalCommandBuilderDependencies(
-                        typeMappingSource)),
+                        typeMappingSource,
+                        new ExceptionDetector())),
                 new RelationalSqlGenerationHelper(
                     new RelationalSqlGenerationHelperDependencies()),
                 sqlGenerator

--- a/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
@@ -414,6 +414,7 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
         public bool AsyncCalled { get; set; }
         public bool SyncCalled { get; set; }
         public bool FailedCalled { get; set; }
+        public bool CanceledCalled { get; set; }
         public bool SavedChangesCalled { get; set; }
         public bool SavingChangesCalled { get; set; }
 
@@ -447,6 +448,15 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
             Context = eventData.Context;
             Exception = eventData.Exception;
             FailedCalled = true;
+            SyncCalled = true;
+        }
+
+        public virtual void SaveChangesCanceled(DbContextEventData eventData)
+        {
+            Assert.NotNull(eventData.Context);
+
+            Context = eventData.Context;
+            CanceledCalled = true;
             SyncCalled = true;
         }
 
@@ -488,6 +498,19 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
             Context = eventData.Context;
             Exception = eventData.Exception;
             FailedCalled = true;
+            AsyncCalled = true;
+
+            return Task.CompletedTask;
+        }
+
+        public virtual Task SaveChangesCanceledAsync(
+            DbContextEventData eventData,
+            CancellationToken cancellationToken = default)
+        {
+            Assert.NotNull(eventData.Context);
+
+            Context = eventData.Context;
+            CanceledCalled = true;
             AsyncCalled = true;
 
             return Task.CompletedTask;

--- a/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -88,7 +88,8 @@ public class SqlServerConnectionTest
                 new RelationalCommandBuilderDependencies(
                     new TestRelationalTypeMappingSource(
                         TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()))));
+                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                    new SqlServerExceptionDetector())));
     }
 
     private const string ConnectionString = "Fake Connection String";

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -27,7 +27,8 @@ public class SqlServerModificationCommandBatchFactoryTest
             new ModificationCommandBatchFactoryDependencies(
                 new RelationalCommandBuilderFactory(
                     new RelationalCommandBuilderDependencies(
-                        typeMapper)),
+                        typeMapper,
+                        new SqlServerExceptionDetector())),
                 new SqlServerSqlGenerationHelper(
                     new RelationalSqlGenerationHelperDependencies()),
                 new SqlServerUpdateSqlGenerator(
@@ -64,7 +65,8 @@ public class SqlServerModificationCommandBatchFactoryTest
             new ModificationCommandBatchFactoryDependencies(
                 new RelationalCommandBuilderFactory(
                     new RelationalCommandBuilderDependencies(
-                        typeMapper)),
+                        typeMapper,
+                        new SqlServerExceptionDetector())),
                 new SqlServerSqlGenerationHelper(
                     new RelationalSqlGenerationHelperDependencies()),
                 new SqlServerUpdateSqlGenerator(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -24,7 +24,8 @@ public class SqlServerModificationCommandBatchTest
             new ModificationCommandBatchFactoryDependencies(
                 new RelationalCommandBuilderFactory(
                     new RelationalCommandBuilderDependencies(
-                        typeMapper)),
+                        typeMapper,
+                        new SqlServerExceptionDetector())),
                 new SqlServerSqlGenerationHelper(
                     new RelationalSqlGenerationHelperDependencies()),
                 new SqlServerUpdateSqlGenerator(


### PR DESCRIPTION
* Instead of QueryIterationFailed, SaveChangesFailed, and CommandError, we now emit QueryCanceled, SaveChangedAsync and CommandCanceled when we detect cancellation. The default log level for the cancellation events is Debug.
* Cancellation is detected by looking at the exception rather than checking whether the token has been triggered. This allows:
  * Avoid race conditions where a non-cancellation error is bubbling up just as the user triggers the token.
  * Detect cancellations not triggered via the cancellation token (e.g. triggered in the database directly). This is also why the sync execution path is covered.
* Unfortunately, SqlClient provides no way to detect cancellation exceptions (see https://github.com/dotnet/SqlClient/issues/26#issuecomment-991934255). As a result, cancellation detection logic is in a new ExceptionDetector singleton service, overridden by SQL Server to check the cancellation token (so the two problems above exist for SQL Server).

Closes #19526

/cc @ajcvickers for logging infra rocket science :rocket::rocket::rocket:

PS We can consider moving transient exception detection into the new ExceptionDetector as well. The default implementation could call the new DbException.IsTransient, the SQL Server implementation would just contain the logic currently in SqlServerTransientExceptionDetector etc.
