### PR TITLE
Query: Mark SelectExpression as immutable after projection has been applied

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -978,12 +978,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, table);
 
         /// <summary>
-        ///     The query contains usage of 'Any' or 'AnyAsync' operation after 'FromSqlRaw' or 'FromSqlInterpolated' method. Using this raw SQL query more than once isn't currently supported. Replace the use of 'Any' or 'AnyAsync' with 'Count' or 'CountAsync'. See https://go.microsoft.com/fwlink/?linkid=2174053 for more information.
-        /// </summary>
-        public static string QueryFromSqlInsideExists
-            => GetString("QueryFromSqlInsideExists");
-
-        /// <summary>
         ///     The entity type '{entityType}' is not mapped to a table, therefore the entities cannot be persisted to the database. Call 'ToTable' in 'OnModelCreating' to map it to a table.
         /// </summary>
         public static string ReadonlyEntitySaved(object? entityType)
@@ -1162,7 +1156,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -725,9 +725,6 @@
   </data>
   <data name="PropertyNotMappedToTable" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' is not mapped to '{table}'.</value>
-  </data>
-  <data name="QueryFromSqlInsideExists" xml:space="preserve">
-    <value>The query contains usage of 'Any' or 'AnyAsync' operation after 'FromSqlRaw' or 'FromSqlInterpolated' method. Using this raw SQL query more than once isn't currently supported. Replace the use of 'Any' or 'AnyAsync' with 'Count' or 'CountAsync'. See https://go.microsoft.com/fwlink/?linkid=2174053 for more information.</value>
   </data>
   <data name="ReadonlyEntitySaved" xml:space="preserve">
     <value>The entity type '{entityType}' is not mapped to a table, therefore the entities cannot be persisted to the database. Call 'ToTable' in 'OnModelCreating' to map it to a table.</value>

--- a/src/EFCore.Relational/Query/Internal/EnumHasFlagTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/EnumHasFlagTranslator.cs
@@ -47,9 +47,7 @@ public class EnumHasFlagTranslator : IMethodCallTranslator
             var argument = arguments[0];
             return instance.Type != argument.Type
                 ? null
-                // TODO: If argument is SelectExpression, we need to clone it.
-                // See issue#26532
-                : (SqlExpression)_sqlExpressionFactory.Equal(_sqlExpressionFactory.And(instance, argument), argument);
+                : _sqlExpressionFactory.Equal(_sqlExpressionFactory.And(instance, argument), argument);
         }
 
         return null;

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -184,7 +184,8 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
 
         var selectExpression = (SelectExpression)source.QueryExpression;
         selectExpression.ApplyPredicate(_sqlExpressionFactory.Not(translation));
-        selectExpression.ReplaceProjection(new Dictionary<ProjectionMember, Expression>());
+        selectExpression.ReplaceProjection(new List<Expression>());
+        selectExpression.ApplyProjection();
         if (selectExpression.Limit == null
             && selectExpression.Offset == null)
         {
@@ -215,7 +216,8 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
         }
 
         var selectExpression = (SelectExpression)source.QueryExpression;
-        selectExpression.ReplaceProjection(new Dictionary<ProjectionMember, Expression>());
+        selectExpression.ReplaceProjection(new List<Expression>());
+        selectExpression.ApplyProjection();
         if (selectExpression.Limit == null
             && selectExpression.Offset == null)
         {
@@ -284,8 +286,8 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             var projection = selectExpression.GetProjection(projectionBindingExpression);
             if (projection is SqlExpression sqlExpression)
             {
-                selectExpression.ReplaceProjection(new List<Expression>());
-                selectExpression.AddToProjection(sqlExpression);
+                selectExpression.ReplaceProjection(new List<Expression> { sqlExpression });
+                selectExpression.ApplyProjection();
 
                 translation = _sqlExpressionFactory.In(translation, selectExpression, false);
 

--- a/src/EFCore.Relational/Query/SqlExpressions/ExistsExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExistsExpression.cs
@@ -26,6 +26,13 @@ public class ExistsExpression : SqlExpression
         RelationalTypeMapping? typeMapping)
         : base(typeof(bool), typeMapping)
     {
+
+#if DEBUG
+        if (subquery.IsMutable() == true)
+        {
+            throw new InvalidOperationException();
+        }
+#endif
         Subquery = subquery;
         IsNegated = negated;
     }

--- a/src/EFCore.Relational/Query/SqlExpressions/InExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InExpression.cs
@@ -56,6 +56,12 @@ public class InExpression : SqlExpression
         RelationalTypeMapping? typeMapping)
         : base(typeof(bool), typeMapping)
     {
+#if DEBUG
+        if (subquery?.IsMutable() == true)
+        {
+            throw new InvalidOperationException();
+        }
+#endif
         Item = item;
         Subquery = subquery;
         Values = values;

--- a/src/EFCore.Relational/Query/SqlExpressions/ScalarSubqueryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ScalarSubqueryExpression.cs
@@ -31,6 +31,13 @@ public class ScalarSubqueryExpression : SqlExpression
             throw new InvalidOperationException(CoreStrings.TranslationFailed(selectExpression.Print()));
         }
 
+#if DEBUG
+        if (selectExpression.IsMutable() == true)
+        {
+            throw new InvalidOperationException();
+        }
+#endif
+
         return selectExpression;
     }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -775,6 +775,7 @@ public sealed partial class SelectExpression
                     _groupingCorrelationPredicate = groupingCorrelationPredicate,
                     _groupingParentSelectExpressionId = selectExpression._groupingParentSelectExpressionId
                 };
+                newSelectExpression._mutable = selectExpression._mutable;
 
                 newSelectExpression._tptLeftJoinTables.AddRange(selectExpression._tptLeftJoinTables);
                 // Since identifiers are ColumnExpression, they are not visited since they don't contain SelectExpression inside it.

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -42,12 +42,13 @@ public sealed partial class SelectExpression : TableExpressionBase
     private readonly List<TableReferenceExpression> _tableReferences = new();
     private readonly List<SqlExpression> _groupBy = new();
     private readonly List<OrderingExpression> _orderings = new();
-    private HashSet<string> _usedAliases = new();
 
     private readonly List<(ColumnExpression Column, ValueComparer Comparer)> _identifier = new();
     private readonly List<(ColumnExpression Column, ValueComparer Comparer)> _childIdentifiers = new();
-
     private readonly List<int> _tptLeftJoinTables = new();
+
+    private bool _mutable = true;
+    private HashSet<string> _usedAliases = new();
     private Dictionary<ProjectionMember, Expression> _projectionMapping = new();
     private List<Expression> _clientProjections = new();
     private readonly List<string?> _aliasForClientProjections = new();
@@ -387,7 +388,71 @@ public sealed partial class SelectExpression : TableExpressionBase
     }
 
     /// <summary>
-    ///     Adds expressions from projection mapping to projection if not done already.
+    ///     Adds expressions from projection mapping to projection ignoring the shaper expression. This method should only be used
+    ///     when populating projection in subquery.
+    /// </summary>
+    public void ApplyProjection()
+    {
+        if (!_mutable)
+        {
+            throw new InvalidOperationException("Applying projection on already finalized select expression");
+        }
+
+        _mutable = false;
+        if (_clientProjections.Count > 0)
+        {
+            for (var i = 0; i < _clientProjections.Count; i++)
+            {
+                switch(_clientProjections[i])
+                {
+                    case EntityProjectionExpression entityProjectionExpression:
+                        AddEntityProjection(entityProjectionExpression);
+                        break;
+
+                    case SqlExpression sqlExpression:
+                        AddToProjection(sqlExpression, _aliasForClientProjections[i]);
+                        break;
+
+                    default:
+                        throw new InvalidOperationException("Invalid type of projection to add when not associated with shaper expression.");
+                }
+
+            }
+
+            _clientProjections.Clear();
+        }
+        else
+        {
+            foreach (var (_, expression) in _projectionMapping)
+            {
+                if (expression is EntityProjectionExpression entityProjectionExpression)
+                {
+                    AddEntityProjection(entityProjectionExpression);
+                }
+                else
+                {
+                    AddToProjection((SqlExpression)expression);
+                }
+            }
+            _projectionMapping.Clear();
+        }
+
+        void AddEntityProjection(EntityProjectionExpression entityProjectionExpression)
+        {
+            foreach (var property in GetAllPropertiesInHierarchy(entityProjectionExpression.EntityType))
+            {
+                AddToProjection(entityProjectionExpression.BindProperty(property), null);
+            }
+
+            if (entityProjectionExpression.DiscriminatorExpression != null)
+            {
+                AddToProjection(entityProjectionExpression.DiscriminatorExpression, DiscriminatorColumnAlias);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Adds expressions from projection mapping to projection and generate updated shaper expression for materialization.
     /// </summary>
     /// <param name="shaperExpression">Current shaper expression which will shape results of this select expression.</param>
     /// <param name="resultCardinality">The result cardinality of this query expression.</param>
@@ -398,11 +463,12 @@ public sealed partial class SelectExpression : TableExpressionBase
         ResultCardinality resultCardinality,
         QuerySplittingBehavior querySplittingBehavior)
     {
-        if (Projection.Any())
+        if (!_mutable)
         {
             throw new InvalidOperationException("Applying projection on already finalized select expression");
         }
 
+        _mutable = false;
         if (_clientProjections.Count > 0)
         {
             EntityShaperNullableMarkingExpressionVisitor? entityShaperNullableMarkingExpressionVisitor = null;
@@ -452,6 +518,8 @@ public sealed partial class SelectExpression : TableExpressionBase
             if (querySplittingBehavior == QuerySplittingBehavior.SplitQuery && containsCollection)
             {
                 baseSelectExpression = (SelectExpression)cloningExpressionVisitor!.Visit(this);
+                // We mark this as mutable because the split query will combine into this and take it over.
+                baseSelectExpression._mutable = true;
                 if (resultCardinality == ResultCardinality.Single
                     || resultCardinality == ResultCardinality.SingleOrDefault)
                 {
@@ -489,6 +557,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                     // again so it does contain the single result subquery too. We erase projections for it since it would be non-empty.
                     earlierClientProjectionCount = _clientProjections.Count;
                     baseSelectExpression = (SelectExpression)cloningExpressionVisitor!.Visit(this);
+                    baseSelectExpression._mutable = true;
                     baseSelectExpression._projection.Clear();
                 }
 
@@ -1601,6 +1670,11 @@ public sealed partial class SelectExpression : TableExpressionBase
         _tables.Add(setExpression);
         _tableReferences.Add(tableReferenceExpression);
 
+        // Mark both inner subqueries as immutable
+        select1._mutable = false;
+        select2._mutable = false;
+
+
         // We should apply _identifiers only when it is distinct and actual select expression had identifiers.
         if (distinct
             && outerIdentifiers.Length > 0)
@@ -1743,6 +1817,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             new List<SqlExpression>(),
             new List<OrderingExpression>(),
             Enumerable.Empty<IAnnotation>());
+        dummySelectExpression._mutable = false;
 
         if (Orderings.Any()
             || Limit != null
@@ -2604,6 +2679,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             _groupingParentSelectExpressionId = _groupingParentSelectExpressionId
         };
         subquery._usedAliases = _usedAliases;
+        subquery._mutable = false;
         _tables.Clear();
         _tableReferences.Clear();
         _groupBy.Clear();
@@ -3079,7 +3155,7 @@ public sealed partial class SelectExpression : TableExpressionBase
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
     {
-        if (_projection.Count == 0)
+        if (_mutable)
         {
             // If projection is not populated then we need to treat this as mutable object since it is not final yet.
             if (_clientProjections.Count > 0)
@@ -3252,7 +3328,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                     _groupingCorrelationPredicate = groupingCorrelationPredicate,
                     _groupingParentSelectExpressionId = _groupingParentSelectExpressionId
                 };
-
+                newSelectExpression._mutable = false;
                 newSelectExpression._tptLeftJoinTables.AddRange(_tptLeftJoinTables);
 
                 newSelectExpression._identifier.AddRange(identifier.Zip(_identifier).Select(e => (e.First, e.Second.Comparer)));
@@ -3341,6 +3417,8 @@ public sealed partial class SelectExpression : TableExpressionBase
         SqlExpression? limit,
         SqlExpression? offset)
     {
+        Check.DebugAssert(!_mutable, "SelectExpression shouldn't be mutable when calling this method.");
+
         var projectionMapping = new Dictionary<ProjectionMember, Expression>();
         foreach (var (projectionMember, expression) in _projectionMapping)
         {
@@ -3360,6 +3438,8 @@ public sealed partial class SelectExpression : TableExpressionBase
             IsDistinct = IsDistinct,
             Tags = Tags
         };
+
+        newSelectExpression._mutable = false;
 
         // We don't copy identifiers because when we are doing reconstruction so projection is already applied.
         // Update method should not be used pre-projection application. There are other methods to change SelectExpression.
@@ -3528,4 +3608,8 @@ public sealed partial class SelectExpression : TableExpressionBase
     public override int GetHashCode()
         // Since equality above is reference equality, hash code can also be based on reference.
         => RuntimeHelpers.GetHashCode(this);
+
+#if DEBUG
+    internal bool IsMutable() => _mutable;
+#endif
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -1260,11 +1260,11 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             ? await query.AnyAsync()
             : query.Any();
 
-        Assert.Equal(
-            RelationalStrings.QueryFromSqlInsideExists,
-            async
-                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.AnyAsync())).Message
-                : Assert.Throws<InvalidOperationException>(() => query.Any()).Message);
+        var result2 = async
+            ? await query.AnyAsync()
+            : query.Any();
+
+        Assert.Equal(result1, result2);
     }
 
     [ConditionalTheory]
@@ -1281,11 +1281,11 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             ? await query.AnyAsync()
             : query.Any();
 
-        Assert.Equal(
-            RelationalStrings.QueryFromSqlInsideExists,
-            async
-                ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.AnyAsync())).Message
-                : Assert.Throws<InvalidOperationException>(() => query.Any()).Message);
+        var result2 = async
+            ? await query.AnyAsync()
+            : query.Any();
+
+        Assert.Equal(result1, result2);
     }
 
     [ConditionalTheory]


### PR DESCRIPTION
- Add an internal state to remember the mutability which is set to false after ApplyProjection is called.
- Add overload of ApplyProjection which ignores shaper to create an immutable select expression to be used as subquery
- Add debug check to verify that all SelectExpression are marked as immutable
~- Clone mapped projection of SqlExpression kind before translating it further to avoid reference sharing with projection which may be applied at later stage~

Resolves #26532 - all those expressions have debug check in ctor
Resolves #26167 - by having more accurate flag for immutability
~Resolves #26104 - by cloning the projection before translating further. This issue may get resolved in other way after pending selector work if we reuse projections from subquery but regardless the change seems better to avoid reference sharing of SelectExpression objects~
