### PR TITLE
Tweak SaveChangesAsync_accepts_changes_with_ConfigureAwait_true_22841

### DIFF
--- a/test/EFCore.Specification.Tests/TestUtilities/SingleThreadSynchronizationContext.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/SingleThreadSynchronizationContext.cs
@@ -14,6 +14,7 @@ public class SingleThreadSynchronizationContext : SynchronizationContext, IDispo
     public SingleThreadSynchronizationContext()
     {
         Thread = new Thread(WorkLoop);
+        Thread.IsBackground = true;
         Thread.Start();
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -9053,6 +9053,10 @@ WHERE JSON_VALUE([b].[JObject], '$.Author') = N'Maumar'");
         var origSynchronizationContext = SynchronizationContext.Current;
         SynchronizationContext.SetSynchronizationContext(trackingSynchronizationContext);
 
+        // Do a dispatch once to make sure we're in the new synchronization context. This is necessary in case the below happens
+        // to complete synchronously, which shouldn't happen in principle - but just to be safe.
+        await Task.Delay(1).ConfigureAwait(true);
+
         bool? isMySyncContext = null;
         Action callback = () => isMySyncContext =
             SynchronizationContext.Current == trackingSynchronizationContext


### PR DESCRIPTION
I can't really see how the failure in #26996 could be possible (and have failed to reproduce it) - but here's a small tweak which should if the test code happens to complete synchronously (which doesn't make much sense to me).


