### PR TITLE
fix: #27138, stream with 64-bit PK

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -373,7 +373,7 @@ namespace Microsoft.Data.Sqlite
             }
 
             var blobColumnName = sqlite3_column_origin_name(Handle, ordinal).utf8_to_string();
-            var rowid = GetInt32(_rowidOrdinal.Value);
+            var rowid = GetInt64(_rowidOrdinal.Value);
 
             return new SqliteBlob(_connection, blobDatabaseName, blobTableName, blobColumnName, rowid, readOnly: true);
         }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -459,18 +459,16 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void GetStream_Blob_works_when_long_pk()
         {
-            long pk = 9223372036854775800;
-
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
 
                 connection.ExecuteNonQuery(
                     "CREATE TABLE DataTable (Id INTEGER PRIMARY KEY, Data BLOB);" +
-                    $"INSERT INTO DataTable VALUES ({pk}, X'01020304');");
+                    $"INSERT INTO DataTable VALUES (2147483648, X'01020304');");
 
                 var selectCommand = connection.CreateCommand();
-                selectCommand.CommandText = $"SELECT Id, Data FROM DataTable WHERE Id = {pk}";
+                selectCommand.CommandText = $"SELECT Id, Data FROM DataTable WHERE Id = 2147483648";
                 using (var reader = selectCommand.ExecuteReader())
                 {
                     Assert.True(reader.Read());


### PR DESCRIPTION
Resolves an issue with blob streaming, where a 32-bit PK was always expected - but SQLite stores integers as signed, 64-bit values.

 - SqlDataRecord.GetStream changed from using `GetInt32` to `GetInt64`
 - Added a new test

Fixes #27138