### PR TITLE
[release/6.0] Fix baselines for IS NULL change

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1895,10 +1895,10 @@ GROUP BY [o].[EmployeeID]");
     WHERE (CAST([o0].[EmployeeID] AS bigint) = CAST(((
         SELECT MAX([o1].[OrderID])
         FROM [Orders] AS [o1]
-        WHERE ([o].[EmployeeID] = [o1].[EmployeeID]) OR ([o].[EmployeeID] IS NULL AND [o1].[EmployeeID] IS NULL)) * 6) AS bigint)) OR ([o0].[EmployeeID] IS NULL AND (
+        WHERE ([o].[EmployeeID] = [o1].[EmployeeID]) OR (([o].[EmployeeID] IS NULL) AND ([o1].[EmployeeID] IS NULL))) * 6) AS bigint)) OR (([o0].[EmployeeID] IS NULL) AND ((
         SELECT MAX([o1].[OrderID])
         FROM [Orders] AS [o1]
-        WHERE ([o].[EmployeeID] = [o1].[EmployeeID]) OR ([o].[EmployeeID] IS NULL AND [o1].[EmployeeID] IS NULL)) IS NULL)) AS [Max]
+        WHERE ([o].[EmployeeID] = [o1].[EmployeeID]) OR (([o].[EmployeeID] IS NULL) AND ([o1].[EmployeeID] IS NULL))) IS NULL))) AS [Max]
 FROM [Orders] AS [o]
 GROUP BY [o].[EmployeeID]");
         }
@@ -2823,7 +2823,7 @@ OUTER APPLY (
     SELECT TOP(1) [e].[City] AS [Key], COUNT(*) + (
         SELECT COUNT(*)
         FROM [Orders] AS [o0]
-        WHERE ([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL)) AS [C], 1 AS [c0]
+        WHERE ([t].[CustomerID] = [o0].[CustomerID]) OR (([t].[CustomerID] IS NULL) AND ([o0].[CustomerID] IS NULL))) AS [C], 1 AS [c0]
     FROM [Employees] AS [e]
     WHERE [e].[City] = N'Seattle'
     GROUP BY [e].[City]
@@ -2855,14 +2855,14 @@ GROUP BY [o].[CustomerID]");
     SELECT TOP(1) COUNT(*) + (
         SELECT COUNT(*)
         FROM [Orders] AS [o0]
-        WHERE ([o].[CustomerID] = [o0].[CustomerID]) OR ([o].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
+        WHERE ([o].[CustomerID] = [o0].[CustomerID]) OR (([o].[CustomerID] IS NULL) AND ([o0].[CustomerID] IS NULL)))
     FROM [Employees] AS [e]
     WHERE [e].[City] = N'Seattle'
     GROUP BY [e].[City]
     ORDER BY COUNT(*) + (
         SELECT COUNT(*)
         FROM [Orders] AS [o0]
-        WHERE ([o].[CustomerID] = [o0].[CustomerID]) OR ([o].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))), 0) AS [A]
+        WHERE ([o].[CustomerID] = [o0].[CustomerID]) OR (([o].[CustomerID] IS NULL) AND ([o0].[CustomerID] IS NULL)))), 0) AS [A]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -174,7 +174,7 @@ GROUP BY [t].[OrderId]");
     FROM [Order] AS [o0]
     WHERE [o0].[CustomerId] = [o].[CustomerId]) AS [CustomerMinHourlyRate], MIN([o].[HourlyRate]) AS [HourlyRate], COUNT(*) AS [Count]
 FROM [Order] AS [o]
-WHERE ([o].[Number] <> N'A1') OR [o].[Number] IS NULL
+WHERE ([o].[Number] <> N'A1') OR ([o].[Number] IS NULL)
 GROUP BY [o].[CustomerId], [o].[Number]");
         }
 
@@ -189,10 +189,10 @@ GROUP BY [o].[CustomerId], [o].[Number]");
     WHERE ([t0].[Value] = ((
         SELECT MAX([t1].[Id])
         FROM [Table] AS [t1]
-        WHERE ([t].[Value] = [t1].[Value]) OR ([t].[Value] IS NULL AND [t1].[Value] IS NULL)) * 6)) OR ([t0].[Value] IS NULL AND (
+        WHERE ([t].[Value] = [t1].[Value]) OR (([t].[Value] IS NULL) AND ([t1].[Value] IS NULL))) * 6)) OR (([t0].[Value] IS NULL) AND ((
         SELECT MAX([t1].[Id])
         FROM [Table] AS [t1]
-        WHERE ([t].[Value] = [t1].[Value]) OR ([t].[Value] IS NULL AND [t1].[Value] IS NULL)) IS NULL)) AS [B]
+        WHERE ([t].[Value] = [t1].[Value]) OR (([t].[Value] IS NULL) AND ([t1].[Value] IS NULL))) IS NULL))) AS [B]
 FROM [Table] AS [t]
 GROUP BY [t].[Value]");
         }
@@ -206,7 +206,7 @@ GROUP BY [t].[Value]");
     SELECT TOP(1) (
         SELECT COALESCE(SUM([t1].[Id]), 0)
         FROM [Table] AS [t1]
-        WHERE ([t].[Value] = [t1].[Value]) OR ([t].[Value] IS NULL AND [t1].[Value] IS NULL)) + COALESCE(SUM([t0].[Id]), 0)
+        WHERE ([t].[Value] = [t1].[Value]) OR (([t].[Value] IS NULL) AND ([t1].[Value] IS NULL))) + COALESCE(SUM([t0].[Id]), 0)
     FROM [Table] AS [t0]
     GROUP BY [t0].[Value]
     ORDER BY (SELECT 1)), 0) AS [C]


### PR DESCRIPTION
This fixes the build failures caused by 021fbcb7f72, and should make the 6.0 build green again.

Sorry for the trouble, should have rebased #26653 before merging.