### PR TITLE
Stop prefixing check constraints.

### DIFF
--- a/src/EFCore.Relational/Metadata/IReadOnlyCheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlyCheckConstraint.cs
@@ -50,7 +50,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             var prefix = $"CK_{storeObject.Name}_";
             return Uniquifier.Truncate(
-                ModelName.StartsWith(prefix, StringComparison.Ordinal)
+                !(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27059", out var enabled) && enabled)
+                || ModelName.StartsWith(prefix, StringComparison.Ordinal)
                     ? ModelName
                     : prefix + ModelName,
                 EntityType.Model.GetMaxIdentifierLength());

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -711,7 +711,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder =>
                 {
                     builder.Entity<EntityWithTwoProperties>()
-                        .HasCheckConstraint("CK_Customer_AlternateId", "AlternateId > Id", ck => ck.HasName("CK_Customer_AlternateId"));
+                        .HasCheckConstraint("AlternateId", "AlternateId > Id", ck => ck.HasName("CK_Customer_AlternateId"));
                     builder.Ignore<EntityWithOneProperty>();
                 },
                 AddBoilerPlate(
@@ -732,7 +732,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.ToTable(""EntityWithTwoProperties"");
 
-                    b.HasCheckConstraint(""CK_Customer_AlternateId"", ""AlternateId > Id"", c => c.HasName(""CK_Customer_AlternateId""));
+                    b.HasCheckConstraint(""AlternateId"", ""AlternateId > Id"", c => c.HasName(""CK_Customer_AlternateId""));
                 });"),
                 o =>
                 {

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                         e.HasKey("CustomId");
                         e.HasAlternateKey("SSN");
-                        e.HasCheckConstraint("EmployerId", $"{DelimitIdentifier("EmployerId")} > 0");
+                        e.HasCheckConstraint("CK_People_EmployerId", $"{DelimitIdentifier("EmployerId")} > 0");
                         e.HasOne("Employers").WithMany("People").HasForeignKey("EmployerId");
 
                         e.HasComment("Table comment");
@@ -641,7 +641,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     "People", e =>
                     {
                         e.Property<int>("DriverLicense");
-                        e.HasCheckConstraint("Foo", $"{DelimitIdentifier("DriverLicense")} > 0");
+                        e.HasCheckConstraint("CK_People_Foo", $"{DelimitIdentifier("DriverLicense")} > 0");
                     }),
                 model =>
                 {
@@ -1307,7 +1307,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         e.Property<int>("DriverLicense");
                     }),
                 builder => { },
-                builder => builder.Entity("People").HasCheckConstraint("Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
+                builder => builder.Entity("People").HasCheckConstraint("CK_People_Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
                 model =>
                 {
                     // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
@@ -1322,8 +1322,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         e.Property<int>("Id");
                         e.Property<int>("DriverLicense");
                     }),
-                builder => builder.Entity("People").HasCheckConstraint("Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
-                builder => builder.Entity("People").HasCheckConstraint("Foo", $"{DelimitIdentifier("DriverLicense")} > 1"),
+                builder => builder.Entity("People").HasCheckConstraint("CK_People_Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
+                builder => builder.Entity("People").HasCheckConstraint("CK_People_Foo", $"{DelimitIdentifier("DriverLicense")} > 1"),
                 model =>
                 {
                     // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
@@ -1338,7 +1338,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         e.Property<int>("Id");
                         e.Property<int>("DriverLicense");
                     }),
-                builder => builder.Entity("People").HasCheckConstraint("Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
+                builder => builder.Entity("People").HasCheckConstraint("CK_People_Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
                 builder => { },
                 model =>
                 {

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -475,9 +475,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var modelBuilder = CreateConventionalModelBuilder();
 
             modelBuilder.Entity<A>().HasOne<B>().WithOne(b => b.A).HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
-            modelBuilder.Entity<A>().HasCheckConstraint("SomeCK", "Id > 0");
+            modelBuilder.Entity<A>().HasCheckConstraint("CK_Table_SomeCK", "Id > 0");
             modelBuilder.Entity<A>().ToTable("Table");
-            modelBuilder.Entity<B>().HasCheckConstraint("SomeCK", "Id > 10");
+            modelBuilder.Entity<B>().HasCheckConstraint("CK_Table_SomeCK", "Id > 10");
             modelBuilder.Entity<B>().ToTable("Table");
 
             var model = Validate(modelBuilder);
@@ -492,9 +492,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var modelBuilder = CreateConventionalModelBuilder();
 
             modelBuilder.Entity<A>().HasOne<B>().WithOne(b => b.A).HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
-            modelBuilder.Entity<A>().HasCheckConstraint("SomeCK", "Id > 0");
+            modelBuilder.Entity<A>().HasCheckConstraint("CK_Table_SomeCK", "Id > 0");
             modelBuilder.Entity<A>().ToTable("Table");
-            modelBuilder.Entity<B>().HasCheckConstraint("SomeCK", "Id > 0");
+            modelBuilder.Entity<B>().HasCheckConstraint("CK_Table_SomeCK", "Id > 0");
             modelBuilder.Entity<B>().ToTable("Table");
 
             var model = Validate(modelBuilder);

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -443,7 +443,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         x.Property<int?>("ParentAltId");
                         x.HasOne("Node").WithMany().HasForeignKey("ParentAltId");
                         x.HasIndex("ParentAltId");
-                        x.HasCheckConstraint("SomeCheckConstraint", "[Id] > 10");
+                        x.HasCheckConstraint("CK_Node_SomeCheckConstraint", "[Id] > 10");
                     }),
                 upOps =>
                 {

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
@@ -338,10 +338,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<Child>()
                     .HasBaseType(null)
-                    .HasCheckConstraint("LargeId", "Id > 1000", c => c.HasName("CK_LargeId"));
+                    .HasCheckConstraint("CK_ChildBase_LargeId", "Id > 1000", c => c.HasName("CK_LargeId"));
                 modelBuilder.Entity<ChildBase>()
                     .HasCheckConstraint("PositiveId", "Id > 0")
-                    .HasCheckConstraint("LargeId", "Id > 1000");
+                    .HasCheckConstraint("CK_ChildBase_LargeId", "Id > 1000");
                 modelBuilder.Entity<Child>()
                     .HasBaseType<ChildBase>();
                 modelBuilder.Entity<DisjointChildSubclass1>();
@@ -354,10 +354,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var firstCheckConstraint = @base.FindCheckConstraint("PositiveId");
                 Assert.Equal("PositiveId", firstCheckConstraint.ModelName);
                 Assert.Equal("Id > 0", firstCheckConstraint.Sql);
-                Assert.Equal("CK_ChildBase_PositiveId", firstCheckConstraint.Name);
+                Assert.Equal("PositiveId", firstCheckConstraint.Name);
 
-                var secondCheckConstraint = @base.FindCheckConstraint("LargeId");
-                Assert.Equal("LargeId", secondCheckConstraint.ModelName);
+                var secondCheckConstraint = @base.FindCheckConstraint("CK_ChildBase_LargeId");
+                Assert.Equal("CK_ChildBase_LargeId", secondCheckConstraint.ModelName);
                 Assert.Equal("Id > 1000", secondCheckConstraint.Sql);
                 Assert.Equal("CK_LargeId", secondCheckConstraint.Name);
 


### PR DESCRIPTION
Fixes #27059

**Description**

In 6.0 we started uniquifying check constraint names if there was a conflict in the database, but we also started adding a prefix to all names that didn't have a prefix that we recognized.

This was unexpected and unnecessary, so we decided to revert the prefixing change.

**Customer impact**

Users get a new migration changing all the check constraint names that don't follow the pattern. The workaround is to manually add overriding configuration for each check constraint.

**How found**

Customer report on 6.0.

**Regression**

Yes, From 5.0

**Testing**

Already present.

**Risk**

Low; only affects migrations. Also added quirk to revert to previous behavior.


