### PR TITLE
[release/6.0] Query: Assign proper type to CollectionResultExpression

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -160,6 +160,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                 _queryableMethodTranslatingExpressionVisitor.TranslateSubquery(
                                     materializeCollectionNavigationExpression.Subquery)!);
                             return new CollectionResultExpression(
+                                // expression.Type will be CLR type of the navigation here so that is fine.
                                 new ProjectionBindingExpression(_selectExpression, _clientProjections.Count - 1, expression.Type),
                                 materializeCollectionNavigationExpression.Navigation,
                                 materializeCollectionNavigationExpression.Navigation.ClrType.GetSequenceType());
@@ -176,6 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                 if (subquery != null)
                                 {
                                     _clientProjections!.Add(subquery);
+                                    // expression.Type here will be List<T>
                                     return new CollectionResultExpression(
                                         new ProjectionBindingExpression(_selectExpression, _clientProjections.Count - 1, expression.Type),
                                         navigation: null,
@@ -195,8 +197,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     }
 
                                     _clientProjections!.Add(subquery);
+                                    var type = expression.Type;
+                                    if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27105", out var enabled) && enabled))
+                                    {
+                                        if (type.IsGenericType
+                                            && type.GetGenericTypeDefinition() == typeof(IQueryable<>))
+                                        {
+                                            type = typeof(IEnumerable<>).MakeGenericType(type.GetSequenceType());
+                                        }
+                                    }
                                     var projectionBindingExpression = new ProjectionBindingExpression(
-                                        _selectExpression, _clientProjections.Count - 1, expression.Type);
+                                        _selectExpression, _clientProjections.Count - 1, type);
                                     return subquery.ResultCardinality == ResultCardinality.Enumerable
                                         ? new CollectionResultExpression(
                                             projectionBindingExpression, navigation: null, subquery.ShaperExpression.Type)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1326,6 +1326,12 @@ ORDER BY c[""OrderID""]");
             return base.MemberInit_in_projection_without_arguments(async);
         }
 
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task List_of_list_of_anonymous_type(bool async)
+        {
+            return base.List_of_list_of_anonymous_type(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1878,6 +1878,22 @@ WHERE [c].[CustomerID] LIKE N'F%'
 ORDER BY [c].[CustomerID]");
         }
 
+        public override async Task List_of_list_of_anonymous_type(bool async)
+        {
+            await base.List_of_list_of_anonymous_type(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [t].[OrderID], [t].[OrderID0], [t].[ProductID]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o0].[OrderID] AS [OrderID0], [o0].[ProductID], [o].[CustomerID]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID], [t].[OrderID0]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
We copied type from subquery itself which is always Queryable type because of conversion we do. We need to convert it back to enumerable.
Issue happens only when nested level because we use element type so for 1 level queryable is gone. But for nested level we get Queryable<T> as element type on outer which is not assignable from List<T>
The conversion doesn't cause issue with user having Queryable in the result since that throws exception much earlier.

Resolves #27105

**Description**
When projecting enumerable of enumerable, we didn't assign correct type to expression tree when translating causing it to have incorrect type which later fails when generating compiled code.

**Customer impact**
Customers with enumerable of enumerable in projection will have query failing.

**How found**
Customer reported on 6.0.1

**Regression**
Yes, From 5.0

**Testing**
Added test for user scenario.

**Risk**
Very low risk. Also added quirk.