### PR TITLE
[release/6.0] Lift GroupByAggregate when correlation predicate matches

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1960,6 +1960,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selector = _sqlExpressionFactory.Case(
                     new List<CaseWhenClause> { new(predicate, selector) },
                     elseResult: null);
+                if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27102", out var enabled) && enabled))
+                {
+                    selectExpression.UpdatePredicate(_groupingElementCorrelationalPredicate!);
+                }
             }
 
             if (selectExpression.IsDistinct)

--- a/src/EFCore.Relational/Query/SqlExpressions/LikeExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LikeExpression.cs
@@ -116,7 +116,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             => base.Equals(likeExpression)
                 && Match.Equals(likeExpression.Match)
                 && Pattern.Equals(likeExpression.Pattern)
-                && EscapeChar?.Equals(likeExpression.EscapeChar) == true;
+                && (EscapeChar == null
+                    ? likeExpression.EscapeChar == null
+                    : EscapeChar.Equals(likeExpression.EscapeChar));
 
         /// <inheritdoc />
         public override int GetHashCode()

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -447,6 +447,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.max);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_with_aggregate_containing_complex_where(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from o in ss.Set<Order>()
+                      group o.OrderID by o.EmployeeID into tg
+                      select new
+                      {
+                          tg.Key,
+                          Max = ss.Set<Order>().Where(e => e.EmployeeID == tg.Max() * 6).Max(t => (int?)t.OrderID)
+                      },
+                elementSorter: e => e.Key);
+        }
+
         #endregion
 
         #region GroupByAnonymousAggregate

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1884,6 +1884,25 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]");
         }
 
+        public override async Task GroupBy_with_aggregate_containing_complex_where(bool async)
+        {
+            await base.GroupBy_with_aggregate_containing_complex_where(async);
+
+            AssertSql(
+                @"SELECT [o].[EmployeeID] AS [Key], (
+    SELECT MAX([o0].[OrderID])
+    FROM [Orders] AS [o0]
+    WHERE (CAST([o0].[EmployeeID] AS bigint) = CAST(((
+        SELECT MAX([o1].[OrderID])
+        FROM [Orders] AS [o1]
+        WHERE ([o].[EmployeeID] = [o1].[EmployeeID]) OR ([o].[EmployeeID] IS NULL AND [o1].[EmployeeID] IS NULL)) * 6) AS bigint)) OR ([o0].[EmployeeID] IS NULL AND (
+        SELECT MAX([o1].[OrderID])
+        FROM [Orders] AS [o1]
+        WHERE ([o].[EmployeeID] = [o1].[EmployeeID]) OR ([o].[EmployeeID] IS NULL AND [o1].[EmployeeID] IS NULL)) IS NULL)) AS [Max]
+FROM [Orders] AS [o]
+GROUP BY [o].[EmployeeID]");
+        }
+
         public override async Task GroupBy_Shadow(bool async)
         {
             await base.GroupBy_Shadow(async);


### PR DESCRIPTION
Earlier, we didn't match on exact predicate

Also fix bug in LikeExpression.Equals

Resolves #27102

**Description**

When projection after group by has an aggregation term which is not aggregate on grouping, incorrect SQL is generated which generates incorrect results or invalid SQL.

**Customer impact**

Customer queries will either give incorrect result or throw exception with invalid SQL.

**How found**

Customer reported on 6.0.1

**Regression**

Yes, From 5.0

**Testing**

Added test for user scenario which validates non grouping related aggregation.

**Risk**

Very low. Added quirk to revert to previous behavior.