### PR TITLE
Fix to #26676 - EF Core 6 - IsTemporal adds an unnecessary migration when DefaultSchema is configured at the DbContext Level

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeExtensions.cs
@@ -252,8 +252,7 @@ public static class SqlServerEntityTypeExtensions
     public static string? GetHistoryTableSchema(this IReadOnlyEntityType entityType)
         => (entityType is RuntimeEntityType)
             ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
-            : entityType[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
-            ?? entityType[RelationalAnnotationNames.Schema] as string;
+            : entityType[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string ?? entityType.GetSchema();
 
     /// <summary>
     ///     Sets a value representing the schema of the history table associated with the entity mapped to a temporal table.

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -118,6 +118,7 @@ public class SqlServerConventionSetBuilder : RelationalConventionSetBuilder
             conventionSet.ModelFinalizingConventions,
             (SharedTableConvention)new SqlServerSharedTableConvention(Dependencies, RelationalDependencies));
         conventionSet.ModelFinalizingConventions.Add(new SqlServerDbFunctionConvention(Dependencies, RelationalDependencies));
+        conventionSet.ModelFinalizingConventions.Add(sqlServerTemporalConvention);
 
         ReplaceConvention(
             conventionSet.ModelFinalizedConventions,

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -534,6 +534,7 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
         {
             var historyTableSchema = operation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
                 ?? model?.GetDefaultSchema();
+
             var needsExec = historyTableSchema == null;
             var subBuilder = needsExec
                 ? new MigrationCommandListBuilder(Dependencies)
@@ -1261,7 +1262,7 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
         {
             var historyTableName = operation[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
             var historyTableSchema = operation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
-                ?? model?.GetDefaultSchema();
+                ?? operation.Schema ?? model?.GetDefaultSchema();
             var periodStartColumnName = operation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
             var periodEndColumnName = operation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
 
@@ -2261,7 +2262,7 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 schema ??= model?.GetDefaultSchema();
                 var historyTableName = operation[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
                 var historyTableSchema = operation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
-                    ?? model?.GetDefaultSchema();
+                    ?? schema;
                 var periodStartColumnName = operation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
                 var periodEndColumnName = operation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -2123,6 +2123,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.ToTable(tb => tb.IsTemporal(ttb =>
                         {
+                            ttb.UseHistoryTable(""EntityWithStringPropertyHistory"");
                             ttb
                                 .HasPeriodStart(""PeriodStart"")
                                 .HasColumnName(""PeriodStart"");
@@ -2138,7 +2139,7 @@ public class ModelSnapshotSqlServerTest
                     "Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty");
                 var annotations = temporalEntity.GetAnnotations().ToList();
 
-                Assert.Equal(5, annotations.Count);
+                Assert.Equal(6, annotations.Count);
                 Assert.Contains(annotations, a => a.Name == SqlServerAnnotationNames.IsTemporal && a.Value as bool? == true);
                 Assert.Contains(
                     annotations,

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1062,6 +1062,7 @@ namespace TestNamespace
             {
                 entity.ToTable(tb => tb.IsTemporal(ttb =>
     {
+        ttb.UseHistoryTable(""CustomerHistory"");
         ttb
             .HasPeriodStart(""PeriodStart"")
             .HasColumnName(""PeriodStart"");


### PR DESCRIPTION
Problem was a discrepancy between RelationalModel build in runtime and the current model (from OnModelCreating) - relational model would set history table schema annotation using the table schema or default schema, however current model wouldn't set those annotations.
Model differ would then pick up on those differences and create migration to set the schema for history table. When building actual migration sql we already compensated for the difference and not generate actual sql code, but the problem persists.

Fix is to improve the temporal convention so that history table schema in current model (more) closely resembles the temporal table schema and therefore is similar to RelationalModel generated in runtime.

Fixes #26676