### PR TITLE
[release/6.0] Query: Avoid stackoverflow in lifting group by aggregate term

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -795,7 +795,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                         Tags = selectExpression.Tags,
                         _usedAliases = selectExpression._usedAliases.ToHashSet(),
                         _projectionMapping = newProjectionMappings,
-                        _groupingCorrelationPredicate = groupingCorrelationPredicate
+                        _groupingCorrelationPredicate = groupingCorrelationPredicate,
+                        _groupingParentSelectExpressionId = selectExpression._groupingParentSelectExpressionId
                     };
 
                     newSelectExpression._tptLeftJoinTables.AddRange(selectExpression._tptLeftJoinTables);
@@ -869,7 +870,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                         && subquery._groupBy.Count == 0
                         && subquery.Predicate != null
                         && ((AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27102", out var enabled) && enabled)
-                            || subquery.Predicate.Equals(subquery._groupingCorrelationPredicate)))
+                            || subquery.Predicate.Equals(subquery._groupingCorrelationPredicate))
+                        && ((AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27094", out var enabled2) && enabled2)
+                            || subquery._groupingParentSelectExpressionId == _selectExpression._groupingParentSelectExpressionId))
                     {
                         var initialTableCounts = 0;
                         var potentialTableCount = Math.Min(_selectExpression._tables.Count, subquery._tables.Count);
@@ -897,7 +900,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                             // We only replace columns from initial tables.
                             // Additional tables may have been added to outer from other terms which may end up matching on table alias
                             var columnExpressionReplacingExpressionVisitor =
-                                AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27083", out var enabled2) && enabled2
+                                AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27083", out var enabled3) && enabled3
                                 ? new ColumnExpressionReplacingExpressionVisitor(
                                     subquery, _selectExpression._tableReferences)
                                 : new ColumnExpressionReplacingExpressionVisitor(
@@ -922,12 +925,6 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                             return updatedProjection;
                         }
                     }
-                }
-
-                if (expression is SelectExpression innerSelectExpression
-                    && innerSelectExpression.GroupBy.Count > 0)
-                {
-                    expression = new GroupByAggregateLiftingExpressionVisitor(innerSelectExpression).Visit(innerSelectExpression);
                 }
 
                 return base.Visit(expression);

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -3415,6 +3415,60 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 15);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_aggregate_from_multiple_query_in_same_projection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().GroupBy(e => e.CustomerID)
+                        .Select(g => new
+                        {
+                            g.Key,
+                            A = ss.Set<Employee>().Where(e => e.City == "Seattle").GroupBy(e => e.City)
+                                    .Select(g2 => new { g2.Key, C = g2.Count() + g.Count() })
+                                    .OrderBy(e => 1)
+                                    .FirstOrDefault()
+                        }),
+                elementSorter: e => e.Key);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_aggregate_from_multiple_query_in_same_projection_2(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().GroupBy(e => e.CustomerID)
+                        .Select(g => new
+                        {
+                            g.Key,
+                            A = ss.Set<Employee>().Where(e => e.City == "Seattle").GroupBy(e => e.City)
+                                    .Select(g2 => g2.Count() + g.Min(e => e.OrderID))
+                                    .OrderBy(e => 1)
+                                    .FirstOrDefault()
+                        }),
+                elementSorter: e => e.Key);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_aggregate_from_multiple_query_in_same_projection_3(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().GroupBy(e => e.CustomerID)
+                        .Select(g => new
+                        {
+                            g.Key,
+                            A = ss.Set<Employee>().Where(e => e.City == "Seattle").GroupBy(e => e.City)
+                                    .Select(g2 => g2.Count() + g.Count() )
+                                    .OrderBy(e => e)
+                                    .FirstOrDefault()
+                        }),
+                elementSorter: e => e.Key);
+        }
+
         #endregion
 
         #region GroupByAndDistinctWithCorrelatedCollection

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -76,5 +77,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public override async Task Odata_groupby_empty_key(bool async)
             => await Assert.ThrowsAsync<NotSupportedException>(() => base.Odata_groupby_empty_key(async));
+
+        public override async Task GroupBy_aggregate_from_multiple_query_in_same_projection(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.GroupBy_aggregate_from_multiple_query_in_same_projection(async))).Message);
+
+        public override async Task GroupBy_aggregate_from_multiple_query_in_same_projection_3(bool async)
+            => await Assert.ThrowsAsync<SqliteException>(() => base.GroupBy_aggregate_from_multiple_query_in_same_projection_3(async));
+
+
     }
 }


### PR DESCRIPTION
Correlate the scalar subquery with parent SelectExpression

Resolves #27094

**Description**
Certain queries with group by aggregate on multiple level generates stackoverflow exception.

**Customer impact**
Program crashes with stackoverflow exception.

**How found**
Customer reported on 6.0.1

**Regression**
Yes. Query used to work in 5.0 version.

**Testing**
Added test for customer scenario and similar variations.

**Risk**
Low risk. Also added quirk mode.