### PR TITLE
There's no escape from those cold north winds

### DIFF
--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -113,15 +113,9 @@ public abstract class QueryContext : IParameterValues
     /// </summary>
     /// <param name="standAlone">Whether a stand-alone <see cref="IStateManager" /> should be created to perform identity resolution.</param>
     public virtual void InitializeStateManager(bool standAlone = false)
-    {
-        Check.DebugAssert(
-            _stateManager == null,
-            "The 'InitializeStateManager' method has been called multiple times on the current query context. This method is intended to be called only once before query enumeration starts.");
-
-        _stateManager = standAlone
+        => _stateManager ??= standAlone
             ? new StateManager(Dependencies.StateManager.Dependencies)
             : Dependencies.StateManager;
-    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindDbFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindDbFunctionsQueryCosmosTest.cs
@@ -13,20 +13,44 @@ public class NorthwindDbFunctionsQueryCosmosTest : NorthwindDbFunctionsQueryTest
         ClearLog();
     }
 
-    public override Task Like_all_literals(bool async)
-        => AssertTranslationFailed(() => base.Like_all_literals(async));
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
-    public override Task Like_all_literals_with_escape(bool async)
-        => AssertTranslationFailed(() => base.Like_all_literals_with_escape(async));
+    public override async Task Like_all_literals(bool async)
+    {
+        await AssertTranslationFailed(() => base.Like_all_literals(async));
 
-    public override Task Like_literal(bool async)
-        => AssertTranslationFailed(() => base.Like_literal(async));
+        AssertSql();
+    }
 
-    public override Task Like_literal_with_escape(bool async)
-        => AssertTranslationFailed(() => base.Like_literal_with_escape(async));
+    public override async Task Like_all_literals_with_escape(bool async)
+    {
+        await AssertTranslationFailed(() => base.Like_all_literals_with_escape(async));
 
-    public override Task Like_identity(bool async)
-        => AssertTranslationFailed(() => base.Like_identity(async));
+        AssertSql();
+    }
+
+    public override async Task Like_literal(bool async)
+    {
+        await AssertTranslationFailed(() => base.Like_literal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Like_literal_with_escape(bool async)
+    {
+        await AssertTranslationFailed(() => base.Like_literal_with_escape(async));
+
+        AssertSql();
+    }
+
+    public override async Task Like_identity(bool async)
+    {
+        await AssertTranslationFailed(() => base.Like_identity(async));
+
+        AssertSql();
+    }
 
     public override async Task Random_return_less_than_1(bool async)
     {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
@@ -15,6 +16,10 @@ public class NorthwindFunctionsQueryCosmosTest : NorthwindFunctionsQueryTestBase
         ClearLog();
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     public override async Task String_StartsWith_Literal(bool async)
     {
@@ -155,136 +160,100 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], ""M""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_simple_zero(bool async)
     {
-        await base.String_Compare_simple_zero(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_simple_zero(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_simple_one(bool async)
     {
-        await base.String_Compare_simple_one(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_simple_one(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_compare_with_parameter(bool async)
     {
-        await base.String_compare_with_parameter(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_compare_with_parameter(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_simple_more_than_one(bool async)
     {
-        await base.String_Compare_simple_more_than_one(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_simple_more_than_one(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_nested(bool async)
     {
-        await base.String_Compare_nested(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_nested(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_multi_predicate(bool async)
     {
-        await base.String_Compare_multi_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_multi_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_to_simple_zero(bool async)
     {
-        await base.String_Compare_to_simple_zero(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_to_simple_zero(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_to_simple_one(bool async)
     {
-        await base.String_Compare_to_simple_one(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_to_simple_one(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_compare_to_with_parameter(bool async)
     {
-        await base.String_compare_to_with_parameter(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_compare_to_with_parameter(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_to_simple_more_than_one(bool async)
     {
-        await base.String_Compare_to_simple_more_than_one(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_to_simple_more_than_one(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_to_nested(bool async)
     {
-        await base.String_Compare_to_nested(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_to_nested(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_Compare_to_multi_predicate(bool async)
     {
-        await base.String_Compare_to_multi_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_Compare_to_multi_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task Where_math_abs1(bool async)
@@ -327,18 +296,14 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""UnitPrice""] < 7.0)) AND (10 < c[""ProductID""]))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_ceiling1(bool async)
     {
-        await base.Where_math_ceiling1(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_ceiling1(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_ceiling2(bool async)
     {
         await base.Where_math_ceiling2(async);
@@ -346,7 +311,7 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (CEILING(c[""UnitPrice""]) > 10.0))");
     }
 
     public override async Task Where_math_floor(bool async)
@@ -359,26 +324,20 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (FLOOR(c[""UnitPrice""]) > 10.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #25120")]
     public override async Task Where_math_power(bool async)
     {
-        await base.Where_math_power(async);
+        // Convert node. Issue #25120.
+        await AssertTranslationFailed(() => base.Where_math_power(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #25120")]
     public override async Task Where_math_square(bool async)
     {
-        await base.Where_math_square(async);
+        // Convert node. Issue #25120.
+        await AssertTranslationFailed(() => base.Where_math_square(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        AssertSql();
     }
 
     public override async Task Where_math_round(bool async)
@@ -411,15 +370,12 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_round2(bool async)
     {
-        await base.Where_math_round2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_round2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (ROUND(c[""UnitPrice""]) > 100.0))");
+        AssertSql();
     }
 
     public override async Task Where_math_truncate(bool async)
@@ -432,136 +388,100 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (TRUNC(c[""UnitPrice""]) > 10.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_exp(bool async)
     {
-        await base.Where_math_exp(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_exp(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_log10(bool async)
     {
-        await base.Where_math_log10(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_log10(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_log(bool async)
     {
-        await base.Where_math_log(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_log(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_log_new_base(bool async)
     {
-        await base.Where_math_log_new_base(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_log_new_base(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_sqrt(bool async)
     {
-        await base.Where_math_sqrt(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_sqrt(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_acos(bool async)
     {
-        await base.Where_math_acos(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_acos(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_asin(bool async)
     {
-        await base.Where_math_asin(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_asin(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_atan(bool async)
     {
-        await base.Where_math_atan(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_atan(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_atan2(bool async)
     {
-        await base.Where_math_atan2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_atan2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_cos(bool async)
     {
-        await base.Where_math_cos(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_cos(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_sin(bool async)
     {
-        await base.Where_math_sin(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_sin(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_tan(bool async)
     {
-        await base.Where_math_tan(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_tan(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
     public override async Task Where_math_sign(bool async)
@@ -574,62 +494,48 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (SIGN(c[""Discount""]) > 0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_min(bool async)
     {
-        await base.Where_math_min(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_min(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_math_max(bool async)
     {
-        await base.Where_math_max(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_max(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_abs1(bool async)
     {
-        await base.Where_mathf_abs1(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_mathf_abs1(async));
 
-        AssertSql(
-            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
-FROM [Products] AS [p]
-WHERE ABS(CAST([p].[ProductID] AS real)) > CAST(10 AS real)");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_ceiling1(bool async)
     {
         await base.Where_mathf_ceiling1(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[UnitPrice] < 7.0) AND (CEILING([o].[Discount]) > CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""UnitPrice""] < 7.0)) AND (CEILING(c[""Discount""]) > 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_floor(bool async)
     {
-        await base.Where_mathf_floor(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_mathf_floor(async));
 
-        AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[Quantity] < CAST(5 AS smallint)) AND (FLOOR(CAST([o].[UnitPrice] AS real)) > CAST(10 AS real))");
+        AssertSql();
     }
 
-    [ConditionalTheory]
     public override async Task Where_mathf_power(bool async)
     {
         await base.Where_mathf_power(async);
@@ -640,7 +546,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (POWER(c[""Discount""], 3.0) > 0.005))");
     }
 
-    [ConditionalTheory]
     public override async Task Where_mathf_square(bool async)
     {
         await base.Where_mathf_square(async);
@@ -651,180 +556,158 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (POWER(c[""Discount""], 2.0) > 0.05))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_round2(bool async)
     {
-        await base.Where_mathf_round2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_mathf_round2(async));
 
-        AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ROUND(CAST([o].[UnitPrice] AS real), 2) > CAST(100 AS real)");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_truncate(bool async)
     {
-        await base.Where_mathf_truncate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_mathf_truncate(async));
 
-        AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[Quantity] < CAST(5 AS smallint)) AND (ROUND(CAST([o].[UnitPrice] AS real), 0, 1) > CAST(10 AS real))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_exp(bool async)
     {
         await base.Where_mathf_exp(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (EXP([o].[Discount]) > CAST(1 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (EXP(c[""Discount""]) > 1.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_log10(bool async)
     {
         await base.Where_mathf_log10(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE (([o].[OrderID] = 11077) AND ([o].[Discount] > CAST(0 AS real))) AND (LOG10([o].[Discount]) < CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0))) AND (LOG10(c[""Discount""]) < 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_log(bool async)
     {
         await base.Where_mathf_log(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE (([o].[OrderID] = 11077) AND ([o].[Discount] > CAST(0 AS real))) AND (LOG([o].[Discount]) < CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0))) AND (LOG(c[""Discount""]) < 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_log_new_base(bool async)
     {
         await base.Where_mathf_log_new_base(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE (([o].[OrderID] = 11077) AND ([o].[Discount] > CAST(0 AS real))) AND (LOG([o].[Discount], CAST(7 AS real)) < CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0))) AND (LOG(c[""Discount""], 7.0) < 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_sqrt(bool async)
     {
         await base.Where_mathf_sqrt(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (SQRT([o].[Discount]) > CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (SQRT(c[""Discount""]) > 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_acos(bool async)
     {
         await base.Where_mathf_acos(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (ACOS([o].[Discount]) > CAST(1 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (ACOS(c[""Discount""]) > 1.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_asin(bool async)
     {
         await base.Where_mathf_asin(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (ASIN([o].[Discount]) > CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (ASIN(c[""Discount""]) > 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_atan(bool async)
     {
         await base.Where_mathf_atan(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (ATAN([o].[Discount]) > CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (ATAN(c[""Discount""]) > 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_atan2(bool async)
     {
         await base.Where_mathf_atan2(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (ATN2([o].[Discount], CAST(1 AS real)) > CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (ATN2(c[""Discount""], 1.0) > 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_cos(bool async)
     {
         await base.Where_mathf_cos(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (COS([o].[Discount]) > CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (COS(c[""Discount""]) > 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_sin(bool async)
     {
         await base.Where_mathf_sin(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (SIN([o].[Discount]) > CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (SIN(c[""Discount""]) > 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_tan(bool async)
     {
         await base.Where_mathf_tan(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (TAN([o].[Discount]) > CAST(0 AS real))");
+            @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (TAN(c[""Discount""]) > 0.0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_mathf_sign(bool async)
     {
         await base.Where_mathf_sign(async);
 
         AssertSql(
-            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE ([o].[OrderID] = 11077) AND (SIGN([o].[Discount]) > 0)");
-    }
-
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override async Task Where_guid_newguid(bool async)
-    {
-        await base.Where_guid_newguid(async);
-
-        AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (SIGN(c[""Discount""]) > 0))");
+    }
+
+    public override async Task Where_guid_newguid(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_guid_newguid(async));
+
+        AssertSql();
     }
 
     public override async Task Where_string_to_upper(bool async)
@@ -847,103 +730,76 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (LOWER(c[""CustomerID""]) = ""alfki""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_functions_nested(bool async)
     {
-        await base.Where_functions_nested(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_functions_nested(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Convert_ToBoolean(bool async)
     {
-        await base.Convert_ToBoolean(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Convert_ToBoolean(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Convert_ToByte(bool async)
     {
-        await base.Convert_ToByte(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Convert_ToByte(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Convert_ToDecimal(bool async)
     {
-        await base.Convert_ToDecimal(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Convert_ToDecimal(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Convert_ToDouble(bool async)
     {
-        await base.Convert_ToDouble(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Convert_ToDouble(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Convert_ToInt16(bool async)
     {
-        await base.Convert_ToInt16(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Convert_ToInt16(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Convert_ToInt32(bool async)
     {
-        await base.Convert_ToInt32(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Convert_ToInt32(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Convert_ToInt64(bool async)
     {
-        await base.Convert_ToInt64(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Convert_ToInt64(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Convert_ToString(bool async)
     {
-        await base.Convert_ToString(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Convert_ToString(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
     public override async Task Indexof_with_emptystring(bool async)
@@ -1070,28 +926,29 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task IsNullOrEmpty_in_predicate(bool async)
     {
-        await base.IsNullOrEmpty_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.IsNullOrEmpty_in_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task IsNullOrEmpty_negated_in_predicate(bool async)
     {
-        await base.IsNullOrEmpty_negated_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.IsNullOrEmpty_negated_in_predicate(async));
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task IsNullOrWhiteSpace_in_predicate_on_non_nullable_column(bool async)
-        => base.IsNullOrWhiteSpace_in_predicate_on_non_nullable_column(async);
+    public override async Task IsNullOrWhiteSpace_in_predicate_on_non_nullable_column(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.IsNullOrWhiteSpace_in_predicate_on_non_nullable_column(async));
+
+        AssertSql();
+    }
 
     public override async Task IsNullOrEmpty_in_projection(bool async)
     {
@@ -1113,15 +970,12 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task IsNullOrWhiteSpace_in_predicate(bool async)
     {
-        await base.IsNullOrWhiteSpace_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.IsNullOrWhiteSpace_in_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task TrimStart_without_arguments_in_predicate(bool async)
@@ -1134,26 +988,20 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (LTRIM(c[""ContactTitle""]) = ""Owner""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task TrimStart_with_char_argument_in_predicate(bool async)
     {
-        await base.TrimStart_with_char_argument_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.TrimStart_with_char_argument_in_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task TrimStart_with_char_array_argument_in_predicate(bool async)
     {
-        await base.TrimStart_with_char_array_argument_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.TrimStart_with_char_array_argument_in_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task TrimEnd_without_arguments_in_predicate(bool async)
@@ -1166,26 +1014,20 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (RTRIM(c[""ContactTitle""]) = ""Owner""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task TrimEnd_with_char_argument_in_predicate(bool async)
     {
-        await base.TrimEnd_with_char_argument_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.TrimEnd_with_char_argument_in_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task TrimEnd_with_char_array_argument_in_predicate(bool async)
     {
-        await base.TrimEnd_with_char_array_argument_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.TrimEnd_with_char_array_argument_in_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task Trim_without_argument_in_predicate(bool async)
@@ -1198,48 +1040,40 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (TRIM(c[""ContactTitle""]) = ""Owner""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Trim_with_char_argument_in_predicate(bool async)
     {
-        await base.Trim_with_char_argument_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Trim_with_char_argument_in_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Trim_with_char_array_argument_in_predicate(bool async)
     {
-        await base.Trim_with_char_array_argument_in_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Trim_with_char_array_argument_in_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Order_by_length_twice(bool async)
     {
-        await base.Order_by_length_twice(async);
+        // Unsupported ORDER BY clause. Issue #27037.
+        await Assert.ThrowsAsync<CosmosException>(() => base.Order_by_length_twice(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY LENGTH(c[""CustomerID""]), c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(bool async)
     {
-        await base.Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task Static_string_equals_in_predicate(bool async)
@@ -1252,18 +1086,18 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ANATR""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Static_equals_nullable_datetime_compared_to_non_nullable(bool async)
     {
         await base.Static_equals_nullable_datetime_compared_to_non_nullable(async);
 
         AssertSql(
-            @"SELECT c
+            @"@__arg_0='1996-07-04T00:00:00'
+
+SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] = @__arg_0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Static_equals_int_compared_to_long(bool async)
     {
         await base.Static_equals_int_compared_to_long(async);
@@ -1271,59 +1105,72 @@ WHERE (c[""Discriminator""] = ""Order"")");
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+WHERE ((c[""Discriminator""] = ""Order"") AND false)");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice(bool async)
     {
-        await base.Projecting_Math_Truncate_and_ordering_by_it_twice(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projecting_Math_Truncate_and_ordering_by_it_twice(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice2(bool async)
     {
-        await base.Projecting_Math_Truncate_and_ordering_by_it_twice2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projecting_Math_Truncate_and_ordering_by_it_twice2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice3(bool async)
     {
-        await base.Projecting_Math_Truncate_and_ordering_by_it_twice3(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projecting_Math_Truncate_and_ordering_by_it_twice3(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task DateTime_Compare_to_simple_zero(bool async, bool compareTo)
-        => base.DateTime_Compare_to_simple_zero(async, compareTo);
+    public override async Task DateTime_Compare_to_simple_zero(bool async, bool compareTo)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DateTime_Compare_to_simple_zero(async, compareTo));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task TimeSpan_Compare_to_simple_zero(bool async, bool compareTo)
-        => base.TimeSpan_Compare_to_simple_zero(async, compareTo);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Int_Compare_to_simple_zero(bool async)
-        => base.Int_Compare_to_simple_zero(async);
+    public override async Task TimeSpan_Compare_to_simple_zero(bool async, bool compareTo)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.TimeSpan_Compare_to_simple_zero(async, compareTo));
 
-    public override Task Regex_IsMatch_MethodCall(bool async)
-        => AssertTranslationFailed(() => base.Regex_IsMatch_MethodCall(async));
+        AssertSql();
+    }
 
-    public override Task Regex_IsMatch_MethodCall_constant_input(bool async)
-        => AssertTranslationFailed(() => base.Regex_IsMatch_MethodCall_constant_input(async));
+    public override async Task Int_Compare_to_simple_zero(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Int_Compare_to_simple_zero(async));
+
+        AssertSql();
+    }
+
+    public override async Task Regex_IsMatch_MethodCall(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Regex_IsMatch_MethodCall(async));
+
+        AssertSql();
+    }
+
+    public override async Task Regex_IsMatch_MethodCall_constant_input(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Regex_IsMatch_MethodCall_constant_input(async));
+
+        AssertSql();
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1385,9 +1232,75 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND STRINGEQUALS(c[""CustomerID""], ""ALFKI""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Datetime_subtraction_TotalDays(bool async)
-        => base.Datetime_subtraction_TotalDays(async);
+    public override async Task Datetime_subtraction_TotalDays(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Datetime_subtraction_TotalDays(async));
+
+        AssertSql();
+    }
+
+    public override async Task String_Contains_constant_with_whitespace(bool async)
+    {
+        await base.String_Contains_constant_with_whitespace(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], ""     ""))");
+    }
+
+    public override async Task String_Contains_parameter_with_whitespace(bool async)
+    {
+        await base.String_Contains_parameter_with_whitespace(async);
+
+        AssertSql(
+            @"@__pattern_0='     '
+
+SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], @__pattern_0))");
+    }
+
+    public override async Task Select_mathf_round(bool async)
+    {
+        await base.Select_mathf_round(async);
+
+        AssertSql(
+            @"SELECT c[""OrderID""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+    }
+
+    public override async Task Select_mathf_round2(bool async)
+    {
+        await base.Select_mathf_round2(async);
+
+        AssertSql(
+            @"SELECT c[""UnitPrice""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5))");
+    }
+
+    public override async Task Select_mathf_truncate(bool async)
+    {
+        await base.Select_mathf_truncate(async);
+
+        AssertSql(
+            @"SELECT c[""UnitPrice""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5))");
+    }
+
+    public override async Task Indexof_with_one_arg(bool async)
+    {
+        await base.Indexof_with_one_arg(async);
+
+        AssertSql(
+            @"SELECT INDEX_OF(c[""ContactName""], ""a"") AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+    }
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -17,7 +17,10 @@ public class NorthwindKeylessEntitiesQueryCosmosTest : NorthwindKeylessEntitiesQ
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ConditionalTheory]
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override async Task KeylessEntity_simple(bool async)
     {
         await base.KeylessEntity_simple(async);
@@ -28,7 +31,6 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
     }
 
-    [ConditionalTheory]
     public override async Task KeylessEntity_where_simple(bool async)
     {
         await base.KeylessEntity_where_simple(async);
@@ -39,52 +41,60 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
     }
 
-    [ConditionalFact] // views are not supported
     public override void KeylessEntity_by_database_view()
     {
-    }
-
-    public override void Entity_mapped_to_view_on_right_side_of_join()
-    {
-    }
-
-    [ConditionalFact(Skip = "See issue#17246")]
-    public override void Auto_initialized_view_set()
-        => base.Auto_initialized_view_set();
-
-    [ConditionalFact(Skip = "issue #17246")] // collection support
-    public override void KeylessEntity_with_nav_defining_query()
-    {
-        base.KeylessEntity_with_nav_defining_query();
-
-        AssertSql(
-            @"");
-    }
-
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override async Task KeylessEntity_with_mixed_tracking(bool async)
-    {
-        await AssertQuery(
-            async,
-            ss => from c in ss.Set<Customer>().Where(ct => ct.City == "London")
-                  from o in ss.Set<OrderQuery>().Where(ov => ov.CustomerID == c.CustomerID)
-                  select new { c, o },
-            elementSorter: e => (e.c.CustomerID, e.o.CustomerID),
-            elementAsserter: (e, a) =>
-            {
-                AssertEqual(e.c, a.c);
-                AssertEqual(e.o, a.o);
-            });
+        // Views are not supported.
+        Assert.Equal(
+            "0",
+            Assert.Throws<EqualException>(
+                () => base.KeylessEntity_by_database_view()).Actual);
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+WHERE (c[""Discriminator""] = ""ProductView"")");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task KeylessEntity_with_included_nav(bool async)
-        => base.KeylessEntity_with_included_nav(async);
+    public override void Entity_mapped_to_view_on_right_side_of_join()
+    {
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Entity_mapped_to_view_on_right_side_of_join();
+                return Task.CompletedTask;
+            });
+
+        AssertSql();
+    }
+
+    public override void KeylessEntity_with_nav_defining_query()
+    {
+        Assert.Equal(
+            "0",
+            Assert.Throws<EqualException>(
+                () => base.KeylessEntity_with_nav_defining_query()).Actual);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""OrderCount""] > 0))");
+    }
+
+    public override async Task KeylessEntity_with_mixed_tracking(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.KeylessEntity_with_mixed_tracking(async));
+
+        AssertSql();
+    }
+
+    public override async Task KeylessEntity_with_included_nav(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.KeylessEntity_with_included_nav(async));
+
+        AssertSql();
+    }
 
     public override async Task KeylessEntity_with_defining_query(bool async)
     {
@@ -96,59 +106,62 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task KeylessEntity_with_defining_query_and_correlated_collection(bool async)
     {
-        await base.KeylessEntity_with_defining_query_and_correlated_collection(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.KeylessEntity_with_defining_query_and_correlated_collection(async));
+
+        AssertSql();
+    }
+
+    public override async Task KeylessEntity_select_where_navigation(bool async)
+    {
+        // Left join translation. Issue #17314.
+        await AssertTranslationFailed(() => base.KeylessEntity_select_where_navigation(async));
+
+        AssertSql();
+    }
+
+    public override async Task KeylessEntity_select_where_navigation_multi_level(bool async)
+    {
+        // Left join translation. Issue #17314.
+        await AssertTranslationFailed(() => base.KeylessEntity_select_where_navigation_multi_level(async));
+
+        AssertSql();
+    }
+
+    public override async Task KeylessEntity_with_included_navs_multi_level(bool async)
+    {
+        // Left join translation. Issue #17314.
+        await AssertTranslationFailed(() => base.KeylessEntity_with_included_navs_multi_level(async));
+
+        AssertSql();
+    }
+
+    public override async Task KeylessEntity_groupby(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.KeylessEntity_groupby(async));
+
+        AssertSql();
+    }
+
+    public override async Task Collection_correlated_with_keyless_entity_in_predicate_works(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_correlated_with_keyless_entity_in_predicate_works(async));
+
+        AssertSql();
+    }
+
+    public override void Auto_initialized_view_set()
+    {
+        base.Auto_initialized_view_set();
 
         AssertSql(
             @"SELECT c
 FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
-    }
-
-    [ConditionalTheory(Skip = "issue#17314")] // left join translation
-    public override async Task KeylessEntity_select_where_navigation(bool async)
-    {
-        await base.KeylessEntity_select_where_navigation(async);
-
-        AssertSql(@"");
-    }
-
-    [ConditionalTheory(Skip = "issue#17314")] // left join translation
-    public override async Task KeylessEntity_select_where_navigation_multi_level(bool async)
-    {
-        await AssertQuery(
-            async,
-            ss => from ov in ss.Set<OrderQuery>().Where(o => o.CustomerID == "ALFKI")
-                  where ov.Customer.Orders.Any()
-                  select ov);
-
-        AssertSql(@"");
-    }
-
-    [ConditionalTheory(Skip = "issue#17314")] // left join translation
-    public override async Task KeylessEntity_with_included_navs_multi_level(bool async)
-    {
-        await base.KeylessEntity_with_included_navs_multi_level(async);
-
-        AssertSql(@"");
-    }
-
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override async Task KeylessEntity_groupby(bool async)
-    {
-        await base.KeylessEntity_groupby(async);
-
-        AssertSql(@"");
-    }
-
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override async Task Collection_correlated_with_keyless_entity_in_predicate_works(bool async)
-    {
-        await base.Collection_correlated_with_keyless_entity_in_predicate_works(async);
-
-        AssertSql(@"");
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit.Sdk;
 
 #pragma warning disable RCS1202 // Avoid NullReferenceException.
 
@@ -19,6 +22,10 @@ public class NorthwindMiscellaneousQueryCosmosTest : NorthwindMiscellaneousQuery
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Simple_IQueryable(bool async)
@@ -31,41 +38,50 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Shaper_command_caching_when_parameter_names_different()
     {
-        base.Shaper_command_caching_when_parameter_names_different();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Shaper_command_caching_when_parameter_names_different();
+                return Task.CompletedTask;
+            });
 
         AssertSql(
-            @"SELECT c
+            @"SELECT COUNT(1) AS c
 FROM root c
-WHERE (((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")) AND true)",
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))",
             //
-            @"SELECT c
+            @"SELECT COUNT(1) AS c
 FROM root c
-WHERE (((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")) AND true)");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Lifting_when_subquery_nested_order_by_anonymous()
     {
-        base.Lifting_when_subquery_nested_order_by_anonymous();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Lifting_when_subquery_nested_order_by_anonymous();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Lifting_when_subquery_nested_order_by_simple()
     {
-        base.Lifting_when_subquery_nested_order_by_simple();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Lifting_when_subquery_nested_order_by_simple();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
     public override async Task Local_dictionary(bool async)
@@ -103,26 +119,25 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = @__entity_equality_local_0_CustomerID))");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Entity_equality_local_composite_key(bool async)
     {
         await base.Entity_equality_local_composite_key(async);
 
         AssertSql(
-            @"SELECT c
+            @"@__entity_equality_local_0_OrderID='10248'
+@__entity_equality_local_0_ProductID='11'
+
+SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = @__entity_equality_local_0_OrderID) AND (c[""ProductID""] = @__entity_equality_local_0_ProductID)))");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Join_with_entity_equality_local_on_both_sources(bool async)
     {
-        await base.Join_with_entity_equality_local_on_both_sources(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_with_entity_equality_local_on_both_sources(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task Entity_equality_local_inline(bool async)
@@ -135,7 +150,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ANATR""))");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Entity_equality_local_inline_composite_key(bool async)
     {
         await base.Entity_equality_local_inline_composite_key(async);
@@ -143,7 +157,7 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ANATR"")
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 10248) AND (c[""ProductID""] = 11)))");
     }
 
     public override async Task Entity_equality_null(bool async)
@@ -166,437 +180,378 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != null))");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Query_when_evaluatable_queryable_method_call_with_repository()
     {
-        using (var context = CreateContext())
-        {
-            context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Query_when_evaluatable_queryable_method_call_with_repository();
+                return Task.CompletedTask;
+            });
 
-            var customerRepository = new Repository<Customer>(context);
-            var orderRepository = new Repository<Order>(context);
-
-            var results
-                = customerRepository.Find().Where(c => c.CustomerID == "ALFKI")
-                    .Where(c => orderRepository.Find().Any(o => o.CustomerID == c.CustomerID))
-                    .ToList();
-
-            Assert.Single(results);
-
-            results
-                = (from c in customerRepository.Find().Where(c => c.CustomerID == "ALFKI")
-                   where orderRepository.Find().Any(o => o.CustomerID == c.CustomerID)
-                   select c)
-                .ToList();
-
-            Assert.Single(results);
-
-            var orderQuery = orderRepository.Find();
-
-            results = customerRepository.Find().Where(c => c.CustomerID == "ALFKI")
-                .Where(c => orderQuery.Any(o => o.CustomerID == c.CustomerID))
-                .ToList();
-
-            Assert.Single(results);
-
-            context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
-        }
-
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Queryable_reprojection(bool async)
     {
         await base.Queryable_reprojection(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Default_if_empty_top_level(bool async)
     {
-        await base.Default_if_empty_top_level(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Default_if_empty_top_level(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Join_with_default_if_empty_on_both_sources(bool async)
     {
-        await base.Join_with_default_if_empty_on_both_sources(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_with_default_if_empty_on_both_sources(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Default_if_empty_top_level_followed_by_projecting_constant(bool async)
     {
-        await base.Default_if_empty_top_level_followed_by_projecting_constant(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Default_if_empty_top_level_followed_by_projecting_constant(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Default_if_empty_top_level_positive(bool async)
     {
-        await base.Default_if_empty_top_level_positive(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Default_if_empty_top_level_positive(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] > 0))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17783")]
-    public override Task Default_if_empty_top_level_arg(bool async)
-        => base.Default_if_empty_top_level_arg(async);
+    public override async Task Default_if_empty_top_level_arg(bool async)
+    {
+        await base.Default_if_empty_top_level_arg(async);
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool async)
-        => base.Default_if_empty_top_level_arg_followed_by_projecting_constant(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
+    public override async Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool async)
+    {
+        await base.Default_if_empty_top_level_arg_followed_by_projecting_constant(async);
+
+        AssertSql();
+    }
+
     public override async Task Default_if_empty_top_level_projection(bool async)
     {
-        await base.Default_if_empty_top_level_projection(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Default_if_empty_top_level_projection(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_query_composition(bool async)
     {
-        await base.Where_query_composition(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_query_composition_is_null(bool async)
     {
-        await base.Where_query_composition_is_null(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_is_null(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_query_composition_is_not_null(bool async)
     {
-        await base.Where_query_composition_is_null(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_is_not_null(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_query_composition_entity_equality_one_element_SingleOrDefault(bool async)
     {
-        await base.Where_query_composition_entity_equality_one_element_SingleOrDefault(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_one_element_SingleOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_query_composition_entity_equality_one_element_Single(bool async)
-        => base.Where_query_composition_entity_equality_one_element_Single(async);
+    public override async Task Where_query_composition_entity_equality_one_element_Single(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_one_element_Single(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
+        AssertSql();
+    }
+
     public override async Task Where_query_composition_entity_equality_one_element_FirstOrDefault(bool async)
     {
-        await base.Where_query_composition_entity_equality_one_element_FirstOrDefault(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_one_element_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_query_composition_entity_equality_one_element_First(bool async)
-        => base.Where_query_composition_entity_equality_one_element_First(async);
+    public override async Task Where_query_composition_entity_equality_one_element_First(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_one_element_First(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
+        AssertSql();
+    }
+
     public override async Task Where_query_composition_entity_equality_no_elements_SingleOrDefault(bool async)
     {
-        await base.Where_query_composition_entity_equality_no_elements_SingleOrDefault(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_no_elements_SingleOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_query_composition_entity_equality_no_elements_Single(bool async)
-        => base.Where_query_composition_entity_equality_no_elements_Single(async);
+    public override async Task Where_query_composition_entity_equality_no_elements_Single(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_no_elements_Single(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
+        AssertSql();
+    }
+
     public override async Task Where_query_composition_entity_equality_no_elements_FirstOrDefault(bool async)
     {
-        await base.Where_query_composition_entity_equality_no_elements_FirstOrDefault(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_no_elements_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_query_composition_entity_equality_no_elements_First(bool async)
-        => base.Where_query_composition_entity_equality_no_elements_First(async);
+    public override async Task Where_query_composition_entity_equality_no_elements_First(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_no_elements_First(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(bool async)
-        => base.Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_query_composition_entity_equality_multiple_elements_Single(bool async)
-        => base.Where_query_composition_entity_equality_multiple_elements_Single(async);
+    public override async Task Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
+        AssertSql();
+    }
+
+    public override async Task Where_query_composition_entity_equality_multiple_elements_Single(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_multiple_elements_Single(async));
+
+        AssertSql();
+    }
+
     public override async Task Where_query_composition_entity_equality_multiple_elements_FirstOrDefault(bool async)
     {
-        await base.Where_query_composition_entity_equality_multiple_elements_FirstOrDefault(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_multiple_elements_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_query_composition_entity_equality_multiple_elements_First(bool async)
-        => base.Where_query_composition_entity_equality_multiple_elements_First(async);
+    public override async Task Where_query_composition_entity_equality_multiple_elements_First(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition_entity_equality_multiple_elements_First(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
+        AssertSql();
+    }
+
     public override async Task Where_query_composition2(bool async)
     {
-        await base.Where_query_composition2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_query_composition2_FirstOrDefault(bool async)
     {
-        await base.Where_query_composition2_FirstOrDefault(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition2_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_query_composition2_FirstOrDefault_with_anonymous(bool async)
     {
-        await base.Where_query_composition2_FirstOrDefault_with_anonymous(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_query_composition2_FirstOrDefault_with_anonymous(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Cross collection join Issue#17246")]
     public override void Select_Subquery_Single()
     {
-        base.Select_Subquery_Single();
+        // Cross collection join. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_Subquery_Single();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_Where_Subquery_Deep_Single()
     {
-        base.Select_Where_Subquery_Deep_Single();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_Where_Subquery_Deep_Single();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 10344))");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_Where_Subquery_Deep_First()
     {
-        base.Select_Where_Subquery_Deep_First();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_Where_Subquery_Deep_First();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_Where_Subquery_Equality()
     {
-        base.Select_Where_Subquery_Equality();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_Where_Subquery_Equality();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_subquery_anon(bool async)
     {
-        await base.Where_subquery_anon(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_subquery_anon(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_subquery_anon_nested(bool async)
     {
-        await base.Where_subquery_anon_nested(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_subquery_anon_nested(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_SelectMany(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>().Where(c => c.CustomerID == "VINET")
-                from o in ss.Set<Order>().OrderBy(o => o.OrderID).Take(3)
-                where c.CustomerID == o.CustomerID
-                select new { c.ContactName, o.OrderID },
-            ss =>
-                ss.Set<Customer>().Where(c => c.CustomerID == "VINET")
-                    .SelectMany(
-                        _ => ss.Set<Order>().OrderBy(o => o.OrderID).Take(3),
-                        (c, o) => new { c, o }).Where(t => t.c.CustomerID == t.o.CustomerID)
-                    .Select(
-                        t => new { t.c.ContactName, t.o.OrderID }),
-            assertOrder: true);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.OrderBy_SelectMany(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""VINET""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Let_any_subquery_anonymous(bool async)
     {
-        await base.Let_any_subquery_anonymous(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Let_any_subquery_anonymous(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_arithmetic(bool async)
     {
-        await base.OrderBy_arithmetic(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_arithmetic(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+WHERE (c[""Discriminator""] = ""Employee"")
+ORDER BY (c[""EmployeeID""] - c[""EmployeeID""])");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_condition_comparison(bool async)
     {
-        await base.OrderBy_condition_comparison(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_condition_comparison(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+WHERE (c[""Discriminator""] = ""Product"")
+ORDER BY (c[""UnitsInStock""] > 0), c[""ProductID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_ternary_conditions(bool async)
     {
-        await base.OrderBy_ternary_conditions(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_ternary_conditions(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+WHERE (c[""Discriminator""] = ""Product"")
+ORDER BY ((c[""UnitsInStock""] > 10) ? (c[""ProductID""] > 40) : (c[""ProductID""] <= 40)), c[""ProductID""]");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void OrderBy_any()
     {
-        base.OrderBy_any();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.OrderBy_any();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Skip(bool async)
     {
-        await base.Skip(async);
+        Assert.Equal(
+            CosmosStrings.OffsetRequiresLimit,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Skip_Distinct(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Skip_no_orderby(bool async)
     {
-        await base.Skip_no_orderby(async);
+        Assert.Equal(
+            CosmosStrings.OffsetRequiresLimit,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Skip_no_orderby(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task Skip_Take(bool async)
@@ -614,103 +569,82 @@ ORDER BY c[""ContactName""]
 OFFSET @__p_0 LIMIT @__p_1");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Join_Customers_Orders_Skip_Take(bool async)
     {
-        await base.Join_Customers_Orders_Skip_Take(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_Customers_Orders_Skip_Take(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Join_Customers_Orders_Skip_Take_followed_by_constant_projection(bool async)
     {
-        await base.Join_Customers_Orders_Skip_Take_followed_by_constant_projection(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_Customers_Orders_Skip_Take_followed_by_constant_projection(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Join_Customers_Orders_Projection_With_String_Concat_Skip_Take(bool async)
     {
-        await base.Join_Customers_Orders_Projection_With_String_Concat_Skip_Take(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_Customers_Orders_Projection_With_String_Concat_Skip_Take(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Join_Customers_Orders_Orders_Skip_Take_Same_Properties(bool async)
     {
-        await base.Join_Customers_Orders_Orders_Skip_Take_Same_Properties(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_Customers_Orders_Orders_Skip_Take_Same_Properties(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_Skip(bool async)
     {
-        await base.Take_Skip(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Take_Skip(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_Skip_Distinct(bool async)
     {
-        await base.Take_Skip_Distinct(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Take_Skip_Distinct(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_Skip_Distinct_Caching(bool async)
     {
-        await base.Take_Skip_Distinct_Caching(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Take_Skip_Distinct_Caching(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_Distinct_Count(bool async)
     {
-        await base.Take_Distinct_Count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Take_Distinct_Count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_Where_Distinct_Count(bool async)
     {
-        await base.Take_Where_Distinct_Count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Take_Where_Distinct_Count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""FRANK""))");
+        AssertSql();
     }
 
     public override async Task Queryable_simple(bool async)
@@ -825,781 +759,516 @@ ORDER BY c[""CustomerID""]
 OFFSET 0 LIMIT @__p_0");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_Take_Count(bool async)
     {
-        await base.OrderBy_Take_Count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.OrderBy_Take_Count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_OrderBy_Count(bool async)
     {
-        await base.Take_OrderBy_Count(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Take_OrderBy_Count(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Any_simple(bool async)
     {
-        await base.Any_simple(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Any_simple(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Any_predicate(bool async)
     {
-        await base.Any_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Any_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Any_nested_negated(bool async)
     {
-        await base.Any_nested_negated(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Any_nested_negated(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Any_nested_negated2(bool async)
     {
-        await base.Any_nested_negated2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Any_nested_negated2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Any_nested_negated3(bool async)
     {
-        await base.Any_nested_negated3(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Any_nested_negated3(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Any_nested(bool async)
     {
-        await base.Any_nested(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Any_nested(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Any_nested2(bool async)
     {
-        await base.Any_nested2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Any_nested2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Any_nested3(bool async)
     {
-        await base.Any_nested3(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Any_nested3(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Any_with_multiple_conditions_still_uses_exists()
     {
-        base.Any_with_multiple_conditions_still_uses_exists();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Any_with_multiple_conditions_still_uses_exists();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task All_top_level(bool async)
     {
-        await base.All_top_level(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.All_top_level(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task All_top_level_column(bool async)
     {
-        await base.All_top_level_column(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.All_top_level_column(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task All_top_level_subquery(bool async)
     {
-        await AssertSingleResult(
-            async,
-            syncQuery: ss => ss.Set<Customer>()
-                .All(
-                    c1 => c1.CustomerID == "ALFKI"
-                        && ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID))),
-            asyncQuery: ss => ss.Set<Customer>()
-                .AllAsync(
-                    c1 => c1.CustomerID == "ALFKI"
-                        && ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID)),
-                    default));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.All_top_level_subquery(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task All_top_level_subquery_ef_property(bool async)
     {
-        await AssertSingleResult(
-            async,
-            syncQuery: ss => ss.Set<Customer>()
-                .All(
-                    c1 => c1.CustomerID == "ALFKI"
-                        && ss.Set<Customer>()
-                            .Any(
-                                c2 => ss.Set<Customer>()
-                                    .Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))),
-            asyncQuery: ss => ss.Set<Customer>()
-                .AllAsync(
-                    c1 => c1.CustomerID == "ALFKI"
-                        && ss.Set<Customer>()
-                            .Any(
-                                c2 => ss.Set<Customer>()
-                                    .Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID)),
-                    default));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.All_top_level_subquery_ef_property(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task First_client_predicate(bool async)
     {
         await base.First_client_predicate(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_select_many_or(bool async)
     {
-        await base.Where_select_many_or(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_select_many_or(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_select_many_or2(bool async)
     {
-        await base.Where_select_many_or2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_select_many_or2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_select_many_or3(bool async)
     {
-        await base.Where_select_many_or3(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_select_many_or3(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_select_many_or4(bool async)
     {
-        await base.Where_select_many_or4(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_select_many_or4(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_select_many_or_with_parameter(bool async)
     {
-        await base.Where_select_many_or_with_parameter(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_select_many_or_with_parameter(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_mixed(bool async)
     {
         await base.SelectMany_mixed(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_simple_subquery(bool async)
     {
-        await base.SelectMany_simple_subquery(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_simple_subquery(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_simple1(bool async)
     {
-        await base.SelectMany_simple1(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_simple1(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_simple2(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from e1 in ss.Set<Employee>().Where(ct => ct.City == "London")
-                from c in ss.Set<Customer>().Where(ct => ct.City == "London")
-                from e2 in ss.Set<Employee>().Where(ct => ct.City == "London")
-                select new
-                {
-                    e1,
-                    c,
-                    e2.FirstName
-                },
-            e => (e.e1.EmployeeID, e.c.CustomerID, e.FirstName),
-            entryCount: 10);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_simple2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""City""] = ""London""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_entity_deep(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => from e1 in ss.Set<Employee>().Where(e => e.EmployeeID == 1)
-                  from e2 in ss.Set<Employee>()
-                  from e3 in ss.Set<Employee>()
-                  from e4 in ss.Set<Employee>()
-                  select new
-                  {
-                      e2,
-                      e3,
-                      e1,
-                      e4
-                  },
-            e => (e.e2.EmployeeID, e.e3.EmployeeID, e.e1.EmployeeID, e.e4.EmployeeID),
-            entryCount: 9);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_entity_deep(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 1))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_projection1(bool async)
     {
-        await base.SelectMany_projection1(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_projection1(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_projection2(bool async)
     {
-        await base.SelectMany_projection2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_projection2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_customer_orders(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>().Where(ct => ct.City == "London")
-                from o in ss.Set<Order>()
-                where c.CustomerID == o.CustomerID
-                select new { c.ContactName, o.OrderID },
-            e => (e.ContactName, e.OrderID));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_customer_orders(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_Count(bool async)
     {
-        await AssertCount(
-            async,
-            ss => from c in ss.Set<Customer>().Where(ct => ct.City == "London")
-                  from o in ss.Set<Order>()
-                  select c.CustomerID);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_Count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_LongCount(bool async)
     {
-        await AssertLongCount(
-            async,
-            ss => from c in ss.Set<Customer>().Where(ct => ct.City == "London")
-                  from o in ss.Set<Order>()
-                  select c.CustomerID);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_LongCount(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_OrderBy_ThenBy_Any(bool async)
     {
-        await base.SelectMany_OrderBy_ThenBy_Any(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_OrderBy_ThenBy_Any(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Join_Where_Count(bool async)
     {
-        await base.Join_Where_Count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_Where_Count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_Join_Any(bool async)
     {
-        await base.Where_Join_Any(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_Join_Any(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_Join_Exists(bool async)
     {
         await base.Where_Join_Exists(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_Join_Exists_Inequality(bool async)
     {
         await base.Where_Join_Exists_Inequality(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_Join_Exists_Constant(bool async)
     {
         await base.Where_Join_Exists_Constant(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_Join_Not_Exists(bool async)
     {
         await base.Where_Join_Not_Exists(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Join_OrderBy_Count(bool async)
     {
-        await base.Join_OrderBy_Count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_OrderBy_Count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Multiple_joins_Where_Order_Any(bool async)
     {
-        await base.Multiple_joins_Where_Order_Any(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Multiple_joins_Where_Order_Any(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_join_select(bool async)
     {
-        await base.Where_join_select(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_join_select(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_orderby_join_select(bool async)
     {
-        await base.Where_orderby_join_select(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_orderby_join_select(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_join_orderby_join_select(bool async)
     {
-        await base.Where_join_orderby_join_select(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_join_orderby_join_select(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_select_many(bool async)
     {
-        await base.Where_select_many(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_select_many(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_orderby_select_many(bool async)
     {
-        await base.Where_orderby_select_many(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_orderby_select_many(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_cartesian_product_with_ordering(bool async)
     {
-        await base.SelectMany_cartesian_product_with_ordering(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_cartesian_product_with_ordering(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_Joined_DefaultIfEmpty(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>().Where(cst => cst.CustomerID == "ALFKI")
-                from o in ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
-                select new { c.ContactName, o },
-            e => (e.ContactName, +e.o?.OrderID),
-            entryCount: 6);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_Joined_DefaultIfEmpty(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_Joined_DefaultIfEmpty2(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>().Where(cst => cst.CustomerID == "ALFKI")
-                from o in ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
-                select o,
-            entryCount: 6);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_Joined_DefaultIfEmpty2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_Joined_DefaultIfEmpty3(bool async)
-        => base.SelectMany_Joined_DefaultIfEmpty3(async);
+    public override async Task SelectMany_Joined_DefaultIfEmpty3(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_Joined_DefaultIfEmpty3(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
+        AssertSql();
+    }
+
     public override async Task SelectMany_Joined(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>().Where(cst => cst.CustomerID == "ALFKI")
-                from o in ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID)
-                select new { c.ContactName, o.OrderDate },
-            e => (e.ContactName, e.OrderDate));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_Joined(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_Joined_Take(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>().Where(cst => cst.CustomerID == "ALFKI")
-                from o in ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).Take(1000)
-                select new { c.ContactName, o },
-            e => (e.ContactName, e.o.OrderID),
-            entryCount: 6);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_Joined_Take(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_with_single(bool async)
     {
-        await base.Take_with_single(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Take_with_single(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_with_single_select_many(bool async)
     {
-        await AssertSingle(
-            async,
-            ss => (from c in ss.Set<Customer>().Where(cu => cu.CustomerID == "ALFKI")
-                   from o in ss.Set<Order>().Where(or => or.OrderID < 10300)
-                   orderby c.CustomerID, o.OrderID
-                   select new { c, o })
-                .Take(1)
-                .Cast<object>(),
-            entryCount: 2);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Take_with_single_select_many(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Distinct_Skip(bool async)
     {
-        await base.Distinct_Skip(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Distinct_Skip(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Distinct_Skip_Take(bool async)
     {
-        await base.Distinct_Skip_Take(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Distinct_Skip_Take(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Skip_Distinct(bool async)
     {
-        await base.Skip_Distinct(async);
+        Assert.Equal(
+            CosmosStrings.OffsetRequiresLimit,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Skip_Distinct(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Skip_Take_Distinct(bool async)
     {
         await base.Skip_Take_Distinct(async);
 
         AssertSql(
-            @"SELECT c
+            @"@__p_0='5'
+@__p_1='10'
+
+SELECT DISTINCT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""ContactName""]
+OFFSET @__p_0 LIMIT @__p_1");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Skip_Take_Any(bool async)
     {
-        await base.Skip_Take_Any(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Skip_Take_Any(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Skip_Take_All(bool async)
     {
-        await base.Skip_Take_All(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Skip_Take_All(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_All(bool async)
     {
-        await base.Take_All(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Take_All(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Skip_Take_Any_with_predicate(bool async)
     {
-        await base.Skip_Take_Any_with_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Skip_Take_Any_with_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_Any_with_predicate(bool async)
     {
-        await base.Take_Any_with_predicate(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Take_Any_with_predicate(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task OrderBy(bool async)
@@ -1613,37 +1282,45 @@ WHERE (c[""Discriminator""] = ""Customer"")
 ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_true(bool async)
     {
-        await base.OrderBy_true(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_true(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY true");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_integer(bool async)
     {
-        await base.OrderBy_integer(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_integer(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY 3");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_parameter(bool async)
     {
-        await base.OrderBy_parameter(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_parameter(async));
 
         AssertSql(
-            @"SELECT c
+            @"@__param_0='5'
+
+SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY @__param_0");
     }
 
     public override async Task OrderBy_anon(bool async)
@@ -1668,372 +1345,347 @@ WHERE (c[""Discriminator""] = ""Customer"")
 ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_client_mixed(bool async)
     {
         await base.OrderBy_client_mixed(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_multiple_queries(bool async)
     {
         await base.OrderBy_multiple_queries(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_Distinct(bool async)
     {
         await base.Take_Distinct(async);
 
         AssertSql(
-            @"SELECT c
+            @"@__p_0='5'
+
+SELECT DISTINCT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+WHERE (c[""Discriminator""] = ""Order"")
+ORDER BY c[""OrderID""]
+OFFSET 0 LIMIT @__p_0");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Distinct_Take(bool async)
     {
-        await base.Distinct_Take(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Distinct_Take(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Distinct_Take_Count(bool async)
     {
-        await base.Distinct_Take_Count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Distinct_Take_Count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_shadow(bool async)
     {
-        await base.OrderBy_shadow(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_shadow(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+WHERE (c[""Discriminator""] = ""Employee"")
+ORDER BY c[""Title""], c[""EmployeeID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_multiple(bool async)
     {
-        await base.OrderBy_multiple(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_multiple(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT c[""City""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))
+ORDER BY c[""Country""], c[""City""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_ThenBy_Any(bool async)
     {
-        await base.OrderBy_ThenBy_Any(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.OrderBy_ThenBy_Any(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_correlated_subquery1(bool async)
     {
-        await base.OrderBy_correlated_subquery1(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.OrderBy_correlated_subquery1(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_correlated_subquery2(bool async)
     {
-        await base.OrderBy_correlated_subquery2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.OrderBy_correlated_subquery2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_subquery_recursive_trivial(bool async)
     {
-        await base.Where_subquery_recursive_trivial(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_subquery_recursive_trivial(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_query_composition4(bool async)
     {
         await base.Where_query_composition4(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_subquery_expression(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-            {
-                var firstOrder = ss.Set<Order>().First();
-                Expression<Func<Order, bool>> expr = z => z.OrderID == firstOrder.OrderID;
-                return ss.Set<Order>().Where(x => x.OrderID < 10300 && ss.Set<Order>().Where(expr).Any());
-            },
-            entryCount: 52);
+        // Cosmos client evaluation. Issue #17246.
+        Assert.Equal(
+            CoreStrings.ExpressionParameterizationExceptionSensitive(
+                "value(Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase`1+<>c__DisplayClass107_0[Microsoft.EntityFrameworkCore.Query.NorthwindQueryCosmosFixture`1[Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer]]).ss.Set().Where(value(Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase`1+<>c__DisplayClass107_0[Microsoft.EntityFrameworkCore.Query.NorthwindQueryCosmosFixture`1[Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer]]).expr).Any()"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Where_subquery_expression(async))).Message);
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+WHERE (c[""Discriminator""] = ""Order"")
+OFFSET 0 LIMIT 1");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_subquery_expression_same_parametername(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-            {
-                var firstOrder = ss.Set<Order>().OrderBy(o => o.OrderID).First();
-                Expression<Func<Order, bool>> expr = x => x.OrderID == firstOrder.OrderID;
-                return ss.Set<Order>().Where(o => o.OrderID < 10250)
-                    .Where(x => ss.Set<Order>().Where(expr).Where(o => o.CustomerID == x.CustomerID).Any());
-            },
-            entryCount: 1);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_subquery_expression_same_parametername(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+WHERE (c[""Discriminator""] = ""Order"")
+ORDER BY c[""OrderID""]
+OFFSET 0 LIMIT 1");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_DTO_distinct_translated_to_server()
     {
-        base.Select_DTO_distinct_translated_to_server();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_DTO_distinct_translated_to_server();
+                return Task.CompletedTask;
+            });
 
         AssertSql(
-            @"SELECT c
+            @"SELECT DISTINCT 1
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_DTO_constructor_distinct_translated_to_server()
     {
-        base.Select_DTO_constructor_distinct_translated_to_server();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_DTO_constructor_distinct_translated_to_server();
+                return Task.CompletedTask;
+            });
 
         AssertSql(
-            @"SELECT c
+            @"SELECT DISTINCT c[""CustomerID""]
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_DTO_with_member_init_distinct_translated_to_server()
     {
-        base.Select_DTO_with_member_init_distinct_translated_to_server();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_DTO_with_member_init_distinct_translated_to_server();
+                return Task.CompletedTask;
+            });
 
         AssertSql(
-            @"SELECT c
+            @"SELECT DISTINCT VALUE {""Id"" : c[""CustomerID""], ""Count"" : c[""OrderID""]}
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_nested_collection_count_using_DTO()
     {
-        base.Select_nested_collection_count_using_DTO();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_nested_collection_count_using_DTO();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_DTO_with_member_init_distinct_in_subquery_translated_to_server(bool async)
     {
-        await base.Select_DTO_with_member_init_distinct_in_subquery_translated_to_server(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_DTO_with_member_init_distinct_in_subquery_translated_to_server(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server()
     {
-        base.Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
     public override async Task Select_correlated_subquery_filtered(bool async)
     {
-        await base.Select_correlated_subquery_filtered(async);
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_correlated_subquery_filtered(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
     public override async Task Select_correlated_subquery_ordered(bool async)
     {
-        await base.Select_correlated_subquery_ordered(async);
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_correlated_subquery_ordered(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Select_nested_collection_in_anonymous_type(bool async)
-        => base.Select_nested_collection_in_anonymous_type(async);
+    public override async Task Select_nested_collection_in_anonymous_type(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_nested_collection_in_anonymous_type(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Select_subquery_recursive_trivial(bool async)
-        => base.Select_subquery_recursive_trivial(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
+    public override async Task Select_subquery_recursive_trivial(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_subquery_recursive_trivial(async));
+
+        AssertSql();
+    }
+
     public override async Task Where_subquery_on_bool(bool async)
     {
-        await base.Where_subquery_on_bool(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_subquery_on_bool(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Where_subquery_on_collection(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Product>().Where(p => p.ProductID == 72)
-                .Where(
-                    p => ss.Set<OrderDetail>()
-                        .Where(o => o.ProductID == p.ProductID)
-                        .Select(odd => odd.Quantity).Contains<short>(5)),
-            entryCount: 1);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_subquery_on_collection(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] = 72))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_many_cross_join_same_collection(bool async)
     {
-        await base.Select_many_cross_join_same_collection(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_many_cross_join_same_collection(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_null_coalesce_operator(bool async)
     {
-        await base.OrderBy_null_coalesce_operator(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_null_coalesce_operator(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY ((c[""Region""] != null) ? c[""Region""] : ""ZZ""), c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_null_coalesce_operator(bool async)
     {
-        await base.Select_null_coalesce_operator(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.Select_null_coalesce_operator(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""CompanyName"" : c[""CompanyName""], ""Region"" : ((c[""Region""] != null) ? c[""Region""] : ""ZZ"")}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY ((c[""Region""] != null) ? c[""Region""] : ""ZZ""), c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_conditional_operator(bool async)
     {
-        await base.OrderBy_conditional_operator(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_conditional_operator(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY ((c[""Region""] = null) ? ""ZZ"" : c[""Region""]), c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_conditional_operator_where_condition_false(bool async)
     {
         await base.OrderBy_conditional_operator_where_condition_false(async);
 
         AssertSql(
-            @"@__p_0='false'
-
-SELECT c
+            @"SELECT c
 FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")
 ORDER BY c[""City""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_comparison_operator(bool async)
     {
-        await base.OrderBy_comparison_operator(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_comparison_operator(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY (c[""Region""] = ""ASK"")");
     }
 
-    [ConditionalTheory]
     public override async Task Projection_null_coalesce_operator(bool async)
     {
         await base.Projection_null_coalesce_operator(async);
@@ -2054,70 +1706,77 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CompanyName""] != null) ? c[""CompanyName""] : c[""ContactName""]) = ""The Big Cheese""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Take_skip_null_coalesce_operator(bool async)
     {
-        await base.Take_skip_null_coalesce_operator(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Take_skip_null_coalesce_operator(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_null_coalesce_operator(bool async)
     {
-        await base.Select_take_null_coalesce_operator(async);
+        // Subquery pushdown. Issue #16156.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.Select_take_null_coalesce_operator(async));
 
         AssertSql(
-            @"SELECT c
+            @"@__p_0='5'
+
+SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""CompanyName"" : c[""CompanyName""], ""Region"" : ((c[""Region""] != null) ? c[""Region""] : ""ZZ"")}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY ((c[""Region""] != null) ? c[""Region""] : ""ZZ"")
+OFFSET 0 LIMIT @__p_0");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_skip_null_coalesce_operator(bool async)
     {
-        await base.Select_take_skip_null_coalesce_operator(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_take_skip_null_coalesce_operator(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_skip_null_coalesce_operator2(bool async)
     {
-        await base.Select_take_skip_null_coalesce_operator2(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_take_skip_null_coalesce_operator2(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_skip_null_coalesce_operator3(bool async)
     {
-        await base.Select_take_skip_null_coalesce_operator3(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_take_skip_null_coalesce_operator3(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Selected_column_can_coalesce()
     {
-        base.Selected_column_can_coalesce();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Selected_column_can_coalesce();
+                return Task.CompletedTask;
+            });
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY ((c[""Region""] != null) ? c[""Region""] : ""ZZ"")");
     }
 
     public override async Task DateTime_parse_is_inlined(bool async)
@@ -2170,110 +1829,142 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > @__p_0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Random_next_is_not_funcletized_1(bool async)
-        => base.Random_next_is_not_funcletized_1(async);
+    public override async Task Random_next_is_not_funcletized_1(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Random_next_is_not_funcletized_1(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Random_next_is_not_funcletized_2(bool async)
-        => base.Random_next_is_not_funcletized_2(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Random_next_is_not_funcletized_3(bool async)
-        => base.Random_next_is_not_funcletized_3(async);
+    public override async Task Random_next_is_not_funcletized_2(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Random_next_is_not_funcletized_2(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Random_next_is_not_funcletized_4(bool async)
-        => base.Random_next_is_not_funcletized_4(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Random_next_is_not_funcletized_5(bool async)
-        => base.Random_next_is_not_funcletized_5(async);
+    public override async Task Random_next_is_not_funcletized_3(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Random_next_is_not_funcletized_3(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Random_next_is_not_funcletized_6(bool async)
-        => base.Random_next_is_not_funcletized_6(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
+    public override async Task Random_next_is_not_funcletized_4(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Random_next_is_not_funcletized_4(async));
+
+        AssertSql();
+    }
+
+    public override async Task Random_next_is_not_funcletized_5(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Random_next_is_not_funcletized_5(async));
+
+        AssertSql();
+    }
+
+    public override async Task Random_next_is_not_funcletized_6(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Random_next_is_not_funcletized_6(async));
+
+        AssertSql();
+    }
+
     public override async Task Environment_newline_is_funcletized(bool async)
     {
         await base.Environment_newline_is_funcletized(async);
 
         AssertSql(
-            @"SELECT c
+            @"@__NewLine_0='\r\n'
+
+SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""CustomerID""], @__NewLine_0))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_concat_with_navigation1(bool async)
     {
-        await base.String_concat_with_navigation1(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_concat_with_navigation1(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task String_concat_with_navigation2(bool async)
     {
-        await base.String_concat_with_navigation2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.String_concat_with_navigation2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_bitwise_or(bool async)
     {
-        await base.Select_bitwise_or(async);
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""Value"" : ((c[""CustomerID""] = ""ALFKI"") | (c[""CustomerID""] = ""ANATR""))}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_bitwise_or_multiple(bool async)
     {
-        await base.Select_bitwise_or_multiple(async);
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or_multiple(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""Value"" : (((c[""CustomerID""] = ""ALFKI"") | (c[""CustomerID""] = ""ANATR"")) | (c[""CustomerID""] = ""ANTON""))}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_bitwise_and(bool async)
     {
-        await base.Select_bitwise_and(async);
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""Value"" : ((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR""))}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_bitwise_and_or(bool async)
     {
-        await base.Select_bitwise_and_or(async);
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and_or(async));
+
+        AssertSql(
+            @"SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""Value"" : (((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR"")) | (c[""CustomerID""] = ""ANTON""))}
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
+    }
+
+    public override async Task Where_bitwise_or_with_logical_or(bool async)
+    {
+        // Bitwise operators on booleans. Issue #13168.
+        Assert.Equal(
+            "1",
+            (await Assert.ThrowsAsync<EqualException>(() => base.Where_bitwise_or_with_logical_or(async))).Actual);
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"") | (c[""CustomerID""] = ""ANATR"")) OR (c[""CustomerID""] = ""ANTON"")))");
     }
-
-    [ConditionalTheory(Skip = "Issue#13168")]
-    public override Task Where_bitwise_or_with_logical_or(bool async)
-        => base.Where_bitwise_or_with_logical_or(async);
 
     public override async Task Where_bitwise_and_with_logical_and(bool async)
     {
@@ -2285,9 +1976,18 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR"")) AND (c[""CustomerID""] = ""ANTON"")))");
     }
 
-    [ConditionalTheory(Skip = "Issue#13168")]
-    public override Task Where_bitwise_or_with_logical_and(bool async)
-        => base.Where_bitwise_or_with_logical_and(async);
+    public override async Task Where_bitwise_or_with_logical_and(bool async)
+    {
+        // Bitwise operators on booleans. Issue #13168.
+        Assert.Equal(
+            "0",
+            (await Assert.ThrowsAsync<EqualException>(() => base.Where_bitwise_or_with_logical_and(async))).Actual);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"") | (c[""CustomerID""] = ""ANATR"")) AND (c[""Country""] = ""Germany"")))");
+    }
 
     public override async Task Where_bitwise_and_with_logical_or(bool async)
     {
@@ -2331,78 +2031,76 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] | 10248) = 10248))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_bitwise_or_with_logical_or(bool async)
     {
-        await base.Select_bitwise_or_with_logical_or(async);
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_or_with_logical_or(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""Value"" : (((c[""CustomerID""] = ""ALFKI"") | (c[""CustomerID""] = ""ANATR"")) OR (c[""CustomerID""] = ""ANTON""))}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_bitwise_and_with_logical_and(bool async)
     {
-        await base.Select_bitwise_and_with_logical_and(async);
+        // Bitwise operators on booleans. Issue #13168.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_bitwise_and_with_logical_and(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""Value"" : (((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR"")) AND (c[""CustomerID""] = ""ANTON""))}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Handle_materialization_properly_when_more_than_two_query_sources_are_involved(bool async)
     {
-        await base.Handle_materialization_properly_when_more_than_two_query_sources_are_involved(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Handle_materialization_properly_when_more_than_two_query_sources_are_involved(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#13159")]
-    public override Task Parameter_extraction_short_circuits_1(bool async)
-        => base.Parameter_extraction_short_circuits_1(async);
+    public override async Task Parameter_extraction_short_circuits_1(bool async)
+    {
+        // Optimize query SQL. Issue #13159.
+        await AssertTranslationFailed(() => base.Parameter_extraction_short_circuits_1(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
+        AssertSql();
+    }
+
     public override async Task Parameter_extraction_short_circuits_2(bool async)
     {
-        await base.Parameter_extraction_short_circuits_2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Parameter_extraction_short_circuits_2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#13159")]
-    public override Task Parameter_extraction_short_circuits_3(bool async)
-        => base.Parameter_extraction_short_circuits_3(async);
+    public override async Task Parameter_extraction_short_circuits_3(bool async)
+    {
+        // Optimize query SQL. Issue #13159.
+        await AssertTranslationFailed(() => base.Parameter_extraction_short_circuits_3(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
+        AssertSql();
+    }
+
     public override async Task Subquery_member_pushdown_does_not_change_original_subquery_model(bool async)
     {
-        await base.Subquery_member_pushdown_does_not_change_original_subquery_model(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Subquery_member_pushdown_does_not_change_original_subquery_model(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Query_expression_with_to_string_and_contains(bool async)
     {
-        await base.Query_expression_with_to_string_and_contains(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Query_expression_with_to_string_and_contains(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
     public override async Task Select_expression_long_to_string(bool async)
@@ -2540,206 +2238,194 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10500))
 ORDER BY c[""OrderID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_expression_references_are_updated_correctly_with_subquery(bool async)
     {
-        await base.Select_expression_references_are_updated_correctly_with_subquery(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_expression_references_are_updated_correctly_with_subquery(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task DefaultIfEmpty_without_group_join(bool async)
     {
-        await base.DefaultIfEmpty_without_group_join(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_without_group_join(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task DefaultIfEmpty_in_subquery(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => from c in ss.Set<Customer>().Where(c => c.City == "London")
-                  from o in ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
-                  where o != null
-                  select new { c.CustomerID, o.OrderID },
-            elementSorter: e => (e.CustomerID, e.OrderID));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_in_subquery(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task DefaultIfEmpty_in_subquery_not_correlated(bool async)
-        => base.DefaultIfEmpty_in_subquery_not_correlated(async);
+    public override async Task DefaultIfEmpty_in_subquery_not_correlated(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_in_subquery_not_correlated(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
+        AssertSql();
+    }
+
     public override async Task DefaultIfEmpty_in_subquery_nested(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => from c in ss.Set<Customer>().Where(c => c.City == "Seattle")
-                  from o1 in ss.Set<Order>().Where(o => o.OrderID > 11000).DefaultIfEmpty()
-                  from o2 in ss.Set<Order>().Where(o => o.OrderID < 10250).Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
-                  where o1 != null && o2 != null
-                  orderby o1.OrderID, o2.OrderDate
-                  select new
-                  {
-                      c.CustomerID,
-                      o1.OrderID,
-                      o2.OrderDate
-                  },
-            elementSorter: e => (e.CustomerID, e.OrderID));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_in_subquery_nested(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""Seattle""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task DefaultIfEmpty_in_subquery_nested_filter_order_comparison(bool async)
-        => base.DefaultIfEmpty_in_subquery_nested_filter_order_comparison(async);
+    public override async Task DefaultIfEmpty_in_subquery_nested_filter_order_comparison(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_in_subquery_nested_filter_order_comparison(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
+        AssertSql();
+    }
+
     public override async Task OrderBy_skip_take(bool async)
     {
-        await base.OrderBy_skip_take(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_skip_take(async));
 
         AssertSql(
-            @"SELECT c
+            @"@__p_0='5'
+@__p_1='8'
+
+SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""ContactTitle""], c[""ContactName""]
+OFFSET @__p_0 LIMIT @__p_1");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_skip_skip_take(bool async)
     {
-        await base.OrderBy_skip_skip_take(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.OrderBy_skip_skip_take(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_skip_take_take(bool async)
     {
-        await base.OrderBy_skip_take_take(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.OrderBy_skip_take_take(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_skip_take_take_take_take(bool async)
     {
-        await base.OrderBy_skip_take_take_take_take(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.OrderBy_skip_take_take_take_take(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_skip_take_skip_take_skip(bool async)
     {
-        await base.OrderBy_skip_take_skip_take_skip(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.OrderBy_skip_take_skip_take_skip(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_skip_take_distinct(bool async)
     {
-        await base.OrderBy_skip_take_distinct(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_skip_take_distinct(async));
 
         AssertSql(
-            @"SELECT c
+            @"@__p_0='5'
+@__p_1='15'
+
+SELECT DISTINCT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""ContactTitle""], c[""ContactName""]
+OFFSET @__p_0 LIMIT @__p_1");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_coalesce_take_distinct(bool async)
     {
-        await base.OrderBy_coalesce_take_distinct(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_coalesce_take_distinct(async));
 
         AssertSql(
-            @"SELECT c
+            @"@__p_0='15'
+
+SELECT DISTINCT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+WHERE (c[""Discriminator""] = ""Product"")
+ORDER BY ((c[""UnitPrice""] != null) ? c[""UnitPrice""] : 0.0)
+OFFSET 0 LIMIT @__p_0");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_coalesce_skip_take_distinct(bool async)
     {
-        await base.OrderBy_coalesce_skip_take_distinct(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_coalesce_skip_take_distinct(async));
 
         AssertSql(
-            @"SELECT c
+            @"@__p_0='5'
+@__p_1='15'
+
+SELECT DISTINCT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+WHERE (c[""Discriminator""] = ""Product"")
+ORDER BY ((c[""UnitPrice""] != null) ? c[""UnitPrice""] : 0.0)
+OFFSET @__p_0 LIMIT @__p_1");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_coalesce_skip_take_distinct_take(bool async)
     {
-        await base.OrderBy_coalesce_skip_take_distinct_take(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.OrderBy_coalesce_skip_take_distinct_take(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Product"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_skip_take_distinct_orderby_take(bool async)
     {
-        await base.OrderBy_skip_take_distinct_orderby_take(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.OrderBy_skip_take_distinct_orderby_take(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task No_orderby_added_for_fully_translated_manually_constructed_LOJ(bool async)
     {
-        await base.No_orderby_added_for_fully_translated_manually_constructed_LOJ(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.No_orderby_added_for_fully_translated_manually_constructed_LOJ(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
     public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ(bool async)
     {
         await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
     public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(
@@ -2747,10 +2433,7 @@ WHERE (c[""Discriminator""] = ""Order"")");
     {
         await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
     public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(
@@ -2758,270 +2441,212 @@ WHERE (c[""Discriminator""] = ""Order"")");
     {
         await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
     public override async Task Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(bool async)
     {
         await base.Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Contains_with_DateTime_Date(bool async)
     {
-        await base.Contains_with_DateTime_Date(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Contains_with_DateTime_Date(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Contains_with_subquery_involving_join_binds_to_correct_table(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Order>().Where(
-                o => o.OrderID > 11002
-                    && o.OrderID < 11004
-                    && ss.Set<OrderDetail>()
-                        .Where(od => od.Product.ProductName == "Chai")
-                        .Select(od => od.OrderID)
-                        .Contains(o.OrderID)),
-            entryCount: 1);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Contains_with_subquery_involving_join_binds_to_correct_table(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Complex_query_with_repeated_query_model_compiles_correctly(bool async)
     {
-        await base.Complex_query_with_repeated_query_model_compiles_correctly(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Complex_query_with_repeated_query_model_compiles_correctly(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Complex_query_with_repeated_nested_query_model_compiles_correctly(bool async)
     {
-        await base.Complex_query_with_repeated_nested_query_model_compiles_correctly(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Complex_query_with_repeated_nested_query_model_compiles_correctly(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#16144")]
     public override async Task Anonymous_member_distinct_where(bool async)
     {
         await base.Anonymous_member_distinct_where(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT DISTINCT c[""CustomerID""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Anonymous_member_distinct_orderby(bool async)
     {
-        await base.Anonymous_member_distinct_orderby(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Anonymous_member_distinct_orderby(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Anonymous_member_distinct_result(bool async)
     {
-        await base.Anonymous_member_distinct_result(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Anonymous_member_distinct_result(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#16144")]
     public override async Task Anonymous_complex_distinct_where(bool async)
     {
         await base.Anonymous_complex_distinct_where(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT DISTINCT VALUE {""A"" : (c[""CustomerID""] || c[""City""])}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] || c[""City""]) = ""ALFKIBerlin""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Anonymous_complex_distinct_orderby(bool async)
     {
-        await base.Anonymous_complex_distinct_orderby(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Anonymous_complex_distinct_orderby(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Anonymous_complex_distinct_result(bool async)
     {
-        await base.Anonymous_complex_distinct_result(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Anonymous_complex_distinct_result(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Anonymous_complex_orderby(bool async)
     {
-        await base.Anonymous_complex_orderby(async);
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.Anonymous_complex_orderby(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT VALUE {""A"" : (c[""CustomerID""] || c[""City""])}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY (c[""CustomerID""] || c[""City""])");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Anonymous_subquery_orderby(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.City == "London").Where(c => c.Orders.Count > 1).Select(
-                c => new { A = c.Orders.OrderByDescending(o => o.OrderID).FirstOrDefault().OrderDate }).OrderBy(n => n.A),
-            assertOrder: true);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Anonymous_subquery_orderby(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task DTO_member_distinct_where(bool async)
     {
         await base.DTO_member_distinct_where(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT DISTINCT VALUE {""Property"" : c[""CustomerID""]}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task DTO_member_distinct_orderby(bool async)
     {
-        await base.DTO_member_distinct_orderby(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.DTO_member_distinct_orderby(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task DTO_member_distinct_result(bool async)
     {
-        await base.DTO_member_distinct_result(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DTO_member_distinct_result(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task DTO_complex_distinct_where(bool async)
     {
         await base.DTO_complex_distinct_where(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT DISTINCT VALUE {""Property"" : (c[""CustomerID""] || c[""City""])}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] || c[""City""]) = ""ALFKIBerlin""))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task DTO_complex_distinct_orderby(bool async)
     {
-        await base.DTO_complex_distinct_orderby(async);
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.DTO_complex_distinct_orderby(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task DTO_complex_distinct_result(bool async)
     {
-        await base.DTO_complex_distinct_result(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DTO_complex_distinct_result(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task DTO_complex_orderby(bool async)
     {
-        await base.DTO_complex_orderby(async);
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.DTO_complex_orderby(async));
 
         AssertSql(
-            @"SELECT c
+            @"SELECT VALUE {""Property"" : (c[""CustomerID""] || c[""City""])}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY (c[""CustomerID""] || c[""City""])");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task DTO_subquery_orderby(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Where(c => c.Orders.Count > 1).Select(
-                    c => new DTO<DateTime?> { Property = c.Orders.OrderByDescending(o => o.OrderID).FirstOrDefault().OrderDate })
-                .OrderBy(n => n.Property),
-            assertOrder: true,
-            elementAsserter: (e, a) => Assert.Equal(e.Property, a.Property));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.DTO_subquery_orderby(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Include_with_orderby_skip_preserves_ordering(bool async)
     {
-        await base.Include_with_orderby_skip_preserves_ordering(async);
+        // Cosmos client evaluation. Issue #17246.
+        Assert.Equal(
+            CosmosStrings.NonEmbeddedIncludeNotSupported(
+                "Navigation: Customer.Orders (List<Order>) Collection ToDependent Order Inverse: Customer PropertyAccessMode.Field"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Include_with_orderby_skip_preserves_ordering(async)))
+            .Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != ""VAFFE"") AND (c[""CustomerID""] != ""DRACD"")))");
+        AssertSql();
     }
 
     public override async Task Int16_parameter_can_be_used_for_int_column(bool async)
@@ -3034,415 +2659,269 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10300))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Subquery_is_null_translated_correctly(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => from c in ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI")
-                  let lastOrder = c.Orders.OrderByDescending(o => o.OrderID)
-                      .Select(o => o.CustomerID)
-                      .FirstOrDefault()
-                  where lastOrder == null
-                  select c);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Subquery_is_null_translated_correctly(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Subquery_is_not_null_translated_correctly(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => from c in ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI")
-                  let lastOrder = c.Orders.OrderByDescending(o => o.OrderID)
-                      .Select(o => o.CustomerID)
-                      .FirstOrDefault()
-                  where lastOrder != null
-                  select c,
-            entryCount: 1);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Subquery_is_not_null_translated_correctly(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_average(bool async)
     {
-        await base.Select_take_average(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_take_average(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_count(bool async)
     {
-        await base.Select_take_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_take_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_orderBy_take_count(bool async)
     {
-        await base.Select_orderBy_take_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_orderBy_take_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_long_count(bool async)
     {
-        await base.Select_take_long_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_take_long_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_orderBy_take_long_count(bool async)
     {
-        await base.Select_orderBy_take_long_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_orderBy_take_long_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_max(bool async)
     {
-        await base.Select_take_max(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_take_max(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_min(bool async)
     {
-        await base.Select_take_min(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_take_min(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_take_sum(bool async)
     {
-        await base.Select_take_sum(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_take_sum(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_skip_average(bool async)
     {
-        await base.Select_skip_average(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_skip_average(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_skip_count(bool async)
     {
-        await base.Select_skip_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_skip_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_orderBy_skip_count(bool async)
     {
-        await base.Select_orderBy_skip_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_orderBy_skip_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_skip_long_count(bool async)
     {
-        await base.Select_skip_long_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_skip_long_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_orderBy_skip_long_count(bool async)
     {
-        await base.Select_orderBy_skip_long_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_orderBy_skip_long_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_skip_max(bool async)
     {
-        await base.Select_skip_max(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_skip_max(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_skip_min(bool async)
     {
-        await base.Select_skip_min(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_skip_min(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_skip_sum(bool async)
     {
-        await base.Select_skip_sum(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_skip_sum(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_distinct_average(bool async)
     {
-        await base.Select_distinct_average(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_distinct_average(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_distinct_count(bool async)
     {
-        await base.Select_distinct_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_distinct_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_distinct_long_count(bool async)
     {
-        await base.Select_distinct_long_count(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_distinct_long_count(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_distinct_max(bool async)
     {
-        await base.Select_distinct_max(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_distinct_max(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_distinct_min(bool async)
     {
-        await base.Select_distinct_min(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_distinct_min(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_distinct_sum(bool async)
     {
-        await base.Select_distinct_sum(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_distinct_sum(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Comparing_to_fixed_string_parameter(bool async)
     {
         await base.Comparing_to_fixed_string_parameter(async);
 
         AssertSql(
-            @"SELECT c
+            @"@__prefix_0='A'
+
+SELECT c[""CustomerID""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((@__prefix_0 = """") OR ((c[""CustomerID""] != null) AND ((@__prefix_0 != null) AND STARTSWITH(c[""CustomerID""], @__prefix_0)))))");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Comparing_entities_using_Equals(bool async)
     {
-        await base.Comparing_entities_using_Equals(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Comparing_entities_using_Equals(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Comparing_different_entity_types_using_Equals(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => from c in ss.Set<Customer>()
-                  where c.CustomerID == "ALFKI"
-                  from o in ss.Set<Order>()
-                  where o.CustomerID == "ALFKI"
-                  where c.Equals(o)
-                  select c.CustomerID);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Comparing_different_entity_types_using_Equals(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Comparing_entity_to_null_using_Equals(bool async)
     {
         await base.Comparing_entity_to_null_using_Equals(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT c[""CustomerID""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A"")))) AND NOT((c[""CustomerID""] = null)))
+ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Comparing_navigations_using_Equals(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from o1 in ss.Set<Order>()
-                where o1.CustomerID.StartsWith("A")
-                from o2 in ss.Set<Order>()
-                where o1.Customer.Equals(o2.Customer)
-                orderby o1.OrderID, o2.OrderID
-                select new { Id1 = o1.OrderID, Id2 = o2.OrderID },
-            elementSorter: e => (e.Id1, e.Id2));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Comparing_navigations_using_Equals(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Comparing_navigations_using_static_Equals(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from o1 in ss.Set<Order>()
-                where o1.CustomerID.StartsWith("A")
-                from o2 in ss.Set<Order>()
-                where Equals(o1.Customer, o2.Customer)
-                orderby o1.OrderID, o2.OrderID
-                select new { Id1 = o1.OrderID, Id2 = o2.OrderID },
-            elementSorter: e => (e.Id1, e.Id2));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Comparing_navigations_using_static_Equals(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Comparing_non_matching_entities_using_Equals(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>()
-                where c.CustomerID == "ALFKI"
-                from o in ss.Set<Order>()
-                where Equals(c, o)
-                select new { Id1 = c.CustomerID, Id2 = o.OrderID },
-            elementSorter: e => (e.Id1, e.Id2));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Comparing_non_matching_entities_using_Equals(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Comparing_non_matching_collection_navigations_using_Equals(bool async)
     {
-        await AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>()
-                where c.CustomerID == "ALFKI"
-                from o in ss.Set<Order>()
-                where c.Orders.Equals(o.OrderDetails)
-                select new { Id1 = c.CustomerID, Id2 = o.OrderID },
-            elementSorter: e => (e.Id1, e.Id2));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Comparing_non_matching_collection_navigations_using_Equals(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Comparing_collection_navigation_to_null(bool async)
     {
         await base.Comparing_collection_navigation_to_null(async);
@@ -3453,119 +2932,86 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Comparing_collection_navigation_to_null_complex(bool async)
     {
-        await base.Comparing_collection_navigation_to_null_complex(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Comparing_collection_navigation_to_null_complex(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Compare_collection_navigation_with_itself(bool async)
     {
         await base.Compare_collection_navigation_with_itself(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT c[""CustomerID""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A"")))) AND (c[""CustomerID""] = c[""CustomerID""]))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Compare_two_collection_navigations_with_different_query_sources(bool async)
     {
-        await base.Compare_two_collection_navigations_with_different_query_sources(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Compare_two_collection_navigations_with_different_query_sources(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Compare_two_collection_navigations_using_equals(bool async)
     {
-        await base.Compare_two_collection_navigations_using_equals(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Compare_two_collection_navigations_using_equals(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Compare_two_collection_navigations_with_different_property_chains(bool async)
     {
-        await base.Compare_two_collection_navigations_with_different_property_chains(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Compare_two_collection_navigations_with_different_property_chains(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_ThenBy_same_column_different_direction(bool async)
     {
         await base.OrderBy_ThenBy_same_column_different_direction(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT c[""CustomerID""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))
+ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task OrderBy_OrderBy_same_column_different_direction(bool async)
     {
         await base.OrderBy_OrderBy_same_column_different_direction(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT c[""CustomerID""]
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))
+ORDER BY c[""CustomerID""] DESC");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result(bool async)
     {
-        await base.Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Complex_nested_query_properly_binds_to_grandparent_when_parent_returns_scalar_result(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI")
-                .Select(
-                    c => new { c.CustomerID, OuterOrders = c.Orders.Where(o => o.OrderID < 10250).Count(o => c.Orders.Count() > 0) }));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Complex_nested_query_properly_binds_to_grandparent_when_parent_returns_scalar_result(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))",
-            //
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))",
-            //
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")",
-            //
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
     public override async Task OrderBy_Dto_projection_skip_take(bool async)
@@ -3583,368 +3029,543 @@ ORDER BY c[""CustomerID""]
 OFFSET @__p_0 LIMIT @__p_1");
     }
 
-    [ConditionalFact(Skip = "Cross collection join Issue#17246")]
     public override void Streaming_chained_sync_query()
     {
-        using (var context = CreateContext())
-        {
-            var results
-                = (context.Customers.Where(c => c.CustomerID == "ALFKI")
-                    .Select(
-                        c => new { c.CustomerID, Orders = context.Orders.Where(o => o.Customer.CustomerID == c.CustomerID) }).ToList())
-                .Select(
-                    x => new
-                    {
-                        Orders = x.Orders
-                            .GroupJoin(
-                                new[] { "ALFKI" }, y => x.CustomerID, y => y, (h, id) => new { h.Customer })
-                    })
-                .ToList();
+        // Cross collection join. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Streaming_chained_sync_query();
+                return Task.CompletedTask;
+            });
 
-            Assert.Equal(6, results.SelectMany(r => r.Orders).ToList().Count);
-        }
-
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Join_take_count_works(bool async)
     {
-        await base.Join_take_count_works(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Join_take_count_works(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] > 690) AND (c[""OrderID""] < 710)))");
+        AssertSql();
     }
 
     public override async Task OrderBy_empty_list_contains(bool async)
     {
-        await base.OrderBy_empty_list_contains(async);
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_empty_list_contains(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY (true = false)");
     }
 
     public override async Task OrderBy_empty_list_does_not_contains(bool async)
     {
-        await base.OrderBy_empty_list_does_not_contains(async);
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_empty_list_does_not_contains(async));
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY NOT((true = false))");
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Manual_expression_tree_typed_null_equality()
     {
-        base.Manual_expression_tree_typed_null_equality();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Manual_expression_tree_typed_null_equality();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Let_subquery_with_multiple_occurrences(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => from o in ss.Set<Order>().Where(or => or.OrderID < 10250)
-                  let details =
-                      from od in o.OrderDetails
-                      where od.Quantity < 10
-                      select od.Quantity
-                  where details.Any()
-                  select new { Count = details.Count() });
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Let_subquery_with_multiple_occurrences(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))",
-            //
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))",
-            //
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))",
-            //
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))",
-            //
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 10))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Let_entity_equality_to_null(bool async)
     {
-        await base.Let_entity_equality_to_null(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Let_entity_equality_to_null(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Let_entity_equality_to_other_entity(bool async)
     {
-        await base.Let_entity_equality_to_other_entity(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Let_entity_equality_to_other_entity(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task SelectMany_after_client_method(bool async)
     {
         await base.SelectMany_after_client_method(async);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Collection_navigation_equal_to_null_for_subquery(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(
-                c => c.Orders.Where(o => o.OrderID < 10250).OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails == null),
-            ss => ss.Set<Customer>().Where(
-                c => c.Orders.Where(o => o.OrderID < 10250).OrderBy(o => o.OrderID).FirstOrDefault() == null),
-            entryCount: 89);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_navigation_equal_to_null_for_subquery(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17314")]
     public override async Task Dependent_to_principal_navigation_equal_to_null_for_subquery(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(
-                c => c.Orders.Where(o => o.OrderID < 10250).OrderBy(o => o.OrderID).FirstOrDefault().Customer == null),
-            ss => ss.Set<Customer>().Where(
-                c => c.Orders.Where(o => o.OrderID < 10250).OrderBy(o => o.OrderID).Select(o => o.CustomerID).FirstOrDefault() == null),
-            entryCount: 89);
+        // Left join translation. Issue #17314.
+        await AssertTranslationFailed(() => base.Dependent_to_principal_navigation_equal_to_null_for_subquery(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Collection_navigation_equality_rewrite_for_subquery(bool async)
     {
         await base.Collection_navigation_equality_rewrite_for_subquery(async);
 
+        AssertSql();
+    }
+
+    public override async Task Entity_equality_through_nested_anonymous_type_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Entity_equality_through_nested_anonymous_type_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Entity_equality_through_DTO_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Entity_equality_through_DTO_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Entity_equality_through_subquery(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Entity_equality_through_subquery(async));
+
+        AssertSql();
+    }
+
+    public override void Can_convert_manually_build_expression_with_default()
+    {
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Can_convert_manually_build_expression_with_default();
+                return Task.CompletedTask;
+            });
+
+        AssertSql(
+            @"SELECT COUNT(1) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] != null))",
+            //
+            @"SELECT COUNT(1) AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] != null))");
+    }
+
+    public override async Task Entity_equality_orderby_descending_composite_key(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.Entity_equality_orderby_descending_composite_key(async));
+
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""OrderDetail"")
+ORDER BY c[""OrderID""] DESC, c[""ProductID""] DESC");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Entity_equality_through_nested_anonymous_type_projection(bool async)
-        => base.Entity_equality_through_nested_anonymous_type_projection(async);
+    public override async Task Entity_equality_orderby_subquery(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Entity_equality_orderby_subquery(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override async Task Entity_equality_through_DTO_projection(bool async)
-        => await base.Entity_equality_through_DTO_projection(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Entity_equality_through_subquery(bool async)
-        => base.Entity_equality_through_subquery(async);
+    public override async Task Entity_equality_orderby_descending_subquery_composite_key(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Entity_equality_orderby_descending_subquery_composite_key(async));
 
-    [ConditionalFact(Skip = "Issue #17246")]
-    public override void Can_convert_manually_build_expression_with_default()
-        => base.Can_convert_manually_build_expression_with_default();
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Entity_equality_orderby_descending_composite_key(bool async)
-        => base.Entity_equality_orderby_descending_composite_key(async);
+    public override async Task Null_Coalesce_Short_Circuit(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Null_Coalesce_Short_Circuit(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Entity_equality_orderby_subquery(bool async)
-        => base.Entity_equality_orderby_subquery(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Entity_equality_orderby_descending_subquery_composite_key(bool async)
-        => base.Entity_equality_orderby_descending_subquery_composite_key(async);
+    public override async Task OrderByDescending_ThenBy(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderByDescending_ThenBy(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Null_Coalesce_Short_Circuit(bool async)
-        => base.Null_Coalesce_Short_Circuit(async);
+        AssertSql(
+            @"SELECT c[""City""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""] DESC, c[""Country""]");
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task OrderByDescending_ThenBy(bool async)
-        => base.OrderByDescending_ThenBy(async);
+    public override async Task OrderByDescending_ThenByDescending(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderByDescending_ThenByDescending(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task OrderByDescending_ThenByDescending(bool async)
-        => base.OrderByDescending_ThenByDescending(async);
+        AssertSql(
+            @"SELECT c[""City""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""] DESC, c[""Country""] DESC");
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task OrderBy_Join(bool async)
-        => base.OrderBy_Join(async);
+    public override async Task OrderBy_Join(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.OrderBy_Join(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task OrderBy_ThenBy(bool async)
-        => base.OrderBy_ThenBy(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task OrderBy_ThenBy_predicate(bool async)
-        => base.OrderBy_ThenBy_predicate(async);
+    public override async Task OrderBy_ThenBy(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_ThenBy(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_correlated_simple(bool async)
-        => base.SelectMany_correlated_simple(async);
+        AssertSql(
+            @"SELECT c[""City""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""], c[""Country""]");
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_nested_simple(bool async)
-        => base.SelectMany_nested_simple(async);
+    public override async Task OrderBy_ThenBy_predicate(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await Assert.ThrowsAsync<CosmosException>(
+            async () => await base.OrderBy_ThenBy_predicate(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_primitive(bool async)
-        => base.SelectMany_primitive(async);
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))
+ORDER BY c[""City""], c[""CustomerID""]");
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_primitive_select_subquery(bool async)
-        => base.SelectMany_primitive_select_subquery(async);
+    public override async Task SelectMany_correlated_simple(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_simple(async));
 
-    [ConditionalFact(Skip = "Issue #17246")]
+        AssertSql();
+    }
+
+    public override async Task SelectMany_nested_simple(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_nested_simple(async));
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_primitive(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_primitive(async));
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_primitive_select_subquery(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        // Cosmos client evaluation. Issue #17246.
+        Assert.Equal(
+            CoreStrings.ExpressionParameterizationExceptionSensitive(
+                "value(Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase`1+<>c__DisplayClass168_0[Microsoft.EntityFrameworkCore.Query.NorthwindQueryCosmosFixture`1[Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer]]).ss.Set().Any()"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_primitive_select_subquery(async))).Message);
+
+        AssertSql();
+    }
+
     public override void Select_DTO_constructor_distinct_with_navigation_translated_to_server()
-        => base.Select_DTO_constructor_distinct_with_navigation_translated_to_server();
+    {
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_DTO_constructor_distinct_with_navigation_translated_to_server();
+                return Task.CompletedTask;
+            });
 
-    [ConditionalFact(Skip = "Issue #17246")]
+        AssertSql();
+    }
+
     public override void Select_DTO_constructor_distinct_with_collection_projection_translated_to_server()
-        => base.Select_DTO_constructor_distinct_with_collection_projection_translated_to_server();
+    {
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_DTO_constructor_distinct_with_collection_projection_translated_to_server();
+                return Task.CompletedTask;
+            });
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Select_Property_when_shadow_unconstrained_generic_method(bool async)
-        => base.Select_Property_when_shadow_unconstrained_generic_method(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Skip_orderby_const(bool async)
-        => base.Skip_orderby_const(async);
+    public override async Task Select_Property_when_shadow_unconstrained_generic_method(bool async)
+    {
+        await base.Select_Property_when_shadow_unconstrained_generic_method(async);
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_Property_when_shadow_unconstrained_generic_method(bool async)
-        => base.Where_Property_when_shadow_unconstrained_generic_method(async);
+        AssertSql(
+            @"SELECT c[""Title""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Inner_parameter_in_nested_lambdas_gets_preserved(bool async)
-        => base.Inner_parameter_in_nested_lambdas_gets_preserved(async);
+    public override async Task Skip_orderby_const(bool async)
+    {
+        Assert.Equal(
+            CosmosStrings.OffsetRequiresLimit,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Skip_orderby_const(async))).Message);
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Navigation_inside_interpolated_string_is_expanded(bool async)
-        => base.Navigation_inside_interpolated_string_is_expanded(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Select_DTO_with_member_init_distinct_in_subquery_translated_to_server_2(bool async)
-        => base.Select_DTO_with_member_init_distinct_in_subquery_translated_to_server_2(async);
+    public override async Task Where_Property_when_shadow_unconstrained_generic_method(bool async)
+    {
+        await base.Where_Property_when_shadow_unconstrained_generic_method(async);
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task All_client(bool async)
-        => base.All_client(async);
+        AssertSql(
+            @"@__value_0='Sales Representative'
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Client_OrderBy_GroupBy_Group_ordering_works(bool async)
-        => base.Client_OrderBy_GroupBy_Group_ordering_works(async);
+SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""Title""] = @__value_0))");
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Subquery_member_pushdown_does_not_change_original_subquery_model2(bool async)
-        => base.Subquery_member_pushdown_does_not_change_original_subquery_model2(async);
+    public override async Task Inner_parameter_in_nested_lambdas_gets_preserved(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Inner_parameter_in_nested_lambdas_gets_preserved(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Where_query_composition3(bool async)
-        => base.Where_query_composition3(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task OrderBy_object_type_server_evals(bool async)
-        => base.OrderBy_object_type_server_evals(async);
+    public override async Task Navigation_inside_interpolated_string_is_expanded(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Navigation_inside_interpolated_string_is_expanded(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task AsQueryable_in_query_server_evals(bool async)
-        => base.AsQueryable_in_query_server_evals(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_correlated_subquery_simple(bool async)
-        => base.SelectMany_correlated_subquery_simple(async);
+    public override async Task Select_DTO_with_member_init_distinct_in_subquery_translated_to_server_2(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_DTO_with_member_init_distinct_in_subquery_translated_to_server_2(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_correlated_subquery_hard(bool async)
-        => base.SelectMany_correlated_subquery_hard(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Subquery_DefaultIfEmpty_Any(bool async)
-        => base.Subquery_DefaultIfEmpty_Any(async);
+    public override async Task All_client(bool async)
+    {
+        await base.All_client(async);
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Projection_skip_collection_projection(bool async)
-        => base.Projection_skip_collection_projection(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Projection_take_collection_projection(bool async)
-        => base.Projection_take_collection_projection(async);
+    public override async Task Client_OrderBy_GroupBy_Group_ordering_works(bool async)
+    {
+        await base.Client_OrderBy_GroupBy_Group_ordering_works(async);
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Projection_skip_take_collection_projection(bool async)
-        => base.Projection_skip_take_collection_projection(async);
+        AssertSql();
+    }
 
-    public override Task Projection_skip_projection(bool async)
-        => AssertTranslationFailed(() => base.Projection_skip_projection(async));
+    public override async Task Subquery_member_pushdown_does_not_change_original_subquery_model2(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Subquery_member_pushdown_does_not_change_original_subquery_model2(async));
 
-    public override Task Projection_take_projection(bool async)
-        => AssertTranslationFailed(() => base.Projection_take_projection(async));
+        AssertSql();
+    }
 
-    public override Task Projection_skip_take_projection(bool async)
-        => AssertTranslationFailed(() => base.Projection_skip_take_projection(async));
+    public override async Task Where_query_composition3(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await base.Where_query_composition3(async);
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Collection_projection_skip(bool async)
-        => base.Collection_projection_skip(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Collection_projection_take(bool async)
-        => base.Collection_projection_take(async);
+    public override async Task OrderBy_object_type_server_evals(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.OrderBy_object_type_server_evals(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Collection_projection_skip_take(bool async)
-        => base.Collection_projection_skip_take(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Anonymous_projection_skip_empty_collection_FirstOrDefault(bool async)
-        => base.Anonymous_projection_skip_empty_collection_FirstOrDefault(async);
+    public override async Task AsQueryable_in_query_server_evals(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.AsQueryable_in_query_server_evals(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Anonymous_projection_take_empty_collection_FirstOrDefault(bool async)
-        => base.Anonymous_projection_take_empty_collection_FirstOrDefault(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Anonymous_projection_skip_take_empty_collection_FirstOrDefault(bool async)
-        => base.Anonymous_projection_skip_take_empty_collection_FirstOrDefault(async);
+    public override async Task SelectMany_correlated_subquery_simple(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_subquery_simple(async));
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_correlated_subquery_hard(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_subquery_hard(async));
+
+        AssertSql();
+    }
+
+    public override async Task Subquery_DefaultIfEmpty_Any(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Subquery_DefaultIfEmpty_Any(async));
+
+        AssertSql();
+    }
+
+    public override async Task Projection_skip_collection_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_skip_collection_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Projection_take_collection_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_take_collection_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Projection_skip_take_collection_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_skip_take_collection_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Projection_skip_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_skip_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Projection_take_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_take_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Projection_skip_take_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_skip_take_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Collection_projection_skip(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_projection_skip(async));
+
+        AssertSql();
+    }
+
+    public override async Task Collection_projection_take(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_projection_take(async));
+
+        AssertSql();
+    }
+
+    public override async Task Collection_projection_skip_take(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_projection_skip_take(async));
+
+        AssertSql();
+    }
+
+    public override async Task Anonymous_projection_skip_empty_collection_FirstOrDefault(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Anonymous_projection_skip_empty_collection_FirstOrDefault(async));
+
+        AssertSql();
+    }
+
+    public override async Task Anonymous_projection_take_empty_collection_FirstOrDefault(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Anonymous_projection_take_empty_collection_FirstOrDefault(async));
+
+        AssertSql();
+    }
+
+    public override async Task Anonymous_projection_skip_take_empty_collection_FirstOrDefault(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Anonymous_projection_skip_take_empty_collection_FirstOrDefault(async));
+
+        AssertSql();
+    }
 
     public override async Task Checked_context_with_arithmetic_does_not_fail(bool isAsync)
     {
@@ -3989,92 +3610,765 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] IN (""ALFKI"") OR (c[""CustomerID""] = null)))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Perform_identity_resolution_reuses_same_instances(bool async, bool useAsTracking)
-        => base.Perform_identity_resolution_reuses_same_instances(async, useAsTracking);
+    public override async Task Perform_identity_resolution_reuses_same_instances(bool async, bool useAsTracking)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Perform_identity_resolution_reuses_same_instances(async, useAsTracking));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Perform_identity_resolution_reuses_same_instances_across_joins(bool async, bool useAsTracking)
-        => base.Perform_identity_resolution_reuses_same_instances_across_joins(async, useAsTracking);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task All_client_and_server_top_level(bool async)
-        => base.All_client_and_server_top_level(async);
+    public override async Task Perform_identity_resolution_reuses_same_instances_across_joins(bool async, bool useAsTracking)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Perform_identity_resolution_reuses_same_instances_across_joins(async, useAsTracking));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task All_client_or_server_top_level(bool async)
-        => base.All_client_or_server_top_level(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Single_non_scalar_projection_after_skip_uses_join(bool async)
-        => base.Single_non_scalar_projection_after_skip_uses_join(async);
+    public override async Task All_client_and_server_top_level(bool async)
+    {
+        await base.All_client_and_server_top_level(async);
 
-    [ConditionalTheory(Skip = "No Select after Distinct issue#17246")]
-    public override Task Select_distinct_Select_with_client_bindings(bool async)
-        => base.Select_distinct_Select_with_client_bindings(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Non embedded collection subquery Issue#17246")]
-    public override Task Pending_selector_in_cardinality_reducing_method_is_applied_before_expanding_collection_navigation_member(
+    public override async Task All_client_or_server_top_level(bool async)
+    {
+        await base.All_client_or_server_top_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Single_non_scalar_projection_after_skip_uses_join(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Single_non_scalar_projection_after_skip_uses_join(async));
+
+        AssertSql();
+    }
+
+    public override async Task Select_distinct_Select_with_client_bindings(bool async)
+    {
+        // No Select after Distinct. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_distinct_Select_with_client_bindings(async));
+
+        AssertSql();
+    }
+
+    public override async Task Pending_selector_in_cardinality_reducing_method_is_applied_before_expanding_collection_navigation_member(
         bool async)
-        => base.Pending_selector_in_cardinality_reducing_method_is_applied_before_expanding_collection_navigation_member(async);
+    {
+        // Non embedded collection subquery. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Pending_selector_in_cardinality_reducing_method_is_applied_before_expanding_collection_navigation_member(async));
 
-    [ConditionalTheory(Skip = "Non embedded collection subquery Issue#17246")]
-    public override Task Max_on_empty_sequence_throws(bool async)
-        => base.Max_on_empty_sequence_throws(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "string.IndexOf Issue#17246")]
-    public override Task Distinct_followed_by_ordering_on_condition(bool async)
-        => base.Distinct_followed_by_ordering_on_condition(async);
+    public override async Task Max_on_empty_sequence_throws(bool async)
+    {
+        await AssertTranslationFailed(() => base.Max_on_empty_sequence_throws(async));
 
-    [ConditionalTheory(Skip = "Non embedded collection subquery Issue#17246")]
-    public override Task DefaultIfEmpty_Sum_over_collection_navigation(bool async)
-        => base.DefaultIfEmpty_Sum_over_collection_navigation(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Non embedded collection subquery Issue#17246")]
-    public override Task Entity_equality_on_subquery_with_null_check(bool async)
-        => base.Entity_equality_on_subquery_with_null_check(async);
+    public override async Task Distinct_followed_by_ordering_on_condition(bool async)
+    {
+        // Subquery pushdown. Issue #16156.
+        Assert.Equal(
+            "See issue#16156",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Distinct_followed_by_ordering_on_condition(async))).Message);
 
-    [ConditionalTheory(Skip = "DefaultIfEmpty Issue#17246")]
-    public override Task DefaultIfEmpty_over_empty_collection_followed_by_projecting_constant(bool async)
-        => base.DefaultIfEmpty_over_empty_collection_followed_by_projecting_constant(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Non embedded collection subquery Issue#17246")]
-    public override Task FirstOrDefault_with_predicate_nested(bool async)
-        => base.FirstOrDefault_with_predicate_nested(async);
+    public override async Task DefaultIfEmpty_Sum_over_collection_navigation(bool async)
+    {
+        // Non embedded collection subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_Sum_over_collection_navigation(async));
 
-    [ConditionalTheory(Skip = "Non embedded collection subquery Issue#17246")]
-    public override Task First_on_collection_in_projection(bool async)
-        => base.First_on_collection_in_projection(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Non embedded collection subquery Issue#17246")]
-    public override Task Skip_0_Take_0_works_when_constant(bool async)
-        => base.Skip_0_Take_0_works_when_constant(async);
+    public override async Task Entity_equality_on_subquery_with_null_check(bool async)
+    {
+        // Non embedded collection subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.Entity_equality_on_subquery_with_null_check(async));
 
-    public override Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
-        => AssertTranslationFailedWithDetails(
+        AssertSql();
+    }
+
+    public override async Task DefaultIfEmpty_over_empty_collection_followed_by_projecting_constant(bool async)
+    {
+        // DefaultIfEmpty. Issue #17246.
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_over_empty_collection_followed_by_projecting_constant(async));
+
+        AssertSql();
+    }
+
+    public override async Task FirstOrDefault_with_predicate_nested(bool async)
+    {
+        // Non embedded collection subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.FirstOrDefault_with_predicate_nested(async));
+
+        AssertSql();
+    }
+
+    public override async Task First_on_collection_in_projection(bool async)
+    {
+        // Non embedded collection subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.First_on_collection_in_projection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Skip_0_Take_0_works_when_constant(bool async)
+    {
+        // Non embedded collection subquery. Issue #17246.
+        await AssertTranslationFailed(() => base.Skip_0_Take_0_works_when_constant(async));
+
+        AssertSql();
+    }
+
+    public override async Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
+    {
+        await AssertTranslationFailedWithDetails(
             () => base.Using_static_string_Equals_with_StringComparison_throws_informative_error(async),
             CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
 
-    public override Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
-        => AssertTranslationFailedWithDetails(
+        AssertSql();
+    }
+
+    public override async Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
+    {
+        await AssertTranslationFailedWithDetails(
             () => base.Using_string_Equals_with_StringComparison_throws_informative_error(async),
             CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Select_nested_collection_with_distinct(bool async)
-        => base.Select_nested_collection_with_distinct(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(bool async)
-        => base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(async);
+    public override async Task Select_nested_collection_with_distinct(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_nested_collection_with_distinct(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(bool async)
-        => base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Collection_projection_after_DefaultIfEmpty(bool async)
-        => base.Collection_projection_after_DefaultIfEmpty(async);
+    public override async Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(async));
+
+        AssertSql();
+    }
+
+    public override async Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(
+        bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(async));
+
+        AssertSql();
+    }
+
+    public override async Task Collection_projection_after_DefaultIfEmpty(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_projection_after_DefaultIfEmpty(async));
+
+        AssertSql();
+    }
+
+    public override async Task AsEnumerable_over_string(bool async)
+    {
+        await base.AsEnumerable_over_string(async);
+
+        AssertSql(
+            @"SELECT c[""City""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
+    }
+
+    public override async Task Select_Property_when_non_shadow(bool async)
+    {
+        await base.Select_Property_when_non_shadow(async);
+
+        AssertSql(
+            @"SELECT c[""OrderID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Cast_results_to_object(bool async)
+    {
+        await base.Cast_results_to_object(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Null_Coalesce_Short_Circuit_with_server_correlated_leftover(bool async)
+    {
+        await base.Null_Coalesce_Short_Circuit_with_server_correlated_leftover(async);
+
+        AssertSql(
+            @"SELECT VALUE {""Result"" : false}
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Concat_int_string(bool async)
+    {
+        await base.Concat_int_string(async);
+
+        AssertSql(
+            @"SELECT c[""CustomerID""], c[""OrderID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Select_expression_datetime_add_ticks(bool async)
+    {
+        await base.Select_expression_datetime_add_ticks(async);
+
+        AssertSql(
+            @"SELECT c[""OrderDate""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+    }
+
+    public override async Task Throws_on_concurrent_query_first(bool async)
+    {
+        await base.Throws_on_concurrent_query_first(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Entity_equality_through_include(bool async)
+    {
+        await base.Entity_equality_through_include(async);
+
+        AssertSql(
+            @"SELECT c[""CustomerID""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
+    }
+
+    public override async Task Concat_constant_string_int(bool async)
+    {
+        await base.Concat_constant_string_int(async);
+
+        AssertSql(
+            @"SELECT c[""OrderID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task OrderBy_scalar_primitive(bool async)
+    {
+        await base.OrderBy_scalar_primitive(async);
+
+        AssertSql(
+            @"SELECT c[""EmployeeID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")
+ORDER BY c[""EmployeeID""]");
+    }
+
+    public override async Task Where_Property_when_non_shadow(bool async)
+    {
+        await base.Where_Property_when_non_shadow(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+    }
+
+    public override async Task OrderBy_Select(bool async)
+    {
+        await base.OrderBy_Select(async);
+
+        AssertSql(
+            @"SELECT c[""ContactName""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
+    }
+
+    public override async Task Concat_string_int(bool async)
+    {
+        await base.Concat_string_int(async);
+
+        AssertSql(
+            @"SELECT c[""OrderID""], c[""CustomerID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Non_nullable_property_through_optional_navigation(bool async)
+    {
+        await base.Non_nullable_property_through_optional_navigation(async);
+
+        AssertSql(
+            @"SELECT LENGTH(c[""Region""]) AS Length
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task ToList_over_string(bool async)
+    {
+        await base.ToList_over_string(async);
+
+        AssertSql(
+            @"SELECT c[""City""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
+    }
+
+    public override async Task Entity_equality_not_null_composite_key(bool async)
+    {
+        await base.Entity_equality_not_null_composite_key(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] != null) AND (c[""ProductID""] != null)))");
+    }
+
+    public override void Query_composition_against_ienumerable_set()
+    {
+        base.Query_composition_against_ienumerable_set();
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task ToListAsync_with_canceled_token()
+    {
+        await base.ToListAsync_with_canceled_token();
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+    }
+
+    public override async Task Ternary_should_not_evaluate_both_sides(bool async)
+    {
+        await base.Ternary_should_not_evaluate_both_sides(async);
+
+        AssertSql(
+            @"@__p_0='none'
+
+SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""Data1"" : @__p_0}
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Entity_equality_orderby(bool async)
+    {
+        await base.Entity_equality_orderby(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
+    }
+
+    public override async Task Load_should_track_results(bool async)
+    {
+        await base.Load_should_track_results(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Null_parameter_name_works(bool async)
+    {
+        await base.Null_parameter_name_works(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
+    }
+
+    public override async Task Where_Property_shadow_closure(bool async)
+    {
+        await base.Where_Property_shadow_closure(async);
+
+        AssertSql(
+            @"@__value_0='Sales Representative'
+
+SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""Title""] = @__value_0))",
+            //
+            @"@__value_0='Steven'
+
+SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""FirstName""] = @__value_0))");
+    }
+
+    public override async Task Entity_equality_local_double_check(bool async)
+    {
+        await base.Entity_equality_local_double_check(async);
+
+        AssertSql(
+            @"@__entity_equality_local_0_CustomerID='ANATR'
+
+SELECT c[""CustomerID""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] = @__entity_equality_local_0_CustomerID) AND (@__entity_equality_local_0_CustomerID = c[""CustomerID""])))");
+    }
+
+    public override async Task ToArray_over_string(bool async)
+    {
+        await base.ToArray_over_string(async);
+
+        AssertSql(
+            @"SELECT c[""City""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]");
+    }
+
+    public override async Task MemberInitExpression_NewExpression_is_funcletized_even_when_bindings_are_not_evaluatable(bool async)
+    {
+        await base.MemberInitExpression_NewExpression_is_funcletized_even_when_bindings_are_not_evaluatable(async);
+
+        AssertSql(
+            @"SELECT c[""CustomerID""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))");
+    }
+
+    public override async Task Entity_equality_null_composite_key(bool async)
+    {
+        await base.Entity_equality_null_composite_key(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = null) OR (c[""ProductID""] = null)))");
+    }
+
+    public override async Task Concat_parameter_string_int(bool async)
+    {
+        await base.Concat_parameter_string_int(async);
+
+        AssertSql(
+            @"SELECT c[""OrderID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    // ReSharper disable once RedundantOverriddenMember
+    public override Task ToListAsync_can_be_canceled()
+        // May or may not generate SQL depending on when cancellation happens.
+        => base.ToListAsync_can_be_canceled();
+
+    public override async Task Where_Property_when_shadow(bool async)
+    {
+        await base.Where_Property_when_shadow(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""Title""] = ""Sales Representative""))");
+    }
+
+    public override async Task Throws_on_concurrent_query_list(bool async)
+    {
+        await base.Throws_on_concurrent_query_list(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Convert_to_nullable_on_nullable_value_is_ignored(bool async)
+    {
+        await base.Convert_to_nullable_on_nullable_value_is_ignored(async);
+
+        AssertSql(
+            @"SELECT c[""OrderDate""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Ternary_should_not_evaluate_both_sides_with_parameter(bool async)
+    {
+        await base.Ternary_should_not_evaluate_both_sides_with_parameter(async);
+
+        AssertSql(
+            @"SELECT VALUE {""Data1"" : true}
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Context_based_client_method(bool async)
+    {
+        await base.Context_based_client_method(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")",
+            //
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task OrderByDescending(bool async)
+    {
+        await base.OrderByDescending(async);
+
+        AssertSql(
+            @"SELECT c[""City""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""] DESC");
+    }
+
+    public override async Task Select_Property_when_shadow(bool async)
+    {
+        await base.Select_Property_when_shadow(async);
+
+        AssertSql(
+            @"SELECT c[""Title""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+    }
+
+    public override async Task Skip_0_Take_0_works_when_parameter(bool async)
+    {
+        await base.Skip_0_Take_0_works_when_parameter(async);
+
+        AssertSql(
+            @"@__p_0='0'
+
+SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]
+OFFSET @__p_0 LIMIT @__p_0",
+            //
+            @"@__p_0='1'
+
+SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY c[""CustomerID""]
+OFFSET @__p_0 LIMIT @__p_0");
+    }
+
+    public override async Task Mixed_sync_async_in_query_cache()
+    {
+        await base.Mixed_sync_async_in_query_cache();
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")",
+            //
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Client_code_using_instance_method_throws(bool async)
+    {
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInMethodInstance(
+                "Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryCosmosTest",
+                "InstanceMethod"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_method_throws(async))).Message);
+
+        AssertSql();
+    }
+
+    public override async Task Client_code_using_instance_in_static_method(bool async)
+    {
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInMethodArgument(
+                "Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryCosmosTest",
+                "StaticMethod"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_in_static_method(async))).Message);
+
+        AssertSql();
+    }
+
+    public override async Task Client_code_using_instance_in_anonymous_type(bool async)
+    {
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInTree(
+                "Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryCosmosTest"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_in_anonymous_type(async))).Message);
+
+        AssertSql();
+    }
+
+    public override async Task Client_code_unknown_method(bool async)
+    {
+        await AssertTranslationFailedWithDetails(
+            () => base.Client_code_unknown_method(async),
+            CoreStrings.QueryUnableToTranslateMethod(
+                "Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase<Microsoft.EntityFrameworkCore.Query.NorthwindQueryCosmosFixture<Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer>>",
+                nameof(UnknownMethod)));
+
+        AssertSql();
+    }
+
+
+    public override async Task String_include_on_incorrect_property_throws(bool async)
+    {
+        await base.String_include_on_incorrect_property_throws(async);
+
+        AssertSql();
+    }
+
+    public override async Task SkipWhile_throws_meaningful_exception(bool async)
+    {
+        await base.SkipWhile_throws_meaningful_exception(async);
+
+        AssertSql();
+    }
+
+    public override async Task Mixed_sync_async_query()
+    {
+        await base.Mixed_sync_async_query();
+
+        AssertSql();
+    }
+
+    public override void Parameter_extraction_can_throw_exception_from_user_code()
+    {
+        base.Parameter_extraction_can_throw_exception_from_user_code();
+
+        AssertSql();
+    }
+
+    public override void Parameter_extraction_can_throw_exception_from_user_code_2()
+    {
+        base.Parameter_extraction_can_throw_exception_from_user_code_2();
+
+        AssertSql();
+    }
+
+    public override async Task Where_query_composition5(bool async)
+    {
+        await base.Where_query_composition5(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_query_composition6(bool async)
+    {
+        await base.Where_query_composition6(async);
+
+        AssertSql();
+    }
+
+    public override void Can_cast_CreateQuery_result_to_IQueryable_T_bug_1730()
+    {
+        base.Can_cast_CreateQuery_result_to_IQueryable_T_bug_1730();
+
+        AssertSql();
+    }
+
+    public override void Multiple_context_instances()
+    {
+        base.Multiple_context_instances();
+
+        AssertSql();
+    }
+
+    public override void Multiple_context_instances_2()
+    {
+        base.Multiple_context_instances_2();
+
+        AssertSql();
+    }
+
+    public override void Multiple_context_instances_set()
+    {
+        base.Multiple_context_instances_set();
+
+        AssertSql();
+    }
+
+    public override void Multiple_context_instances_parameter()
+    {
+        base.Multiple_context_instances_parameter();
+
+        AssertSql();
+    }
+
+    public override void Entity_equality_through_subquery_composite_key()
+    {
+        base.Entity_equality_through_subquery_composite_key();
+
+        AssertSql();
+    }
+
+    public override async Task Select_correlated_subquery_filtered_returning_queryable_throws(bool async)
+    {
+        await base.Select_correlated_subquery_filtered_returning_queryable_throws(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_correlated_subquery_ordered_returning_queryable_throws(bool async)
+    {
+        await base.Select_correlated_subquery_ordered_returning_queryable_throws(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_correlated_subquery_ordered_returning_queryable_in_DTO_throws(bool async)
+    {
+        await base.Select_correlated_subquery_ordered_returning_queryable_in_DTO_throws(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_nested_collection_in_anonymous_type_returning_ordered_queryable(bool async)
+    {
+        await base.Select_nested_collection_in_anonymous_type_returning_ordered_queryable(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_subquery_recursive_trivial_returning_queryable(bool async)
+    {
+        await base.Select_subquery_recursive_trivial_returning_queryable(async);
+
+        AssertSql();
+    }
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
@@ -16,6 +17,10 @@ public class NorthwindSelectQueryCosmosTest : NorthwindSelectQueryTestBase<North
         ClearLog();
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -52,26 +57,20 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Projection_when_arithmetic_mixed(bool async)
     {
-        await base.Projection_when_arithmetic_mixed(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_when_arithmetic_mixed(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Projection_when_arithmetic_mixed_subqueries(bool async)
     {
-        await base.Projection_when_arithmetic_mixed_subqueries(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_when_arithmetic_mixed_subqueries(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
     public override async Task Projection_when_null_value(bool async)
@@ -84,15 +83,12 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Projection_when_client_evald_subquery(bool async)
     {
-        await base.Projection_when_client_evald_subquery(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_when_client_evald_subquery(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task Project_to_object_array(bool async)
@@ -105,27 +101,23 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 1))");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Projection_of_entity_type_into_object_array(bool async)
     {
         await base.Projection_of_entity_type_into_object_array(async);
 
         AssertSql(
-            @"SELECT c[""CustomerID""], c[""Address""], c[""City""], c[""CompanyName""], c[""ContactName""], c[""ContactTitle""], c[""Country""], c[""Fax""], c[""Phone""], c[""PostalCode""], c[""Region""]
+            @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND c[""CustomerID""] LIKE N'A%'
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))
 ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Projection_of_multiple_entity_types_into_object_array(bool async)
     {
-        await base.Projection_of_multiple_entity_types_into_object_array(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_of_multiple_entity_types_into_object_array(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
     public override async Task Projection_of_entity_type_into_object_list(bool async)
@@ -149,26 +141,26 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 1))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)
     {
-        await base.Select_bool_closure_with_order_by_property_with_cast_to_nullable(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_bool_closure_with_order_by_property_with_cast_to_nullable(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Select_bool_closure_with_order_parameter_with_cast_to_nullable(bool async)
     {
-        await base.Select_bool_closure_with_order_parameter_with_cast_to_nullable(async);
+        await Assert.ThrowsAsync<CosmosException>(
+            () => base.Select_bool_closure_with_order_parameter_with_cast_to_nullable(async));
 
         AssertSql(
-            @"SELECT c
+            @"@__boolean_0='false'
+
+SELECT VALUE {""c"" : @__boolean_0}
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE (c[""Discriminator""] = ""Customer"")
+ORDER BY @__boolean_0");
     }
 
     public override async Task Select_scalar(bool async)
@@ -316,123 +308,108 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
     }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
     public override async Task Select_nested_collection(bool async)
     {
-        await base.Select_nested_collection(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_nested_collection(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue #17246")]
     public override void Select_nested_collection_multi_level()
     {
-        base.Select_nested_collection_multi_level();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_nested_collection_multi_level();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue#17246")]
     public override void Select_nested_collection_multi_level2()
     {
-        base.Select_nested_collection_multi_level2();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_nested_collection_multi_level2();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue#17246")]
     public override void Select_nested_collection_multi_level3()
     {
-        base.Select_nested_collection_multi_level3();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_nested_collection_multi_level3();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue#17246")]
     public override void Select_nested_collection_multi_level4()
     {
-        base.Select_nested_collection_multi_level4();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_nested_collection_multi_level4();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue#17246")]
     public override void Select_nested_collection_multi_level5()
     {
-        using (var context = CreateContext())
-        {
-            var customers = context.Customers
-                .Where(c => c.CustomerID == "ALFKI")
-                .Select(
-                    c => new
-                    {
-                        Order = (int?)c.Orders
-                            .Where(o => o.OrderID < 10500)
-                            .Select(
-                                o => o.OrderDetails
-                                    .Where(od => od.OrderID != c.Orders.Count)
-                                    .Select(od => od.ProductID)
-                                    .FirstOrDefault())
-                            .FirstOrDefault()
-                    })
-                .ToList();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_nested_collection_multi_level5();
+                return Task.CompletedTask;
+            });
 
-            Assert.Single(customers);
-            Assert.Equal(0, customers.Count(c => c.Order != null && c.Order != 0));
-        }
-
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalFact(Skip = "Issue#17246")]
     public override void Select_nested_collection_multi_level6()
     {
-        base.Select_nested_collection_multi_level6();
+        // Cosmos client evaluation. Issue #17246.
+        AssertTranslationFailed(
+            () =>
+            {
+                base.Select_nested_collection_multi_level6();
+                return Task.CompletedTask;
+            });
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Select_nested_collection_count_using_anonymous_type(bool async)
     {
-        await base.Select_nested_collection_count_using_anonymous_type(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_nested_collection_count_using_anonymous_type(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task New_date_time_in_anonymous_type_works(bool async)
     {
         await base.New_date_time_in_anonymous_type_works(async);
 
         AssertSql(
-            @"SELECT c
+            @"SELECT 1
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))");
     }
 
     public override async Task Select_non_matching_value_types_int_to_long_introduces_explicit_cast(bool async)
@@ -557,15 +534,15 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))
 ORDER BY c[""OrderID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task
-        Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(
-            bool async)
+        Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(bool async)
     {
-        await base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(
-            async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base
+                .Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(async));
 
-        AssertSql("");
+        AssertSql();
     }
 
     public override async Task Select_conditional_with_null_comparison_in_test(bool async)
@@ -578,15 +555,14 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Projection_in_a_subquery_should_be_liftable(bool async)
     {
-        await base.Projection_in_a_subquery_should_be_liftable(async);
+        Assert.Equal(
+            CosmosStrings.OffsetRequiresLimit,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Projection_in_a_subquery_should_be_liftable(async))).Message);
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Employee"")");
+        AssertSql();
     }
 
     public override async Task Projection_containing_DateTime_subtraction(bool async)
@@ -599,147 +575,95 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(
-                c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Take(1).FirstOrDefault()));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(
-                c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Skip(1).FirstOrDefault()));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(
-                c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Distinct().FirstOrDefault()));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(bool async)
     {
-        await base.Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(
-                c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Take(1).FirstOrDefault()));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(
-                c => c.Orders.OrderBy(o => o.OrderID)
-                    .ThenByDescending(o => o.OrderDate)
-                    .Select(o => o.CustomerID)
-                    .Take(2)
-                    .FirstOrDefault()));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
     public override async Task
         Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(
             bool async)
     {
-        await base
-            .Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(
-                async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base
+                .Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(
+                    async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool async)
     {
-        await AssertQuery(
-            async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(
-                c => c.Orders.OrderBy(o => o.CustomerID)
-                    .ThenByDescending(o => o.OrderDate)
-                    .Select(o => o.CustomerID)
-                    .Take(2)
-                    .FirstOrDefault()));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(bool async)
     {
-        await AssertQueryScalar(
-            async,
-            ss => ss.Set<Order>().Where(o => o.OrderID < 10250)
-                .Select(o => o.OrderDetails.OrderBy(od => od.Product.ProductName).Select(od => od.OrderID).Take(1).FirstOrDefault()));
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(
         bool async)
     {
-        await base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        AssertSql();
     }
 
     public override async Task Select_datetime_year_component(bool async)
@@ -873,15 +797,12 @@ WHERE (c[""Discriminator""] = ""Customer"")
 ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
     public override async Task Anonymous_projection_with_repeated_property_being_ordered_2(bool async)
     {
-        await base.Anonymous_projection_with_repeated_property_being_ordered_2(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Anonymous_projection_with_repeated_property_being_ordered_2(async));
 
-        AssertSql(
-            @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Order"")");
+        AssertSql();
     }
 
     public override async Task Select_GetValueOrDefault_on_DateTime(bool async)
@@ -894,95 +815,177 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
     public override async Task Select_GetValueOrDefault_on_DateTime_with_null_values(bool async)
     {
-        await base.Select_GetValueOrDefault_on_DateTime_with_null_values(async);
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_GetValueOrDefault_on_DateTime_with_null_values(async));
+
+        AssertSql();
+    }
+
+    public override async Task Client_method_in_projection_requiring_materialization_1(bool async)
+    {
+        await base.Client_method_in_projection_requiring_materialization_1(async);
 
         AssertSql(
             @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Client_method_in_projection_requiring_materialization_1(bool async)
-        => base.Client_method_in_projection_requiring_materialization_1(async);
+    public override async Task Client_method_in_projection_requiring_materialization_2(bool async)
+    {
+        await base.Client_method_in_projection_requiring_materialization_2(async);
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Client_method_in_projection_requiring_materialization_2(bool async)
-        => base.Client_method_in_projection_requiring_materialization_2(async);
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))");
+    }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Multiple_select_many_with_predicate(bool async)
-        => base.Multiple_select_many_with_predicate(async);
+    public override async Task Multiple_select_many_with_predicate(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Multiple_select_many_with_predicate(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_without_result_selector_naked_collection_navigation(bool async)
-        => base.SelectMany_without_result_selector_naked_collection_navigation(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_without_result_selector_collection_navigation_composed(bool async)
-        => base.SelectMany_without_result_selector_collection_navigation_composed(async);
+    public override async Task SelectMany_without_result_selector_naked_collection_navigation(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_without_result_selector_naked_collection_navigation(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task SelectMany_correlated_with_outer_1(bool async)
-        => base.SelectMany_correlated_with_outer_1(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task SelectMany_correlated_with_outer_2(bool async)
-        => base.SelectMany_correlated_with_outer_2(async);
+    public override async Task SelectMany_without_result_selector_collection_navigation_composed(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_without_result_selector_collection_navigation_composed(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task SelectMany_correlated_with_outer_3(bool async)
-        => base.SelectMany_correlated_with_outer_3(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task SelectMany_correlated_with_outer_4(bool async)
-        => base.SelectMany_correlated_with_outer_4(async);
+    public override async Task SelectMany_correlated_with_outer_1(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_1(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task SelectMany_correlated_with_outer_5(bool async)
-        => base.SelectMany_correlated_with_outer_5(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task SelectMany_correlated_with_outer_6(bool async)
-        => base.SelectMany_correlated_with_outer_6(async);
+    public override async Task SelectMany_correlated_with_outer_2(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_2(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task SelectMany_correlated_with_outer_7(bool async)
-        => base.SelectMany_correlated_with_outer_7(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(bool async)
-        => base.FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(async);
+    public override async Task SelectMany_correlated_with_outer_3(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_3(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(bool async)
-        => base.Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(async);
+        AssertSql();
+    }
 
-    public override Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool async)
-        => AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(async));
+    public override async Task SelectMany_correlated_with_outer_4(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_4(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Filtered_collection_projection_is_tracked(bool async)
-        => base.Filtered_collection_projection_is_tracked(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Filtered_collection_projection_with_to_list_is_tracked(bool async)
-        => base.Filtered_collection_projection_with_to_list_is_tracked(async);
+    public override async Task SelectMany_correlated_with_outer_5(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_5(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(bool async)
-        => base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(bool async)
-        => base.Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(async);
+    public override async Task SelectMany_correlated_with_outer_6(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_6(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Select_entity_compared_to_null(bool async)
-        => base.Select_entity_compared_to_null(async);
+        AssertSql();
+    }
+
+    public override async Task SelectMany_correlated_with_outer_7(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_7(async));
+
+        AssertSql();
+    }
+
+    public override async Task FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(async));
+
+        AssertSql();
+    }
+
+    public override async Task Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(async));
+
+        AssertSql();
+    }
+
+    public override async Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool async)
+    {
+        await AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(async));
+
+        AssertSql();
+    }
+
+    public override async Task Filtered_collection_projection_is_tracked(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(async));
+
+        AssertSql();
+    }
+
+    public override async Task Filtered_collection_projection_with_to_list_is_tracked(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Filtered_collection_projection_with_to_list_is_tracked(async));
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async));
+
+        AssertSql();
+    }
+
+    public override async Task Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(async));
+
+        AssertSql();
+    }
+
+    public override async Task Select_entity_compared_to_null(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_entity_compared_to_null(async));
+
+        AssertSql();
+    }
 
     public override async Task Explicit_cast_in_arithmetic_operation_is_preserved(bool async)
     {
@@ -994,29 +997,53 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10243))");
     }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task SelectMany_whose_selector_references_outer_source(bool async)
-        => base.SelectMany_whose_selector_references_outer_source(async);
+    public override async Task SelectMany_whose_selector_references_outer_source(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.SelectMany_whose_selector_references_outer_source(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Collection_FirstOrDefault_with_entity_equality_check_in_projection(bool async)
-        => base.Collection_FirstOrDefault_with_entity_equality_check_in_projection(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Collection_FirstOrDefault_with_nullable_unsigned_int_column(bool async)
-        => base.Collection_FirstOrDefault_with_nullable_unsigned_int_column(async);
+    public override async Task Collection_FirstOrDefault_with_entity_equality_check_in_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_FirstOrDefault_with_entity_equality_check_in_projection(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task ToList_Count_in_projection_works(bool async)
-        => base.ToList_Count_in_projection_works(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task LastOrDefault_member_access_in_projection_translates_to_server(bool async)
-        => base.LastOrDefault_member_access_in_projection_translates_to_server(async);
+    public override async Task Collection_FirstOrDefault_with_nullable_unsigned_int_column(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_FirstOrDefault_with_nullable_unsigned_int_column(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Collection_projection_AsNoTracking_OrderBy(bool async)
-        => base.Collection_projection_AsNoTracking_OrderBy(async);
+        AssertSql();
+    }
+
+    public override async Task ToList_Count_in_projection_works(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.ToList_Count_in_projection_works(async));
+
+        AssertSql();
+    }
+
+    public override async Task LastOrDefault_member_access_in_projection_translates_to_server(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.LastOrDefault_member_access_in_projection_translates_to_server(async));
+
+        AssertSql();
+    }
+
+    public override async Task Collection_projection_AsNoTracking_OrderBy(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_projection_AsNoTracking_OrderBy(async));
+
+        AssertSql();
+    }
 
     public override async Task Coalesce_over_nullable_uint(bool async)
     {
@@ -1028,13 +1055,21 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Order"")");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Project_uint_through_collection_FirstOrDefault(bool async)
-        => base.Project_uint_through_collection_FirstOrDefault(async);
+    public override async Task Project_uint_through_collection_FirstOrDefault(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Project_uint_through_collection_FirstOrDefault(async));
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Project_keyless_entity_FirstOrDefault_without_orderby(bool async)
-        => base.Project_keyless_entity_FirstOrDefault_without_orderby(async);
+        AssertSql();
+    }
+
+    public override async Task Project_keyless_entity_FirstOrDefault_without_orderby(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Project_keyless_entity_FirstOrDefault_without_orderby(async));
+
+        AssertSql();
+    }
 
     public override async Task Reverse_changes_asc_order_to_desc(bool async)
     {
@@ -1058,9 +1093,13 @@ WHERE (c[""Discriminator""] = ""Employee"")
 ORDER BY c[""EmployeeID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Projection_AsEnumerable_projection(bool async)
-        => base.Projection_AsEnumerable_projection(async);
+    public override async Task Projection_AsEnumerable_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_AsEnumerable_projection(async));
+
+        AssertSql();
+    }
 
     public override async Task Projection_custom_type_in_both_sides_of_ternary(bool async)
     {
@@ -1073,45 +1112,89 @@ WHERE (c[""Discriminator""] = ""Customer"")
 ORDER BY c[""CustomerID""]");
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Projecting_multiple_collection_with_same_constant_works(bool async)
-        => base.Projecting_multiple_collection_with_same_constant_works(async);
+    public override async Task Projecting_multiple_collection_with_same_constant_works(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projecting_multiple_collection_with_same_constant_works(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Projecting_after_navigation_and_distinct(bool async)
-        => base.Projecting_after_navigation_and_distinct(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(bool async)
-        => base.Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(async);
+    public override async Task Projecting_after_navigation_and_distinct(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projecting_after_navigation_and_distinct(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
-        => base.Correlated_collection_after_distinct_not_containing_original_identifier(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
-        => base.Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(async);
+    public override async Task Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(bool async)
-        => base.Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(async);
+        AssertSql();
+    }
 
-    public override Task Reverse_without_explicit_ordering(bool async)
-        => AssertTranslationFailedWithDetails(
+    public override async Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Correlated_collection_after_distinct_not_containing_original_identifier(async));
+
+        AssertSql();
+    }
+
+    public override async Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(async));
+
+        AssertSql();
+    }
+
+    public override async Task Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_without_explicit_ordering(bool async)
+    {
+        await AssertTranslationFailedWithDetails(
             () => base.Reverse_without_explicit_ordering(async), CosmosStrings.MissingOrderingInSelectExpression);
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Custom_projection_reference_navigation_PK_to_FK_optimization(bool async)
-        => base.Custom_projection_reference_navigation_PK_to_FK_optimization(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Select_nested_collection_deep(bool async)
-        => base.Select_nested_collection_deep(async);
+    public override async Task Custom_projection_reference_navigation_PK_to_FK_optimization(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Custom_projection_reference_navigation_PK_to_FK_optimization(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Projecting_Length_of_a_string_property_after_FirstOrDefault_on_correlated_collection(bool async)
-        => base.Projecting_Length_of_a_string_property_after_FirstOrDefault_on_correlated_collection(async);
+        AssertSql();
+    }
+
+    public override async Task Select_nested_collection_deep(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_nested_collection_deep(async));
+
+        AssertSql();
+    }
+
+    public override async Task Projecting_Length_of_a_string_property_after_FirstOrDefault_on_correlated_collection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Projecting_Length_of_a_string_property_after_FirstOrDefault_on_correlated_collection(async));
+
+        AssertSql();
+    }
 
     public override async Task Projection_take_predicate_projection(bool async)
     {
@@ -1149,29 +1232,59 @@ OFFSET 0 LIMIT @__p_0");
         Assert.Equal(CosmosStrings.OffsetRequiresLimit, message);
     }
 
-    [ConditionalTheory(Skip = "Issue#17246")]
-    public override Task Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(bool async)
-        => base.Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(async);
+    public override async Task Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Projecting_count_of_navigation_which_is_generic_collection(bool async)
-        => base.Projecting_count_of_navigation_which_is_generic_collection(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Projecting_count_of_navigation_which_is_generic_list(bool async)
-        => base.Projecting_count_of_navigation_which_is_generic_list(async);
+    public override async Task Projecting_count_of_navigation_which_is_generic_collection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projecting_count_of_navigation_which_is_generic_collection(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Do_not_erase_projection_mapping_when_adding_single_projection(bool async)
-        => base.Do_not_erase_projection_mapping_when_adding_single_projection(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Select_nested_collection_deep_distinct_no_identifiers(bool async)
-        => base.Select_nested_collection_deep_distinct_no_identifiers(async);
+    public override async Task Projecting_count_of_navigation_which_is_generic_list(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Projecting_count_of_navigation_which_is_generic_list(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(bool async)
-        => base.Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(async);
+        AssertSql();
+    }
+
+    public override async Task Do_not_erase_projection_mapping_when_adding_single_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        Assert.Equal(
+            CosmosStrings.NonEmbeddedIncludeNotSupported(
+                "Navigation: Order.OrderDetails (ICollection<OrderDetail>) Collection ToDependent OrderDetail Inverse: Order"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Do_not_erase_projection_mapping_when_adding_single_projection(async)))
+            .Message);
+
+        AssertSql();
+    }
+
+    public override async Task Select_nested_collection_deep_distinct_no_identifiers(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Select_nested_collection_deep_distinct_no_identifiers(async));
+
+        AssertSql();
+    }
+
+    public override async Task Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(
+            () => base.Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(async));
+
+        AssertSql();
+    }
 
     public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)
     {
@@ -1184,81 +1297,169 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))
 ORDER BY c[""OrderID""]");
     }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Collection_include_over_result_of_single_non_scalar(bool async)
-        => base.Collection_include_over_result_of_single_non_scalar(async);
+    public override async Task Collection_include_over_result_of_single_non_scalar(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        Assert.Equal(
+            CosmosStrings.NonEmbeddedIncludeNotSupported(
+                "Navigation: Customer.Orders (List<Order>) Collection ToDependent Order Inverse: Customer PropertyAccessMode.Field"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Collection_include_over_result_of_single_non_scalar(async)))
+            .Message);
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Collection_projection_selecting_outer_element_followed_by_take(bool async)
-        => base.Collection_projection_selecting_outer_element_followed_by_take(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Take_on_top_level_and_on_collection_projection_with_outer_apply(bool async)
-        => base.Take_on_top_level_and_on_collection_projection_with_outer_apply(async);
+    public override async Task Collection_projection_selecting_outer_element_followed_by_take(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Collection_projection_selecting_outer_element_followed_by_take(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Take_on_correlated_collection_in_first(bool async)
-        => base.Take_on_correlated_collection_in_first(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Client_projection_via_ctor_arguments(bool async)
-        => base.Client_projection_via_ctor_arguments(async);
+    public override async Task Take_on_top_level_and_on_collection_projection_with_outer_apply(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Take_on_top_level_and_on_collection_projection_with_outer_apply(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Client_projection_with_string_initialization_with_scalar_subquery(bool async)
-        => base.Client_projection_with_string_initialization_with_scalar_subquery(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Projecting_count_of_navigation_which_is_generic_collection_using_convert(bool async)
-        => base.Projecting_count_of_navigation_which_is_generic_collection_using_convert(async);
+    public override async Task Take_on_correlated_collection_in_first(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Take_on_correlated_collection_in_first(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task MemberInit_in_projection_without_arguments(bool async)
-        => base.MemberInit_in_projection_without_arguments(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Reverse_in_join_outer(bool async)
-        => base.Reverse_in_join_outer(async);
+    public override async Task Client_projection_via_ctor_arguments(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Client_projection_via_ctor_arguments(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Reverse_in_join_outer_with_take(bool async)
-        => base.Reverse_in_join_outer_with_take(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Reverse_in_join_inner(bool async)
-        => base.Reverse_in_join_inner(async);
+    public override async Task Client_projection_with_string_initialization_with_scalar_subquery(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Client_projection_with_string_initialization_with_scalar_subquery(async));
 
-    [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
-    public override Task Reverse_in_join_inner_with_skip(bool async)
-        => base.Reverse_in_join_inner_with_skip(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Reverse_in_SelectMany(bool async)
-        => base.Reverse_in_SelectMany(async);
+    public override async Task Projecting_count_of_navigation_which_is_generic_collection_using_convert(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Projecting_count_of_navigation_which_is_generic_collection_using_convert(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Reverse_in_SelectMany_with_Take(bool async)
-        => base.Reverse_in_SelectMany_with_Take(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Reverse_in_projection_subquery(bool async)
-        => base.Reverse_in_projection_subquery(async);
+    public override async Task MemberInit_in_projection_without_arguments(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.MemberInit_in_projection_without_arguments(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Reverse_in_projection_subquery_single_result(bool async)
-        => base.Reverse_in_projection_subquery_single_result(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Reverse_in_subquery_via_pushdown(bool async)
-        => base.Reverse_in_subquery_via_pushdown(async);
+    public override async Task Reverse_in_join_outer(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_join_outer(async));
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Reverse_in_projection_scalar_subquery(bool async)
-        => base.Reverse_in_projection_scalar_subquery(async);
+        AssertSql();
+    }
 
-    [ConditionalTheory(Skip = "Issue #17246")]
-    public override Task Reverse_after_orderby_thenby(bool async)
-        => base.Reverse_after_orderby_thenby(async);
+    public override async Task Reverse_in_join_outer_with_take(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_join_outer_with_take(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_in_join_inner(bool async)
+    {
+        // Cross collection join. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_join_inner(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_in_join_inner_with_skip(bool async)
+    {
+        Assert.Equal(
+            CosmosStrings.ReverseAfterSkipTakeNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Reverse_in_join_inner_with_skip(async))).Message);
+
+        AssertSql();
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_in_SelectMany(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_SelectMany(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_in_SelectMany_with_Take(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_SelectMany_with_Take(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_in_projection_subquery(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_projection_subquery(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_in_projection_subquery_single_result(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_projection_subquery_single_result(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_in_subquery_via_pushdown(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_subquery_via_pushdown(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_in_projection_scalar_subquery(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Reverse_in_projection_scalar_subquery(async));
+
+        AssertSql();
+    }
+
+    public override async Task Reverse_after_orderby_thenby(bool async)
+    {
+        await Assert.ThrowsAsync<CosmosException>(
+            () => base.Reverse_after_orderby_thenby(async));
+
+        AssertSql(
+            @"SELECT c[""EmployeeID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")
+ORDER BY c[""EmployeeID""] DESC, c[""City""]");
+    }
 
     public override async Task Reverse_after_orderBy_and_take(bool async)
     {
@@ -1271,6 +1472,213 @@ ORDER BY c[""OrderID""]");
     [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
     public override Task List_of_list_of_anonymous_type(bool async)
         => base.List_of_list_of_anonymous_type(async);
+
+    public override async Task
+        SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
+            bool async)
+    {
+        await AssertTranslationFailed(
+            () => base
+                .SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
+                    async));
+
+        AssertSql();
+    }
+
+    public override async Task Select_bool_closure(bool async)
+    {
+        await base.Select_bool_closure(async);
+
+        AssertSql(
+            @"SELECT 1
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")",
+            //
+            @"SELECT 1
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Select_datetime_DayOfWeek_component(bool async)
+    {
+        await base.Select_datetime_DayOfWeek_component(async);
+
+        AssertSql(
+            @"SELECT c[""OrderDate""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Reverse_after_multiple_orderbys(bool async)
+    {
+        await base.Reverse_after_multiple_orderbys(async);
+
+        AssertSql(
+            @"SELECT c[""EmployeeID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")
+ORDER BY c[""EmployeeID""]");
+    }
+
+    public override async Task VisitLambda_should_not_be_visited_trivially(bool async)
+    {
+        await base.VisitLambda_should_not_be_visited_trivially(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""CustomerID""] != null) AND ((""A"" != null) AND STARTSWITH(c[""CustomerID""], ""A""))))");
+    }
+
+    public override async Task Projecting_nullable_struct(bool async)
+    {
+        await base.Projecting_nullable_struct(async);
+
+        AssertSql(
+            @"SELECT c[""CustomerID""], (c[""CustomerID""] = ""ALFKI"") AS c, c[""OrderID""], LENGTH(c[""CustomerID""]) AS c0
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Select_customer_identity(bool async)
+    {
+        await base.Select_customer_identity(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Projection_with_parameterized_constructor(bool async)
+    {
+        await base.Projection_with_parameterized_constructor(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+    }
+
+    public override async Task Select_anonymous_nested(bool async)
+    {
+        await base.Select_anonymous_nested(async);
+
+        AssertSql(
+            @"SELECT c[""City""], c[""Country""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Cast_on_top_level_projection_brings_explicit_Cast(bool async)
+    {
+        await base.Cast_on_top_level_projection_brings_explicit_Cast(async);
+
+        AssertSql(
+            @"SELECT c[""OrderID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Select_anonymous_empty(bool async)
+    {
+        await base.Select_anonymous_empty(async);
+
+        AssertSql(
+            @"SELECT 1
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Select_scalar_primitive(bool async)
+    {
+        await base.Select_scalar_primitive(async);
+
+        AssertSql(
+            @"SELECT c[""EmployeeID""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+    }
+
+    public override async Task Select_into(bool async)
+    {
+        await base.Select_into(async);
+
+        AssertSql(
+            @"SELECT c[""CustomerID""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+    }
+
+    public override async Task Projection_with_parameterized_constructor_with_member_assignment(bool async)
+    {
+        await base.Projection_with_parameterized_constructor_with_member_assignment(async);
+
+        AssertSql(
+            @"SELECT c, c[""City""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+    }
+
+    public override async Task Select_datetime_TimeOfDay_component(bool async)
+    {
+        await base.Select_datetime_TimeOfDay_component(async);
+
+        AssertSql(
+            @"SELECT c[""OrderDate""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Select_with_complex_expression_that_can_be_funcletized(bool async)
+    {
+        await base.Select_with_complex_expression_that_can_be_funcletized(async);
+
+        AssertSql(
+            @"SELECT INDEX_OF(c[""ContactName""], """") AS c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+    }
+
+    public override async Task Select_datetime_Ticks_component(bool async)
+    {
+        await base.Select_datetime_Ticks_component(async);
+
+        AssertSql(
+            @"SELECT c[""OrderDate""]
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+    }
+
+    public override async Task Select_anonymous_literal(bool async)
+    {
+        await base.Select_anonymous_literal(async);
+
+        AssertSql(
+            @"SELECT VALUE {""X"" : 10}
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Select_customer_table(bool async)
+    {
+        await base.Select_customer_table(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
+
+    public override async Task Select_over_10_nested_ternary_condition(bool async)
+    {
+        await base.Select_over_10_nested_ternary_condition(async);
+
+        AssertSql(
+            @"SELECT VALUE {""c"" : ((c[""CustomerID""] = ""1"") ? ""01"" : ((c[""CustomerID""] = ""2"") ? ""02"" : ((c[""CustomerID""] = ""3"") ? ""03"" : ((c[""CustomerID""] = ""4"") ? ""04"" : ((c[""CustomerID""] = ""5"") ? ""05"" : ((c[""CustomerID""] = ""6"") ? ""06"" : ((c[""CustomerID""] = ""7"") ? ""07"" : ((c[""CustomerID""] = ""8"") ? ""08"" : ((c[""CustomerID""] = ""9"") ? ""09"" : ((c[""CustomerID""] = ""10"") ? ""10"" : ((c[""CustomerID""] = ""11"") ? ""11"" : null)))))))))))}
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+    }
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindJoinQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindJoinQueryInMemoryTest.cs
@@ -15,19 +15,19 @@ public class NorthwindJoinQueryInMemoryTest : NorthwindJoinQueryTestBase<Northwi
         //TestLoggerFactory.TestOutputHelper = testOutputHelper;
     }
 
-    [ConditionalTheory(Skip = "Issue#21200")]
     public override Task SelectMany_with_client_eval(bool async)
-        => base.SelectMany_with_client_eval(async);
+        // Joins between sources with client eval. Issue #21200.
+        => Assert.ThrowsAsync<NotImplementedException>(() => base.SelectMany_with_client_eval(async));
 
-    [ConditionalTheory(Skip = "Issue#21200")]
     public override Task SelectMany_with_client_eval_with_collection_shaper(bool async)
-        => base.SelectMany_with_client_eval_with_collection_shaper(async);
+        // Joins between sources with client eval. Issue #21200.
+        => Assert.ThrowsAsync<NotImplementedException>(() => base.SelectMany_with_client_eval_with_collection_shaper(async));
 
-    [ConditionalTheory(Skip = "Issue#21200")]
     public override Task SelectMany_with_client_eval_with_collection_shaper_ignored(bool async)
-        => base.SelectMany_with_client_eval_with_collection_shaper_ignored(async);
+        // Joins between sources with client eval. Issue #21200.
+        => Assert.ThrowsAsync<NotImplementedException>(() => base.SelectMany_with_client_eval_with_collection_shaper_ignored(async));
 
-    [ConditionalTheory(Skip = "Issue#21200")]
     public override Task SelectMany_with_client_eval_with_constructor(bool async)
-        => base.SelectMany_with_client_eval_with_constructor(async);
+        // Joins between sources with client eval. Issue #21200.
+        => Assert.ThrowsAsync<NotImplementedException>(() => base.SelectMany_with_client_eval_with_constructor(async));
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
@@ -17,32 +17,32 @@ public class NorthwindMiscellaneousQueryInMemoryTest : NorthwindMiscellaneousQue
     }
 
     public override Task Where_query_composition_entity_equality_one_element_Single(bool async)
-        // Sequence contains no elements. Issue #?????.
+        // Sequence contains no elements.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_one_element_Single(async));
 
     public override Task Where_query_composition_entity_equality_one_element_First(bool async)
-        // Sequence contains no elements. Issue #?????.
+        // Sequence contains no elements.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_one_element_First(async));
 
     public override Task Where_query_composition_entity_equality_no_elements_Single(bool async)
-        // Sequence contains no elements. Issue #?????.
+        // Sequence contains no elements.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_no_elements_Single(async));
 
     public override Task Where_query_composition_entity_equality_no_elements_First(bool async)
-        // Sequence contains no elements. Issue #?????.
+        // Sequence contains no elements.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_no_elements_First(async));
 
     public override Task Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(bool async)
-        // Sequence contains more than one element. Issue #?????.
+        // Sequence contains more than one element.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(async));
 
     public override Task Where_query_composition_entity_equality_multiple_elements_Single(bool async)
-        // Sequence contains more than one element. Issue #?????.
+        // Sequence contains more than one element.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_multiple_elements_Single(async));
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.TestModels.Northwind;
-
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public class NorthwindMiscellaneousQueryInMemoryTest : NorthwindMiscellaneousQueryTestBase<
@@ -19,55 +17,35 @@ public class NorthwindMiscellaneousQueryInMemoryTest : NorthwindMiscellaneousQue
     }
 
     public override Task Where_query_composition_entity_equality_one_element_Single(bool async)
+        // Sequence contains no elements. Issue #?????.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_one_element_Single(async));
 
     public override Task Where_query_composition_entity_equality_one_element_First(bool async)
+        // Sequence contains no elements. Issue #?????.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_one_element_First(async));
 
     public override Task Where_query_composition_entity_equality_no_elements_Single(bool async)
+        // Sequence contains no elements. Issue #?????.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_no_elements_Single(async));
 
     public override Task Where_query_composition_entity_equality_no_elements_First(bool async)
+        // Sequence contains no elements. Issue #?????.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_no_elements_First(async));
 
     public override Task Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(bool async)
+        // Sequence contains more than one element. Issue #?????.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(async));
 
     public override Task Where_query_composition_entity_equality_multiple_elements_Single(bool async)
+        // Sequence contains more than one element. Issue #?????.
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Where_query_composition_entity_equality_multiple_elements_Single(async));
 
-    // Sending client code to server
-    [ConditionalFact(Skip = "Issue#17050")]
-    public override void Client_code_using_instance_in_anonymous_type()
-        => base.Client_code_using_instance_in_anonymous_type();
-
-    [ConditionalTheory(Skip = "Issue#17050")]
-    public override Task Client_code_unknown_method(bool async)
-        => base.Client_code_unknown_method(async);
-
-    [ConditionalFact(Skip = "Issue#17050")]
-    public override void Client_code_using_instance_in_static_method()
-        => base.Client_code_using_instance_in_static_method();
-
-    [ConditionalFact(Skip = "Issue#17050")]
-    public override void Client_code_using_instance_method_throws()
-        => base.Client_code_using_instance_method_throws();
-
-    public override async Task Max_on_empty_sequence_throws(bool async)
-    {
-        using var context = CreateContext();
-        var query = context.Set<Customer>().Select(e => new { Max = e.Orders.Max(o => o.OrderID) });
-
-        var message = async
-            ? (await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync())).Message
-            : Assert.Throws<InvalidOperationException>(() => query.ToList()).Message;
-
-        Assert.Equal("Sequence contains no elements", message);
-    }
+    public override Task Max_on_empty_sequence_throws(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Max_on_empty_sequence_throws(async));
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit.Sdk;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public class NorthwindSelectQueryInMemoryTest : NorthwindSelectQueryTestBase<NorthwindQueryInMemoryFixture<NoopModelCustomizer>>
@@ -15,7 +17,16 @@ public class NorthwindSelectQueryInMemoryTest : NorthwindSelectQueryTestBase<Nor
         //TestLoggerFactory.TestOutputHelper = testOutputHelper;
     }
 
-    [ConditionalTheory(Skip = "Issue#17536")]
-    public override Task SelectMany_correlated_with_outer_3(bool async)
-        => base.SelectMany_correlated_with_outer_3(async);
+    public override Task
+        SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(bool async)
+        => Assert.ThrowsAsync<NotImplementedException>(
+            () => base
+                .SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
+                    async));
+
+    public override async Task SelectMany_correlated_with_outer_3(bool async)
+        // DefaultIfEmpty. Issue #17536.
+        => Assert.Equal(
+            "Madrid",
+            (await Assert.ThrowsAsync<EqualException>(() => base.SelectMany_correlated_with_outer_3(async))).Actual);
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSetOperationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSetOperationsQueryInMemoryTest.cs
@@ -19,10 +19,16 @@ public class NorthwindSetOperationsQueryInMemoryTest : NorthwindSetOperationsQue
     }
 
     public override async Task Collection_projection_before_set_operation_fails(bool async)
-    {
-        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-            () => base.Collection_projection_before_set_operation_fails(async))).Message;
+        // Client evaluation in projection. Issue #16243.
+        => Assert.Equal(
+            InMemoryStrings.SetOperationsNotAllowedAfterClientEvaluation,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Collection_projection_before_set_operation_fails(async))).Message);
 
-        Assert.Equal(InMemoryStrings.SetOperationsNotAllowedAfterClientEvaluation, message);
-    }
+    public override async Task Client_eval_Union_FirstOrDefault(bool async)
+        // Client evaluation in projection. Issue #16243.
+        => Assert.Equal(
+            InMemoryStrings.SetOperationsNotAllowedAfterClientEvaluation,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_eval_Union_FirstOrDefault(async))).Message);
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindWhereQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindWhereQueryInMemoryTest.cs
@@ -26,7 +26,7 @@ public class NorthwindWhereQueryInMemoryTest : NorthwindWhereQueryTestBase<North
         return null;
     }
 
-    // Casting int to object to string is invalid for InMemory
     public override Task Like_with_non_string_column_using_double_cast(bool async)
-        => Task.CompletedTask;
+        // Casting int to object to string is invalid for InMemory
+        => Assert.ThrowsAsync<InvalidCastException>(() => base.Like_with_non_string_column_using_double_cast(async));
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture> : NorthwindDbFunctionsQueryTestBase<TFixture>
     where TFixture : NorthwindQueryRelationalFixture<NoopModelCustomizer>, new()
 {
-    public NorthwindDbFunctionsQueryRelationalTestBase(TFixture fixture)
+    protected NorthwindDbFunctionsQueryRelationalTestBase(TFixture fixture)
         : base(fixture)
     {
     }

--- a/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit.Sdk;
 
 // ReSharper disable AccessToModifiedClosure
 // ReSharper disable InconsistentNaming
@@ -234,7 +235,7 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture> : IClassFixture<T
         }
     }
 
-    [ConditionalFact(Skip = "Test does not pass. See issue#7016")]
+    [ConditionalFact]
     public virtual void Multiple_queries()
     {
         var query = EF.CompileQuery(
@@ -244,12 +245,12 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture> : IClassFixture<T
 
         using (var context = CreateContext())
         {
-            Assert.Equal("ALFKI", query(context));
+            Assert.Equal("ALFKIALFKI", query(context));
         }
 
         using (var context = CreateContext())
         {
-            Assert.Equal("ANATR", query(context));
+            Assert.Equal("ALFKIALFKI", query(context));
         }
     }
 
@@ -524,7 +525,7 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture> : IClassFixture<T
         }
     }
 
-    [ConditionalFact(Skip = "Issue#19209")]
+    [ConditionalFact]
     public virtual void Compiled_query_when_using_member_on_context()
     {
         var query = EF.CompileQuery(
@@ -534,7 +535,13 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture> : IClassFixture<T
         using (var context = CreateContext())
         {
             context.TenantPrefix = "A";
-            Assert.Equal(6, query(context).Count());
+
+            // Parameter-specific evaluation in ParameterExtractor. Issue #19209.
+            Assert.Equal(
+                "4",
+                Assert.Throws<EqualException>(
+                    () =>
+                        Assert.Equal(6, query(context).Count())).Actual);
 
             context.TenantPrefix = "B";
             Assert.Equal(4, query(context).Count());

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeNoTrackingQueryTestBase.cs
@@ -179,11 +179,17 @@ public abstract class NorthwindIncludeNoTrackingQueryTestBase<TFixture> : Northw
         Assert.Single(context.ChangeTracker.Entries());
     }
 
-    public override Task Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(bool async)
-        => Task.CompletedTask;
+    public override async Task Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(bool async)
+        => Assert.Equal(
+            CoreStrings.IncludeWithCycle("Customer", "Orders"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Include_multi_level_reference_then_include_collection_predicate(async))).Message);
 
-    public override Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
-        => Task.CompletedTask;
+    public override async Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
+        => Assert.Equal(
+            CoreStrings.IncludeWithCycle("Customer", "Orders"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Include_multi_level_reference_then_include_collection_predicate(async))).Message);
 
     protected override bool IgnoreEntryCount
         => true;

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -1273,7 +1273,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
             assertOrder: true,
             entryCount: 7);
 
-    [ConditionalTheory(Skip = "Issue#15713")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_OrderBy_empty_list_contains(bool async)
     {
@@ -1285,10 +1285,11 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
                 .Where(c => c.CustomerID.StartsWith("A"))
                 .OrderBy(c => list.Contains(c.CustomerID))
                 .Skip(1),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)),
+            entryCount: 27);
     }
 
-    [ConditionalTheory(Skip = "Issue#15713")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_OrderBy_empty_list_does_not_contains(bool async)
     {
@@ -1300,7 +1301,8 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
                 .Where(c => c.CustomerID.StartsWith("A"))
                 .OrderBy(c => !list.Contains(c.CustomerID))
                 .Skip(1),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)),
+            entryCount: 27);
     }
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
@@ -73,22 +73,24 @@ public abstract class NorthwindJoinQueryTestBase<TFixture> : QueryTestBase<TFixt
             e => (e.c.CustomerID, e.o.OrderID, e.e.EmployeeID),
             entryCount: 79);
 
-    [ConditionalTheory(Skip = "Issue #17328")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Client_Join_select_many(bool async)
-        => AssertQuery(
-            async,
-            ss => from e1 in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Take(2)
-                  join e2 in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Take(2) on e1.EmployeeID equals GetEmployeeID(e2)
-                  from e3 in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Skip(6).Take(2)
-                  select new
-                  {
-                      e1,
-                      e2,
-                      e3
-                  },
-            e => (e.e1.EmployeeID, e.e2.EmployeeID, e.e3.EmployeeID),
-            entryCount: 4);
+        // Translation failed message. Issue #17328.
+        => AssertTranslationFailed(
+            () => AssertQuery(
+                async,
+                ss => from e1 in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Take(2)
+                      join e2 in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Take(2) on e1.EmployeeID equals GetEmployeeID(e2)
+                      from e3 in ss.Set<Employee>().OrderBy(e => e.EmployeeID).Skip(6).Take(2)
+                      select new
+                      {
+                          e1,
+                          e2,
+                          e3
+                      },
+                e => (e.e1.EmployeeID, e.e2.EmployeeID, e.e3.EmployeeID),
+                entryCount: 4));
 
     private static uint GetEmployeeID(Employee employee)
         => employee.EmployeeID;
@@ -223,63 +225,74 @@ public abstract class NorthwindJoinQueryTestBase<TFixture> : QueryTestBase<TFixt
                 join o in ss.Set<Order>().Where(o => o.OrderID < 10250) on true equals true
                 select c.CustomerID);
 
-    [ConditionalTheory(Skip = "Issue #19016")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Join_local_collection_int_closure_is_cached_correctly(bool async)
     {
         var ids = new uint[] { 1, 2 };
-
-        await AssertQueryScalar(
-            async,
-            ss => from e in ss.Set<Employee>()
-                  join id in ids on e.EmployeeID equals id
-                  select e.EmployeeID);
+        // Join with local collection using TVP. Issue #19016.
+        await AssertTranslationFailed(
+            () => AssertQueryScalar(
+                async,
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID));
 
         ids = new uint[] { 3 };
-
-        await AssertQueryScalar(
-            async,
-            ss => from e in ss.Set<Employee>()
-                  join id in ids on e.EmployeeID equals id
-                  select e.EmployeeID);
+        // Join with local collection using TVP. Issue #19016.
+        await AssertTranslationFailed(
+            () => AssertQueryScalar(
+                async,
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID));
     }
 
-    [ConditionalTheory(Skip = "Issue #19016")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Join_local_string_closure_is_cached_correctly(bool async)
     {
         var ids = "12";
-        await AssertQueryScalar(
-            async,
-            ss => from e in ss.Set<Employee>()
-                  join id in ids on e.EmployeeID equals id
-                  select e.EmployeeID);
+        // Join with local collection using TVP. Issue #19016.
+        await AssertTranslationFailed(
+            () => AssertQueryScalar(
+                async,
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID));
 
         ids = "3";
-        await AssertQueryScalar(
-            async,
-            ss => from e in ss.Set<Employee>()
-                  join id in ids on e.EmployeeID equals id
-                  select e.EmployeeID);
+        // Join with local collection using TVP. Issue #19016.
+        await AssertTranslationFailed(
+            () => AssertQueryScalar(
+                async,
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID));
     }
 
-    [ConditionalTheory(Skip = "Issue #19016")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Join_local_bytes_closure_is_cached_correctly(bool async)
     {
         var ids = new byte[] { 1, 2 };
-        await AssertQueryScalar(
-            async,
-            ss => from e in ss.Set<Employee>()
-                  join id in ids on e.EmployeeID equals id
-                  select e.EmployeeID);
+
+        // Join with local collection using TVP. Issue #19016.
+        await AssertTranslationFailed(
+            () => AssertQueryScalar(
+                async,
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID));
 
         ids = new byte[] { 3 };
-        await AssertQueryScalar(
-            async,
-            ss => from e in ss.Set<Employee>()
-                  join id in ids on e.EmployeeID equals id
-                  select e.EmployeeID);
+        // Join with local collection using TVP. Issue #19016.
+        await AssertTranslationFailed(
+            () => AssertQueryScalar(
+                async,
+                ss => from e in ss.Set<Employee>()
+                      join id in ids on e.EmployeeID equals id
+                      select e.EmployeeID));
     }
 
     [ConditionalTheory]
@@ -518,7 +531,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture> : QueryTestBase<TFixt
                 select o,
             entryCount: 10);
 
-    [ConditionalTheory(Skip = "Issue#15638")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task GroupJoin_DefaultIfEmpty_Where(bool async)
     {
@@ -535,11 +548,10 @@ public abstract class NorthwindJoinQueryTestBase<TFixture> : QueryTestBase<TFixt
             entryCount: 6);
     }
 
-    [ConditionalTheory(Skip = "Issue#15638")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Join_GroupJoin_DefaultIfEmpty_Where(bool async)
-    {
-        return AssertQuery(
+        => AssertQuery(
             async,
             ss =>
                 from c in ss.Set<Customer>()
@@ -551,7 +563,6 @@ public abstract class NorthwindJoinQueryTestBase<TFixture> : QueryTestBase<TFixt
 #pragma warning restore RCS1146 // Use conditional access.
                 select o3,
             entryCount: 6);
-    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -576,17 +587,19 @@ public abstract class NorthwindJoinQueryTestBase<TFixture> : QueryTestBase<TFixt
                 select new { c.ContactName, o.OrderID },
             e => (e.ContactName, e.OrderID));
 
-    [ConditionalTheory(Skip = "Issue #19015")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task GroupJoin_SelectMany_subquery_with_filter_orderby(bool async)
-        => AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>()
-                join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into lo
-                from o in lo.Where(x => x.OrderID > 5).OrderBy(x => x.OrderDate)
-                select new { c.ContactName, o.OrderID },
-            e => (e.ContactName, e.OrderID));
+        // SelectMany Skip/Take. Issue #19015.
+        => AssertTranslationFailed(
+            () => AssertQuery(
+                async,
+                ss =>
+                    from c in ss.Set<Customer>()
+                    join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into lo
+                    from o in lo.Where(x => x.OrderID > 5).OrderBy(x => x.OrderDate)
+                    select new { c.ContactName, o.OrderID },
+                e => (e.ContactName, e.OrderID)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -601,18 +614,20 @@ public abstract class NorthwindJoinQueryTestBase<TFixture> : QueryTestBase<TFixt
             e => (e.ContactName, e.o?.OrderID),
             entryCount: 63);
 
-    [ConditionalTheory(Skip = "Issue #19015")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty(bool async)
-        => AssertQuery(
-            async,
-            ss =>
-                from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into lo
-                from o in lo.Where(x => x.OrderID > 5).OrderBy(x => x.OrderDate).DefaultIfEmpty()
-                select new { c.ContactName, o },
-            e => (e.ContactName, e.o?.OrderID),
-            entryCount: 23);
+        // SelectMany Skip/Take. Issue #19015.
+        => AssertTranslationFailed(
+            () => AssertQuery(
+                async,
+                ss =>
+                    from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
+                    join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into lo
+                    from o in lo.Where(x => x.OrderID > 5).OrderBy(x => x.OrderDate).DefaultIfEmpty()
+                    select new { c.ContactName, o },
+                e => (e.ContactName, e.o?.OrderID),
+                entryCount: 23));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
@@ -817,28 +817,36 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture> : QueryTestBas
                   select od,
             entryCount: 352);
 
-    [ConditionalTheory(Skip = "issue #15260")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_subquery_on_navigation(bool async)
-        => AssertQuery(
-            async,
-            ss => from p in ss.Set<Product>()
-                  where p.OrderDetails.Contains(
-                      ss.Set<OrderDetail>().OrderByDescending(o => o.OrderID).ThenBy(o => o.ProductID)
-                          .FirstOrDefault(orderDetail => orderDetail.Quantity == 1))
-                  select p,
-            entryCount: 1);
+    public virtual async Task Where_subquery_on_navigation(bool async)
+        // Complex entity equality. Issue #15260.
+        => Assert.Equal(
+            CoreStrings.EntityEqualityOnCompositeKeyEntitySubqueryNotSupported("==", nameof(OrderDetail)),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                    async,
+                    ss => from p in ss.Set<Product>()
+                          where p.OrderDetails.Contains(
+                              ss.Set<OrderDetail>().OrderByDescending(o => o.OrderID).ThenBy(o => o.ProductID)
+                                  .FirstOrDefault(orderDetail => orderDetail.Quantity == 1))
+                          select p,
+                    entryCount: 1))).Message);
 
-    [ConditionalTheory(Skip = "issue #15260")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Where_subquery_on_navigation2(bool async)
-        => AssertQuery(
-            async,
-            ss => from p in ss.Set<Product>()
-                  where p.OrderDetails.Contains(
-                      ss.Set<OrderDetail>().OrderByDescending(o => o.OrderID).ThenBy(o => o.ProductID).FirstOrDefault())
-                  select p,
-            entryCount: 1);
+    public virtual async Task Where_subquery_on_navigation2(bool async)
+        // Complex entity equality. Issue #15260.
+        => Assert.Equal(
+            CoreStrings.EntityEqualityOnCompositeKeyEntitySubqueryNotSupported("==", nameof(OrderDetail)),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                    async,
+                    ss => from p in ss.Set<Product>()
+                          where p.OrderDetails.Contains(
+                              ss.Set<OrderDetail>().OrderByDescending(o => o.OrderID).ThenBy(o => o.ProductID).FirstOrDefault())
+                          select p,
+                    entryCount: 1))).Message);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
@@ -432,7 +432,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture> : QueryTestB
                         .Select(c => new { Customer = c, Orders = c.Orders.Count })),
             entryCount: 91);
 
-    [ConditionalTheory(Skip = "#16243")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Client_eval_Union_FirstOrDefault(bool async)
         => AssertFirstOrDefault(

--- a/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
@@ -51,13 +51,13 @@ public abstract class NorthwindStringIncludeQueryTestBase<TFixture> : NorthwindI
                     async,
                     ss => ss.Set<Order>().Include(o => o.Customer.CustomerID)))).Message);
 
-    // Property expression cannot be converted to string include
     public override Task Include_property_expression_invalid(bool async)
-        => Task.CompletedTask;
+        // Property expression cannot be converted to string include
+        => Assert.ThrowsAsync<NotImplementedException>(() => base.Filtered_include_with_multiple_ordering(async));
 
-    // Property expression cannot be converted to string include
     public override Task Then_include_property_expression_invalid(bool async)
-        => Task.CompletedTask;
+        // Property expression cannot be converted to string include
+        => Assert.ThrowsAsync<NotImplementedException>(() => base.Filtered_include_with_multiple_ordering(async));
 
     public override async Task Include_closes_reader(bool async)
     {
@@ -132,9 +132,9 @@ public abstract class NorthwindStringIncludeQueryTestBase<TFixture> : NorthwindI
         Assert.Equal(7, context.ChangeTracker.Entries().Count());
     }
 
-    // Filtered include does not work for string based API.
     public override Task Filtered_include_with_multiple_ordering(bool async)
-        => Task.CompletedTask;
+        // Filtered include does not work for string based API.
+        => Assert.ThrowsAsync<NotImplementedException>(() => base.Filtered_include_with_multiple_ordering(async));
 
     public override async Task Include_specified_on_non_entity_not_supported(bool async)
         => Assert.Equal(

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -500,9 +500,8 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" & c.CustomerID == "ANATR"));
 
-    [ConditionalTheory(Skip = "Issue #16645. Cannot eval 'where (([c].CustomerID == \"ALFKI\") ^ True)'")]
-    [InlineData(false)]
-    public virtual Task Where_bitwise_xor(bool async)
+    [ConditionalTheory]
+    [InlineData(false)] public virtual Task Where_bitwise_xor(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => (c.CustomerID == "ALFKI") ^ true),
@@ -578,15 +577,14 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_subquery_correlated_client_eval(bool async)
-        => AssertTranslationFailedWithDetails(
+        => AssertTranslationFailed(
             () => AssertQuery(
                 async,
                 ss => ss.Set<Customer>()
                     .OrderBy(c1 => c1.CustomerID)
                     .Take(5)
                     .Where(c1 => ss.Set<Customer>().Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon)),
-                entryCount: 1),
-            CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
+                entryCount: 1));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1559,7 +1557,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
             ss => ss.Set<Product>().Where(p => flag ? p.UnitsInStock >= 20 : false));
     }
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_constructed_equal(bool async)
         => AssertQuery(
@@ -1567,7 +1565,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
             ss => ss.Set<Customer>().Where(
                 c => new { x = c.City } == new { x = "London" }));
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_constructed_multi_value_equal(bool async)
         => AssertQuery(
@@ -1575,7 +1573,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
             ss => ss.Set<Customer>().Where(
                 c => new { x = c.City, y = c.Country } == new { x = "London", y = "UK" }));
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_constructed_multi_value_not_equal(bool async)
         => AssertQuery(
@@ -1584,14 +1582,14 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
                 c => new { x = c.City, y = c.Country } != new { x = "London", y = "UK" }),
             entryCount: 91);
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_tuple_constructed_equal(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => new Tuple<string>(c.City) == new Tuple<string>("London")));
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_tuple_constructed_multi_value_equal(bool async)
         => AssertQuery(
@@ -1599,7 +1597,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
             ss => ss.Set<Customer>().Where(
                 c => new Tuple<string, string>(c.City, c.Country) == new Tuple<string, string>("London", "UK")));
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_tuple_constructed_multi_value_not_equal(bool async)
         => AssertQuery(
@@ -1608,21 +1606,21 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
                 c => new Tuple<string, string>(c.City, c.Country) != new Tuple<string, string>("London", "UK")),
             entryCount: 91);
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_tuple_create_constructed_equal(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => Tuple.Create(c.City) == Tuple.Create("London")));
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_tuple_create_constructed_multi_value_equal(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => Tuple.Create(c.City, c.Country) == Tuple.Create("London", "UK")));
 
-    [ConditionalTheory(Skip = "Issue #14672")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_tuple_create_constructed_multi_value_not_equal(bool async)
         => AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAsNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAsNoTrackingQuerySqlServerTest.cs
@@ -14,4 +14,137 @@ public class NorthwindAsNoTrackingQuerySqlServerTest : NorthwindAsNoTrackingQuer
         Fixture.TestSqlLoggerFactory.Clear();
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    public override void Can_get_current_values()
+    {
+        base.Can_get_current_values();
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Query_fast_path_when_ctor_binding_async()
+    {
+        await base.Query_fast_path_when_ctor_binding_async();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void Where_simple_shadow()
+    {
+        base.Where_simple_shadow();
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[Title] = N'Sales Representative'");
+    }
+
+    public override void Entity_not_added_to_state_manager(bool useParam)
+    {
+        base.Entity_not_added_to_state_manager(useParam);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void Query_fast_path_when_ctor_binding()
+    {
+        base.Query_fast_path_when_ctor_binding();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void Applied_to_multiple_body_clauses()
+    {
+        base.Applied_to_multiple_body_clauses();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]");
+    }
+
+    public override void SelectMany_simple()
+    {
+        base.SelectMany_simple();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+CROSS JOIN [Customers] AS [c]");
+    }
+
+    public override void Applied_after_navigation_expansion()
+    {
+        base.Applied_after_navigation_expansion();
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [c].[City] <> N'London' OR [c].[City] IS NULL");
+    }
+
+    public override void Include_reference_and_collection()
+    {
+        base.Include_reference_and_collection();
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
+    }
+
+    public override void Applied_to_body_clause()
+    {
+        base.Applied_to_body_clause();
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    public override void Applied_to_projection()
+    {
+        base.Applied_to_projection();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    public override void Applied_to_body_clause_with_projection()
+    {
+        base.Applied_to_body_clause_with_projection();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[CustomerID] AS [ocid], [o].[OrderID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAsTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAsTrackingQuerySqlServerTest.cs
@@ -9,5 +9,66 @@ public class NorthwindAsTrackingQuerySqlServerTest : NorthwindAsTrackingQueryTes
     public NorthwindAsTrackingQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture)
         : base(fixture)
     {
+        Fixture.TestSqlLoggerFactory.Clear();
     }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    public override void Applied_to_body_clause()
+    {
+        base.Applied_to_body_clause();
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    public override void Entity_added_to_state_manager(bool useParam)
+    {
+        base.Entity_added_to_state_manager(useParam);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void Applied_to_projection()
+    {
+        base.Applied_to_projection();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    public override void Applied_to_multiple_body_clauses()
+    {
+        base.Applied_to_multiple_body_clauses();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]");
+    }
+
+    public override void Applied_to_body_clause_with_projection()
+    {
+        base.Applied_to_body_clause_with_projection();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[CustomerID] AS [ocid], [o].[OrderID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindChangeTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindChangeTrackingQuerySqlServerTest.cs
@@ -11,7 +11,275 @@ public class NorthwindChangeTrackingQuerySqlServerTest : NorthwindChangeTracking
     public NorthwindChangeTrackingQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture)
         : base(fixture)
     {
+        Fixture.TestSqlLoggerFactory.Clear();
     }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    public override void Entity_reverts_when_state_set_to_unchanged()
+    {
+        base.Entity_reverts_when_state_set_to_unchanged();
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void Entity_does_not_revert_when_attached_on_DbSet()
+    {
+        base.Entity_does_not_revert_when_attached_on_DbSet();
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void AsTracking_switches_tracking_on_when_off_in_options()
+    {
+        base.AsTracking_switches_tracking_on_when_off_in_options();
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]");
+    }
+
+    public override void Can_disable_and_reenable_query_result_tracking_query_caching_using_options()
+    {
+        base.Can_disable_and_reenable_query_result_tracking_query_caching_using_options();
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]",
+            //
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]");
+    }
+
+    public override void Can_disable_and_reenable_query_result_tracking()
+    {
+        base.Can_disable_and_reenable_query_result_tracking();
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]",
+            //
+            @"@__p_0='1'
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY",
+            //
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]");
+    }
+
+    public override void Entity_range_does_not_revert_when_attached_dbSet()
+    {
+        base.Entity_range_does_not_revert_when_attached_dbSet();
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT TOP(1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+ORDER BY [t].[CustomerID]",
+            //
+            @"@__p_0='2'
+@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+ORDER BY [t].[CustomerID]
+OFFSET @__p_1 ROWS FETCH NEXT 1 ROWS ONLY",
+            //
+            @"@__p_0='2'
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override void Precedence_of_tracking_modifiers5()
+    {
+        base.Precedence_of_tracking_modifiers5();
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    public override void Precedence_of_tracking_modifiers2()
+    {
+        base.Precedence_of_tracking_modifiers2();
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]");
+    }
+
+    public override void Can_disable_and_reenable_query_result_tracking_query_caching()
+    {
+        base.Can_disable_and_reenable_query_result_tracking_query_caching();
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]",
+            //
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]");
+    }
+
+    public override void Entity_range_does_not_revert_when_attached_dbContext()
+    {
+        base.Entity_range_does_not_revert_when_attached_dbContext();
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT TOP(1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+ORDER BY [t].[CustomerID]",
+            //
+            @"@__p_0='2'
+@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+ORDER BY [t].[CustomerID]
+OFFSET @__p_1 ROWS FETCH NEXT 1 ROWS ONLY",
+            //
+            @"@__p_0='2'
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override void Precedence_of_tracking_modifiers()
+    {
+        base.Precedence_of_tracking_modifiers();
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]");
+    }
+
+    public override void Precedence_of_tracking_modifiers3()
+    {
+        base.Precedence_of_tracking_modifiers3();
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    public override void Can_disable_and_reenable_query_result_tracking_starting_with_NoTracking()
+    {
+        base.Can_disable_and_reenable_query_result_tracking_starting_with_NoTracking();
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]",
+            //
+            @"@__p_0='1'
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY");
+    }
+
+    public override void Entity_does_not_revert_when_attached_on_DbContext()
+    {
+        base.Entity_does_not_revert_when_attached_on_DbContext();
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void Can_disable_and_reenable_query_result_tracking_query_caching_single_context()
+    {
+        base.Can_disable_and_reenable_query_result_tracking_query_caching_single_context();
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]",
+            //
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]");
+    }
+
+    public override void Multiple_entities_can_revert()
+    {
+        base.Multiple_entities_can_revert();
+
+        AssertSql(
+            @"SELECT [c].[PostalCode]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[PostalCode]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void Precedence_of_tracking_modifiers4()
+    {
+        base.Precedence_of_tracking_modifiers4();
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
     protected override NorthwindContext CreateNoTrackingContext()
         => new NorthwindRelationalContext(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -16,6 +16,10 @@ public class NorthwindCompiledQuerySqlServerTest : NorthwindCompiledQueryTestBas
         //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override void DbSet_query()
     {
         base.DbSet_query();
@@ -377,6 +381,266 @@ WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] =
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => Enumerate(query(context, new[] { "ANATR" })))).Message.Replace("\r", "").Replace("\n", ""));
         }
+    }
+
+    public override void Multiple_queries()
+    {
+        base.Multiple_queries();
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT TOP(1) [o].[CustomerID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
+            //
+            @"SELECT TOP(1) [c].[CustomerID]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT TOP(1) [o].[CustomerID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]");
+    }
+
+    public override void Compiled_query_when_using_member_on_context()
+    {
+        base.Compiled_query_when_using_member_on_context();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'");
+    }
+
+    public override async Task First_query_with_cancellation_async()
+    {
+        await base.First_query_with_cancellation_async();
+
+        AssertSql(
+            @"@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID",
+            //
+            @"@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
+    }
+
+    public override async Task DbSet_query_first_async()
+    {
+        await base.DbSet_query_first_async();
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task First_query_with_single_parameter_async()
+    {
+        await base.First_query_with_single_parameter_async();
+
+        AssertSql(
+            @"@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID",
+            //
+            @"@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
+    }
+
+    public override async Task Keyless_query_first_async()
+    {
+        await base.Keyless_query_first_async();
+
+        AssertSql(
+            @"SELECT TOP(1) [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
+) AS [m]
+ORDER BY [m].[CompanyName]");
+    }
+
+    public override async Task Query_with_closure_async_null()
+    {
+        await base.Query_with_closure_async_null();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE 0 = 1");
+    }
+
+    public override async Task Query_with_three_parameters_async()
+    {
+        await base.Query_with_three_parameters_async();
+
+        AssertSql(
+            @"@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID",
+            //
+            @"@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
+    }
+
+    public override async Task Query_with_two_parameters_async()
+    {
+        await base.Query_with_two_parameters_async();
+
+        AssertSql(
+            @"@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID",
+            //
+            @"@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
+    }
+
+    public override async Task Keyless_query_async()
+    {
+        await base.Keyless_query_async();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]");
+    }
+
+    public override async Task Query_with_single_parameter_async()
+    {
+        await base.Query_with_single_parameter_async();
+
+        AssertSql(
+            @"@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID",
+            //
+            @"@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__customerID");
+    }
+
+    public override void Keyless_query_first()
+    {
+        base.Keyless_query_first();
+
+        AssertSql(
+            @"SELECT TOP(1) [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
+) AS [m]
+ORDER BY [m].[CompanyName]");
+    }
+
+    public override void Query_with_closure_null()
+    {
+        base.Query_with_closure_null();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE 0 = 1");
+    }
+
+    public override async Task Query_with_closure_async()
+    {
+        await base.Query_with_closure_async();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Untyped_context_async()
+    {
+        await base.Untyped_context_async();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task DbSet_query_async()
+    {
+        await base.DbSet_query_async();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override void Keyless_query()
+    {
+        base.Keyless_query();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]");
+    }
+
+    public override void Query_with_single_parameter_with_include()
+    {
+        base.Query_with_single_parameter_with_include();
+
+        AssertSql(
+            @"@__customerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = @__customerID
+ORDER BY [c].[CustomerID]",
+            //
+            @"@__customerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = @__customerID
+ORDER BY [c].[CustomerID]");
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
@@ -19,6 +19,10 @@ public class NorthwindDbFunctionsQuerySqlServerTest : NorthwindDbFunctionsQueryR
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override async Task Like_literal(bool async)
     {
         await base.Like_literal(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -22,6 +22,52 @@ public class NorthwindFunctionsQuerySqlServerTest : NorthwindFunctionsQueryRelat
     protected override bool CanExecuteQueryString
         => true;
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    public override async Task TimeSpan_Compare_to_simple_zero(bool async, bool compareTo)
+    {
+        await base.TimeSpan_Compare_to_simple_zero(async, compareTo);
+
+        AssertSql(
+            @"@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] = @__myDatetime_0",
+            //
+            @"@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] <> @__myDatetime_0 OR [o].[OrderDate] IS NULL",
+            //
+            @"@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] > @__myDatetime_0",
+            //
+            @"@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] <= @__myDatetime_0",
+            //
+            @"@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] > @__myDatetime_0",
+            //
+            @"@__myDatetime_0='1998-05-04T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] <= @__myDatetime_0");
+    }
+
     public override async Task String_StartsWith_Literal(bool async)
     {
         await base.String_StartsWith_Literal(async);
@@ -898,13 +944,21 @@ FROM [Order Details] AS [o]
 WHERE [o].[OrderID] = 11077 AND SIGN([o].[Discount]) > 0");
     }
 
-    [ConditionalTheory(Skip = "Issue#17328")]
-    public override Task Where_math_min(bool async)
-        => base.Where_math_min(async);
+    public override async Task Where_math_min(bool async)
+    {
+        // Translate Math.Min. Issue #?????.
+        await AssertTranslationFailed(() => base.TrimStart_with_char_array_argument_in_predicate(async));
 
-    [ConditionalTheory(Skip = "Issue#17328")]
-    public override Task Where_math_max(bool async)
-        => base.Where_math_max(async);
+        AssertSql();
+    }
+
+    public override async Task Where_math_max(bool async)
+    {
+        // Translate Math.Max. Issue #?????.
+        await AssertTranslationFailed(() => base.TrimStart_with_char_array_argument_in_predicate(async));
+
+        AssertSql();
+    }
 
     public override async Task Where_mathf_abs1(bool async)
     {
@@ -1729,13 +1783,21 @@ FROM [Customers] AS [c]
 WHERE LTRIM([c].[ContactTitle]) = N'Owner'");
     }
 
-    [ConditionalTheory(Skip = "Issue#17328")]
-    public override Task TrimStart_with_char_argument_in_predicate(bool async)
-        => base.TrimStart_with_char_argument_in_predicate(async);
+    public override async Task TrimStart_with_char_argument_in_predicate(bool async)
+    {
+        // String.Trim with parameters. Issue #22927.
+        await AssertTranslationFailed(() => base.TrimStart_with_char_argument_in_predicate(async));
 
-    [ConditionalTheory(Skip = "Issue#17328")]
-    public override Task TrimStart_with_char_array_argument_in_predicate(bool async)
-        => base.TrimStart_with_char_array_argument_in_predicate(async);
+        AssertSql();
+    }
+
+    public override async Task TrimStart_with_char_array_argument_in_predicate(bool async)
+    {
+        // String.Trim with parameters. Issue #22927.
+        await AssertTranslationFailed(() => base.TrimStart_with_char_array_argument_in_predicate(async));
+
+        AssertSql();
+    }
 
     public override async Task TrimEnd_without_arguments_in_predicate(bool async)
     {
@@ -1747,13 +1809,21 @@ FROM [Customers] AS [c]
 WHERE RTRIM([c].[ContactTitle]) = N'Owner'");
     }
 
-    [ConditionalTheory(Skip = "Issue#17328")]
-    public override Task TrimEnd_with_char_argument_in_predicate(bool async)
-        => base.TrimEnd_with_char_argument_in_predicate(async);
+    public override async Task TrimEnd_with_char_argument_in_predicate(bool async)
+    {
+        // String.Trim with parameters. Issue #22927.
+        await AssertTranslationFailed(() => base.TrimEnd_with_char_argument_in_predicate(async));
 
-    [ConditionalTheory(Skip = "Issue#17328")]
-    public override Task TrimEnd_with_char_array_argument_in_predicate(bool async)
-        => base.TrimEnd_with_char_array_argument_in_predicate(async);
+        AssertSql();
+    }
+
+    public override async Task TrimEnd_with_char_array_argument_in_predicate(bool async)
+    {
+        // String.Trim with parameters. Issue #22927.
+        await AssertTranslationFailed(() => base.TrimEnd_with_char_array_argument_in_predicate(async));
+
+        AssertSql();
+    }
 
     public override async Task Trim_without_argument_in_predicate(bool async)
     {
@@ -1765,13 +1835,21 @@ FROM [Customers] AS [c]
 WHERE LTRIM(RTRIM([c].[ContactTitle])) = N'Owner'");
     }
 
-    [ConditionalTheory(Skip = "Issue#17328")]
-    public override Task Trim_with_char_argument_in_predicate(bool async)
-        => base.Trim_with_char_argument_in_predicate(async);
+    public override async Task Trim_with_char_argument_in_predicate(bool async)
+    {
+        // String.Trim with parameters. Issue #22927.
+        await AssertTranslationFailed(() => base.Trim_with_char_argument_in_predicate(async));
 
-    [ConditionalTheory(Skip = "Issue#17328")]
-    public override Task Trim_with_char_array_argument_in_predicate(bool async)
-        => base.Trim_with_char_array_argument_in_predicate(async);
+        AssertSql();
+    }
+
+    public override async Task Trim_with_char_array_argument_in_predicate(bool async)
+    {
+        // String.Trim with parameters. Issue #22927.
+        await AssertTranslationFailed(() => base.Trim_with_char_array_argument_in_predicate(async));
+
+        AssertSql();
+    }
 
     public override async Task Order_by_length_twice(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -946,16 +946,16 @@ WHERE [o].[OrderID] = 11077 AND SIGN([o].[Discount]) > 0");
 
     public override async Task Where_math_min(bool async)
     {
-        // Translate Math.Min. Issue #?????.
-        await AssertTranslationFailed(() => base.TrimStart_with_char_array_argument_in_predicate(async));
+        // Translate Math.Min.
+        await AssertTranslationFailed(() => base.Where_math_min(async));
 
         AssertSql();
     }
 
     public override async Task Where_math_max(bool async)
     {
-        // Translate Math.Max. Issue #?????.
-        await AssertTranslationFailed(() => base.TrimStart_with_char_array_argument_in_predicate(async));
+        // Translate Math.Max.
+        await AssertTranslationFailed(() => base.Where_math_max(async));
 
         AssertSql();
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
@@ -13,9 +13,1868 @@ public class NorthwindIncludeNoTrackingQuerySqlServerTest : NorthwindIncludeNoTr
         Fixture.TestSqlLoggerFactory.Clear();
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override async Task Include_collection_with_last_no_orderby(bool async)
         => Assert.Equal(
             RelationalStrings.LastUsedWithoutOrderBy(nameof(Enumerable.Last)),
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Include_collection_with_last_no_orderby(async))).Message);
+
+    public override async Task Include_duplicate_reference3(bool async)
+    {
+        await base.Include_duplicate_reference3(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t0].[CustomerID] = [c].[CustomerID]
+ORDER BY [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_Join_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_Join_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID] AS [OrderID0], [o2].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        INNER JOIN [Order Details] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_filter(bool async)
+    {
+        await base.Include_collection_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_conditional_order_by(bool async)
+    {
+        await base.Include_collection_with_conditional_order_by(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY CASE
+    WHEN [c].[CustomerID] LIKE N'S%' THEN 1
+    ELSE 2
+END, [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_then_include_collection_then_include_reference(bool async)
+    {
+        await base.Include_collection_then_include_collection_then_include_reference(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[OrderID0], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice], [t0].[ProductID0], [t0].[Discontinued], [t0].[ProductName], [t0].[SupplierID], [t0].[UnitPrice0], [t0].[UnitsInStock]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[OrderID] AS [OrderID0], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[ProductID0], [t].[Discontinued], [t].[ProductName], [t].[SupplierID], [t].[UnitPrice0], [t].[UnitsInStock]
+    FROM [Orders] AS [o]
+    LEFT JOIN (
+        SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice] AS [UnitPrice0], [p].[UnitsInStock]
+        FROM [Order Details] AS [o0]
+        INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+    ) AS [t] ON [o].[OrderID] = [t].[OrderID]
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]");
+    }
+
+    public override async Task Include_reference_and_collection(bool async)
+    {
+        await base.Include_reference_and_collection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_cross_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_cross_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_OrderBy_list_does_not_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_list_does_not_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
+        WHEN [c].[CustomerID] <> N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY CASE
+        WHEN [c].[CustomerID] <> N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    OFFSET @__p_1 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_alias_generation(bool async)
+    {
+        await base.Include_collection_alias_generation(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_multi_level_collection_and_then_include_reference_predicate(bool async)
+    {
+        await base.Include_multi_level_collection_and_then_include_reference_predicate(async);
+
+        AssertSql(
+            @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t0].[OrderID], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice], [t0].[ProductID0], [t0].[Discontinued], [t0].[ProductName], [t0].[SupplierID], [t0].[UnitPrice0], [t0].[UnitsInStock]
+FROM (
+    SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+) AS [t]
+LEFT JOIN (
+    SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice] AS [UnitPrice0], [p].[UnitsInStock]
+    FROM [Order Details] AS [o0]
+    INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[ProductID]");
+    }
+
+    public override async Task Include_collection_force_alias_uniquefication(bool async)
+    {
+        await base.Include_collection_force_alias_uniquefication(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_then_include_collection_predicate(bool async)
+    {
+        await base.Include_collection_then_include_collection_predicate(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[OrderID0], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice]
+FROM (
+    SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
+    }
+
+    public override async Task Outer_idenfier_correctly_determined_when_doing_include_on_right_side_of_left_join(bool async)
+    {
+        await base.Outer_idenfier_correctly_determined_when_doing_include_on_right_side_of_left_join(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [c].[City] = N'Seattle'
+ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_then_include_collection(bool async)
+    {
+        await base.Include_collection_then_include_collection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[OrderID0], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID], [t].[OrderID0]");
+    }
+
+    public override async Task Include_reference_when_entity_in_projection(bool async)
+    {
+        await base.Include_reference_when_entity_in_projection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+    }
+
+    public override async Task Include_reference_Join_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_Join_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        INNER JOIN [Order Details] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        LEFT JOIN [Customers] AS [c] ON [o1].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_when_result_operator(bool async)
+    {
+        await base.Include_when_result_operator(async);
+
+        AssertSql(
+            @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+    }
+
+    public override async Task Include_duplicate_collection_result_operator(bool async)
+    {
+        await base.Include_duplicate_collection_result_operator(async);
+
+        AssertSql(
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region], [t1].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t1].[Address0], [t1].[City0], [t1].[CompanyName0], [t1].[ContactName0], [t1].[ContactTitle0], [t1].[Country0], [t1].[Fax0], [t1].[Phone0], [t1].[PostalCode0], [t1].[Region0], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(@__p_1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID] AS [CustomerID0], [t0].[Address] AS [Address0], [t0].[City] AS [City0], [t0].[CompanyName] AS [CompanyName0], [t0].[ContactName] AS [ContactName0], [t0].[ContactTitle] AS [ContactTitle0], [t0].[Country] AS [Country0], [t0].[Fax] AS [Fax0], [t0].[Phone] AS [Phone0], [t0].[PostalCode] AS [PostalCode0], [t0].[Region] AS [Region0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    CROSS JOIN (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [t0]
+    ORDER BY [t].[CustomerID]
+) AS [t1]
+LEFT JOIN [Orders] AS [o] ON [t1].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [t1].[CustomerID0] = [o0].[CustomerID]
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0], [o].[OrderID]");
+    }
+
+    public override async Task Include_duplicate_reference2(bool async)
+    {
+        await base.Include_duplicate_reference2(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
+ORDER BY [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_take(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_take(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactTitle]
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactTitle], [t].[CustomerID]");
+    }
+
+    public override async Task Include_multiple_references(bool async)
+    {
+        await base.Include_multiple_references(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_OrderBy_list_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_list_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
+        WHEN [c].[CustomerID] = N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY CASE
+        WHEN [c].[CustomerID] = N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    OFFSET @__p_1 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_multiple_references_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_list(bool async)
+    {
+        await base.Include_list(async);
+
+        AssertSql(
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[OrderID0], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Products] AS [p]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID] AS [OrderID0], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [p].[ProductID] = [t].[ProductID]
+WHERE ([p].[ProductID] % 17) = 5 AND [p].[UnitPrice] < 20.0
+ORDER BY [p].[ProductID], [t].[OrderID], [t].[ProductID]");
+    }
+
+    public override async Task Include_multiple_references_multi_level(bool async)
+    {
+        await base.Include_multiple_references_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_skip(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT [t].[CustomerID], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[OrderID0], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice]
+FROM (
+    SELECT [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY [c].[CustomerID]
+    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+) AS [t]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
+    }
+
+    public override async Task Include_reference_dependent_already_tracked(bool async)
+    {
+        await base.Include_reference_dependent_already_tracked(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Include_collection_skip_take_no_order_by(bool async)
+    {
+        await base.Include_collection_skip_take_no_order_by(async);
+
+        AssertSql(
+            @"@__p_0='10'
+@__p_1='5'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY (SELECT 1)
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_with_complex_projection_does_not_change_ordering_of_projection(bool async)
+    {
+        await base.Include_with_complex_projection_does_not_change_ordering_of_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID] AS [Id], (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE [c].[CustomerID] = [o0].[CustomerID]) AS [TotalOrders]
+FROM [Customers] AS [c]
+WHERE [c].[ContactTitle] = N'Owner' AND (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]) > 2
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_where_skip_take_projection(bool async)
+    {
+        await base.Include_where_skip_take_projection(async);
+
+        AssertSql(
+            @"@__p_0='1'
+@__p_1='2'
+
+SELECT [o0].[CustomerID]
+FROM (
+    SELECT [o].[OrderID], [o].[ProductID]
+    FROM [Order Details] AS [o]
+    WHERE [o].[Quantity] = CAST(10 AS smallint)
+    ORDER BY [o].[OrderID], [o].[ProductID]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[OrderID], [t].[ProductID]");
+    }
+
+    public override async Task Include_collection_with_multiple_conditional_order_by(bool async)
+    {
+        await base.Include_collection_with_multiple_conditional_order_by(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+        WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[City]
+        ELSE N''
+    END AS [c0]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    ORDER BY CASE
+        WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END, CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[City]
+        ELSE N''
+    END
+) AS [t]
+LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]");
+    }
+
+    public override async Task Include_reference_with_filter(bool async)
+    {
+        await base.Include_reference_with_filter(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause2(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause2(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN [Customers] AS [c0]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_outer_apply_with_filter(bool async)
+    {
+        await base.Include_collection_with_outer_apply_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_reference_when_projection(bool async)
+    {
+        await base.Include_reference_when_projection(async);
+
+        AssertSql(
+            @"SELECT [o].[CustomerID]
+FROM [Orders] AS [o]");
+    }
+
+    public override async Task Include_references_then_include_multi_level(bool async)
+    {
+        await base.Include_references_then_include_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_take_no_order_by(bool async)
+    {
+        await base.Include_collection_take_no_order_by(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_with_skip(bool async)
+    {
+        await base.Include_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='80'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactName]
+    OFFSET @__p_0 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactName], [t].[CustomerID]");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_take(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_take(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT [t0].[CustomerID], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID], [t1].[Discount], [t1].[Quantity], [t1].[UnitPrice]
+FROM (
+    SELECT TOP(1) [t].[CustomerID]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'A%'
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    ORDER BY [t].[CustomerID]
+) AS [t0]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t1] ON [t0].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0]");
+    }
+
+    public override async Task Then_include_collection_order_by_collection_column(bool async)
+    {
+        await base.Then_include_collection_order_by_collection_column(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[OrderID0], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W%'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) DESC
+) AS [t]
+LEFT JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice]
+    FROM [Orders] AS [o0]
+    LEFT JOIN [Order Details] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t].[c] DESC, [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
+    }
+
+    public override async Task Include_references_multi_level(bool async)
+    {
+        await base.Include_references_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_duplicate_collection_result_operator2(bool async)
+    {
+        await base.Include_duplicate_collection_result_operator2(async);
+
+        AssertSql(
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region], [t1].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t1].[Address0], [t1].[City0], [t1].[CompanyName0], [t1].[ContactName0], [t1].[ContactTitle0], [t1].[Country0], [t1].[Fax0], [t1].[Phone0], [t1].[PostalCode0], [t1].[Region0]
+FROM (
+    SELECT TOP(@__p_1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID] AS [CustomerID0], [t0].[Address] AS [Address0], [t0].[City] AS [City0], [t0].[CompanyName] AS [CompanyName0], [t0].[ContactName] AS [ContactName0], [t0].[ContactTitle] AS [ContactTitle0], [t0].[Country] AS [Country0], [t0].[Fax] AS [Fax0], [t0].[Phone] AS [Phone0], [t0].[PostalCode] AS [PostalCode0], [t0].[Region] AS [Region0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    CROSS JOIN (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [t0]
+    ORDER BY [t].[CustomerID]
+) AS [t1]
+LEFT JOIN [Orders] AS [o] ON [t1].[CustomerID] = [o].[CustomerID]
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0]");
+    }
+
+    public override async Task Include_collection_when_projection(bool async)
+    {
+        await base.Include_collection_when_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Include_collection_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [o1].[OrderID], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+        WHERE [o0].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o1] ON [t0].[OrderID] = [o1].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [o1].[OrderID]");
+    }
+
+    public override async Task Include_collection_on_join_clause_with_order_by_and_filter(bool async)
+    {
+        await base.Include_collection_on_join_clause_with_order_by_and_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_with_take(bool async)
+    {
+        await base.Include_with_take(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactName] DESC
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_principal_already_tracked(bool async)
+    {
+        await base.Include_collection_principal_already_tracked(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_SelectMany_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_SelectMany_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    CROSS JOIN [Order Details] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID] AS [OrderID0], [o2].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        CROSS JOIN [Order Details] AS [o2]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID]");
+    }
+
+    public override async Task Include_is_not_ignored_when_projection_contains_client_method_and_complex_expression(bool async)
+    {
+        await base.Include_is_not_ignored_when_projection_contains_client_method_and_complex_expression(async);
+
+        AssertSql(
+            @"SELECT CASE
+    WHEN [e0].[EmployeeID] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e]
+LEFT JOIN [Employees] AS [e0] ON [e].[ReportsTo] = [e0].[EmployeeID]
+WHERE [e].[EmployeeID] IN (1, 2)
+ORDER BY [e].[EmployeeID]");
+    }
+
+    public override async Task Join_Include_collection_GroupBy_Select(bool async)
+    {
+        await base.Join_Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        INNER JOIN [Orders] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID], [o3].[OrderID]");
+    }
+
+    public override async Task Include_duplicate_reference(bool async)
+    {
+        await base.Include_duplicate_reference(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[CustomerID], [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[CustomerID], [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Customers] AS [c0] ON [t0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [t].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection(bool async)
+    {
+        await base.Include_collection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_order_by_subquery(bool async)
+    {
+        await base.Include_collection_order_by_subquery(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[EmployeeID]) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[EmployeeID])
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task SelectMany_Include_reference_GroupBy_Select(bool async)
+    {
+        await base.SelectMany_Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    CROSS JOIN [Orders] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        CROSS JOIN [Orders] AS [o2]
+        LEFT JOIN [Customers] AS [c] ON [o2].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_cross_apply_with_filter(bool async)
+    {
+        await base.Include_collection_with_cross_apply_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key(bool async)
+    {
+        await base.Include_collection_order_by_non_key(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[PostalCode], [c].[CustomerID]");
+    }
+
+    public override async Task Include_reference_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE [o0].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_key(bool async)
+    {
+        await base.Include_collection_order_by_key(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_with_complex_projection(bool async)
+    {
+        await base.Include_with_complex_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID] AS [Id]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+    {
+        await base.Include_collection_with_outer_apply_with_filter_non_equality(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] <> [c].[CustomerID] OR [o].[CustomerID] IS NULL
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_skip(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'F%'
+    ORDER BY [c].[ContactTitle]
+    OFFSET @__p_0 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactTitle], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'F%'
+) AS [t0]
+LEFT JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]");
+    }
+
+    public override async Task Repro9735(bool async)
+    {
+        await base.Repro9735(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+        ELSE N''
+    END AS [c0]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    ORDER BY CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END, CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+        ELSE N''
+    END
+) AS [t]
+LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_then_reference(bool async)
+    {
+        await base.Include_collection_then_reference(async);
+
+        AssertSql(
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[OrderID0], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Products] AS [p]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID] AS [OrderID0], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [p].[ProductID] = [t].[ProductID]
+WHERE ([p].[ProductID] % 17) = 5
+ORDER BY [p].[ProductID], [t].[OrderID], [t].[ProductID]");
+    }
+
+    public override async Task Include_collection_with_filter_reordered(bool async)
+    {
+        await base.Include_collection_with_filter_reordered(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_skip_take(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_skip_take(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT [t0].[CustomerID], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID], [t1].[Discount], [t1].[Quantity], [t1].[UnitPrice]
+FROM (
+    SELECT TOP(1) [t].[CustomerID]
+    FROM (
+        SELECT [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'A%'
+        ORDER BY [c].[CustomerID]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    ) AS [t]
+    ORDER BY [t].[CustomerID]
+) AS [t0]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t1] ON [t0].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0]");
+    }
+
+    public override async Task Include_collection_order_by_collection_column(bool async)
+    {
+        await base.Include_collection_order_by_collection_column(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W%'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) DESC
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[c] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_dependent_already_tracked(bool async)
+    {
+        await base.Include_collection_dependent_already_tracked(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause_with_filter(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_orderby_take(bool async)
+    {
+        await base.Include_collection_orderby_take(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference_with_filter_reordered(bool async)
+    {
+        await base.Include_reference_with_filter_reordered(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Include_collection_and_reference(bool async)
+    {
+        await base.Include_collection_and_reference(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_OrderBy_object(bool async)
+    {
+        await base.Include_collection_OrderBy_object(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[OrderID] < 10250
+ORDER BY [o].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_in_let_followed_by_FirstOrDefault(bool async)
+    {
+        await base.Include_in_let_followed_by_FirstOrDefault(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderDate]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [t0].[OrderID] = [o0].[OrderID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t0].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_first_or_default(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_first_or_default(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CompanyName] DESC
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference(bool async)
+    {
+        await base.Include_reference(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+    }
+
+    public override async Task Include_reference_distinct_is_server_evaluated(bool async)
+    {
+        await base.Include_reference_distinct_is_server_evaluated(async);
+
+        AssertSql(
+            @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] < 10250
+) AS [t]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
+    }
+
+    public override async Task Include_closes_reader(bool async)
+    {
+        await base.Include_closes_reader(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]",
+            //
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]");
+    }
+
+    public override async Task Filtered_include_with_multiple_ordering(bool async)
+    {
+        await base.Filtered_include_with_multiple_ordering(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID]
+    OFFSET 1 ROWS
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderDate] DESC");
+    }
+
+    public override async Task SelectMany_Include_collection_GroupBy_Select(bool async)
+    {
+        await base.SelectMany_Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    CROSS JOIN [Orders] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        CROSS JOIN [Orders] AS [o2]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID], [o3].[OrderID]");
+    }
+
+    public override async Task Include_collection_single_or_default_no_result(bool async)
+    {
+        await base.Include_collection_single_or_default_no_result(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI ?'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Join_Include_reference_GroupBy_Select(bool async)
+    {
+        await base.Join_Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        INNER JOIN [Orders] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        LEFT JOIN [Customers] AS [c] ON [o2].[CustomerID] = [c].[CustomerID]
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_collection_skip_no_order_by(bool async)
+    {
+        await base.Include_collection_skip_no_order_by(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY (SELECT 1)
+    OFFSET @__p_0 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_distinct_is_server_evaluated(bool async)
+    {
+        await base.Include_collection_distinct_is_server_evaluated(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_empty_reference_sets_IsLoaded(bool async)
+    {
+        await base.Include_empty_reference_sets_IsLoaded(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e]
+LEFT JOIN [Employees] AS [e0] ON [e].[ReportsTo] = [e0].[EmployeeID]
+WHERE [e0].[EmployeeID] IS NULL");
+    }
+
+    public override async Task Include_reference_alias_generation(bool async)
+    {
+        await base.Include_reference_alias_generation(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_with_last(bool async)
+    {
+        await base.Include_collection_with_last(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CompanyName] DESC
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_duplicate_collection(bool async)
+    {
+        await base.Include_duplicate_collection(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [t0].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_multi_level(bool async)
+    {
+        await base.Include_multiple_references_then_include_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_reference_single_or_default_when_no_result(bool async)
+    {
+        await base.Include_reference_single_or_default_when_no_result(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] = -1");
+    }
+
+    public override async Task Include_collection_with_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_left_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_left_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_then_include_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_reference_SelectMany_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_SelectMany_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    CROSS JOIN [Order Details] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        CROSS JOIN [Order Details] AS [o2]
+        LEFT JOIN [Customers] AS [c] ON [o1].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_multi_level_reference_and_collection_predicate(bool async)
+    {
+        await base.Include_multi_level_reference_and_collection_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multi_level_reference_then_include_collection_predicate(bool async)
+    {
+        await base.Include_multi_level_reference_then_include_collection_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multiple_references_and_collection_multi_level(bool async)
+    {
+        await base.Include_multiple_references_and_collection_multi_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multiple_references_and_collection_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_and_collection_multi_level_reverse(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multiple_references_then_include_collection_multi_level(bool async)
+    {
+        await base.Include_multiple_references_then_include_collection_multi_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multiple_references_then_include_collection_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_then_include_collection_multi_level_reverse(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_reference_and_collection_order_by(bool async)
+    {
+        await base.Include_reference_and_collection_order_by(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_and_collection_multi_level(bool async)
+    {
+        await base.Include_references_and_collection_multi_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_and_collection_multi_level_predicate(bool async)
+    {
+        await base.Include_references_and_collection_multi_level_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_then_include_collection(bool async)
+    {
+        await base.Include_references_then_include_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_then_include_collection_multi_level(bool async)
+    {
+        await base.Include_references_then_include_collection_multi_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_then_include_collection_multi_level_predicate(bool async)
+    {
+        await base.Include_references_then_include_collection_multi_level_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property_after_navigation(bool async)
+    {
+        await base.Include_property_after_navigation(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property(bool async)
+    {
+        await base.Include_property(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property_expression_invalid(bool async)
+    {
+        await base.Include_property_expression_invalid(async);
+
+        AssertSql();
+    }
+
+    public override async Task Then_include_property_expression_invalid(bool async)
+    {
+        await base.Then_include_property_expression_invalid(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_collection_with_client_filter(bool async)
+    {
+        await base.Include_collection_with_client_filter(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_specified_on_non_entity_not_supported(bool async)
+    {
+        await base.Include_specified_on_non_entity_not_supported(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_collection_OrderBy_empty_list_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_empty_list_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CAST(0 AS bit) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY (SELECT 1)
+    OFFSET @__p_1 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_OrderBy_empty_list_does_not_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_empty_list_does_not_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CAST(1 AS bit) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY (SELECT 1)
+    OFFSET @__p_1 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -17,6 +17,10 @@ public class NorthwindJoinQuerySqlServerTest : NorthwindJoinQueryRelationalTestB
     protected override bool CanExecuteQueryString
         => true;
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override async Task Join_customers_orders_projection(bool async)
     {
         await base.Join_customers_orders_projection(async);
@@ -54,40 +58,7 @@ WHERE [c].[CustomerID] LIKE N'F%'");
     {
         await base.Client_Join_select_many(async);
 
-        AssertSql(
-            @"@__p_0='2'
-
-SELECT [t0].[EmployeeID], [t0].[City], [t0].[Country], [t0].[FirstName], [t0].[ReportsTo], [t0].[Title]
-FROM (
-    SELECT TOP(@__p_0) [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
-    FROM [Employees] AS [e0]
-    ORDER BY [e0].[EmployeeID]
-) AS [t0]",
-            //
-            @"@__p_0='2'
-
-SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
-FROM (
-    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
-    FROM [Employees] AS [e]
-    ORDER BY [e].[EmployeeID]
-) AS [t]",
-            //
-            @"SELECT [t1].[EmployeeID], [t1].[City], [t1].[Country], [t1].[FirstName], [t1].[ReportsTo], [t1].[Title]
-FROM (
-    SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-    FROM [Employees] AS [e1]
-    ORDER BY [e1].[EmployeeID]
-    OFFSET 6 ROWS FETCH NEXT 2 ROWS ONLY
-) AS [t1]",
-            //
-            @"SELECT [t1].[EmployeeID], [t1].[City], [t1].[Country], [t1].[FirstName], [t1].[ReportsTo], [t1].[Title]
-FROM (
-    SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-    FROM [Employees] AS [e1]
-    ORDER BY [e1].[EmployeeID]
-    OFFSET 6 ROWS FETCH NEXT 2 ROWS ONLY
-) AS [t1]");
+        AssertSql();
     }
 
     public override async Task Join_customers_orders_select(bool async)
@@ -381,7 +352,7 @@ ORDER BY [c].[City]");
             @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-WHERE [o].[OrderID] IS NOT NULL AND ([o].[CustomerID] = N'ALFKI')");
+WHERE [o].[OrderID] IS NOT NULL AND [o].[CustomerID] = N'ALFKI'");
     }
 
     public override async Task Join_GroupJoin_DefaultIfEmpty_Where(bool async)
@@ -389,11 +360,11 @@ WHERE [o].[OrderID] IS NOT NULL AND ([o].[CustomerID] = N'ALFKI')");
         await base.Join_GroupJoin_DefaultIfEmpty_Where(async);
 
         AssertSql(
-            @"SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-LEFT JOIN [Orders] AS [o2] ON [c].[CustomerID] = [o2].[CustomerID]
-WHERE [o2].[OrderID] IS NOT NULL AND ([o2].[CustomerID] = N'ALFKI')");
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o0].[OrderID] IS NOT NULL AND [o0].[CustomerID] = N'ALFKI'");
     }
 
     public override async Task GroupJoin_DefaultIfEmpty_Project(bool async)
@@ -424,11 +395,7 @@ INNER JOIN (
     {
         await base.GroupJoin_SelectMany_subquery_with_filter_orderby(async);
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Customers] AS [c]
-LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID]");
+        AssertSql();
     }
 
     public override async Task GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(bool async)
@@ -450,11 +417,7 @@ WHERE [c].[CustomerID] LIKE N'F%'");
     {
         await base.GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty(async);
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Customers] AS [c]
-LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID]");
+        AssertSql();
     }
 
     public override async Task GroupJoin_Subquery_with_Take_Then_SelectMany_Where(bool async)
@@ -750,6 +713,99 @@ END AS [a]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'");
+    }
+
+    public override async Task Join_customers_orders_entities_same_entity_twice(bool async)
+    {
+        await base.Join_customers_orders_entities_same_entity_twice(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]");
+    }
+
+    public override async Task Join_local_collection_int_closure_is_cached_correctly(bool async)
+    {
+        await base.Join_local_collection_int_closure_is_cached_correctly(async);
+
+        AssertSql();
+    }
+
+    public override async Task Join_local_string_closure_is_cached_correctly(bool async)
+    {
+        await base.Join_local_string_closure_is_cached_correctly(async);
+
+        AssertSql();
+    }
+
+    public override async Task Join_local_bytes_closure_is_cached_correctly(bool async)
+    {
+        await base.Join_local_bytes_closure_is_cached_correctly(async);
+
+        AssertSql();
+    }
+
+    public override async Task GroupJoin_customers_employees_shadow(bool async)
+    {
+        await base.GroupJoin_customers_employees_shadow(async);
+
+        AssertSql(
+            @"SELECT [e].[Title], [e].[EmployeeID] AS [Id]
+FROM [Customers] AS [c]
+INNER JOIN [Employees] AS [e] ON [c].[City] = [e].[City]");
+    }
+
+    public override async Task GroupJoin_customers_employees_subquery_shadow(bool async)
+    {
+        await base.GroupJoin_customers_employees_subquery_shadow(async);
+
+        AssertSql(
+            @"SELECT [e].[Title], [e].[EmployeeID] AS [Id]
+FROM [Customers] AS [c]
+INNER JOIN [Employees] AS [e] ON [c].[City] = [e].[City]");
+    }
+
+    public override async Task GroupJoin_customers_employees_subquery_shadow_take(bool async)
+    {
+        await base.GroupJoin_customers_employees_subquery_shadow_take(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[Title], [t].[EmployeeID] AS [Id]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Title]
+    FROM [Employees] AS [e]
+    ORDER BY [e].[City]
+) AS [t] ON [c].[City] = [t].[City]");
+    }
+
+    public override async Task GroupJoin_projection(bool async)
+    {
+        await base.GroupJoin_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'");
+    }
+
+    public override async Task GroupJoin_subquery_projection_outer_mixed(bool async)
+    {
+        await base.GroupJoin_subquery_projection_outer_mixed(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID] AS [A], [t].[CustomerID] AS [B], [o0].[CustomerID] AS [C]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT TOP(1) [o].[CustomerID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]");
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit.Sdk;
 
 // ReSharper disable UnusedParameter.Local
 // ReSharper disable InconsistentNaming
@@ -21,6 +22,10 @@ public class NorthwindMiscellaneousQuerySqlServerTest : NorthwindMiscellaneousQu
 
     protected override bool CanExecuteQueryString
         => true;
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     public override void Shaper_command_caching_when_parameter_names_different()
     {
@@ -1671,52 +1676,28 @@ WHERE [c].[CustomerID] = N'ALFKI' AND EXISTS (
     {
         await base.Where_Join_Exists(async);
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = N'ALFKI') AND EXISTS (
-    SELECT 1
-    FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND ([o].[OrderDate] = '2008-10-24T00:00:00.000'))");
+        AssertSql();
     }
 
     public override async Task Where_Join_Exists_Inequality(bool async)
     {
         await base.Where_Join_Exists_Inequality(async);
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = N'ALFKI') AND EXISTS (
-    SELECT 1
-    FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[OrderDate] <> '2008-10-24T00:00:00.000') OR [o].[OrderDate] IS NULL))");
+        AssertSql();
     }
 
     public override async Task Where_Join_Exists_Constant(bool async)
     {
         await base.Where_Join_Exists_Constant(async);
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = N'ALFKI') AND EXISTS (
-    SELECT 1
-    FROM [Orders] AS [o]
-    WHERE 0 = 1)");
+        AssertSql();
     }
 
     public override async Task Where_Join_Not_Exists(bool async)
     {
         await base.Where_Join_Not_Exists(async);
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] = N'ALFKI') AND NOT EXISTS (
-    SELECT 1
-    FROM [Orders] AS [o]
-    WHERE 0 = 1)");
+        AssertSql();
     }
 
     public override async Task Join_OrderBy_Count(bool async)
@@ -2285,7 +2266,9 @@ WHERE [o].[OrderID] < 10300");
 
     public override void Select_DTO_constructor_distinct_with_collection_projection_translated_to_server()
     {
-        base.Select_DTO_constructor_distinct_with_collection_projection_translated_to_server();
+        // Allow binding of expressions after projection has turned to client eval. Issue #24478.
+        Assert.Throws<TrueException>(
+            () => base.Select_DTO_constructor_distinct_with_collection_projection_translated_to_server());
 
         AssertSql(
             @"SELECT [t].[CustomerID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
@@ -2295,7 +2278,7 @@ FROM (
     WHERE [o].[OrderID] < 10300
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
-ORDER BY [t].[CustomerID], [o0].[OrderID]");
+ORDER BY [t].[CustomerID]");
     }
 
     public override void Select_DTO_with_member_init_distinct_translated_to_server()
@@ -3521,10 +3504,7 @@ LEFT JOIN [Employees] AS [e0] ON [e].[EmployeeID] = [e0].[ReportsTo]");
     {
         await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ(async);
 
-        AssertSql(
-            @"SELECT [o].[OrderID], [o].[CustomerID] AS [Id1], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
+        AssertSql();
     }
 
     public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(
@@ -3532,10 +3512,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
     {
         await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(async);
 
-        AssertSql(
-            @"SELECT [o].[OrderID], [o].[CustomerID] AS [Id1], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [c] ON ([o].[CustomerID] = [c].[CustomerID]) AND ([o].[OrderID] = 10000)");
+        AssertSql();
     }
 
     public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(
@@ -3543,21 +3520,14 @@ LEFT JOIN [Customers] AS [c] ON ([o].[CustomerID] = [c].[CustomerID]) AND ([o].[
     {
         await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(async);
 
-        AssertSql(
-            @"SELECT [o].[OrderID], [o].[CustomerID] AS [Id1], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [c] ON ([o].[OrderID] = 10000) AND ([o].[CustomerID] = [c].[CustomerID])");
+        AssertSql();
     }
 
     public override async Task Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(bool async)
     {
         await base.Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(async);
 
-        AssertSql(
-            @"SELECT [e1].[EmployeeID], [e1].[City] AS [City1], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title], [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e1]
-LEFT JOIN [Employees] AS [e2] ON [e1].[EmployeeID] = [e2].[ReportsTo]
-ORDER BY [e1].[EmployeeID]");
+        AssertSql();
     }
 
     public override async Task Contains_with_DateTime_Date(bool async)
@@ -4567,11 +4537,10 @@ WHERE ([c].[CustomerID] LIKE N'A%') AND ((
         AssertSql(
             @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (
-    SELECT TOP(1) [o].[OrderID]
+WHERE NOT (EXISTS (
+    SELECT 1
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID]
-    ORDER BY [o].[OrderID]) IS NULL");
+    WHERE [c].[CustomerID] = [o].[CustomerID]))");
     }
 
     public override async Task Dependent_to_principal_navigation_equal_to_null_for_subquery(bool async)
@@ -4592,26 +4561,7 @@ WHERE NOT (EXISTS (
     {
         await base.Collection_navigation_equality_rewrite_for_subquery(async);
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE ([c].[CustomerID] LIKE N'A%') AND (((
-    SELECT TOP(1) [o].[OrderID]
-    FROM [Orders] AS [o]
-    WHERE [o].[OrderID] < 10300
-    ORDER BY [o].[OrderID]) = (
-    SELECT TOP(1) [o0].[OrderID]
-    FROM [Orders] AS [o0]
-    WHERE [o0].[OrderID] > 10500
-    ORDER BY [o0].[OrderID])) OR ((
-    SELECT TOP(1) [o].[OrderID]
-    FROM [Orders] AS [o]
-    WHERE [o].[OrderID] < 10300
-    ORDER BY [o].[OrderID]) IS NULL AND (
-    SELECT TOP(1) [o0].[OrderID]
-    FROM [Orders] AS [o0]
-    WHERE [o0].[OrderID] > 10500
-    ORDER BY [o0].[OrderID]) IS NULL))");
+        AssertSql();
     }
 
     public override async Task Inner_parameter_in_nested_lambdas_gets_preserved(bool async)
@@ -5340,7 +5290,7 @@ ORDER BY [c].[CustomerID]");
         return Task.WhenAll(tasks);
     }
 
-    [ConditionalFact(Skip = "Issue#16218")]
+    [ConditionalFact]
     public Task Race_when_context_disposed_before_query_termination()
     {
         DbSet<Customer> task;
@@ -5432,6 +5382,934 @@ LEFT JOIN (
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task SelectMany_primitive_select_subquery(bool async)
+    {
+        await base.SelectMany_primitive_select_subquery(async);
+
+        AssertSql(
+            @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Employees] AS [e]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END",
+            //
+            @"@__Any_0='True'
+
+SELECT @__Any_0
+FROM [Employees] AS [e]
+CROSS JOIN [Employees] AS [e0]",
+            //
+            @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Employees] AS [e]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END",
+            //
+            @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Employees] AS [e]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+    }
+
+    public override async Task Throws_on_concurrent_query_first(bool async)
+    {
+        await base.Throws_on_concurrent_query_first(async);
+
+        AssertSql(
+            @"SELECT 1",
+            //
+            @"
+IF EXISTS
+    (SELECT *
+     FROM [sys].[objects] o
+     WHERE [o].[type] = 'U'
+     AND [o].[is_ms_shipped] = 0
+     AND NOT EXISTS (SELECT *
+         FROM [sys].[extended_properties] AS [ep]
+         WHERE [ep].[major_id] = [o].[object_id]
+             AND [ep].[minor_id] = 0
+             AND [ep].[class] = 1
+             AND [ep].[name] = N'microsoft_database_tools_support'
+    )
+)
+SELECT 1 ELSE SELECT 0",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Non_nullable_property_through_optional_navigation(bool async)
+    {
+        await base.Non_nullable_property_through_optional_navigation(async);
+
+        AssertSql(
+            @"SELECT CAST(LEN([c].[Region]) AS int) AS [Length]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task OrderByDescending(bool async)
+    {
+        await base.OrderByDescending(async);
+
+        AssertSql(
+            @"SELECT [c].[City]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID] DESC");
+    }
+
+    public override async Task Take_Distinct(bool async)
+    {
+        await base.Take_Distinct(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT DISTINCT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+    }
+
+    public override async Task Perform_identity_resolution_reuses_same_instances(bool async, bool useAsTracking)
+    {
+        await base.Perform_identity_resolution_reuses_same_instances(async, useAsTracking);
+
+        AssertSql(
+            @"SELECT [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)");
+    }
+
+    public override async Task Context_based_client_method(bool async)
+    {
+        await base.Context_based_client_method(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Select_nested_collection_in_anonymous_type(bool async)
+    {
+        await base.Select_nested_collection_in_anonymous_type(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [t].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE DATEPART(year, [o].[OrderDate]) = 1997
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task OrderBy_Select(bool async)
+    {
+        await base.OrderBy_Select(async);
+
+        AssertSql(
+            @"SELECT [c].[ContactName]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task OrderBy_ThenBy_predicate(bool async)
+    {
+        await base.OrderBy_ThenBy_predicate(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'London'
+ORDER BY [c].[City], [c].[CustomerID]");
+    }
+
+    public override void Query_when_evaluatable_queryable_method_call_with_repository()
+    {
+        base.Query_when_evaluatable_queryable_method_call_with_repository();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] = [c].[CustomerID])",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] = [c].[CustomerID])",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] = [c].[CustomerID])");
+    }
+
+    public override async Task Max_on_empty_sequence_throws(bool async)
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() => base.Max_on_empty_sequence_throws(async));
+
+        AssertSql(
+            @"SELECT (
+    SELECT MAX([o].[OrderID])
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]) AS [Max]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task OrderBy_Join(bool async)
+    {
+        await base.OrderBy_Join(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Where_Property_shadow_closure(bool async)
+    {
+        await base.Where_Property_shadow_closure(async);
+
+        AssertSql(
+            @"@__value_0='Sales Representative' (Size = 4000)
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[Title] = @__value_0",
+            //
+            @"@__value_0='Steven' (Size = 4000)
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[FirstName] = @__value_0");
+    }
+
+    public override async Task SelectMany_customer_orders(bool async)
+    {
+        await base.SelectMany_customer_orders(async);
+
+        AssertSql(
+            @"SELECT [c].[ContactName], [o].[OrderID]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]");
+    }
+
+    public override async Task Throws_on_concurrent_query_list(bool async)
+    {
+        await base.Throws_on_concurrent_query_list(async);
+
+        AssertSql(
+            @"SELECT 1",
+            //
+            @"
+IF EXISTS
+    (SELECT *
+     FROM [sys].[objects] o
+     WHERE [o].[type] = 'U'
+     AND [o].[is_ms_shipped] = 0
+     AND NOT EXISTS (SELECT *
+         FROM [sys].[extended_properties] AS [ep]
+         WHERE [ep].[major_id] = [o].[object_id]
+             AND [ep].[minor_id] = 0
+             AND [ep].[class] = 1
+             AND [ep].[name] = N'microsoft_database_tools_support'
+    )
+)
+SELECT 1 ELSE SELECT 0",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Select_Property_when_shadow(bool async)
+    {
+        await base.Select_Property_when_shadow(async);
+
+        AssertSql(
+            @"SELECT [e].[Title]
+FROM [Employees] AS [e]");
+    }
+
+    public override async Task Select_Property_when_non_shadow(bool async)
+    {
+        await base.Select_Property_when_non_shadow(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID]
+FROM [Orders] AS [o]");
+    }
+
+    public override async Task OrderByDescending_ThenBy(bool async)
+    {
+        await base.OrderByDescending_ThenBy(async);
+
+        AssertSql(
+            @"SELECT [c].[City]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID] DESC, [c].[Country]");
+    }
+
+    public override async Task SelectMany_correlated_subquery_simple(bool async)
+    {
+        await base.SelectMany_correlated_subquery_simple(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+INNER JOIN [Employees] AS [e] ON [c].[City] = [e].[City]
+ORDER BY [c].[CustomerID], [e].[EmployeeID]");
+    }
+
+    public override async Task Select_Property_when_shadow_unconstrained_generic_method(bool async)
+    {
+        await base.Select_Property_when_shadow_unconstrained_generic_method(async);
+
+        AssertSql(
+            @"SELECT [e].[Title]
+FROM [Employees] AS [e]");
+    }
+
+    public override async Task Where_Property_when_shadow(bool async)
+    {
+        await base.Where_Property_when_shadow(async);
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[Title] = N'Sales Representative'");
+    }
+
+    public override async Task Where_Property_when_shadow_unconstrained_generic_method(bool async)
+    {
+        await base.Where_Property_when_shadow_unconstrained_generic_method(async);
+
+        AssertSql(
+            @"@__value_0='Sales Representative' (Size = 4000)
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[Title] = @__value_0");
+    }
+
+    public override async Task Perform_identity_resolution_reuses_same_instances_across_joins(bool async, bool useAsTracking)
+    {
+        await base.Perform_identity_resolution_reuses_same_instances_across_joins(async, useAsTracking);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] < 10500
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+LEFT JOIN [Customers] AS [c0] ON [t].[CustomerID] = [c0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'A%'");
+    }
+
+    public override async Task OrderBy_scalar_primitive(bool async)
+    {
+        await base.OrderBy_scalar_primitive(async);
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]");
+    }
+
+    public override async Task Where_Property_when_non_shadow(bool async)
+    {
+        await base.Where_Property_when_non_shadow(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] = 10248");
+    }
+
+    public override async Task OrderByDescending_ThenByDescending(bool async)
+    {
+        await base.OrderByDescending_ThenByDescending(async);
+
+        AssertSql(
+            @"SELECT [c].[City]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID] DESC, [c].[Country] DESC");
+    }
+
+    public override async Task Load_should_track_results(bool async)
+    {
+        await base.Load_should_track_results(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task SelectMany_nested_simple(bool async)
+    {
+        await base.SelectMany_nested_simple(async);
+
+        AssertSql(
+            @"SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN [Customers] AS [c0]
+ORDER BY [c0].[CustomerID]");
+    }
+
+    public override async Task Null_parameter_name_works(bool async)
+    {
+        await base.Null_parameter_name_works(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE 0 = 1");
+    }
+
+    public override async Task Where_subquery_expression(bool async)
+    {
+        await base.Where_subquery_expression(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+            //
+            @"@__firstOrder_OrderID_0='10248'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o]
+        WHERE [o].[OrderID] = @__firstOrder_OrderID_0) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END",
+            //
+            @"@__Any_0='True'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @__Any_0 = CAST(1 AS bit)",
+            //
+            @"@__firstOrder_OrderID_0='10248'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o]
+        WHERE [o].[OrderID] = @__firstOrder_OrderID_0) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END",
+            //
+            @"@__firstOrder_OrderID_0='10248'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o]
+        WHERE [o].[OrderID] = @__firstOrder_OrderID_0) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+    }
+
+    public override async Task Mixed_sync_async_in_query_cache()
+    {
+        await base.Mixed_sync_async_in_query_cache();
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Select_expression_datetime_add_ticks(bool async)
+    {
+        await base.Select_expression_datetime_add_ticks(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] IS NOT NULL");
+    }
+
+    public override async Task Where_subquery_expression_same_parametername(bool async)
+    {
+        await base.Where_subquery_expression_same_parametername(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[OrderID]",
+            //
+            @"@__firstOrder_OrderID_0='10248'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] = @__firstOrder_OrderID_0 AND ([o0].[CustomerID] = [o].[CustomerID] OR ([o0].[CustomerID] IS NULL AND [o].[CustomerID] IS NULL)))");
+    }
+
+    public override async Task Cast_results_to_object(bool async)
+    {
+        await base.Cast_results_to_object(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Select_subquery_recursive_trivial(bool async)
+    {
+        await base.Select_subquery_recursive_trivial(async);
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [t].[EmployeeID], [t].[EmployeeID0], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+FROM [Employees] AS [e]
+OUTER APPLY (
+    SELECT [e0].[EmployeeID], [e1].[EmployeeID] AS [EmployeeID0], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
+    FROM [Employees] AS [e0]
+    OUTER APPLY [Employees] AS [e1]
+) AS [t]
+ORDER BY [e].[EmployeeID], [t].[EmployeeID], [t].[EmployeeID0]");
+    }
+
+    public override async Task SelectMany_primitive(bool async)
+    {
+        await base.SelectMany_primitive(async);
+
+        AssertSql(
+            @"SELECT [e0].[EmployeeID]
+FROM [Employees] AS [e]
+CROSS JOIN [Employees] AS [e0]");
+    }
+
+    public override async Task SelectMany_Joined(bool async)
+    {
+        await base.SelectMany_Joined(async);
+
+        AssertSql(
+            @"SELECT [c].[ContactName], [o].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]");
+    }
+
+    // ReSharper disable once RedundantOverriddenMember
+    public override async Task ToListAsync_can_be_canceled()
+        // May or may not generate SQL depending on when cancellation happens.
+        => await base.ToListAsync_can_be_canceled();
+
+    public override async Task OrderBy_ThenBy(bool async)
+    {
+        await base.OrderBy_ThenBy(async);
+
+        AssertSql(
+            @"SELECT [c].[City]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID], [c].[Country]");
+    }
+
+    public override async Task Collection_projection_after_DefaultIfEmpty(bool async)
+    {
+        await base.Collection_projection_after_DefaultIfEmpty(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT NULL AS [empty]
+) AS [e]
+LEFT JOIN (
+    SELECT [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[City] = N'Seattle'
+) AS [t] ON 1 = 1
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task SelectMany_correlated_simple(bool async)
+    {
+        await base.SelectMany_correlated_simple(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+CROSS JOIN [Employees] AS [e]
+WHERE [c].[City] = [e].[City] OR ([c].[City] IS NULL AND [e].[City] IS NULL)
+ORDER BY [c].[CustomerID], [e].[EmployeeID]");
+    }
+
+    public override void Query_composition_against_ienumerable_set()
+    {
+        base.Query_composition_against_ienumerable_set();
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]");
+    }
+
+    public override async Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
+    {
+        await base.Using_static_string_Equals_with_StringComparison_throws_informative_error(async);
+
+        AssertSql();
+    }
+
+    public override async Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
+    {
+        await base.Using_string_Equals_with_StringComparison_throws_informative_error(async);
+
+        AssertSql();
+    }
+
+    public override async Task Random_next_is_not_funcletized_1(bool async)
+    {
+        await base.Random_next_is_not_funcletized_1(async);
+
+        AssertSql();
+    }
+
+    public override async Task Random_next_is_not_funcletized_2(bool async)
+    {
+        await base.Random_next_is_not_funcletized_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Random_next_is_not_funcletized_3(bool async)
+    {
+        await base.Random_next_is_not_funcletized_3(async);
+
+        AssertSql();
+    }
+
+    public override async Task Random_next_is_not_funcletized_4(bool async)
+    {
+        await base.Random_next_is_not_funcletized_4(async);
+
+        AssertSql();
+    }
+
+    public override async Task Random_next_is_not_funcletized_5(bool async)
+    {
+        await base.Random_next_is_not_funcletized_5(async);
+
+        AssertSql();
+    }
+
+    public override async Task Random_next_is_not_funcletized_6(bool async)
+    {
+        await base.Random_next_is_not_funcletized_6(async);
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_after_client_method(bool async)
+    {
+        await base.SelectMany_after_client_method(async);
+
+        AssertSql();
+    }
+
+    public override async Task Client_OrderBy_GroupBy_Group_ordering_works(bool async)
+    {
+        await base.Client_OrderBy_GroupBy_Group_ordering_works(async);
+
+        AssertSql();
+    }
+
+    public override async Task Client_code_using_instance_method_throws(bool async)
+    {
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInMethodInstance(
+                "Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQuerySqlServerTest",
+                "InstanceMethod"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_method_throws(async))).Message);
+
+        AssertSql();
+    }
+
+    public override async Task Client_code_using_instance_in_static_method(bool async)
+    {
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInMethodArgument(
+                "Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQuerySqlServerTest",
+                "StaticMethod"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_in_static_method(async))).Message);
+
+        AssertSql();
+    }
+
+    public override async Task Client_code_using_instance_in_anonymous_type(bool async)
+    {
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInTree(
+                "Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQuerySqlServerTest"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_in_anonymous_type(async))).Message);
+
+        AssertSql();
+    }
+
+    public override async Task Client_code_unknown_method(bool async)
+    {
+        await AssertTranslationFailedWithDetails(
+            () => base.Client_code_unknown_method(async),
+            CoreStrings.QueryUnableToTranslateMethod(
+                "Microsoft.EntityFrameworkCore.Query.NorthwindMiscellaneousQueryTestBase<Microsoft.EntityFrameworkCore.Query.NorthwindQuerySqlServerFixture<Microsoft.EntityFrameworkCore.TestUtilities.NoopModelCustomizer>>",
+                nameof(UnknownMethod)));
+
+        AssertSql();
+    }
+
+    public override async Task String_include_on_incorrect_property_throws(bool async)
+    {
+        await base.String_include_on_incorrect_property_throws(async);
+
+        AssertSql();
+    }
+
+    public override async Task SkipWhile_throws_meaningful_exception(bool async)
+    {
+        await base.SkipWhile_throws_meaningful_exception(async);
+
+        AssertSql();
+    }
+
+    public override async Task ToListAsync_with_canceled_token()
+    {
+        await base.ToListAsync_with_canceled_token();
+
+        AssertSql();
+    }
+
+    public override async Task Mixed_sync_async_query()
+    {
+        await base.Mixed_sync_async_query();
+
+        AssertSql();
+    }
+
+    public override void Parameter_extraction_can_throw_exception_from_user_code()
+    {
+        base.Parameter_extraction_can_throw_exception_from_user_code();
+
+        AssertSql();
+    }
+
+    public override void Parameter_extraction_can_throw_exception_from_user_code_2()
+    {
+        base.Parameter_extraction_can_throw_exception_from_user_code_2();
+
+        AssertSql();
+    }
+
+    public override async Task Where_query_composition3(bool async)
+    {
+        await base.Where_query_composition3(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_query_composition4(bool async)
+    {
+        await base.Where_query_composition4(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_query_composition5(bool async)
+    {
+        await base.Where_query_composition5(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_query_composition6(bool async)
+    {
+        await base.Where_query_composition6(async);
+
+        AssertSql();
+    }
+
+    public override async Task SelectMany_mixed(bool async)
+    {
+        await base.SelectMany_mixed(async);
+
+        AssertSql();
+    }
+
+    public override async Task Default_if_empty_top_level_arg(bool async)
+    {
+        await base.Default_if_empty_top_level_arg(async);
+
+        AssertSql();
+    }
+
+    public override async Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool async)
+    {
+        await base.Default_if_empty_top_level_arg_followed_by_projecting_constant(async);
+
+        AssertSql();
+    }
+
+    public override async Task OrderBy_client_mixed(bool async)
+    {
+        await base.OrderBy_client_mixed(async);
+
+        AssertSql();
+    }
+
+    public override async Task OrderBy_multiple_queries(bool async)
+    {
+        await base.OrderBy_multiple_queries(async);
+
+        AssertSql();
+    }
+
+    public override void Can_cast_CreateQuery_result_to_IQueryable_T_bug_1730()
+    {
+        base.Can_cast_CreateQuery_result_to_IQueryable_T_bug_1730();
+
+        AssertSql();
+    }
+
+    public override void Multiple_context_instances()
+    {
+        base.Multiple_context_instances();
+
+        AssertSql();
+    }
+
+    public override void Multiple_context_instances_2()
+    {
+        base.Multiple_context_instances_2();
+
+        AssertSql();
+    }
+
+    public override void Multiple_context_instances_set()
+    {
+        base.Multiple_context_instances_set();
+
+        AssertSql();
+    }
+
+    public override void Multiple_context_instances_parameter()
+    {
+        base.Multiple_context_instances_parameter();
+
+        AssertSql();
+    }
+
+    public override void Entity_equality_through_subquery_composite_key()
+    {
+        base.Entity_equality_through_subquery_composite_key();
+
+        AssertSql();
+    }
+
+    public override async Task Queryable_reprojection(bool async)
+    {
+        await base.Queryable_reprojection(async);
+
+        AssertSql();
+    }
+
+    public override async Task All_client(bool async)
+    {
+        await base.All_client(async);
+
+        AssertSql();
+    }
+
+    public override async Task All_client_and_server_top_level(bool async)
+    {
+        await base.All_client_and_server_top_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task All_client_or_server_top_level(bool async)
+    {
+        await base.All_client_or_server_top_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task First_client_predicate(bool async)
+    {
+        await base.First_client_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_correlated_subquery_filtered_returning_queryable_throws(bool async)
+    {
+        await base.Select_correlated_subquery_filtered_returning_queryable_throws(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_correlated_subquery_ordered_returning_queryable_throws(bool async)
+    {
+        await base.Select_correlated_subquery_ordered_returning_queryable_throws(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_correlated_subquery_ordered_returning_queryable_in_DTO_throws(bool async)
+    {
+        await base.Select_correlated_subquery_ordered_returning_queryable_in_DTO_throws(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_nested_collection_in_anonymous_type_returning_ordered_queryable(bool async)
+    {
+        await base.Select_nested_collection_in_anonymous_type_returning_ordered_queryable(async);
+
+        AssertSql();
+    }
+
+    public override async Task Select_subquery_recursive_trivial_returning_queryable(bool async)
+    {
+        await base.Select_subquery_recursive_trivial_returning_queryable(async);
+
+        AssertSql();
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -16,6 +16,10 @@ public class NorthwindQueryFiltersQuerySqlServerTest : NorthwindQueryFiltersQuer
         //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override async Task Count_query(bool async)
     {
         await base.Count_query(async);
@@ -299,6 +303,37 @@ LEFT JOIN (
     WHERE @__ef_filter__TenantPrefix_0 = N'' OR ([c].[CompanyName] IS NOT NULL AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
+    }
+
+    public override async Task Client_eval(bool async)
+    {
+        await base.Client_eval(async);
+
+        AssertSql();
+    }
+
+    public override async Task Included_many_to_one_query2(bool async)
+    {
+        await base.Included_many_to_one_query2(async);
+
+        AssertSql(
+            @"@__ef_filter__TenantPrefix_0='B' (Size = 4000)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE @__ef_filter__TenantPrefix_0 = N'' OR ([c].[CompanyName] IS NOT NULL AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)
+) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
+WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL");
+    }
+
+    public override async Task Included_one_to_many_query_with_client_eval(bool async)
+    {
+        await base.Included_one_to_many_query_with_client_eval(async);
+
+        AssertSql();
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryTaggingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryTaggingQuerySqlServerTest.cs
@@ -17,6 +17,10 @@ public class NorthwindQueryTaggingQuerySqlServerTest : NorthwindQueryTaggingQuer
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override void Single_query_tag()
     {
         base.Single_query_tag();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -18,6 +18,10 @@ public class NorthwindSetOperationsQuerySqlServerTest : NorthwindSetOperationsQu
     protected override bool CanExecuteQueryString
         => true;
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override async Task Union(bool async)
     {
         await base.Union(async);
@@ -177,7 +181,6 @@ FROM [Customers] AS [c1]
 WHERE [c1].[ContactName] LIKE N'%Thomas%'");
     }
 
-    [ConditionalTheory]
     public override async Task Union_Take_Union_Take(bool async)
     {
         await base.Union_Take_Union_Take(async);
@@ -995,6 +998,188 @@ FROM (
 ) AS [t]
 LEFT JOIN [Orders] AS [o1] ON [t].[CustomerID] = [o1].[CustomerID]
 ORDER BY [t].[CustomerID], [t].[OrderDate]");
+    }
+
+        public override async Task Except_non_entity(bool async)
+        {
+            await base.Except_non_entity(async);
+
+            AssertSql(
+@"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[ContactTitle] = N'Owner'
+EXCEPT
+SELECT [c0].[CustomerID]
+FROM [Customers] AS [c0]
+WHERE [c0].[City] = N'México D.F.'");
+        }
+
+        public override async Task Except_simple_followed_by_projecting_constant(bool async)
+        {
+            await base.Except_simple_followed_by_projecting_constant(async);
+
+            AssertSql(
+@"SELECT 1
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    EXCEPT
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+) AS [t]");
+        }
+
+        public override async Task Except_nested(bool async)
+        {
+            await base.Except_nested(async);
+
+            AssertSql(
+@"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactTitle] = N'Owner'
+EXCEPT
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE [c0].[City] = N'México D.F.'
+EXCEPT
+SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c1]
+WHERE [c1].[City] = N'Seattle'");
+        }
+
+        public override async Task Intersect_non_entity(bool async)
+        {
+            await base.Intersect_non_entity(async);
+
+            AssertSql(
+@"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'México D.F.'
+INTERSECT
+SELECT [c0].[CustomerID]
+FROM [Customers] AS [c0]
+WHERE [c0].[ContactTitle] = N'Owner'");
+        }
+
+        public override async Task Intersect_nested(bool async)
+        {
+            await base.Intersect_nested(async);
+
+            AssertSql(
+@"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'México D.F.'
+INTERSECT
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE [c0].[ContactTitle] = N'Owner'
+INTERSECT
+SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c1]
+WHERE [c1].[Fax] IS NOT NULL");
+        }
+
+        public override async Task Concat_nested(bool async)
+        {
+            await base.Concat_nested(async);
+
+            AssertSql(
+@"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'México D.F.'
+UNION ALL
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE [c0].[City] = N'Berlin'
+UNION ALL
+SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c1]
+WHERE [c1].[City] = N'London'");
+        }
+
+        public override async Task Union_nested(bool async)
+        {
+            await base.Union_nested(async);
+
+            AssertSql(
+@"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactTitle] = N'Owner'
+UNION
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE [c0].[City] = N'México D.F.'
+UNION
+SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c1]
+WHERE [c1].[City] = N'London'");
+        }
+
+        public override async Task Union_non_entity(bool async)
+        {
+            await base.Union_non_entity(async);
+
+            AssertSql(
+@"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[ContactTitle] = N'Owner'
+UNION
+SELECT [c0].[CustomerID]
+FROM [Customers] AS [c0]
+WHERE [c0].[City] = N'México D.F.'");
+        }
+
+        public override async Task Concat_non_entity(bool async)
+        {
+            await base.Concat_non_entity(async);
+
+            AssertSql(
+@"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'México D.F.'
+UNION ALL
+SELECT [c0].[CustomerID]
+FROM [Customers] AS [c0]
+WHERE [c0].[ContactTitle] = N'Owner'");
+        }
+
+    public override async Task Collection_projection_after_set_operation_fails_if_distinct(bool async)
+    {
+        await base.Collection_projection_after_set_operation_fails_if_distinct(async);
+
+        AssertSql();
+    }
+
+    public override async Task Collection_projection_before_set_operation_fails(bool async)
+    {
+        await base.Collection_projection_before_set_operation_fails(async);
+
+        AssertSql();
+    }
+
+    public override void Include_Union_only_on_one_side_throws()
+    {
+        base.Include_Union_only_on_one_side_throws();
+
+        AssertSql();
+    }
+
+    public override void Include_Union_different_includes_throws()
+    {
+        base.Include_Union_different_includes_throws();
+
+        AssertSql();
+    }
+
+    public override async Task Client_eval_Union_FirstOrDefault(bool async)
+    {
+        // Client evaluation in projection. Issue #16243.
+        Assert.Equal(
+            RelationalStrings.SetOperationsNotAllowedAfterClientEvaluation,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_eval_Union_FirstOrDefault(async))).Message);
+
+        AssertSql();
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit.Sdk;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public class NorthwindSplitIncludeNoTrackingQuerySqlServerTest : NorthwindSplitIncludeNoTrackingQueryTestBase<
@@ -16,11 +18,2527 @@ public class NorthwindSplitIncludeNoTrackingQuerySqlServerTest : NorthwindSplitI
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ConditionalTheory(Skip = "Issue#21202")]
-    public override async Task Include_collection_skip_take_no_order_by(bool async)
-        => await base.Include_collection_skip_take_no_order_by(async);
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
-    [ConditionalTheory(Skip = "Issue#21202")]
+    public override async Task Include_collection_skip_take_no_order_by(bool async)
+    {
+        // Split query Skip without OrderBy. Issue #21202.
+        Assert.Equal(
+            "0",
+            (((EqualException)(await Assert.ThrowsAsync<TargetInvocationException>(
+                () => base.Include_collection_skip_take_no_order_by(async))).InnerException!.InnerException)!).Actual);
+
+        AssertSql(
+            @"@__p_0='10'
+@__p_1='5'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
+            //
+            @"@__p_0='10'
+@__p_1='5'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY (SELECT 1)
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
     public override async Task Include_collection_skip_no_order_by(bool async)
-        => await base.Include_collection_skip_no_order_by(async);
+    {
+        // Split query Skip without OrderBy. Issue #21202.
+        Assert.Equal(
+            "0",
+            (((EqualException)(await Assert.ThrowsAsync<TargetInvocationException>(
+                () => base.Include_collection_skip_no_order_by(async))).InnerException!.InnerException)!).Actual);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+OFFSET @__p_0 ROWS",
+            //
+            @"@__p_0='10'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY (SELECT 1)
+    OFFSET @__p_0 ROWS
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE [o0].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_multi_level_collection_and_then_include_reference_predicate(bool async)
+    {
+        await base.Include_multi_level_collection_and_then_include_reference_predicate(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] = 10248
+ORDER BY [o].[OrderID]",
+            //
+            @"SELECT [t0].[OrderID], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice], [t0].[ProductID0], [t0].[Discontinued], [t0].[ProductName], [t0].[SupplierID], [t0].[UnitPrice0], [t0].[UnitsInStock], [t].[OrderID]
+FROM (
+    SELECT TOP(1) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+) AS [t]
+INNER JOIN (
+    SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice] AS [UnitPrice0], [p].[UnitsInStock]
+    FROM [Order Details] AS [o0]
+    INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+ORDER BY [t].[OrderID]");
+    }
+
+    public override async Task Include_when_result_operator(bool async)
+    {
+        await base.Include_when_result_operator(async);
+
+        AssertSql(
+            @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+    }
+
+    public override async Task Include_collection_OrderBy_list_does_not_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_list_does_not_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'
+ORDER BY CASE
+    WHEN [c].[CustomerID] <> N'ALFKI' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [c].[CustomerID]
+OFFSET @__p_1 ROWS",
+            //
+            @"@__p_1='1'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID], CASE
+        WHEN [c].[CustomerID] <> N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY CASE
+        WHEN [c].[CustomerID] <> N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    OFFSET @__p_1 ROWS
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_order_by_collection_column(bool async)
+    {
+        await base.Include_collection_order_by_collection_column(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'W%'
+ORDER BY (
+    SELECT TOP(1) [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderDate] DESC) DESC, [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W%'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) DESC
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[c] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key(bool async)
+    {
+        await base.Include_collection_order_by_non_key(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[PostalCode], [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[PostalCode], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause2(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause2(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN [Customers] AS [c0]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_skip(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'
+ORDER BY [c].[CustomerID]
+OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY",
+            //
+            @"@__p_0='1'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY [c].[CustomerID]
+    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [o].[OrderID]",
+            //
+            @"@__p_0='1'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [t].[CustomerID], [o].[OrderID]
+FROM (
+    SELECT [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY [c].[CustomerID]
+    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_references_multi_level(bool async)
+    {
+        await base.Include_references_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_multiple_references_then_include_multi_level(bool async)
+    {
+        await base.Include_multiple_references_then_include_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_duplicate_collection_result_operator(bool async)
+    {
+        await base.Include_duplicate_collection_result_operator(async);
+
+        AssertSql(
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT TOP(@__p_1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]",
+            //
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t1].[CustomerID], [t1].[CustomerID0]
+FROM (
+    SELECT TOP(@__p_1) [t].[CustomerID], [t0].[CustomerID] AS [CustomerID0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    CROSS JOIN (
+        SELECT [c0].[CustomerID]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [t0]
+    ORDER BY [t].[CustomerID]
+) AS [t1]
+INNER JOIN [Orders] AS [o] ON [t1].[CustomerID] = [o].[CustomerID]
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0]",
+            //
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t1].[CustomerID], [t1].[CustomerID0]
+FROM (
+    SELECT TOP(@__p_1) [t].[CustomerID], [t0].[CustomerID] AS [CustomerID0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    CROSS JOIN (
+        SELECT [c0].[CustomerID]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [t0]
+    ORDER BY [t].[CustomerID]
+) AS [t1]
+INNER JOIN [Orders] AS [o] ON [t1].[CustomerID0] = [o].[CustomerID]
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0]");
+    }
+
+    public override async Task Include_collection_with_filter_reordered(bool async)
+    {
+        await base.Include_collection_with_filter_reordered(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_duplicate_reference(bool async)
+    {
+        await base.Include_duplicate_reference(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[CustomerID], [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[CustomerID], [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Customers] AS [c0] ON [t0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [t].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_with_complex_projection(bool async)
+    {
+        await base.Include_with_complex_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID] AS [Id]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
+    }
+
+    public override async Task Include_empty_reference_sets_IsLoaded(bool async)
+    {
+        await base.Include_empty_reference_sets_IsLoaded(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e]
+LEFT JOIN [Employees] AS [e0] ON [e].[ReportsTo] = [e0].[EmployeeID]
+WHERE [e0].[EmployeeID] IS NULL");
+    }
+
+    public override async Task Include_multiple_references_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_and_reference(bool async)
+    {
+        await base.Include_collection_and_reference(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_multiple_conditional_order_by(bool async)
+    {
+        await base.Include_collection_with_multiple_conditional_order_by(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+ORDER BY CASE
+    WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, CASE
+    WHEN [c].[CustomerID] IS NOT NULL THEN [c].[City]
+    ELSE N''
+END, [o].[OrderID], [c].[CustomerID]",
+            //
+            @"@__p_0='5'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [t].[OrderID], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [c].[CustomerID], CASE
+        WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[City]
+        ELSE N''
+    END AS [c0]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    ORDER BY CASE
+        WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END, CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[City]
+        ELSE N''
+    END
+) AS [t]
+INNER JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID]");
+    }
+
+    public override async Task Include_where_skip_take_projection(bool async)
+    {
+        await base.Include_where_skip_take_projection(async);
+
+        AssertSql(
+            @"@__p_0='1'
+@__p_1='2'
+
+SELECT [o0].[CustomerID]
+FROM (
+    SELECT [o].[OrderID], [o].[ProductID]
+    FROM [Order Details] AS [o]
+    WHERE [o].[Quantity] = CAST(10 AS smallint)
+    ORDER BY [o].[OrderID], [o].[ProductID]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[OrderID], [t].[ProductID]");
+    }
+
+    public override async Task Include_collection_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+        WHERE [o0].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice], [t].[OrderID], [t0].[OrderID]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID]
+    FROM (
+        SELECT [o0].[OrderID], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+        WHERE [o0].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+INNER JOIN [Order Details] AS [o1] ON [t0].[OrderID] = [o1].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID]");
+    }
+
+    public override async Task Join_Include_collection_GroupBy_Select(bool async)
+    {
+        await base.Join_Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        INNER JOIN [Orders] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID]",
+            //
+            @"SELECT [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o2].[OrderID], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        INNER JOIN [Orders] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+INNER JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID]");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause_with_filter(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [c].[CustomerID]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
+) AS [t]
+ORDER BY [c].[CustomerID], [t].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [t].[CustomerID]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_then_include_collection(bool async)
+    {
+        await base.Include_collection_then_include_collection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [c].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_first_or_default(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_first_or_default(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CompanyName] DESC, [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[CompanyName]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CompanyName] DESC
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Join_Include_reference_GroupBy_Select(bool async)
+    {
+        await base.Join_Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        INNER JOIN [Orders] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        LEFT JOIN [Customers] AS [c] ON [o2].[CustomerID] = [c].[CustomerID]
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task SelectMany_Include_collection_GroupBy_Select(bool async)
+    {
+        await base.SelectMany_Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    CROSS JOIN [Orders] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        CROSS JOIN [Orders] AS [o2]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID]",
+            //
+            @"SELECT [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    CROSS JOIN [Orders] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o2].[OrderID], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        CROSS JOIN [Orders] AS [o2]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+INNER JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID]");
+    }
+
+    public override async Task Include_references_then_include_multi_level(bool async)
+    {
+        await base.Include_references_then_include_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_SelectMany_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_SelectMany_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    CROSS JOIN [Order Details] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID] AS [OrderID0], [o2].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        CROSS JOIN [Order Details] AS [o2]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]",
+            //
+            @"SELECT [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice], [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    CROSS JOIN [Order Details] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o1].[OrderID], [o2].[OrderID] AS [OrderID0], [o2].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        CROSS JOIN [Order Details] AS [o2]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+INNER JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]");
+    }
+
+    public override async Task Include_multiple_references_multi_level(bool async)
+    {
+        await base.Include_multiple_references_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_order_by_subquery(bool async)
+    {
+        await base.Include_collection_order_by_subquery(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY (
+    SELECT TOP(1) [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[EmployeeID]), [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[EmployeeID]) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[EmployeeID])
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_last(bool async)
+    {
+        await base.Include_collection_with_last(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CompanyName] DESC, [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[CompanyName]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CompanyName] DESC
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_cross_apply_with_filter(bool async)
+    {
+        await base.Include_collection_with_cross_apply_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [t].[OrderID]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_cross_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_cross_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [t].[OrderID]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_in_let_followed_by_FirstOrDefault(bool async)
+    {
+        await base.Include_in_let_followed_by_FirstOrDefault(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderDate]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t0].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [c].[CustomerID], [t0].[OrderID]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderDate]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [t0].[OrderID] = [o0].[OrderID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t0].[OrderID]");
+    }
+
+    public override async Task Include_reference_alias_generation(bool async)
+    {
+        await base.Include_reference_alias_generation(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_dependent_already_tracked(bool async)
+    {
+        await base.Include_collection_dependent_already_tracked(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_OrderBy_list_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_list_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'
+ORDER BY CASE
+    WHEN [c].[CustomerID] = N'ALFKI' THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [c].[CustomerID]
+OFFSET @__p_1 ROWS",
+            //
+            @"@__p_1='1'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID], CASE
+        WHEN [c].[CustomerID] = N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY CASE
+        WHEN [c].[CustomerID] = N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    OFFSET @__p_1 ROWS
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_principal_already_tracked(bool async)
+    {
+        await base.Include_collection_principal_already_tracked(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_alias_generation(bool async)
+    {
+        await base.Include_collection_alias_generation(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID]
+FROM [Orders] AS [o]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID]");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_take(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_take(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT TOP(1) [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY [c].[CustomerID]
+) AS [t]
+ORDER BY [t].[CustomerID]",
+            //
+            @"@__p_0='1'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t0].[CustomerID]
+FROM (
+    SELECT TOP(1) [t].[CustomerID]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'A%'
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    ORDER BY [t].[CustomerID]
+) AS [t0]
+INNER JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
+ORDER BY [t0].[CustomerID], [o].[OrderID]",
+            //
+            @"@__p_0='1'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [t0].[CustomerID], [o].[OrderID]
+FROM (
+    SELECT TOP(1) [t].[CustomerID]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'A%'
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    ORDER BY [t].[CustomerID]
+) AS [t0]
+INNER JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [t0].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_duplicate_reference2(bool async)
+    {
+        await base.Include_duplicate_reference2(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
+ORDER BY [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_then_reference(bool async)
+    {
+        await base.Include_collection_then_reference(async);
+
+        AssertSql(
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ([p].[ProductID] % 17) = 5
+ORDER BY [p].[ProductID]",
+            //
+            @"SELECT [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[OrderID0], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [p].[ProductID]
+FROM [Products] AS [p]
+INNER JOIN (
+    SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID] AS [OrderID0], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [p].[ProductID] = [t].[ProductID]
+WHERE ([p].[ProductID] % 17) = 5
+ORDER BY [p].[ProductID]");
+    }
+
+    public override async Task Include_duplicate_reference3(bool async)
+    {
+        await base.Include_duplicate_reference3(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t0].[CustomerID] = [c].[CustomerID]
+ORDER BY [t].[OrderID]");
+    }
+
+    public override async Task Outer_idenfier_correctly_determined_when_doing_include_on_right_side_of_left_join(bool async)
+    {
+        await base.Outer_idenfier_correctly_determined_when_doing_include_on_right_side_of_left_join(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[City] = N'Seattle'
+ORDER BY [c].[CustomerID], [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [c].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [c].[City] = N'Seattle'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Then_include_collection_order_by_collection_column(bool async)
+    {
+        await base.Then_include_collection_order_by_collection_column(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'W%'
+ORDER BY (
+    SELECT TOP(1) [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderDate] DESC) DESC, [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W%'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) DESC
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[c] DESC, [t].[CustomerID], [o0].[OrderID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice], [t].[CustomerID], [o0].[OrderID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W%'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) DESC
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+INNER JOIN [Order Details] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
+ORDER BY [t].[c] DESC, [t].[CustomerID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_key(bool async)
+    {
+        await base.Include_collection_order_by_key(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Filtered_include_with_multiple_ordering(bool async)
+    {
+        await base.Filtered_include_with_multiple_ordering(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID]
+    OFFSET 1 ROWS
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderDate] DESC");
+    }
+
+    public override async Task Include_collection_on_join_clause_with_order_by_and_filter(bool async)
+    {
+        await base.Include_collection_on_join_clause_with_order_by_and_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_duplicate_collection(bool async)
+    {
+        await base.Include_duplicate_collection(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]",
+            //
+            @"@__p_0='2'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t0].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]",
+            //
+            @"@__p_0='2'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t0].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+INNER JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]");
+    }
+
+    public override async Task Include_collection_OrderBy_empty_list_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_empty_list_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'
+ORDER BY (SELECT 1), [c].[CustomerID]
+OFFSET @__p_1 ROWS",
+            //
+            @"@__p_1='1'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID], CAST(0 AS bit) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY (SELECT 1)
+    OFFSET @__p_1 ROWS
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference_single_or_default_when_no_result(bool async)
+    {
+        await base.Include_reference_single_or_default_when_no_result(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] = -1");
+    }
+
+    public override async Task Include_list(bool async)
+    {
+        await base.Include_list(async);
+
+        AssertSql(
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ([p].[ProductID] % 17) = 5 AND [p].[UnitPrice] < 20.0
+ORDER BY [p].[ProductID]",
+            //
+            @"SELECT [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[OrderID0], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [p].[ProductID]
+FROM [Products] AS [p]
+INNER JOIN (
+    SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID] AS [OrderID0], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [p].[ProductID] = [t].[ProductID]
+WHERE ([p].[ProductID] % 17) = 5 AND [p].[UnitPrice] < 20.0
+ORDER BY [p].[ProductID]");
+    }
+
+    public override async Task Include_closes_reader(bool async)
+    {
+        await base.Include_closes_reader(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID]
+    FROM [Customers] AS [c]
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]",
+            //
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]");
+    }
+
+    public override async Task Include_collection_with_outer_apply_with_filter(bool async)
+    {
+        await base.Include_collection_with_outer_apply_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [t].[OrderID]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_when_projection(bool async)
+    {
+        await base.Include_collection_when_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Include_with_complex_projection_does_not_change_ordering_of_projection(bool async)
+    {
+        await base.Include_with_complex_projection_does_not_change_ordering_of_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID] AS [Id], (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE [c].[CustomerID] = [o0].[CustomerID]) AS [TotalOrders]
+FROM [Customers] AS [c]
+WHERE [c].[ContactTitle] = N'Owner' AND (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]) > 2
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_OrderBy_empty_list_does_not_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_empty_list_does_not_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'
+ORDER BY (SELECT 1), [c].[CustomerID]
+OFFSET @__p_1 ROWS",
+            //
+            @"@__p_1='1'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID], CAST(1 AS bit) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY (SELECT 1)
+    OFFSET @__p_1 ROWS
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection(bool async)
+    {
+        await base.Include_collection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_reference_with_filter(bool async)
+    {
+        await base.Include_reference_with_filter(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_skip_take(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_skip_take(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT TOP(1) [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY [c].[CustomerID]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+) AS [t]
+ORDER BY [t].[CustomerID]",
+            //
+            @"@__p_0='1'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t0].[CustomerID]
+FROM (
+    SELECT TOP(1) [t].[CustomerID]
+    FROM (
+        SELECT [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'A%'
+        ORDER BY [c].[CustomerID]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    ) AS [t]
+    ORDER BY [t].[CustomerID]
+) AS [t0]
+INNER JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
+ORDER BY [t0].[CustomerID], [o].[OrderID]",
+            //
+            @"@__p_0='1'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [t0].[CustomerID], [o].[OrderID]
+FROM (
+    SELECT TOP(1) [t].[CustomerID]
+    FROM (
+        SELECT [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'A%'
+        ORDER BY [c].[CustomerID]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    ) AS [t]
+    ORDER BY [t].[CustomerID]
+) AS [t0]
+INNER JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [t0].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Repro9735(bool async)
+    {
+        await base.Repro9735(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+ORDER BY CASE
+    WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, CASE
+    WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+    ELSE N''
+END, [o].[OrderID], [c].[CustomerID]",
+            //
+            @"@__p_0='2'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [t].[OrderID], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [c].[CustomerID], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+        ELSE N''
+    END AS [c0]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    ORDER BY CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END, CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+        ELSE N''
+    END
+) AS [t]
+INNER JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference(bool async)
+    {
+        await base.Include_reference(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+    }
+
+    public override async Task Include_reference_with_filter_reordered(bool async)
+    {
+        await base.Include_reference_with_filter_reordered(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Include_reference_when_projection(bool async)
+    {
+        await base.Include_reference_when_projection(async);
+
+        AssertSql(
+            @"SELECT [o].[CustomerID]
+FROM [Orders] AS [o]");
+    }
+
+    public override async Task Include_multiple_references(bool async)
+    {
+        await base.Include_multiple_references(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_is_not_ignored_when_projection_contains_client_method_and_complex_expression(bool async)
+    {
+        await base.Include_is_not_ignored_when_projection_contains_client_method_and_complex_expression(async);
+
+        AssertSql(
+            @"SELECT CASE
+    WHEN [e0].[EmployeeID] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e]
+LEFT JOIN [Employees] AS [e0] ON [e].[ReportsTo] = [e0].[EmployeeID]
+WHERE [e].[EmployeeID] IN (1, 2)
+ORDER BY [e].[EmployeeID]");
+    }
+
+    public override async Task Include_reference_dependent_already_tracked(bool async)
+    {
+        await base.Include_reference_dependent_already_tracked(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Include_reference_when_entity_in_projection(bool async)
+    {
+        await base.Include_reference_when_entity_in_projection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+    }
+
+    public override async Task Include_collection_force_alias_uniquefication(bool async)
+    {
+        await base.Include_collection_force_alias_uniquefication(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID]
+FROM [Orders] AS [o]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+    }
+
+    public override async Task Include_reference_Join_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_Join_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        INNER JOIN [Order Details] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        LEFT JOIN [Customers] AS [c] ON [o1].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_filter(bool async)
+    {
+        await base.Include_collection_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_with_skip(bool async)
+    {
+        await base.Include_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='80'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[ContactName], [c].[CustomerID]
+OFFSET @__p_0 ROWS",
+            //
+            @"@__p_0='80'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID], [c].[ContactName]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactName]
+    OFFSET @__p_0 ROWS
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactName], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_take_no_order_by(bool async)
+    {
+        await base.Include_collection_take_no_order_by(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+            //
+            @"@__p_0='10'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_then_include_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_with_left_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_left_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_reference_distinct_is_server_evaluated(bool async)
+    {
+        await base.Include_reference_distinct_is_server_evaluated(async);
+
+        AssertSql(
+            @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] < 10250
+) AS [t]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'F%'
+) AS [t0]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]",
+            //
+            @"@__p_0='5'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t0].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'F%'
+) AS [t0]
+INNER JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_duplicate_collection_result_operator2(bool async)
+    {
+        await base.Include_duplicate_collection_result_operator2(async);
+
+        AssertSql(
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT TOP(@__p_1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]",
+            //
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t1].[CustomerID], [t1].[CustomerID0]
+FROM (
+    SELECT TOP(@__p_1) [t].[CustomerID], [t0].[CustomerID] AS [CustomerID0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    CROSS JOIN (
+        SELECT [c0].[CustomerID]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [t0]
+    ORDER BY [t].[CustomerID]
+) AS [t1]
+INNER JOIN [Orders] AS [o] ON [t1].[CustomerID] = [o].[CustomerID]
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0]");
+    }
+
+    public override async Task Include_collection_then_include_collection_then_include_reference(bool async)
+    {
+        await base.Include_collection_then_include_collection_then_include_reference(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]",
+            //
+            @"SELECT [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[ProductID0], [t].[Discontinued], [t].[ProductName], [t].[SupplierID], [t].[UnitPrice0], [t].[UnitsInStock], [c].[CustomerID], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+INNER JOIN (
+    SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice] AS [UnitPrice0], [p].[UnitsInStock]
+    FROM [Order Details] AS [o0]
+    INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+) AS [t] ON [o].[OrderID] = [t].[OrderID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task SelectMany_Include_reference_GroupBy_Select(bool async)
+    {
+        await base.SelectMany_Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    CROSS JOIN [Orders] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        CROSS JOIN [Orders] AS [o2]
+        LEFT JOIN [Customers] AS [c] ON [o2].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_reference_SelectMany_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_SelectMany_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    CROSS JOIN [Order Details] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        CROSS JOIN [Order Details] AS [o2]
+        LEFT JOIN [Customers] AS [c] ON [o1].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_take(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_take(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[ContactTitle], [c].[CustomerID]",
+            //
+            @"@__p_0='10'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[ContactTitle]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactTitle]
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactTitle], [t].[CustomerID]");
+    }
+
+    public override async Task Include_with_take(bool async)
+    {
+        await base.Include_with_take(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[ContactName] DESC, [c].[CustomerID]",
+            //
+            @"@__p_0='10'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[ContactName]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactName] DESC
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+    {
+        await base.Include_collection_with_outer_apply_with_filter_non_equality(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] <> [c].[CustomerID] OR [o].[CustomerID] IS NULL
+    ORDER BY [c].[CustomerID]
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [t].[OrderID]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] <> [c].[CustomerID] OR [o].[CustomerID] IS NULL
+    ORDER BY [c].[CustomerID]
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_distinct_is_server_evaluated(bool async)
+    {
+        await base.Include_collection_distinct_is_server_evaluated(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+) AS [t]
+ORDER BY [t].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_OrderBy_object(bool async)
+    {
+        await base.Include_collection_OrderBy_object(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10250
+ORDER BY [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID]
+FROM [Orders] AS [o]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[OrderID] < 10250
+ORDER BY [o].[OrderID]");
+    }
+
+    public override async Task Include_collection_then_include_collection_predicate(bool async)
+    {
+        await base.Include_collection_then_include_collection_predicate(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [t].[CustomerID], [o].[OrderID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_skip(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[ContactTitle], [c].[CustomerID]
+OFFSET @__p_0 ROWS",
+            //
+            @"@__p_0='2'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID], [c].[ContactTitle]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'F%'
+    ORDER BY [c].[ContactTitle]
+    OFFSET @__p_0 ROWS
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactTitle], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_conditional_order_by(bool async)
+    {
+        await base.Include_collection_with_conditional_order_by(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY CASE
+    WHEN [c].[CustomerID] LIKE N'S%' THEN 1
+    ELSE 2
+END, [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY CASE
+    WHEN [c].[CustomerID] LIKE N'S%' THEN 1
+    ELSE 2
+END, [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_orderby_take(bool async)
+    {
+        await base.Include_collection_orderby_take(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+            //
+            @"@__p_0='5'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_single_or_default_no_result(bool async)
+    {
+        await base.Include_collection_single_or_default_no_result(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI ?'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_Join_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_Join_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID] AS [OrderID0], [o2].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        INNER JOIN [Order Details] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]",
+            //
+            @"SELECT [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice], [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o1].[OrderID], [o2].[OrderID] AS [OrderID0], [o2].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        INNER JOIN [Order Details] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+INNER JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]");
+    }
+
+    public override async Task Include_reference_and_collection(bool async)
+    {
+        await base.Include_reference_and_collection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_last_no_orderby(bool async)
+    {
+        await base.Include_collection_with_last_no_orderby(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multi_level_reference_and_collection_predicate(bool async)
+    {
+        await base.Include_multi_level_reference_and_collection_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multi_level_reference_then_include_collection_predicate(bool async)
+    {
+        await base.Include_multi_level_reference_then_include_collection_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multiple_references_and_collection_multi_level(bool async)
+    {
+        await base.Include_multiple_references_and_collection_multi_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multiple_references_and_collection_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_and_collection_multi_level_reverse(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multiple_references_then_include_collection_multi_level(bool async)
+    {
+        await base.Include_multiple_references_then_include_collection_multi_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_multiple_references_then_include_collection_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_then_include_collection_multi_level_reverse(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_reference_and_collection_order_by(bool async)
+    {
+        await base.Include_reference_and_collection_order_by(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_and_collection_multi_level(bool async)
+    {
+        await base.Include_references_and_collection_multi_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_and_collection_multi_level_predicate(bool async)
+    {
+        await base.Include_references_and_collection_multi_level_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_then_include_collection(bool async)
+    {
+        await base.Include_references_then_include_collection(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_then_include_collection_multi_level(bool async)
+    {
+        await base.Include_references_then_include_collection_multi_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_references_then_include_collection_multi_level_predicate(bool async)
+    {
+        await base.Include_references_then_include_collection_multi_level_predicate(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property_after_navigation(bool async)
+    {
+        await base.Include_property_after_navigation(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property(bool async)
+    {
+        await base.Include_property(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property_expression_invalid(bool async)
+    {
+        await base.Include_property_expression_invalid(async);
+
+        AssertSql();
+    }
+
+    public override async Task Then_include_property_expression_invalid(bool async)
+    {
+        await base.Then_include_property_expression_invalid(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_collection_with_client_filter(bool async)
+    {
+        await base.Include_collection_with_client_filter(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_specified_on_non_entity_not_supported(bool async)
+    {
+        await base.Include_specified_on_non_entity_not_supported(async);
+
+        AssertSql();
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -17,6 +18,10 @@ public class NorthwindSplitIncludeQuerySqlServerTest : NorthwindSplitIncludeQuer
         Fixture.TestSqlLoggerFactory.Clear();
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     public override async Task Include_list(bool async)
     {
@@ -99,23 +104,33 @@ INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
 ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
     }
 
-    [ConditionalTheory(Skip = "Issue#21202")]
     public override async Task Include_collection_skip_no_order_by(bool async)
     {
-        await base.Include_collection_skip_no_order_by(async);
+        // Split query Skip without OrderBy. Issue #21202.
+        Assert.Equal(
+            "0",
+            (((EqualException)(await Assert.ThrowsAsync<TargetInvocationException>(
+                () => base.Include_collection_skip_no_order_by(async))).InnerException!.InnerException)!).Actual);
 
         AssertSql(
             @"@__p_0='10'
 
-SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+OFFSET @__p_0 ROWS",
+            //
+            @"@__p_0='10'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS
 ) AS [t]
-LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
     }
 
     public override async Task Include_collection_take_no_order_by(bool async)
@@ -140,24 +155,35 @@ INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
 ORDER BY [t].[CustomerID]");
     }
 
-    [ConditionalTheory(Skip = "Issue#21202")]
     public override async Task Include_collection_skip_take_no_order_by(bool async)
     {
-        await base.Include_collection_skip_take_no_order_by(async);
+        // Split query Skip without OrderBy. Issue #21202.
+        Assert.Equal(
+            "0",
+            (((EqualException)(await Assert.ThrowsAsync<TargetInvocationException>(
+                () => base.Include_collection_skip_take_no_order_by(async))).InnerException!.InnerException)!).Actual);
 
         AssertSql(
             @"@__p_0='10'
 @__p_1='5'
 
-SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
+            //
+            @"@__p_0='10'
+@__p_1='5'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
-LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
     }
 
     public override async Task Include_reference_and_collection(bool async)
@@ -1827,15 +1853,15 @@ OFFSET @__p_1 ROWS",
             //
             @"@__p_1='1'
 
-SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
-FROM [Orders] AS [c.Orders]
-INNER JOIN (
-    SELECT [c0].[CustomerID], CAST(0 AS bit) AS [c]
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A%'
-    ORDER BY [c], [c0].[CustomerID]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID], CAST(0 AS bit) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY (SELECT 1)
     OFFSET @__p_1 ROWS
-) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
 ORDER BY [t].[c], [t].[CustomerID]");
     }
 
@@ -1854,15 +1880,15 @@ OFFSET @__p_1 ROWS",
             //
             @"@__p_1='1'
 
-SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
-FROM [Orders] AS [c.Orders]
-INNER JOIN (
-    SELECT [c0].[CustomerID], CAST(1 AS bit) AS [c]
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'A%'
-    ORDER BY [c], [c0].[CustomerID]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT [c].[CustomerID], CAST(1 AS bit) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY (SELECT 1)
     OFFSET @__p_1 ROWS
-) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
 ORDER BY [t].[c], [t].[CustomerID]");
     }
 
@@ -2170,6 +2196,564 @@ LEFT JOIN (
 INNER JOIN [Order Details] AS [o0] ON [t0].[OrderID] = [o0].[OrderID]
 WHERE [c].[CustomerID] LIKE N'F%'
 ORDER BY [c].[CustomerID], [t0].[OrderID]");
+    }
+
+    public override async Task Include_multiple_references_and_collection_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_and_collection_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [p].[ProductID], [o0].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o].[OrderID], [o].[ProductID], [p].[ProductID], [o0].[OrderID], [c].[CustomerID]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [p].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_force_alias_uniquefication(bool async)
+    {
+        await base.Include_collection_force_alias_uniquefication(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID]
+FROM [Orders] AS [o]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+    }
+
+    public override async Task Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] < 10800
+ORDER BY [o].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o].[OrderID], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o].[OrderID] < 10800
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_reference_when_entity_in_projection(bool async)
+    {
+        await base.Include_reference_when_entity_in_projection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+    }
+
+    public override async Task Include_closes_reader(bool async)
+    {
+        await base.Include_closes_reader(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID]
+    FROM [Customers] AS [c]
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]",
+            //
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]");
+    }
+
+    public override async Task Include_collection_then_reference(bool async)
+    {
+        await base.Include_collection_then_reference(async);
+
+        AssertSql(
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ([p].[ProductID] % 17) = 5
+ORDER BY [p].[ProductID]",
+            //
+            @"SELECT [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[OrderID0], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [p].[ProductID]
+FROM [Products] AS [p]
+INNER JOIN (
+    SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID] AS [OrderID0], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [p].[ProductID] = [t].[ProductID]
+WHERE ([p].[ProductID] % 17) = 5
+ORDER BY [p].[ProductID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_collection_multi_level(bool async)
+    {
+        await base.Include_multiple_references_then_include_collection_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[ProductID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[ProductID]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[ProductID]");
+    }
+
+    public override async Task Include_collection_orderby_take(bool async)
+    {
+        await base.Include_collection_orderby_take(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+            //
+            @"@__p_0='5'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_references_and_collection_multi_level_predicate(bool async)
+    {
+        await base.Include_references_and_collection_multi_level_predicate(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] = 10248
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE [o].[OrderID] = 10248
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_references_then_include_collection_multi_level_predicate(bool async)
+    {
+        await base.Include_references_then_include_collection_multi_level_predicate(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] = 10248
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE [o].[OrderID] = 10248
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_multi_level(bool async)
+    {
+        await base.Include_multiple_references_then_include_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_empty_reference_sets_IsLoaded(bool async)
+    {
+        await base.Include_empty_reference_sets_IsLoaded(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e]
+LEFT JOIN [Employees] AS [e0] ON [e].[ReportsTo] = [e0].[EmployeeID]
+WHERE [e0].[EmployeeID] IS NULL");
+    }
+
+    public override async Task Include_reference_and_collection_order_by(bool async)
+    {
+        await base.Include_reference_and_collection_order_by(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o].[OrderID], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_collection_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_then_include_collection_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [p].[ProductID], [o0].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o].[OrderID], [o].[ProductID], [p].[ProductID], [o0].[OrderID], [c].[CustomerID]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [p].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_references_then_include_collection_multi_level(bool async)
+    {
+        await base.Include_references_then_include_collection_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[ProductID] % 23) = 17 AND [o].[Quantity] < CAST(10 AS smallint)
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[ProductID] % 23) = 17 AND [o].[Quantity] < CAST(10 AS smallint)
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_and_reference(bool async)
+    {
+        await base.Include_collection_and_reference(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_then_include_collection_predicate(bool async)
+    {
+        await base.Include_collection_then_include_collection_predicate(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [o].[OrderID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [t].[CustomerID], [o].[OrderID]
+FROM (
+    SELECT TOP(1) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+INNER JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_references_then_include_multi_level(bool async)
+    {
+        await base.Include_references_then_include_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] < 10800
+ORDER BY [o].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o].[OrderID], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o].[OrderID] < 10800
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_references_then_include_collection(bool async)
+    {
+        await base.Include_references_then_include_collection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o].[OrderID], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_single_or_default_no_result(bool async)
+    {
+        await base.Include_collection_single_or_default_no_result(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI ?'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_then_include_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_multiple_references_and_collection_multi_level(bool async)
+    {
+        await base.Include_multiple_references_and_collection_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[ProductID]",
+            //
+            @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[ProductID]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[ProductID]");
+    }
+
+    public override async Task Repro9735(bool async)
+    {
+        await base.Repro9735(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+ORDER BY CASE
+    WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, CASE
+    WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+    ELSE N''
+END, [o].[OrderID], [c].[CustomerID]",
+            //
+            @"@__p_0='2'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [t].[OrderID], [t].[CustomerID]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [c].[CustomerID], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+        ELSE N''
+    END AS [c0]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    ORDER BY CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END, CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+        ELSE N''
+    END
+) AS [t]
+INNER JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference_single_or_default_when_no_result(bool async)
+    {
+        await base.Include_reference_single_or_default_when_no_result(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] = -1");
+    }
+
+    public override async Task Include_multi_level_reference_then_include_collection_predicate(bool async)
+    {
+        await base.Include_multi_level_reference_then_include_collection_predicate(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] = 10248
+ORDER BY [o].[OrderID], [c].[CustomerID]",
+            //
+            @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [t].[OrderID], [t].[CustomerID]
+FROM (
+    SELECT TOP(1) [o].[OrderID], [c].[CustomerID]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    WHERE [o].[OrderID] = 10248
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[OrderID], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_last_no_orderby(bool async)
+    {
+        await base.Include_collection_with_last_no_orderby(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property_after_navigation(bool async)
+    {
+        await base.Include_property_after_navigation(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property(bool async)
+    {
+        await base.Include_property(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property_expression_invalid(bool async)
+    {
+        await base.Include_property_expression_invalid(async);
+
+        AssertSql();
+    }
+
+    public override async Task Then_include_property_expression_invalid(bool async)
+    {
+        await base.Then_include_property_expression_invalid(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_collection_with_client_filter(bool async)
+    {
+        await base.Include_collection_with_client_filter(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_specified_on_non_entity_not_supported(bool async)
+    {
+        await base.Include_specified_on_non_entity_not_supported(async);
+
+        AssertSql();
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
@@ -13,9 +13,1971 @@ public class NorthwindStringIncludeQuerySqlServerTest : NorthwindStringIncludeQu
         Fixture.TestSqlLoggerFactory.Clear();
     }
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override async Task Include_collection_with_last_no_orderby(bool async)
-        => Assert.Equal(
+    {
+        Assert.Equal(
             RelationalStrings.LastUsedWithoutOrderBy(nameof(Enumerable.Last)),
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Include_collection_with_last_no_orderby(async))).Message);
+
+        AssertSql();
+    }
+
+    public override async Task Include_collection_with_filter_reordered(bool async)
+    {
+        await base.Include_collection_with_filter_reordered(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_first_or_default(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_first_or_default(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CompanyName] DESC
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o].[OrderID] < 10800
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_filter(bool async)
+    {
+        await base.Include_collection_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_references_then_include_multi_level(bool async)
+    {
+        await base.Include_references_then_include_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_order_by_collection_column(bool async)
+    {
+        await base.Include_collection_order_by_collection_column(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W%'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) DESC
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[c] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_alias_generation(bool async)
+    {
+        await base.Include_collection_alias_generation(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_skip_take_no_order_by(bool async)
+    {
+        await base.Include_collection_skip_take_no_order_by(async);
+
+        AssertSql(
+            @"@__p_0='10'
+@__p_1='5'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY (SELECT 1)
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_cross_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_cross_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Join_Include_reference_GroupBy_Select(bool async)
+    {
+        await base.Join_Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        INNER JOIN [Orders] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        LEFT JOIN [Customers] AS [c] ON [o2].[CustomerID] = [c].[CustomerID]
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_multi_level_reference_and_collection_predicate(bool async)
+    {
+        await base.Include_multi_level_reference_and_collection_predicate(async);
+
+        AssertSql(
+            @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[CustomerID0], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    WHERE [o].[OrderID] = 10248
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID0] = [o0].[CustomerID]
+ORDER BY [t].[OrderID], [t].[CustomerID0]");
+    }
+
+    public override async Task Include_references_then_include_collection(bool async)
+    {
+        await base.Include_references_then_include_collection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause_with_filter(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID], [t].[CustomerID]");
+    }
+
+    public override async Task Include_duplicate_reference3(bool async)
+    {
+        await base.Include_duplicate_reference3(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t0].[CustomerID] = [c].[CustomerID]
+ORDER BY [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_take(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_take(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactTitle]
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactTitle], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_then_include_collection_predicate(bool async)
+    {
+        await base.Include_collection_then_include_collection_predicate(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[OrderID0], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice]
+FROM (
+    SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
+    }
+
+    public override async Task Include_collection_take_no_order_by(bool async)
+    {
+        await base.Include_collection_take_no_order_by(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_principal_already_tracked(bool async)
+    {
+        await base.Include_collection_principal_already_tracked(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_OrderBy_object(bool async)
+    {
+        await base.Include_collection_OrderBy_object(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[OrderID] < 10250
+ORDER BY [o].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_duplicate_collection_result_operator2(bool async)
+    {
+        await base.Include_duplicate_collection_result_operator2(async);
+
+        AssertSql(
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region], [t1].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t1].[Address0], [t1].[City0], [t1].[CompanyName0], [t1].[ContactName0], [t1].[ContactTitle0], [t1].[Country0], [t1].[Fax0], [t1].[Phone0], [t1].[PostalCode0], [t1].[Region0]
+FROM (
+    SELECT TOP(@__p_1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID] AS [CustomerID0], [t0].[Address] AS [Address0], [t0].[City] AS [City0], [t0].[CompanyName] AS [CompanyName0], [t0].[ContactName] AS [ContactName0], [t0].[ContactTitle] AS [ContactTitle0], [t0].[Country] AS [Country0], [t0].[Fax] AS [Fax0], [t0].[Phone] AS [Phone0], [t0].[PostalCode] AS [PostalCode0], [t0].[Region] AS [Region0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    CROSS JOIN (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [t0]
+    ORDER BY [t].[CustomerID]
+) AS [t1]
+LEFT JOIN [Orders] AS [o] ON [t1].[CustomerID] = [o].[CustomerID]
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0]");
+    }
+
+    public override async Task Repro9735(bool async)
+    {
+        await base.Repro9735(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+        ELSE N''
+    END AS [c0]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    ORDER BY CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END, CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[CustomerID]
+        ELSE N''
+    END
+) AS [t]
+LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_single_or_default_no_result(bool async)
+    {
+        await base.Include_collection_single_or_default_no_result(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI ?'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_cross_apply_with_filter(bool async)
+    {
+        await base.Include_collection_with_cross_apply_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_left_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_left_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_duplicate_collection(bool async)
+    {
+        await base.Include_duplicate_collection(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [t0].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_collection(bool async)
+    {
+        await base.Include_collection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_then_include_collection_then_include_reference(bool async)
+    {
+        await base.Include_collection_then_include_collection_then_include_reference(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[OrderID0], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice], [t0].[ProductID0], [t0].[Discontinued], [t0].[ProductName], [t0].[SupplierID], [t0].[UnitPrice0], [t0].[UnitsInStock]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[OrderID] AS [OrderID0], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[ProductID0], [t].[Discontinued], [t].[ProductName], [t].[SupplierID], [t].[UnitPrice0], [t].[UnitsInStock]
+    FROM [Orders] AS [o]
+    LEFT JOIN (
+        SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice] AS [UnitPrice0], [p].[UnitsInStock]
+        FROM [Order Details] AS [o0]
+        INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+    ) AS [t] ON [o].[OrderID] = [t].[OrderID]
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]");
+    }
+
+    public override async Task Include_reference_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE [o0].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_multiple_references_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_with_join_clause_with_filter(bool async)
+    {
+        await base.Include_collection_with_join_clause_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Include_collection_OrderBy_list_does_not_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_list_does_not_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
+        WHEN [c].[CustomerID] <> N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY CASE
+        WHEN [c].[CustomerID] <> N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    OFFSET @__p_1 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference_dependent_already_tracked(bool async)
+    {
+        await base.Include_reference_dependent_already_tracked(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Include_reference_with_filter(bool async)
+    {
+        await base.Include_reference_with_filter(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Include_duplicate_reference(bool async)
+    {
+        await base.Include_duplicate_reference(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[CustomerID], [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[CustomerID], [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Customers] AS [c0] ON [t0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [t].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_with_complex_projection(bool async)
+    {
+        await base.Include_with_complex_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID] AS [Id]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key_with_skip(bool async)
+    {
+        await base.Include_collection_order_by_non_key_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'F%'
+    ORDER BY [c].[ContactTitle]
+    OFFSET @__p_0 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactTitle], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_on_join_clause_with_order_by_and_filter(bool async)
+    {
+        await base.Include_collection_on_join_clause_with_order_by_and_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_take(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_take(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT [t0].[CustomerID], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID], [t1].[Discount], [t1].[Quantity], [t1].[UnitPrice]
+FROM (
+    SELECT TOP(1) [t].[CustomerID]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'A%'
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    ORDER BY [t].[CustomerID]
+) AS [t0]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t1] ON [t0].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0]");
+    }
+
+    public override async Task Include_multiple_references_then_include_collection_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_then_include_collection_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [p].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_then_reference(bool async)
+    {
+        await base.Include_collection_then_reference(async);
+
+        AssertSql(
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[OrderID0], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Products] AS [p]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID] AS [OrderID0], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [p].[ProductID] = [t].[ProductID]
+WHERE ([p].[ProductID] % 17) = 5
+ORDER BY [p].[ProductID], [t].[OrderID], [t].[ProductID]");
+    }
+
+    public override async Task Include_collection_order_by_key(bool async)
+    {
+        await base.Include_collection_order_by_key(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_outer_apply_with_filter(bool async)
+    {
+        await base.Include_collection_with_outer_apply_with_filter(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause2(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause2(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN [Customers] AS [c0]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_dependent_already_tracked(bool async)
+    {
+        await base.Include_collection_dependent_already_tracked(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'",
+            //
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_with_complex_projection_does_not_change_ordering_of_projection(bool async)
+    {
+        await base.Include_with_complex_projection_does_not_change_ordering_of_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID] AS [Id], (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE [c].[CustomerID] = [o0].[CustomerID]) AS [TotalOrders]
+FROM [Customers] AS [c]
+WHERE [c].[ContactTitle] = N'Owner' AND (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]) > 2
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Include_multi_level_collection_and_then_include_reference_predicate(bool async)
+    {
+        await base.Include_multi_level_collection_and_then_include_reference_predicate(async);
+
+        AssertSql(
+            @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t0].[OrderID], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice], [t0].[ProductID0], [t0].[Discontinued], [t0].[ProductName], [t0].[SupplierID], [t0].[UnitPrice0], [t0].[UnitsInStock]
+FROM (
+    SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+) AS [t]
+LEFT JOIN (
+    SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice] AS [UnitPrice0], [p].[UnitsInStock]
+    FROM [Order Details] AS [o0]
+    INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[ProductID]");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_skip_take(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_skip_take(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT [t0].[CustomerID], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID], [t1].[Discount], [t1].[Quantity], [t1].[UnitPrice]
+FROM (
+    SELECT TOP(1) [t].[CustomerID]
+    FROM (
+        SELECT [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'A%'
+        ORDER BY [c].[CustomerID]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+    ) AS [t]
+    ORDER BY [t].[CustomerID]
+) AS [t0]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t1] ON [t0].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0]");
+    }
+
+    public override async Task Include_collection_OrderBy_empty_list_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_empty_list_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CAST(0 AS bit) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY (SELECT 1)
+    OFFSET @__p_1 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_references_and_collection_multi_level(bool async)
+    {
+        await base.Include_references_and_collection_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13 AND [o].[UnitPrice] < 10.0
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_force_alias_uniquefication(bool async)
+    {
+        await base.Include_collection_force_alias_uniquefication(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+    {
+        await base.Include_collection_with_outer_apply_with_filter_non_equality(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] <> [c].[CustomerID] OR [o].[CustomerID] IS NULL
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+    }
+
+    public override async Task Include_in_let_followed_by_FirstOrDefault(bool async)
+    {
+        await base.Include_in_let_followed_by_FirstOrDefault(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o].[CustomerID] ORDER BY [o].[OrderDate]) AS [row]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [t0].[OrderID] = [o0].[OrderID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t0].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_references_multi_level(bool async)
+    {
+        await base.Include_references_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_then_include_collection(bool async)
+    {
+        await base.Include_collection_then_include_collection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[OrderID0], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID], [t].[OrderID0]");
+    }
+
+    public override async Task Include_collection_with_multiple_conditional_order_by(bool async)
+    {
+        await base.Include_collection_with_multiple_conditional_order_by(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[CustomerID0], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], CASE
+        WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c], CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[City]
+        ELSE N''
+    END AS [c0]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    ORDER BY CASE
+        WHEN [o].[OrderID] > 0 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END, CASE
+        WHEN [c].[CustomerID] IS NOT NULL THEN [c].[City]
+        ELSE N''
+    END
+) AS [t]
+LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]");
+    }
+
+    public override async Task Include_reference_when_entity_in_projection(bool async)
+    {
+        await base.Include_reference_when_entity_in_projection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+    }
+
+    public override async Task Include_reference_single_or_default_when_no_result(bool async)
+    {
+        await base.Include_reference_single_or_default_when_no_result(async);
+
+        AssertSql(
+            @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[OrderID] = -1");
+    }
+
+    public override async Task Include_reference_alias_generation(bool async)
+    {
+        await base.Include_reference_alias_generation(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(bool async)
+    {
+        await base.Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o].[OrderID] < 10800
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_references_then_include_collection_multi_level(bool async)
+    {
+        await base.Include_references_then_include_collection_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[ProductID] % 23) = 17 AND [o].[Quantity] < CAST(10 AS smallint)
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_reference_Join_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_Join_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        INNER JOIN [Order Details] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        LEFT JOIN [Customers] AS [c] ON [o1].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_collection_when_projection(bool async)
+    {
+        await base.Include_collection_when_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]");
+    }
+
+    public override async Task Include_reference_SelectMany_GroupBy_Select(bool async)
+    {
+        await base.Include_reference_SelectMany_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    CROSS JOIN [Order Details] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        CROSS JOIN [Order Details] AS [o2]
+        LEFT JOIN [Customers] AS [c] ON [o1].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_collection_multi_level(bool async)
+    {
+        await base.Include_multiple_references_then_include_collection_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[ProductID]");
+    }
+
+    public override async Task Outer_idenfier_correctly_determined_when_doing_include_on_right_side_of_left_join(bool async)
+    {
+        await base.Outer_idenfier_correctly_determined_when_doing_include_on_right_side_of_left_join(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [c].[City] = N'Seattle'
+ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
+    }
+
+    public override async Task SelectMany_Include_reference_GroupBy_Select(bool async)
+    {
+        await base.SelectMany_Include_reference_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    CROSS JOIN [Orders] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[CustomerID0], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        CROSS JOIN [Orders] AS [o2]
+        LEFT JOIN [Customers] AS [c] ON [o2].[CustomerID] = [c].[CustomerID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]");
+    }
+
+    public override async Task Include_collection_SelectMany_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_SelectMany_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    CROSS JOIN [Order Details] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID] AS [OrderID0], [o2].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        CROSS JOIN [Order Details] AS [o2]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID]");
+    }
+
+    public override async Task Include_collection_OrderBy_list_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_list_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
+        WHEN [c].[CustomerID] = N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY CASE
+        WHEN [c].[CustomerID] = N'ALFKI' THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    OFFSET @__p_1 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Multi_level_includes_are_applied_with_skip(bool async)
+    {
+        await base.Multi_level_includes_are_applied_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='1'
+
+SELECT [t].[CustomerID], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[OrderID0], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice]
+FROM (
+    SELECT [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY [c].[CustomerID]
+    OFFSET @__p_0 ROWS FETCH NEXT 1 ROWS ONLY
+) AS [t]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
+    }
+
+    public override async Task Include_collection_on_additional_from_clause(bool async)
+    {
+        await base.Include_collection_on_additional_from_clause(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+CROSS JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'F%'
+) AS [t0]
+LEFT JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID], [t0].[CustomerID]");
+    }
+
+    public override async Task Include_reference_distinct_is_server_evaluated(bool async)
+    {
+        await base.Include_reference_distinct_is_server_evaluated(async);
+
+        AssertSql(
+            @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] < 10250
+) AS [t]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_distinct_is_server_evaluated(bool async)
+    {
+        await base.Include_collection_distinct_is_server_evaluated(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference_when_projection(bool async)
+    {
+        await base.Include_reference_when_projection(async);
+
+        AssertSql(
+            @"SELECT [o].[CustomerID]
+FROM [Orders] AS [o]");
+    }
+
+    public override async Task Include_duplicate_collection_result_operator(bool async)
+    {
+        await base.Include_duplicate_collection_result_operator(async);
+
+        AssertSql(
+            @"@__p_1='1'
+@__p_0='2'
+
+SELECT [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region], [t1].[CustomerID0], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t1].[Address0], [t1].[City0], [t1].[CompanyName0], [t1].[ContactName0], [t1].[ContactTitle0], [t1].[Country0], [t1].[Fax0], [t1].[Phone0], [t1].[PostalCode0], [t1].[Region0], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(@__p_1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID] AS [CustomerID0], [t0].[Address] AS [Address0], [t0].[City] AS [City0], [t0].[CompanyName] AS [CompanyName0], [t0].[ContactName] AS [ContactName0], [t0].[ContactTitle] AS [ContactTitle0], [t0].[Country] AS [Country0], [t0].[Fax] AS [Fax0], [t0].[Phone] AS [Phone0], [t0].[PostalCode] AS [PostalCode0], [t0].[Region] AS [Region0]
+    FROM (
+        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+    ) AS [t]
+    CROSS JOIN (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [t0]
+    ORDER BY [t].[CustomerID]
+) AS [t1]
+LEFT JOIN [Orders] AS [o] ON [t1].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [t1].[CustomerID0] = [o0].[CustomerID]
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0], [o].[OrderID]");
+    }
+
+    public override async Task Include_reference(bool async)
+    {
+        await base.Include_reference(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')");
+    }
+
+    public override async Task Include_multiple_references_and_collection_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_and_collection_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [p].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_closes_reader(bool async)
+    {
+        await base.Include_closes_reader(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]",
+            //
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]");
+    }
+
+    public override async Task Include_with_skip(bool async)
+    {
+        await base.Include_with_skip(async);
+
+        AssertSql(
+            @"@__p_0='80'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactName]
+    OFFSET @__p_0 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactName], [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_Join_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_Join_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID] AS [OrderID0], [o2].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o1].[OrderID] ORDER BY [o1].[OrderID]) AS [row]
+        FROM [Orders] AS [o1]
+        INNER JOIN [Order Details] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID]");
+    }
+
+    public override async Task Include_collection_GroupBy_Select(bool async)
+    {
+        await base.Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [o1].[OrderID], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice]
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[OrderID]) AS [row]
+        FROM [Orders] AS [o0]
+        WHERE [o0].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o1] ON [t0].[OrderID] = [o1].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID], [o1].[OrderID]");
+    }
+
+    public override async Task Include_collection_orderby_take(bool async)
+    {
+        await base.Include_collection_orderby_take(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Join_Include_collection_GroupBy_Select(bool async)
+    {
+        await base.Join_Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        INNER JOIN [Orders] AS [o2] ON [o1].[OrderID] = [o2].[OrderID]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID], [o3].[OrderID]");
+    }
+
+    public override async Task Include_collection_order_by_non_key(bool async)
+    {
+        await base.Include_collection_order_by_non_key(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[PostalCode], [c].[CustomerID]");
+    }
+
+    public override async Task Include_when_result_operator(bool async)
+    {
+        await base.Include_when_result_operator(async);
+
+        AssertSql(
+            @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+    }
+
+    public override async Task Include_duplicate_reference2(bool async)
+    {
+        await base.Include_duplicate_reference2(async);
+
+        AssertSql(
+            @"@__p_0='2'
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+CROSS JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    ORDER BY [o0].[OrderID]
+    OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+) AS [t0]
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
+ORDER BY [t].[OrderID]");
+    }
+
+    public override async Task Include_collection_and_reference(bool async)
+    {
+        await base.Include_collection_and_reference(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_multiple_references_multi_level(bool async)
+    {
+        await base.Include_multiple_references_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_references_and_collection_multi_level_predicate(bool async)
+    {
+        await base.Include_references_and_collection_multi_level_predicate(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE [o].[OrderID] = 10248
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task SelectMany_Include_collection_GroupBy_Select(bool async)
+    {
+        await base.SelectMany_Include_collection_GroupBy_Select(async);
+
+        AssertSql(
+            @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [o3].[OrderID], [o3].[ProductID], [o3].[Discount], [o3].[Quantity], [o3].[UnitPrice]
+FROM (
+    SELECT [o0].[OrderID]
+    FROM [Order Details] AS [o]
+    CROSS JOIN [Orders] AS [o0]
+    WHERE [o].[OrderID] = 10248
+    GROUP BY [o0].[OrderID]
+) AS [t]
+LEFT JOIN (
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [t1].[OrderID0], [t1].[ProductID]
+    FROM (
+        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], ROW_NUMBER() OVER(PARTITION BY [o2].[OrderID] ORDER BY [o2].[OrderID]) AS [row]
+        FROM [Order Details] AS [o1]
+        CROSS JOIN [Orders] AS [o2]
+        WHERE [o1].[OrderID] = 10248
+    ) AS [t1]
+    WHERE [t1].[row] <= 1
+) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
+LEFT JOIN [Order Details] AS [o3] ON [t0].[OrderID] = [o3].[OrderID]
+ORDER BY [t].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[OrderID], [o3].[OrderID]");
+    }
+
+    public override async Task Include_collection_with_last(bool async)
+    {
+        await base.Include_collection_with_last(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CompanyName] DESC
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_collection_OrderBy_empty_list_does_not_contains(bool async)
+    {
+        await base.Include_collection_OrderBy_empty_list_does_not_contains(async);
+
+        AssertSql(
+            @"@__p_1='1'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CAST(1 AS bit) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    ORDER BY (SELECT 1)
+    OFFSET @__p_1 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_multiple_references_then_include_multi_level_reverse(bool async)
+    {
+        await base.Include_multiple_references_then_include_multi_level_reverse(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [o]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_reference_and_collection(bool async)
+    {
+        await base.Include_reference_and_collection(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
+    }
+
+    public override async Task Include_is_not_ignored_when_projection_contains_client_method_and_complex_expression(bool async)
+    {
+        await base.Include_is_not_ignored_when_projection_contains_client_method_and_complex_expression(async);
+
+        AssertSql(
+            @"SELECT CASE
+    WHEN [e0].[EmployeeID] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e]
+LEFT JOIN [Employees] AS [e0] ON [e].[ReportsTo] = [e0].[EmployeeID]
+WHERE [e].[EmployeeID] IN (1, 2)
+ORDER BY [e].[EmployeeID]");
+    }
+
+    public override async Task Include_reference_with_filter_reordered(bool async)
+    {
+        await base.Include_reference_with_filter_reordered(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Include_collection_order_by_subquery(bool async)
+    {
+        await base.Include_collection_order_by_subquery(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[EmployeeID]) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[EmployeeID])
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+    }
+
+    public override async Task Include_reference_and_collection_order_by(bool async)
+    {
+        await base.Include_reference_and_collection_order_by(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
+ORDER BY [o].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Then_include_collection_order_by_collection_column(bool async)
+    {
+        await base.Then_include_collection_order_by_collection_column(async);
+
+        AssertSql(
+            @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[OrderID0], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice]
+FROM (
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) AS [c]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W%'
+    ORDER BY (
+        SELECT TOP(1) [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]
+        ORDER BY [o].[OrderDate] DESC) DESC
+) AS [t]
+LEFT JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o1].[OrderID] AS [OrderID0], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice]
+    FROM [Orders] AS [o0]
+    LEFT JOIN [Order Details] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t].[c] DESC, [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
+    }
+
+    public override async Task Include_multiple_references_then_include_multi_level(bool async)
+    {
+        await base.Include_multiple_references_then_include_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_collection_skip_no_order_by(bool async)
+    {
+        await base.Include_collection_skip_no_order_by(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY (SELECT 1)
+    OFFSET @__p_0 ROWS
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[CustomerID]");
+    }
+
+    public override async Task Include_multi_level_reference_then_include_collection_predicate(bool async)
+    {
+        await base.Include_multi_level_reference_then_include_collection_predicate(async);
+
+        AssertSql(
+            @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[CustomerID0], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    WHERE [o].[OrderID] = 10248
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID0] = [o0].[CustomerID]
+ORDER BY [t].[OrderID], [t].[CustomerID0]");
+    }
+
+    public override async Task Include_multiple_references_and_collection_multi_level(bool async)
+    {
+        await base.Include_multiple_references_and_collection_multi_level(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE ([o].[OrderID] % 23) = 13
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [p].[ProductID]");
+    }
+
+    public override async Task Include_where_skip_take_projection(bool async)
+    {
+        await base.Include_where_skip_take_projection(async);
+
+        AssertSql(
+            @"@__p_0='1'
+@__p_1='2'
+
+SELECT [o0].[CustomerID]
+FROM (
+    SELECT [o].[OrderID], [o].[ProductID]
+    FROM [Order Details] AS [o]
+    WHERE [o].[Quantity] = CAST(10 AS smallint)
+    ORDER BY [o].[OrderID], [o].[ProductID]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+ORDER BY [t].[OrderID], [t].[ProductID]");
+    }
+
+    public override async Task Include_with_take(bool async)
+    {
+        await base.Include_with_take(async);
+
+        AssertSql(
+            @"@__p_0='10'
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactName] DESC
+) AS [t]
+LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
+ORDER BY [t].[ContactName] DESC, [t].[CustomerID]");
+    }
+
+    public override async Task Include_multiple_references(bool async)
+    {
+        await base.Include_multiple_references(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
+WHERE ([o].[OrderID] % 23) = 13");
+    }
+
+    public override async Task Include_list(bool async)
+    {
+        await base.Include_list(async);
+
+        AssertSql(
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[OrderID0], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Products] AS [p]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID] AS [OrderID0], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Order Details] AS [o]
+    INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [p].[ProductID] = [t].[ProductID]
+WHERE ([p].[ProductID] % 17) = 5 AND [p].[UnitPrice] < 20.0
+ORDER BY [p].[ProductID], [t].[OrderID], [t].[ProductID]");
+    }
+
+    public override async Task Include_empty_reference_sets_IsLoaded(bool async)
+    {
+        await base.Include_empty_reference_sets_IsLoaded(async);
+
+        AssertSql(
+            @"SELECT TOP(1) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e]
+LEFT JOIN [Employees] AS [e0] ON [e].[ReportsTo] = [e0].[EmployeeID]
+WHERE [e0].[EmployeeID] IS NULL");
+    }
+
+    public override async Task Include_references_then_include_collection_multi_level_predicate(bool async)
+    {
+        await base.Include_references_then_include_collection_multi_level_predicate(async);
+
+        AssertSql(
+            @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
+WHERE [o].[OrderID] = 10248
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
+    }
+
+    public override async Task Include_collection_with_conditional_order_by(bool async)
+    {
+        await base.Include_collection_with_conditional_order_by(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY CASE
+    WHEN [c].[CustomerID] LIKE N'S%' THEN 1
+    ELSE 2
+END, [c].[CustomerID]");
+    }
+
+    public override async Task Include_non_existing_navigation(bool async)
+    {
+        await base.Include_non_existing_navigation(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property(bool async)
+    {
+        await base.Include_property(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property_after_navigation(bool async)
+    {
+        await base.Include_property_after_navigation(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_property_expression_invalid(bool async)
+    {
+        await base.Include_property_expression_invalid(async);
+
+        AssertSql();
+    }
+
+    public override async Task Then_include_property_expression_invalid(bool async)
+    {
+        await base.Then_include_property_expression_invalid(async);
+
+        AssertSql();
+    }
+
+    public override async Task Filtered_include_with_multiple_ordering(bool async)
+    {
+        await base.Filtered_include_with_multiple_ordering(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_specified_on_non_entity_not_supported(bool async)
+    {
+        await base.Include_specified_on_non_entity_not_supported(async);
+
+        AssertSql();
+    }
+
+    public override async Task Include_collection_with_client_filter(bool async)
+    {
+        await base.Include_collection_with_client_filter(async);
+
+        AssertSql();
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -18,6 +18,10 @@ public class NorthwindWhereQuerySqlServerTest : NorthwindWhereQueryRelationalTes
     protected override bool CanExecuteQueryString
         => true;
 
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     public override async Task Where_simple(bool async)
     {
         await base.Where_simple(async);
@@ -440,11 +444,10 @@ END) = CAST(1 AS bit)");
 
     public override async Task Where_bitwise_xor(bool async)
     {
-        await base.Where_bitwise_xor(async);
+        // Cannot eval 'where (([c].CustomerID == \"ALFKI\") ^ True)'. Issue #16645.
+        await AssertTranslationFailed(() => base.Where_bitwise_xor(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_simple_shadow(bool async)
@@ -1455,83 +1458,74 @@ WHERE 0 = 1");
 
     public override async Task Where_compare_constructed_equal(bool async)
     {
-        await base.Where_compare_constructed_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_constructed_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_constructed_multi_value_equal(bool async)
     {
-        await base.Where_compare_constructed_multi_value_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_constructed_multi_value_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_constructed_multi_value_not_equal(bool async)
     {
-        await base.Where_compare_constructed_multi_value_not_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_constructed_multi_value_not_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_tuple_constructed_equal(bool async)
     {
-        await base.Where_compare_tuple_constructed_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_constructed_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_tuple_constructed_multi_value_equal(bool async)
     {
-        await base.Where_compare_tuple_constructed_multi_value_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_constructed_multi_value_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_tuple_constructed_multi_value_not_equal(bool async)
     {
-        await base.Where_compare_tuple_constructed_multi_value_not_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_constructed_multi_value_not_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_tuple_create_constructed_equal(bool async)
     {
-        await base.Where_compare_tuple_create_constructed_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_create_constructed_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_tuple_create_constructed_multi_value_equal(bool async)
     {
-        await base.Where_compare_tuple_create_constructed_multi_value_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_create_constructed_multi_value_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_tuple_create_constructed_multi_value_not_equal(bool async)
     {
-        await base.Where_compare_tuple_create_constructed_multi_value_not_equal(async);
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_create_constructed_multi_value_not_equal(async));
 
-        AssertSql(
-            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+        AssertSql();
     }
 
     public override async Task Where_compare_null(bool async)
@@ -2493,6 +2487,209 @@ WHERE ([c].[CustomerID] LIKE N'F%') AND [c].[City] = N'Seattle'");
             @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE ([c].[CustomerID] LIKE N'F%') OR [c].[City] = N'Seattle'");
+    }
+
+    public override async Task Where_poco_closure(bool async)
+    {
+        await base.Where_poco_closure(async);
+
+        AssertSql(
+            @"@__entity_equality_customer_0_CustomerID='ALFKI' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__entity_equality_customer_0_CustomerID",
+            //
+            @"@__entity_equality_customer_0_CustomerID='ANATR' (Size = 5) (DbType = StringFixedLength)
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @__entity_equality_customer_0_CustomerID");
+    }
+
+    public override async Task Filter_with_property_compared_to_null_wrapped_in_explicit_convert_to_object(bool async)
+    {
+        await base.Filter_with_property_compared_to_null_wrapped_in_explicit_convert_to_object(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[Region] IS NULL");
+    }
+
+    public override async Task Where_simple_shadow_subquery(bool async)
+    {
+        await base.Where_simple_shadow_subquery(async);
+
+        AssertSql(
+            @"@__p_0='5'
+
+SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+FROM (
+    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    FROM [Employees] AS [e]
+    ORDER BY [e].[EmployeeID]
+) AS [t]
+WHERE [t].[Title] = N'Sales Representative'
+ORDER BY [t].[EmployeeID]");
+    }
+
+    public override async Task Where_primitive_tracked2(bool async)
+    {
+        await base.Where_primitive_tracked2(async);
+
+        AssertSql(
+            @"@__p_0='9'
+
+SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+FROM (
+    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    FROM [Employees] AS [e]
+) AS [t]
+WHERE [t].[EmployeeID] = 5");
+    }
+
+    public override async Task Where_projection(bool async)
+    {
+        await base.Where_projection(async);
+
+        AssertSql(
+            @"SELECT [c].[CompanyName]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'London'");
+    }
+
+    public override async Task Where_bool_closure(bool async)
+    {
+        await base.Where_bool_closure(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE 0 = 1",
+            //
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'");
+    }
+
+    public override async Task Where_primitive_tracked(bool async)
+    {
+        await base.Where_primitive_tracked(async);
+
+        AssertSql(
+            @"@__p_0='9'
+
+SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+FROM (
+    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    FROM [Employees] AS [e]
+) AS [t]
+WHERE [t].[EmployeeID] = 5");
+    }
+
+    public override async Task Where_simple_shadow_projection_mixed(bool async)
+    {
+        await base.Where_simple_shadow_projection_mixed(async);
+
+        AssertSql(
+            @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[Title] = N'Sales Representative'");
+    }
+
+    public override async Task Decimal_cast_to_double_works(bool async)
+    {
+        await base.Decimal_cast_to_double_works(async);
+
+        AssertSql(
+            @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE CAST([p].[UnitPrice] AS float) > 100.0E0");
+    }
+
+    public override async Task Where_bool_client_side_negated(bool async)
+    {
+        await base.Where_bool_client_side_negated(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_equals_method_string_with_ignore_case(bool async)
+    {
+        await base.Where_equals_method_string_with_ignore_case(async);
+
+        AssertSql();
+    }
+
+    public override void Where_nested_field_access_closure_via_query_cache_error_null()
+    {
+        base.Where_nested_field_access_closure_via_query_cache_error_null();
+
+        AssertSql();
+    }
+
+    public override async Task Where_nested_field_access_closure_via_query_cache_error_null_async()
+    {
+        await base.Where_nested_field_access_closure_via_query_cache_error_null_async();
+
+        AssertSql();
+    }
+
+    public override void Where_nested_field_access_closure_via_query_cache_error_method_null()
+    {
+        base.Where_nested_field_access_closure_via_query_cache_error_method_null();
+
+        AssertSql();
+    }
+
+    public override async Task Where_nested_field_access_closure_via_query_cache_error_method_null_async()
+    {
+        await base.Where_nested_field_access_closure_via_query_cache_error_method_null_async();
+
+        AssertSql();
+    }
+
+    public override async Task Where_client(bool async)
+    {
+        await base.Where_client(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_subquery_correlated_client_eval(bool async)
+    {
+        await base.Where_subquery_correlated_client_eval(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_client_and_server_top_level(bool async)
+    {
+        await base.Where_client_and_server_top_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_client_or_server_top_level(bool async)
+    {
+        await base.Where_client_or_server_top_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_client_and_server_non_top_level(bool async)
+    {
+        await base.Where_client_and_server_non_top_level(async);
+
+        AssertSql();
+    }
+
+    public override async Task Where_client_deep_inside_predicate_and_server_top_level(bool async)
+    {
+        await base.Where_client_deep_inside_predicate_and_server_top_level(async);
+
+        AssertSql();
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
@@ -43,6 +43,13 @@ public class NorthwindGroupByQuerySqliteTest : NorthwindGroupByQueryRelationalTe
     public override Task Complex_query_with_group_by_in_subquery5(bool async)
         => AssertApplyNotSupported(() => base.Complex_query_with_group_by_in_subquery5(async));
 
+    public override Task GroupBy_aggregate_from_multiple_query_in_same_projection(bool async)
+        => AssertApplyNotSupported(() => base.GroupBy_aggregate_from_multiple_query_in_same_projection(async));
+
+    public override Task GroupBy_aggregate_from_multiple_query_in_same_projection_3(bool async)
+        => Assert.ThrowsAsync<SqliteException>(
+            () => base.GroupBy_aggregate_from_multiple_query_in_same_projection_3(async));
+
     public override async Task Odata_groupby_empty_key(bool async)
         => Assert.Equal(
             SqliteStrings.AggregateOperationNotSupported("Sum", "decimal"),

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
@@ -16,69 +16,42 @@ public class NorthwindGroupByQuerySqliteTest : NorthwindGroupByQueryRelationalTe
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    public override async Task Select_uncorrelated_collection_with_groupby_multiple_collections_work(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Select_uncorrelated_collection_with_groupby_multiple_collections_work(async))).Message);
+    public override Task Select_uncorrelated_collection_with_groupby_multiple_collections_work(bool async)
+        => AssertApplyNotSupported(() => base.Select_uncorrelated_collection_with_groupby_multiple_collections_work(async));
 
-    public override async Task Select_uncorrelated_collection_with_groupby_works(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Select_uncorrelated_collection_with_groupby_works(async))).Message);
+    public override Task Select_uncorrelated_collection_with_groupby_works(bool async)
+        => AssertApplyNotSupported(() => base.Select_uncorrelated_collection_with_groupby_multiple_collections_work(async));
 
-    public override async Task Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(async))).Message);
+    public override Task Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(bool async)
+        => AssertApplyNotSupported(() => base.Select_uncorrelated_collection_with_groupby_works(async));
 
-    public override async Task AsEnumerable_in_subquery_for_GroupBy(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.AsEnumerable_in_subquery_for_GroupBy(async))).Message);
+    public override Task AsEnumerable_in_subquery_for_GroupBy(bool async)
+        => AssertApplyNotSupported(() => base.AsEnumerable_in_subquery_for_GroupBy(async));
 
-    public override async Task Complex_query_with_groupBy_in_subquery1(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Complex_query_with_groupBy_in_subquery1(async))).Message);
+    public override Task Complex_query_with_groupBy_in_subquery1(bool async)
+        => AssertApplyNotSupported(() => base.Complex_query_with_groupBy_in_subquery1(async));
 
-    public override async Task Complex_query_with_groupBy_in_subquery2(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Complex_query_with_groupBy_in_subquery2(async))).Message);
+    public override Task Complex_query_with_groupBy_in_subquery2(bool async)
+        => AssertApplyNotSupported(() => base.Complex_query_with_groupBy_in_subquery2(async));
 
-    public override async Task Complex_query_with_groupBy_in_subquery3(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Complex_query_with_groupBy_in_subquery3(async))).Message);
+    public override Task Complex_query_with_groupBy_in_subquery3(bool async)
+        => AssertApplyNotSupported(() => base.Complex_query_with_groupBy_in_subquery3(async));
 
-    public override async Task Select_nested_collection_with_groupby(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Select_nested_collection_with_groupby(async))).Message);
+    public override Task Select_nested_collection_with_groupby(bool async)
+        => AssertApplyNotSupported(() => base.Select_nested_collection_with_groupby(async));
 
-    public override async Task Complex_query_with_group_by_in_subquery5(bool async)
-        => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Complex_query_with_group_by_in_subquery5(async))).Message);
+    public override Task Complex_query_with_group_by_in_subquery5(bool async)
+        => AssertApplyNotSupported(() => base.Complex_query_with_group_by_in_subquery5(async));
 
     public override async Task Odata_groupby_empty_key(bool async)
-        => await Assert.ThrowsAsync<NotSupportedException>(() => base.Odata_groupby_empty_key(async));
+        => Assert.Equal(
+            SqliteStrings.AggregateOperationNotSupported("Sum", "decimal"),
+            (await Assert.ThrowsAsync<NotSupportedException>(
+                () => base.Odata_groupby_empty_key(async))).Message);
 
-    public override async Task GroupBy_aggregate_from_multiple_query_in_same_projection(bool async)
+    private static async Task AssertApplyNotSupported(Func<Task> query)
         => Assert.Equal(
             SqliteStrings.ApplyNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.GroupBy_aggregate_from_multiple_query_in_same_projection(async))).Message);
-
-    public override async Task GroupBy_aggregate_from_multiple_query_in_same_projection_3(bool async)
-        => await Assert.ThrowsAsync<SqliteException>(() => base.GroupBy_aggregate_from_multiple_query_in_same_projection_3(async));
+            (await Assert.ThrowsAsync<InvalidOperationException>(query))
+            .Message);
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqliteTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Data.Sqlite;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public class NorthwindKeylessEntitiesQuerySqliteTest : NorthwindKeylessEntitiesQueryRelationalTestBase<
@@ -15,7 +17,8 @@ public class NorthwindKeylessEntitiesQuerySqliteTest : NorthwindKeylessEntitiesQ
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ConditionalFact(Skip = "Issue#21627")]
     public override void KeylessEntity_with_nav_defining_query()
-        => base.KeylessEntity_with_nav_defining_query();
+        // FromSql mapping. Issue #21627.
+        => Assert.Throws<SqliteException>(
+            () => base.KeylessEntity_with_nav_defining_query());
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -127,6 +127,18 @@ FROM ""Orders"" AS ""o""");
 FROM ""Orders"" AS ""o""");
     }
 
+    public override async Task
+        SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
+            bool async)
+    {
+        await AssertUnableToTranslateEFProperty(
+            () => base
+                .SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
+                    async));
+
+        AssertSql();
+    }
+
     public override async Task SelectMany_correlated_with_outer_1(bool async)
         => Assert.Equal(
             SqliteStrings.ApplyNotSupported,
@@ -199,10 +211,9 @@ FROM ""Orders"" AS ""o""");
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Correlated_collection_after_distinct_not_containing_original_identifier(async))).Message);
 
-    public override async Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(
-        bool async)
+    public override async Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
         => Assert.Equal(
-            SqliteStrings.ApplyNotSupported,
+            RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin,
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(async)))
             .Message);
@@ -238,16 +249,20 @@ FROM ""Orders"" AS ""o""");
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Reverse_in_SelectMany_with_Take(async))).Message);
 
-    [ConditionalTheory(Skip = "Issue#17324")]
-    public override Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool async)
-        => base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(async);
+    public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(async))).Message);
 
     public override Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool async)
         => AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(async));
 
-    [ConditionalTheory(Skip = "Issue#17230")]
-    public override Task SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(bool async)
-        => base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async);
+    public override async Task SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async))).Message);
 
     public override async Task Collection_projection_selecting_outer_element_followed_by_take(bool async)
         => Assert.Equal(

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSetOperationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSetOperationsQuerySqliteTest.cs
@@ -14,4 +14,11 @@ public class NorthwindSetOperationsQuerySqliteTest : NorthwindSetOperationsQuery
         Fixture.TestSqlLoggerFactory.Clear();
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
+
+    public override async Task Client_eval_Union_FirstOrDefault(bool async)
+        // Client evaluation in projection. Issue #16243.
+        => Assert.Equal(
+            RelationalStrings.SetOperationsNotAllowedAfterClientEvaluation,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_eval_Union_FirstOrDefault(async))).Message);
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
@@ -12,11 +12,26 @@ public class NorthwindWhereQuerySqliteTest : NorthwindWhereQueryRelationalTestBa
         //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    public override Task Where_datetimeoffset_now_component(bool async)
-        => AssertTranslationFailed(() => base.Where_datetimeoffset_now_component(async));
+    public override async Task Where_datetimeoffset_now_component(bool async)
+    {
+        await AssertTranslationFailed(() => base.Where_datetimeoffset_now_component(async));
 
-    public override Task Where_datetimeoffset_utcnow_component(bool async)
-        => AssertTranslationFailed(() => base.Where_datetimeoffset_utcnow_component(async));
+        AssertSql();
+    }
+
+    public override async Task Where_datetimeoffset_utcnow_component(bool async)
+    {
+        await AssertTranslationFailed(() => base.Where_datetimeoffset_utcnow_component(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_datetimeoffset_utcnow(bool async)
+    {
+        await AssertTranslationFailed(() => base.Where_datetimeoffset_utcnow_component(async));
+
+        AssertSql();
+    }
 
     public override async Task<string> Where_simple_closure(bool async)
     {
@@ -62,9 +77,6 @@ SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyN
 FROM ""Customers"" AS ""c""
 WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDatetime_0");
     }
-
-    public override Task Where_datetimeoffset_utcnow(bool async)
-        => Task.CompletedTask;
 
     public override async Task Where_datetime_today(bool async)
     {
@@ -158,7 +170,6 @@ FROM ""Orders"" AS ""o""
 WHERE CAST(strftime('%S', ""o"".""OrderDate"") AS INTEGER) = 44");
     }
 
-    [ConditionalTheory(Skip = "Issue#15586")]
     public override async Task Where_datetime_millisecond_component(bool async)
     {
         await base.Where_datetime_millisecond_component(async);
@@ -166,7 +177,7 @@ WHERE CAST(strftime('%S', ""o"".""OrderDate"") AS INTEGER) = 44");
         AssertSql(
             @"SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
 FROM ""Orders"" AS ""o""
-WHERE ((CAST(strftime('%f', ""o"".""OrderDate"") AS REAL) * 1000) % 1000) = 88");
+WHERE ((CAST(strftime('%f', ""o"".""OrderDate"") AS REAL) * 1000.0) % 1000.0) = 88.0");
     }
 
     public override async Task Where_string_length(bool async)
@@ -227,6 +238,86 @@ WHERE CAST(""p"".""UnitPrice"" AS REAL) > 100.0");
             @"SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
 FROM ""Orders"" AS ""o""
 WHERE CAST(""o"".""OrderID"" AS TEXT) LIKE '%20%'");
+    }
+
+    public override async Task Where_bitwise_xor(bool async)
+    {
+        // Cannot eval 'where (([c].CustomerID == \"ALFKI\") ^ True)'. Issue #16645.
+        await AssertTranslationFailed(() => base.Where_bitwise_xor(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_constructed_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_constructed_equal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_constructed_multi_value_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_constructed_multi_value_equal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_constructed_multi_value_not_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_constructed_multi_value_not_equal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_tuple_constructed_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_constructed_equal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_tuple_constructed_multi_value_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_constructed_multi_value_equal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_tuple_constructed_multi_value_not_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_constructed_multi_value_not_equal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_tuple_create_constructed_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_create_constructed_equal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_tuple_create_constructed_multi_value_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_create_constructed_multi_value_equal(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_compare_tuple_create_constructed_multi_value_not_equal(bool async)
+    {
+        //  Anonymous type to constant comparison. Issue #14672.
+        await AssertTranslationFailed(() => base.Where_compare_tuple_create_constructed_multi_value_not_equal(async));
+
+        AssertSql();
     }
 
     private void AssertSql(params string[] expected)


### PR DESCRIPTION
#26088 for Northwind query tests.

Also fixes #7016: Support "non-rooted" query expressions in compiled queries.
