### PR TITLE
[release/6.0] Avoid proxying Clone methods on record types

### DIFF
--- a/test/EFCore.Proxies.Tests/ProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ProxyTests.cs
@@ -82,6 +82,15 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public void CreateProxy_works_for_record_with_base_type_entity_types()
+        {
+            using var context = new NeweyContext();
+
+            Assert.Same(typeof(March86C), context.Set<March86C>().CreateProxy().GetType().BaseType);
+            Assert.Same(typeof(March86C), context.Set<March86C>().CreateProxy(_ => { }).GetType().BaseType);
+        }
+
+        [ConditionalFact]
         public void CreateProxy_throws_for_shared_type_entity_types_when_entity_type_name_not_known()
         {
             using var context = new NeweyContext();
@@ -345,6 +354,15 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        public record March86C : IndyCar
+        {
+            public virtual int Id { get; init; }
+        }
+
+        public record IndyCar
+        {
+        }
+
         private class NeweyContext : DbContext
         {
             private readonly IServiceProvider _internalServiceProvider;
@@ -418,6 +436,8 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.SharedTypeEntity<SharedTypeEntityType>("STET2");
 
                 modelBuilder.Entity<WithWeak>();
+
+                modelBuilder.Entity<March86C>();
             }
         }
 

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesFixtureBase.cs
@@ -388,6 +388,8 @@ namespace Microsoft.EntityFrameworkCore
                         .HasForeignKey<Car>("fk_PersonId")
                         .IsRequired();
                 });
+
+                modelBuilder.Entity<RecordCar>();
             }
 
             protected virtual object CreateFullGraph(DbContext context)
@@ -1904,6 +1906,23 @@ namespace Microsoft.EntityFrameworkCore
         {
             public virtual Guid Id { get; set; }
             public virtual Car Vehicle { get; set; }
+        }
+
+        public record RecordBase
+        {
+            public virtual int Id { get; set; }
+        }
+
+        public record RecordCar : RecordBase
+        {
+            public virtual RecordPerson Owner { get; set; }
+            public virtual int? OwnerId { get; set; }
+        }
+
+        public record RecordPerson : RecordBase
+        {
+            public virtual ICollection<RecordCar> Vehicles { get; }
+                = new ObservableHashSet<RecordCar>(LegacyReferenceEqualityComparer.Instance);
         }
 
         protected DbContext CreateContext()

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseMiscellaneous.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseMiscellaneous.cs
@@ -52,6 +52,62 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public virtual void Can_use_record_proxies_with_base_types_to_load_reference()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    context.AddRange(
+                        context.CreateProxy<RecordCar>(
+                            car =>
+                            {
+                                car.Owner = context.CreateProxy<RecordPerson>();
+                            }));
+
+                    context.SaveChanges();
+                },
+                context =>
+                {
+                    var car = context.Set<RecordCar>().Single();
+                    if (!DoesLazyLoading)
+                    {
+                        context.Entry(car).Reference(e => e.Owner).Load();
+                    }
+
+                    Assert.Equal(car.Owner.Id, car.OwnerId);
+                    Assert.Same(car, car.Owner.Vehicles.Single());
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Can_use_record_proxies_with_base_types_to_load_collection()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    context.AddRange(
+                        context.CreateProxy<RecordCar>(
+                            car =>
+                            {
+                                car.Owner = context.CreateProxy<RecordPerson>();
+                            }));
+
+                    context.SaveChanges();
+                },
+                context =>
+                {
+                    var owner = context.Set<RecordPerson>().Single();
+                    if (!DoesLazyLoading)
+                    {
+                        context.Entry(owner).Collection(e => e.Vehicles).Load();
+                    }
+
+                    Assert.Equal(owner.Id, owner.Vehicles.Single().Id);
+                    Assert.Same(owner, owner.Vehicles.Single().Owner);
+                });
+        }
+
+        [ConditionalFact]
         public virtual void Avoid_nulling_shared_FK_property_when_deleting()
         {
             ExecuteWithStrategyInTransaction(


### PR DESCRIPTION
Fixes #26602

**Description**

The C# compiler changed the emit strategy for records in .NET 6 to take advantage of covariant returns. The Clone method now always has a return type that matches the containing type. Castle dynamic proxies throws when attempting to create a proxy for such types. This means EF Core lazy-loading and change-tracking proxies are broken for any record with a base type.

An bug has been filed on Castle proxies (https://github.com/castleproject/Core/issues/601), which is the correct place to ultimately fix this issue. However, since EF Core never needs to override the Clone method for its proxies, the fix here simply excludes the Clone method from the proxies we create.

**Customer impact**

Proxies for records with base types cannot be used. Reported by multiple customers. No known workaround.

**How found**

Multiple customer reports on 6.0.

**Regression**

Yes, From 5.0

**Testing**

Added unit and functional tests for records with base types.

**Risk**

Very low; Clone methods are never used by EF proxies. Also added quirk to revert to previous behavior.


