### PR TITLE
[release/6.0] Add [DynamicDependency] on System.Math for trimming

### DIFF
--- a/src/EFCore.Relational/Query/IMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/IMethodCallTranslator.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -28,6 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="arguments">SQL representations of <see cref="MethodCallExpression.Arguments" />.</param>
         /// <param name="logger">The query logger to use.</param>
         /// <returns>A SQL translation of the <see cref="MethodCallExpression" />.</returns>
+        // This is a 6.0.x hack to make trimming work, since the linker doesn't see our GetRequiredRuntimeMethod invocations below
+        // (see #26288)
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Math))]
         SqlExpression? Translate(
             SqlExpression? instance,
             MethodInfo method,


### PR DESCRIPTION
### Description

Due to EF Core using wrappers to look up methods via reflection (GetRequiredRuntimeMethod), the linker cannot see the dependency on those methods, and trimmed applications fail 

### Customer impact

It isn't possible to use EF Core in a trimmed application.

### How found

Customer report on 6.0.0.

### Regression

Yes, from 5.0. Although EF Core 5.0 was never officially trimming-compatible, at least basic scenarios were possible.

### Testing

Coverage will be added in 7.0, where trimming will be a focus. The fix was verified manually.

Note that EF Core 6.0 still won't be fully trimming-compatible, but this unlocks at least the basic scenarios which customers were asking for.

### Risk

Very low - the fix only adds an attribute which is meaningful only to the linker.

### Details

This uses the [DynamicDependency] attribute to make sure System.Math isn't trimmed when using EF Core.

I'm not quite sure why System.Math is special here - we have other translators which depend on various other things (string, GUID), but with this attribute all SQL Server method/member translators initialize successfully and the query executes.

I've placed the attribute in IMethodCallTranslator to fix this for all providers, rather than requiring every provider to do this (since everyone translates stuff on Math).

Fixes #27097