### PR TITLE
Add overload to SqlServerDbContextOptionsBuilder.EnableRetryOnFailure with errorNumbersToAdd without forcing maxRetryCount and maxRetryDelay

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
+++ b/src/EFCore.SqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
@@ -68,6 +68,26 @@ public class SqlServerDbContextOptionsBuilder
     /// <remarks>
     ///     <para>
     ///         This strategy is specifically tailored to SQL Server (including SQL Azure). It is pre-configured with
+    ///         error numbers for transient errors that can be retried.
+    ///     </para>
+    ///     <para>
+    ///         Default values of 6 for the maximum retry count and 30 seconds for the maximum default delay are used.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-connection-resiliency">Connection resiliency and database retries</see>
+    ///         for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="errorNumbersToAdd">Additional SQL error numbers that should be considered transient.</param>
+    public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(ICollection<int> errorNumbersToAdd)
+        => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, errorNumbersToAdd));
+
+    /// <summary>
+    ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This strategy is specifically tailored to SQL Server (including SQL Azure). It is pre-configured with
     ///         error numbers for transient errors that can be retried, but additional error numbers can also be supplied.
     ///     </para>
     ///     <para>

--- a/src/EFCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
+++ b/src/EFCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
@@ -89,6 +89,21 @@ public class SqlServerRetryingExecutionStrategy : ExecutionStrategy
     /// <summary>
     ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
     /// </summary>
+    /// <remarks>
+    ///     Default values of 6 for the maximum retry count and 30 seconds for the maximum default delay are used.
+    /// </remarks>
+    /// <param name="dependencies">Parameter object containing service dependencies.</param>
+    /// <param name="errorNumbersToAdd">Additional SQL error numbers that should be considered transient.</param>
+    public SqlServerRetryingExecutionStrategy(
+        ExecutionStrategyDependencies dependencies,
+        ICollection<int> errorNumbersToAdd)
+        : this(dependencies, DefaultMaxRetryCount, DefaultMaxDelay, errorNumbersToAdd)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+    /// </summary>
     /// <param name="context">The context on which the operations will be invoked.</param>
     /// <param name="maxRetryCount">The maximum number of retry attempts.</param>
     /// <param name="maxRetryDelay">The maximum delay between retries.</param>


### PR DESCRIPTION
Add overload to `SqlServerDbContextOptionsBuilder.EnableRetryOnFailure` with `errorNumbersToAdd` without forcing `maxRetryCount` and `maxRetryDelay`

Fixes #27074

Please review
