### PR TITLE
[release/6.0] Query: Match joined tables properly when lifting for group by aggregate

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -63,6 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
         private SqlExpression? _groupingCorrelationPredicate;
         private Guid? _groupingParentSelectExpressionId;
+        private int? _groupingParentSelectExpressionTableCount;
         private CloningExpressionVisitor? _cloningExpressionVisitor;
 
         private SelectExpression(
@@ -1256,7 +1257,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
             // We generate the cloned expression before changing identifier for this SelectExpression
             // because we are going to erase grouping for cloned expression.
-            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27094", out var enabled2) && enabled2))
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27094", out var enabled27094) && enabled27094))
             {
                 _groupingParentSelectExpressionId = Guid.NewGuid();
 
@@ -1267,9 +1268,14 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 .Aggregate((l, r) => sqlExpressionFactory.AndAlso(l, r));
             clonedSelectExpression._groupBy.Clear();
             clonedSelectExpression.ApplyPredicate(correlationPredicate);
-            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27102", out var enabled) && enabled))
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27102", out var enabled27102) && enabled27102))
             {
                 clonedSelectExpression._groupingCorrelationPredicate = clonedSelectExpression.Predicate;
+            }
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27163", out var enabled27163) && enabled27163))
+            {
+                _groupingParentSelectExpressionTableCount = _tables.Count;
+
             }
 
             if (!_identifier.All(e => _groupBy.Contains(e.Column)))
@@ -1495,6 +1501,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 Offset = Offset,
                 Limit = Limit,
                 _groupingParentSelectExpressionId = _groupingParentSelectExpressionId,
+                _groupingParentSelectExpressionTableCount = _groupingParentSelectExpressionTableCount,
                 _groupingCorrelationPredicate = _groupingCorrelationPredicate
             };
             Offset = null;
@@ -1504,6 +1511,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             Having = null;
             _groupingCorrelationPredicate = null;
             _groupingParentSelectExpressionId = null;
+            _groupingParentSelectExpressionTableCount = null;
             _groupBy.Clear();
             _orderings.Clear();
             _tables.Clear();
@@ -2819,7 +2827,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 Having = Having,
                 Offset = Offset,
                 Limit = Limit,
-                _groupingParentSelectExpressionId = _groupingParentSelectExpressionId
+                _groupingParentSelectExpressionId = _groupingParentSelectExpressionId,
+                _groupingParentSelectExpressionTableCount = _groupingParentSelectExpressionTableCount
             };
             subquery._usedAliases = _usedAliases;
             _tables.Clear();
@@ -3482,7 +3491,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                         Tags = Tags,
                         _usedAliases = _usedAliases,
                         _groupingCorrelationPredicate = groupingCorrelationPredicate,
-                        _groupingParentSelectExpressionId = _groupingParentSelectExpressionId
+                        _groupingParentSelectExpressionId = _groupingParentSelectExpressionId,
+                        _groupingParentSelectExpressionTableCount = _groupingParentSelectExpressionTableCount,
                     };
 
                     newSelectExpression._tptLeftJoinTables.AddRange(_tptLeftJoinTables);

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -786,5 +786,108 @@ namespace Microsoft.EntityFrameworkCore
             public int Id { get; set; }
             public int? Value { get; set; }
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Group_by_multiple_aggregate_joining_different_tables(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context27163>();
+            using var context = contextFactory.CreateContext();
+
+            var query = context.Parents
+                .GroupBy(x => new { })
+                .Select(g => new
+                {
+                    Test1 = g
+                        .Select(x => x.Child1.Value1)
+                        .Distinct()
+                        .Count(),
+                    Test2 = g
+                        .Select(x => x.Child2.Value2)
+                        .Distinct()
+                        .Count()
+                });
+
+            var orders = async
+                ? await query.ToListAsync()
+                : query.ToList();
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Group_by_multiple_aggregate_joining_different_tables_with_query_filter(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context27163>();
+            using var context = contextFactory.CreateContext();
+
+            var query = context.Parents
+                .GroupBy(x => new { })
+                .Select(g => new
+                {
+                    Test1 = g
+                        .Select(x => x.ChildFilter1.Value1)
+                        .Distinct()
+                        .Count(),
+                    Test2 = g
+                        .Select(x => x.ChildFilter2.Value2)
+                        .Distinct()
+                        .Count()
+                });
+
+            var orders = async
+                ? await query.ToListAsync()
+                : query.ToList();
+        }
+
+        protected class Context27163 : DbContext
+        {
+            public Context27163(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Parent> Parents { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<ChildFilter1>().HasQueryFilter(e => e.Filter1 == "Filter1");
+                modelBuilder.Entity<ChildFilter2>().HasQueryFilter(e => e.Filter2 == "Filter2");
+            }
+        }
+
+        public class Parent
+        {
+            public int Id { get; set; }
+            public Child1 Child1 { get; set; }
+            public Child2 Child2 { get; set; }
+            public ChildFilter1 ChildFilter1 { get; set; }
+            public ChildFilter2 ChildFilter2 { get; set; }
+        }
+
+        public class Child1
+        {
+            public int Id { get; set; }
+            public string Value1 { get; set; }
+        }
+
+        public class Child2
+        {
+            public int Id { get; set; }
+            public string Value2 { get; set; }
+        }
+
+        public class ChildFilter1
+        {
+            public int Id { get; set; }
+            public string Filter1 { get; set; }
+            public string Value1 { get; set; }
+        }
+
+        public class ChildFilter2
+        {
+            public int Id { get; set; }
+            public string Filter2 { get; set; }
+            public string Value2 { get; set; }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -297,6 +298,18 @@ LEFT JOIN (
     END
     WHERE (([t].[OneToOne_Required_PK_Date] IS NOT NULL) AND ([t].[Level1_Required_Id] IS NOT NULL)) AND ([t].[OneToMany_Required_Inverse2Id] IS NOT NULL)
 ) AS [t0] ON [l].[Id] = [t0].[Level1_Optional_Id]");
+        }
+
+        [ConditionalTheory(Skip = "Issue#26104")]
+        public override Task GroupBy_aggregate_where_required_relationship(bool async)
+        {
+            return base.GroupBy_aggregate_where_required_relationship(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#26104")]
+        public override Task GroupBy_aggregate_where_required_relationship_2(bool async)
+        {
+            return base.GroupBy_aggregate_where_required_relationship_2(async);
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -213,5 +213,49 @@ GROUP BY [t].[Value]");
 FROM [Table] AS [t]
 GROUP BY [t].[Value]");
         }
+
+        public override async Task Group_by_multiple_aggregate_joining_different_tables(bool async)
+        {
+            await base.Group_by_multiple_aggregate_joining_different_tables(async);
+
+            AssertSql(
+                @"SELECT COUNT(DISTINCT ([c].[Value1])) AS [Test1], COUNT(DISTINCT ([c0].[Value2])) AS [Test2]
+FROM (
+    SELECT [p].[Child1Id], [p].[Child2Id], 1 AS [Key]
+    FROM [Parents] AS [p]
+) AS [t]
+LEFT JOIN [Child1] AS [c] ON [t].[Child1Id] = [c].[Id]
+LEFT JOIN [Child2] AS [c0] ON [t].[Child2Id] = [c0].[Id]
+GROUP BY [t].[Key]");
+        }
+
+        public override async Task Group_by_multiple_aggregate_joining_different_tables_with_query_filter(bool async)
+        {
+            await base.Group_by_multiple_aggregate_joining_different_tables_with_query_filter(async);
+
+            AssertSql(
+                @"SELECT COUNT(DISTINCT ([t0].[Value1])) AS [Test1], (
+    SELECT DISTINCT COUNT(DISTINCT ([t2].[Value2]))
+    FROM (
+        SELECT [p0].[Id], [p0].[Child1Id], [p0].[Child2Id], [p0].[ChildFilter1Id], [p0].[ChildFilter2Id], 1 AS [Key]
+        FROM [Parents] AS [p0]
+    ) AS [t1]
+    LEFT JOIN (
+        SELECT [c0].[Id], [c0].[Filter2], [c0].[Value2]
+        FROM [ChildFilter2] AS [c0]
+        WHERE [c0].[Filter2] = N'Filter2'
+    ) AS [t2] ON [t1].[ChildFilter2Id] = [t2].[Id]
+    WHERE [t].[Key] = [t1].[Key]) AS [Test2]
+FROM (
+    SELECT [p].[ChildFilter1Id], 1 AS [Key]
+    FROM [Parents] AS [p]
+) AS [t]
+LEFT JOIN (
+    SELECT [c].[Id], [c].[Value1]
+    FROM [ChildFilter1] AS [c]
+    WHERE [c].[Filter1] = N'Filter1'
+) AS [t0] ON [t].[ChildFilter1Id] = [t0].[Id]
+GROUP BY [t].[Key]");
+        }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
@@ -28,5 +28,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Prune_does_not_throw_null_ref(async))).Message);
+
+        [ConditionalTheory(Skip = "Issue#26104")]
+        public override Task GroupBy_aggregate_where_required_relationship(bool async)
+        {
+            return base.GroupBy_aggregate_where_required_relationship(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#26104")]
+        public override Task GroupBy_aggregate_where_required_relationship_2(bool async)
+        {
+            return base.GroupBy_aggregate_where_required_relationship_2(async);
+        }
     }
 }


### PR DESCRIPTION
Earlier we only matched alias and skipped if alias matched. This could happen if the table name starts with same character.
Even if we do deeper match unwinding joins, we cannot match if the join is to subquery (which can be generated when target of navigation has query filter).

Solution:

When applying group by on SelectExpression, remember the original table count. Once Groupby has been applied we cannot add more joins to SelectExpression other than group by aggregate term lifting.

During lifting:
- If aliases of original tables in parent and subquery doesn't match then we assume subquery is non-grouping element rooted and we don't lift.
- If parent have lifted additional joins, one of them being a subquery join, then we abort lifting if the subquery contains a join to lift which is a subquery.
- If we are allowed to join after first 2 checks then:
  - We copy over owned entity in initial tables
  - We try to match additional joins after initial if they are table joins and joining to same table, in which case we don't need to join them again.
  - We copy over all other joins.

Resolves #27163

**Description**

After group by operator, when there are multiple aggregate terms in projection containing navigation expansion, when alias of joined tables match, then we generate invalid SQL if column referenced doesn't exist on other table which we didn't lift or incorrect result if column reference exists.

**Customer impact**

Customers will have their query throwing invalid SQL error or giving incorrect results.

**How found**

Customer reported on 6.0.1

**Regression**

No. The feature was introduced in 6.0 release only.

**Testing**

Added testing for user scenario and complex scenario in similar pattern.

**Risk**

Low risk. Logic added for lifting is pretty conservative. Also added quirk to revert to previous behavior.