### PR TITLE
[release/6.0] Bundles: Allow argument separator (--)

### DIFF
--- a/src/EFCore.Design/Migrations/Design/MigrationsBundle.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsBundle.cs
@@ -40,11 +40,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             _assembly = assembly;
             _startupAssembly = startupAssembly;
 
-            var app = new CommandLineApplication
-            {
-                Name = "bundle",
-                HandleResponseFiles = true
-            };
+            var app = new CommandLineApplication { Name = "efbundle" };
+
             Configure(app);
 
             try
@@ -73,6 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         internal static void Configure(CommandLineApplication app)
         {
             app.FullName = DesignStrings.BundleFullName;
+            app.AllowArgumentSeparator = true;
 
             _migration = app.Argument("<MIGRATION>", DesignStrings.MigrationDescription);
             _connection = app.Option("--connection <CONNECTION>", DesignStrings.ConnectionDescription);
@@ -82,6 +80,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var verbose = app.Option("-v|--verbose", DesignStrings.VerboseDescription);
             var noColor = app.Option("--no-color", DesignStrings.NoColorDescription);
             var prefixOutput = app.Option("--prefix-output", DesignStrings.PrefixDescription);
+
+            app.HandleResponseFiles = true;
 
             app.OnExecute(
                 args =>

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationsBundleTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationsBundleTest.cs
@@ -44,9 +44,27 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             }
         }
 
+        [Fact]
+        public void HandleResponseFiles_is_true()
+        {
+            var app = new CommandLineApplication { Name = "efbundle" };
+            MigrationsBundle.Configure(app);
+
+            Assert.True(app.HandleResponseFiles);
+        }
+
+        [Fact]
+        public void AllowArgumentSeparator_is_true()
+        {
+            var app = new CommandLineApplication { Name = "efbundle" };
+            MigrationsBundle.Configure(app);
+
+            Assert.True(app.AllowArgumentSeparator);
+        }
+
         private static IEnumerable<CommandLineApplication> GetCommands()
         {
-            var app = new CommandLineApplication { Name = "bundle" };
+            var app = new CommandLineApplication { Name = "efbundle" };
 
             MigrationsBundle.Configure(app);
 


### PR DESCRIPTION
I forgot to set `AllowArgumentSeparator = true` in the bundle's command-line parser. This subverted the remaining code I added to flow additional arguments into application code.

Fixes #26945

### Customer impact

Without this, it's impossible to specify application arguments from the migrations bundle. For example, to specify the ASP.NET Core environment to use when applying migrations.

### Regression?

No. Migration bundles are new in EF Core 6.0.

### Risk

Low. This flag only changes the behavior when specifying `--`. Currently, specifying `--` will result in the following error.

> Unrecognized option '--'

### Verification

Added a unit test to ensure the flag is set.

Manually verified that arguments can now be flown into the application.