### PR TITLE
Enable strict compilation

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
     <IsPackable>True</IsPackable>
     <IncludeSymbols>True</IncludeSymbols>
     <Nullable>enable</Nullable>
-    <Feature>nullablePublicOnly</Feature>
+    <Features>nullablePublicOnly;strict</Features>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\rulesets\EFCore.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 


### PR DESCRIPTION
Enable the compiler "strict" option. No new errors were generated as a result; I suspect that the recent "warning waves" feature simply integrated all of strict's diagnostics and made it unneeded - but there doesn't seem to be any harm in enabling it. 

@sharwell any comment?

Closes #14502

