### PR TITLE
[release/6.0] Query: Update column expression correctly when lifting joins from group by aggregate subquery

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -622,9 +622,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                             if (querySplittingBehavior == QuerySplittingBehavior.SplitQuery)
                             {
                                 var outerSelectExpression = (SelectExpression)cloningExpressionVisitor!.Visit(baseSelectExpression!);
-                                innerSelectExpression =
-                                    (SelectExpression)new ColumnExpressionReplacingExpressionVisitor(this, outerSelectExpression)
-                                        .Visit(innerSelectExpression);
+                                innerSelectExpression = (SelectExpression)new ColumnExpressionReplacingExpressionVisitor(
+                                    this, outerSelectExpression._tableReferences).Visit(innerSelectExpression);
 
                                 if (outerSelectExpression.Limit != null
                                     || outerSelectExpression.Offset != null

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -147,5 +147,35 @@ INNER JOIN (
 WHERE [o].[OrderId] = @__orderId_0
 ORDER BY [o].[OrderId]");
         }
+
+        public override async Task GroupBy_Aggregate_over_navigations_repeated(bool async)
+        {
+            await base.GroupBy_Aggregate_over_navigations_repeated(async);
+
+            AssertSql(
+                @"SELECT MIN([o].[HourlyRate]) AS [HourlyRate], MIN([c].[Id]) AS [CustomerId], MIN([c0].[Name]) AS [CustomerName]
+FROM [TimeSheets] AS [t]
+LEFT JOIN [Order] AS [o] ON [t].[OrderId] = [o].[Id]
+INNER JOIN [Project] AS [p] ON [t].[ProjectId] = [p].[Id]
+INNER JOIN [Customers] AS [c] ON [p].[CustomerId] = [c].[Id]
+INNER JOIN [Project] AS [p0] ON [t].[ProjectId] = [p0].[Id]
+INNER JOIN [Customers] AS [c0] ON [p0].[CustomerId] = [c0].[Id]
+WHERE [t].[OrderId] IS NOT NULL
+GROUP BY [t].[OrderId]");
+        }
+
+        public override async Task Aggregate_over_subquery_in_group_by_projection(bool async)
+        {
+            await base.Aggregate_over_subquery_in_group_by_projection(async);
+
+            AssertSql(
+                @"SELECT [o].[CustomerId], (
+    SELECT MIN([o0].[HourlyRate])
+    FROM [Order] AS [o0]
+    WHERE [o0].[CustomerId] = [o].[CustomerId]) AS [CustomerMinHourlyRate], MIN([o].[HourlyRate]) AS [HourlyRate], COUNT(*) AS [Count]
+FROM [Order] AS [o]
+WHERE ([o].[Number] <> N'A1') OR [o].[Number] IS NULL
+GROUP BY [o].[CustomerId], [o].[Number]");
+        }
     }
 }


### PR DESCRIPTION
When replacing columns, we used the outer select expression which had additional joins from previous term whose aliases match tables in current join and it got updated with wrong table.
The fix is to utilize the original tables when replacing columns. These column replacement is to map the columns from initial tables of group by from subquery to outer group by query.

Resolves #27083

This PR is targeting another PR in release/6.0. If the earlier PR is not approved, I will rebase this PR direct on 6.0. The dependency between PR related to group by is to avoid unintentional side-effects between different patch fixes.

**Description**

When expanding navigation in aggregate operation in projection after GroupBy operator, we lift the joins generated from navigation to main group by query. In certain conditions we end up generating SQL referencing wrong tables which could generate incorrect results.

**Customer impact**

Customer will get incorrect results without any exception.

**How found**

Customer reported on 6.0.1

**Regression**

No. The scenario of navigations inside aggregate operation was not supported prior to 6.0

**Testing**

Added test for user mentioned scenario which covers the root cause of the issue. (matching alias)

**Risk**

Low risk. Change only affects above scenario. Also added quirk to revert back to earlier behavior in case working scenario breaks.
