### PR TITLE
Reverting SqlClient package upgrade to fix build

### DIFF
--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Due to a [major breaking change](https://github.com/dotnet/SqlClient/blob/main/release-notes/4.0/4.0.0.md#encrypt-default-value-set-to-true) in SqlClient 4.0, updating to 4.0 breaks all tests that do not use LocalDb.

This PR reverts the update until we can decide how to handle the breaks.