### PR TITLE
Don't issue a warning when replacing an optional dependent with non-null values

### DIFF
--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -282,7 +282,7 @@ public class ModificationCommand : IModificationCommand
             }
 
             var optionalDependentWithAllNull =
-                (entry.EntityState == EntityState.Deleted
+                (entry.EntityState == EntityState.Modified
                     || entry.EntityState == EntityState.Added)
                 && tableMapping.Table.IsOptional(entry.EntityType)
                 && tableMapping.Table.GetRowInternalForeignKeys(entry.EntityType).Any();
@@ -352,11 +352,18 @@ public class ModificationCommand : IModificationCommand
                     columnModifications.Add(columnModification);
 
                     if (optionalDependentWithAllNull
-                        && columnModification.IsWrite
-                        && (entry.EntityState != EntityState.Added || columnModification.Value is not null))
+                        && (columnModification.IsWrite
+                            || (columnModification.IsCondition && !isKey))
+                        && columnModification.Value is not null)
                     {
                         optionalDependentWithAllNull = false;
                     }
+                }
+                else if (optionalDependentWithAllNull
+                    && state == EntityState.Modified
+                    && entry.GetCurrentValue(property) is not null)
+                {
+                    optionalDependentWithAllNull = false;
                 }
             }
 

--- a/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
@@ -578,6 +578,22 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
         var log = TestSqlLoggerFactory.Log.Single(l => l.Level == LogLevel.Warning);
 
         Assert.Equal(expected, log.Message);
+
+        TestSqlLoggerFactory.Clear();
+
+        meterReading.MeterReadingDetails = new MeterReadingDetail { CurrentRead = "100" };
+
+        context.SaveChanges();
+
+        Assert.Empty(TestSqlLoggerFactory.Log.Where(l => l.Level == LogLevel.Warning));
+
+        meterReading.MeterReadingDetails = new MeterReadingDetail();
+
+        context.SaveChanges();
+
+        log = TestSqlLoggerFactory.Log.Single(l => l.Level == LogLevel.Warning);
+
+        Assert.Equal(expected, log.Message);
     }
 
     [ConditionalFact]
@@ -595,9 +611,11 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
 
         context.SaveChanges();
 
-        var log = TestSqlLoggerFactory.Log.SingleOrDefault(l => l.Level == LogLevel.Warning);
+        meterReading.MeterReadingDetails = new MeterReadingDetail { CurrentRead = "100" };
 
-        Assert.Null(log.Message);
+        context.SaveChanges();
+
+        Assert.Empty(TestSqlLoggerFactory.Log.Where(l => l.Level == LogLevel.Warning));
     }
 
     protected override string StoreName { get; } = "TableSplittingTest";
@@ -684,8 +702,8 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
         {
         }
 
-        protected DbSet<MeterReading> MeterReadings { get; set; }
-        protected DbSet<MeterReadingDetail> MeterReadingDetails { get; set; }
+        public DbSet<MeterReading> MeterReadings { get; set; }
+        public DbSet<MeterReadingDetail> MeterReadingDetails { get; set; }
     }
 
     protected class MeterReading


### PR DESCRIPTION
Fixes #26712