### PR TITLE
Add support for index sort order (descending)

### DIFF
--- a/src/EFCore.Abstractions/IndexAttribute.cs
+++ b/src/EFCore.Abstractions/IndexAttribute.cs
@@ -55,8 +55,7 @@ public sealed class IndexAttribute : Attribute
     }
 
     /// <summary>
-    ///     Gets a set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
     /// </summary>
     public bool[]? IsDescending { get; set; }
 

--- a/src/EFCore.Abstractions/IndexAttribute.cs
+++ b/src/EFCore.Abstractions/IndexAttribute.cs
@@ -15,8 +15,9 @@ namespace Microsoft.EntityFrameworkCore;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public sealed class IndexAttribute : Attribute
 {
-    private bool? _isUnique;
     private string? _name;
+    private bool? _isUnique;
+    private bool[]? _isDescending;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="IndexAttribute" /> class.
@@ -57,7 +58,20 @@ public sealed class IndexAttribute : Attribute
     /// <summary>
     ///     A set of values indicating whether each corresponding index column has descending sort order.
     /// </summary>
-    public bool[]? IsDescending { get; set; }
+    public bool[]? IsDescending
+    {
+        get => _isDescending;
+        set
+        {
+            if (value is not null && value.Length != PropertyNames.Count)
+            {
+                throw new ArgumentException(
+                    AbstractionsStrings.InvalidNumberOfIndexSortOrderValues(value.Length, PropertyNames.Count), nameof(IsDescending));
+            }
+
+            _isDescending = value;
+        }
+    }
 
     /// <summary>
     ///     Checks whether <see cref="IsUnique" /> has been explicitly set to a value.

--- a/src/EFCore.Abstractions/IndexAttribute.cs
+++ b/src/EFCore.Abstractions/IndexAttribute.cs
@@ -55,6 +55,12 @@ public sealed class IndexAttribute : Attribute
     }
 
     /// <summary>
+    ///     Gets a set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </summary>
+    public bool[]? IsDescending { get; set; }
+
+    /// <summary>
     ///     Checks whether <see cref="IsUnique" /> has been explicitly set to a value.
     /// </summary>
     public bool IsUniqueHasValue

--- a/src/EFCore.Abstractions/Properties/AbstractionsStrings.Designer.cs
+++ b/src/EFCore.Abstractions/Properties/AbstractionsStrings.Designer.cs
@@ -52,6 +52,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("CollectionArgumentIsEmpty", nameof(argumentName)),
                 argumentName);
 
+        /// <summary>
+        ///     Invalid number of index sort order values: {numValues} values were provided, but the index has {numProperties} properties.
+        /// </summary>
+        public static string InvalidNumberOfIndexSortOrderValues(object? numValues, object? numProperties)
+            => string.Format(
+                GetString("CollectionArgumentIsEmpty", nameof(numValues), nameof(numProperties)),
+                numValues, numProperties);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name)!;

--- a/src/EFCore.Abstractions/Properties/AbstractionsStrings.resx
+++ b/src/EFCore.Abstractions/Properties/AbstractionsStrings.resx
@@ -129,4 +129,7 @@
   <data name="CollectionArgumentIsEmpty" xml:space="preserve">
     <value>The collection argument '{argumentName}' must contain at least one element.</value>
   </data>
+  <data name="InvalidNumberOfIndexSortOrderValues" xml:space="preserve">
+    <value>Invalid number of index sort order values: {numValues} values were provided, but the index has {numProperties} properties.</value>
+  </data>
 </root>

--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -911,7 +911,7 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                     .Append("unique: true");
             }
 
-            if (operation.IsDescending.Length > 0)
+            if (operation.IsDescending is not null)
             {
                 builder
                     .AppendLine(",")

--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -911,6 +911,14 @@ public class CSharpMigrationOperationGenerator : ICSharpMigrationOperationGenera
                     .Append("unique: true");
             }
 
+            if (operation.IsDescending.Length > 0)
+            {
+                builder
+                    .AppendLine(",")
+                    .Append("descending: ")
+                    .Append(Code.Literal(operation.IsDescending));
+            }
+
             if (operation.Filter != null)
             {
                 builder

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -634,7 +634,7 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
                 .Append(".IsUnique()");
         }
 
-        if (index.IsDescending.Count > 0)
+        if (index.IsDescending is not null)
         {
             stringBuilder
                 .AppendLine()

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -634,6 +634,15 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
                 .Append(".IsUnique()");
         }
 
+        if (index.IsDescending.Count > 0)
+        {
+            stringBuilder
+                .AppendLine()
+                .Append(".IsDescending(")
+                .Append(string.Join(", ", index.IsDescending.Select(Code.Literal)))
+                .Append(')');
+        }
+
         GenerateIndexAnnotations(indexBuilderName, index, stringBuilder);
     }
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -567,46 +567,9 @@ public class CSharpDbContextGenerator : ICSharpDbContextGenerator
             lines.Add($".{nameof(IndexBuilder.IsUnique)}()");
         }
 
-        // Ascending/descending:
-        // If all ascending (IsDescending.Count == 0), no need to scaffold IsDescending() call (default)
-        // If all descending (IsDescending is all true), scaffold parameterless IsDescending()
-        // Otherwise, scaffold IsDescending() with values up until the last true (unspecified values default to false)
-        if (index.IsDescending.Count > 0)
+        if (index.IsDescending is not null)
         {
-            var descendingBuilder = new StringBuilder()
-                .Append('.')
-                .Append(nameof(IndexBuilder.IsDescending))
-                .Append('(');
-
-            var isAnyAscending = false;
-            var lastDescending = -1;
-            for (var i = 0; i < index.IsDescending.Count; i++)
-            {
-                if (index.IsDescending[i])
-                {
-                    lastDescending = i;
-                }
-                else
-                {
-                    isAnyAscending = true;
-                }
-            }
-
-            if (isAnyAscending)
-            {
-                for (var i = 0; i <= lastDescending; i++)
-                {
-                    if (i > 0)
-                    {
-                        descendingBuilder.Append(", ");
-                    }
-
-                    descendingBuilder.Append(_code.Literal(index.IsDescending[i]));
-                }
-            }
-
-            descendingBuilder.Append(')');
-            lines.Add(descendingBuilder.ToString());
+            lines.Add($".{nameof(IndexBuilder.IsDescending)}({string.Join(", ", index.IsDescending.Select(d => _code.Literal(d)))})");
         }
 
         GenerateAnnotations(index, annotations, lines);

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -212,6 +212,11 @@ public class CSharpEntityTypeGenerator : ICSharpEntityTypeGenerator
                     indexAttribute.AddParameter($"{nameof(IndexAttribute.IsUnique)} = {_code.Literal(index.IsUnique)}");
                 }
 
+                if (index.IsDescending.Count > 0)
+                {
+                    indexAttribute.AddParameter($"{nameof(IndexAttribute.IsDescending)} = {_code.UnknownLiteral(index.IsDescending)}");
+                }
+
                 _sb.AppendLine(indexAttribute.ToString());
             }
         }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -212,7 +212,7 @@ public class CSharpEntityTypeGenerator : ICSharpEntityTypeGenerator
                     indexAttribute.AddParameter($"{nameof(IndexAttribute.IsUnique)} = {_code.Literal(index.IsUnique)}");
                 }
 
-                if (index.IsDescending.Count > 0)
+                if (index.IsDescending is not null)
                 {
                     indexAttribute.AddParameter($"{nameof(IndexAttribute.IsDescending)} = {_code.UnknownLiteral(index.IsDescending)}");
                 }

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -625,16 +625,16 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
             ? builder.HasIndex(propertyNames)
             : builder.HasIndex(propertyNames, index.Name);
 
-        indexBuilder.IsUnique(index.IsUnique);
+        indexBuilder = indexBuilder.IsUnique(index.IsUnique);
 
         if (index.IsDescending.Any(desc => desc))
         {
-            indexBuilder.IsDescending(index.IsDescending.ToArray());
+            indexBuilder = indexBuilder.IsDescending(index.IsDescending.ToArray());
         }
 
         if (index.Filter != null)
         {
-            indexBuilder.HasFilter(index.Filter);
+            indexBuilder = indexBuilder.HasFilter(index.Filter);
         }
 
         indexBuilder.Metadata.AddAnnotations(index.GetAnnotations());

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -625,7 +625,12 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
             ? builder.HasIndex(propertyNames)
             : builder.HasIndex(propertyNames, index.Name);
 
-        indexBuilder = indexBuilder.IsUnique(index.IsUnique);
+        indexBuilder.IsUnique(index.IsUnique);
+
+        if (index.IsDescending.Any(desc => desc))
+        {
+            indexBuilder.IsDescending(index.IsDescending.ToArray());
+        }
 
         if (index.Filter != null)
         {

--- a/src/EFCore.Relational/Metadata/ITableIndex.cs
+++ b/src/EFCore.Relational/Metadata/ITableIndex.cs
@@ -81,7 +81,14 @@ public interface ITableIndex : IAnnotatable
                 Enumerable.Range(0, Columns.Count)
                     .Select(
                         i =>
-                            $"'{Columns[i].Name}'{(IsDescending is not null && i < IsDescending.Count && IsDescending[i] ? " Desc" : "")}"))
+                            $@"'{Columns[i].Name}'{(
+                                MappedIndexes.First() is not RuntimeIndex
+                                && IsDescending is not null
+                                && i < IsDescending.Count
+                                && IsDescending[i]
+                                    ? " Desc"
+                                    : ""
+                                )}"))
             .Append('}');
 
         if (IsUnique)

--- a/src/EFCore.Relational/Metadata/ITableIndex.cs
+++ b/src/EFCore.Relational/Metadata/ITableIndex.cs
@@ -40,6 +40,12 @@ public interface ITableIndex : IAnnotatable
     bool IsUnique { get; }
 
     /// <summary>
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </summary>
+    IReadOnlyList<bool> IsDescending { get; }
+
+    /// <summary>
     ///     Gets the expression used as the index filter.
     /// </summary>
     string? Filter { get; }
@@ -70,8 +76,12 @@ public interface ITableIndex : IAnnotatable
 
         builder
             .Append(Name)
-            .Append(' ')
-            .Append(ColumnBase.Format(Columns));
+            .Append(" {")
+            .AppendJoin(
+                ", ",
+                Enumerable.Range(0, Columns.Count)
+                    .Select(i => $"'{Columns[i].Name}'{(i < IsDescending.Count && IsDescending[i] ? " Desc" : "")}"))
+            .Append('}');
 
         if (IsUnique)
         {

--- a/src/EFCore.Relational/Metadata/ITableIndex.cs
+++ b/src/EFCore.Relational/Metadata/ITableIndex.cs
@@ -41,9 +41,8 @@ public interface ITableIndex : IAnnotatable
 
     /// <summary>
     ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
     /// </summary>
-    IReadOnlyList<bool> IsDescending { get; }
+    IReadOnlyList<bool>? IsDescending { get; }
 
     /// <summary>
     ///     Gets the expression used as the index filter.
@@ -80,7 +79,9 @@ public interface ITableIndex : IAnnotatable
             .AppendJoin(
                 ", ",
                 Enumerable.Range(0, Columns.Count)
-                    .Select(i => $"'{Columns[i].Name}'{(i < IsDescending.Count && IsDescending[i] ? " Desc" : "")}"))
+                    .Select(
+                        i =>
+                            $"'{Columns[i].Name}'{(IsDescending is not null && i < IsDescending.Count && IsDescending[i] ? " Desc" : "")}"))
             .Append('}');
 
         if (IsUnique)

--- a/src/EFCore.Relational/Metadata/Internal/RelationalIndexExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalIndexExtensions.cs
@@ -32,9 +32,9 @@ public static class RelationalIndexExtensions
             {
                 throw new InvalidOperationException(
                     RelationalStrings.DuplicateIndexTableMismatch(
-                        index.Properties.Format(),
+                        index.DisplayName(),
                         index.DeclaringEntityType.DisplayName(),
-                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DisplayName(),
                         duplicateIndex.DeclaringEntityType.DisplayName(),
                         index.GetDatabaseName(storeObject),
                         index.DeclaringEntityType.GetSchemaQualifiedTableName(),
@@ -50,9 +50,9 @@ public static class RelationalIndexExtensions
             {
                 throw new InvalidOperationException(
                     RelationalStrings.DuplicateIndexColumnMismatch(
-                        index.Properties.Format(),
+                        index.DisplayName(),
                         index.DeclaringEntityType.DisplayName(),
-                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DisplayName(),
                         duplicateIndex.DeclaringEntityType.DisplayName(),
                         index.DeclaringEntityType.GetSchemaQualifiedTableName(),
                         index.GetDatabaseName(storeObject),
@@ -69,9 +69,9 @@ public static class RelationalIndexExtensions
             {
                 throw new InvalidOperationException(
                     RelationalStrings.DuplicateIndexUniquenessMismatch(
-                        index.Properties.Format(),
+                        index.DisplayName(),
                         index.DeclaringEntityType.DisplayName(),
-                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DisplayName(),
                         duplicateIndex.DeclaringEntityType.DisplayName(),
                         index.DeclaringEntityType.GetSchemaQualifiedTableName(),
                         index.GetDatabaseName(storeObject)));
@@ -89,9 +89,9 @@ public static class RelationalIndexExtensions
             {
                 throw new InvalidOperationException(
                     RelationalStrings.DuplicateIndexSortOrdersMismatch(
-                        index.Properties.Format(),
+                        index.DisplayName(),
                         index.DeclaringEntityType.DisplayName(),
-                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DisplayName(),
                         duplicateIndex.DeclaringEntityType.DisplayName(),
                         index.DeclaringEntityType.GetSchemaQualifiedTableName(),
                         index.GetDatabaseName(storeObject)));
@@ -106,9 +106,9 @@ public static class RelationalIndexExtensions
             {
                 throw new InvalidOperationException(
                     RelationalStrings.DuplicateIndexFiltersMismatch(
-                        index.Properties.Format(),
+                        index.DisplayName(),
                         index.DeclaringEntityType.DisplayName(),
-                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DisplayName(),
                         duplicateIndex.DeclaringEntityType.DisplayName(),
                         index.DeclaringEntityType.GetSchemaQualifiedTableName(),
                         index.GetDatabaseName(storeObject),

--- a/src/EFCore.Relational/Metadata/Internal/RelationalIndexExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalIndexExtensions.cs
@@ -80,18 +80,43 @@ public static class RelationalIndexExtensions
             return false;
         }
 
+        if (index.IsDescending is null != duplicateIndex.IsDescending is null
+            || (index.IsDescending is not null
+                && duplicateIndex.IsDescending is not null
+                && !index.IsDescending.SequenceEqual(duplicateIndex.IsDescending)))
+        {
+            if (shouldThrow)
+            {
+                throw new InvalidOperationException(
+                    RelationalStrings.DuplicateIndexSortOrdersMismatch(
+                        index.Properties.Format(),
+                        index.DeclaringEntityType.DisplayName(),
+                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DeclaringEntityType.DisplayName(),
+                        index.DeclaringEntityType.GetSchemaQualifiedTableName(),
+                        index.GetDatabaseName(storeObject)));
+            }
+
+            return false;
+        }
+
         if (index.GetFilter(storeObject) != duplicateIndex.GetFilter(storeObject))
         {
-            throw new InvalidOperationException(
-                RelationalStrings.DuplicateIndexFiltersMismatch(
-                    index.Properties.Format(),
-                    index.DeclaringEntityType.DisplayName(),
-                    duplicateIndex.Properties.Format(),
-                    duplicateIndex.DeclaringEntityType.DisplayName(),
-                    index.DeclaringEntityType.GetSchemaQualifiedTableName(),
-                    index.GetDatabaseName(storeObject),
-                    index.GetFilter(),
-                    duplicateIndex.GetFilter()));
+            if (shouldThrow)
+            {
+                throw new InvalidOperationException(
+                    RelationalStrings.DuplicateIndexFiltersMismatch(
+                        index.Properties.Format(),
+                        index.DeclaringEntityType.DisplayName(),
+                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DeclaringEntityType.DisplayName(),
+                        index.DeclaringEntityType.GetSchemaQualifiedTableName(),
+                        index.GetDatabaseName(storeObject),
+                        index.GetFilter(),
+                        duplicateIndex.GetFilter()));
+            }
+
+            return false;
         }
 
         return true;

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -952,7 +952,7 @@ public class RelationalModel : Annotatable, IRelationalModel
                         continue;
                     }
 
-                    tableIndex = new TableIndex(name, table, columns, index.IsUnique, index.IsDescending);
+                    tableIndex = new TableIndex(name, table, columns, index.IsUnique);
 
                     table.Indexes.Add(name, tableIndex);
                 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -952,7 +952,7 @@ public class RelationalModel : Annotatable, IRelationalModel
                         continue;
                     }
 
-                    tableIndex = new TableIndex(name, table, columns, index.IsUnique);
+                    tableIndex = new TableIndex(name, table, columns, index.IsUnique, index.IsDescending);
 
                     table.Indexes.Add(name, tableIndex);
                 }

--- a/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
@@ -21,14 +21,12 @@ public class TableIndex : Annotatable, ITableIndex
         string name,
         Table table,
         IReadOnlyList<Column> columns,
-        bool unique,
-        IReadOnlyList<bool>? isDescending)
+        bool unique)
     {
         Name = name;
         Table = table;
         Columns = columns;
         IsUnique = unique;
-        IsDescending = isDescending;
     }
 
     /// <inheritdoc />
@@ -71,7 +69,8 @@ public class TableIndex : Annotatable, ITableIndex
     public virtual bool IsUnique { get; }
 
     /// <inheritdoc />
-    public virtual IReadOnlyList<bool>? IsDescending { get; }
+    public virtual IReadOnlyList<bool>? IsDescending
+        => MappedIndexes.First().IsDescending;
 
     /// <inheritdoc />
     public virtual string? Filter

--- a/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
@@ -21,12 +21,14 @@ public class TableIndex : Annotatable, ITableIndex
         string name,
         Table table,
         IReadOnlyList<Column> columns,
-        bool unique)
+        bool unique,
+        IReadOnlyList<bool> isDescending)
     {
         Name = name;
         Table = table;
         Columns = columns;
         IsUnique = unique;
+        IsDescending = isDescending;
     }
 
     /// <inheritdoc />
@@ -67,6 +69,9 @@ public class TableIndex : Annotatable, ITableIndex
 
     /// <inheritdoc />
     public virtual bool IsUnique { get; }
+
+    /// <inheritdoc />
+    public virtual IReadOnlyList<bool> IsDescending { get; }
 
     /// <inheritdoc />
     public virtual string? Filter

--- a/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
@@ -22,7 +22,7 @@ public class TableIndex : Annotatable, ITableIndex
         Table table,
         IReadOnlyList<Column> columns,
         bool unique,
-        IReadOnlyList<bool> isDescending)
+        IReadOnlyList<bool>? isDescending)
     {
         Name = name;
         Table = table;
@@ -71,7 +71,7 @@ public class TableIndex : Annotatable, ITableIndex
     public virtual bool IsUnique { get; }
 
     /// <inheritdoc />
-    public virtual IReadOnlyList<bool> IsDescending { get; }
+    public virtual IReadOnlyList<bool>? IsDescending { get; }
 
     /// <inheritdoc />
     public virtual string? Filter

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1393,6 +1393,7 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
 
     private bool IndexStructureEquals(ITableIndex source, ITableIndex target, DiffContext diffContext)
         => source.IsUnique == target.IsUnique
+            && source.IsDescending.SequenceEqual(target.IsDescending)
             && source.Filter == target.Filter
             && !HasDifferences(source.GetAnnotations(), target.GetAnnotations())
             && source.Columns.Select(p => p.Name).SequenceEqual(

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1394,10 +1394,10 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
     private bool IndexStructureEquals(ITableIndex source, ITableIndex target, DiffContext diffContext)
         => source.IsUnique == target.IsUnique
             && (
-                source.IsDescending is null == target.IsDescending is null
-                || source.IsDescending is not null
-                && target.IsDescending is not null
-                && source.IsDescending.SequenceEqual(target.IsDescending))
+                (source.IsDescending is null && target.IsDescending is null)
+                || (source.IsDescending is not null
+                    && target.IsDescending is not null
+                    && source.IsDescending.SequenceEqual(target.IsDescending)))
             && source.Filter == target.Filter
             && !HasDifferences(source.GetAnnotations(), target.GetAnnotations())
             && source.Columns.Select(p => p.Name).SequenceEqual(

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1393,7 +1393,11 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
 
     private bool IndexStructureEquals(ITableIndex source, ITableIndex target, DiffContext diffContext)
         => source.IsUnique == target.IsUnique
-            && source.IsDescending.SequenceEqual(target.IsDescending)
+            && (
+                source.IsDescending is null == target.IsDescending is null
+                || source.IsDescending is not null
+                && target.IsDescending is not null
+                && source.IsDescending.SequenceEqual(target.IsDescending))
             && source.Filter == target.Filter
             && !HasDifferences(source.GetAnnotations(), target.GetAnnotations())
             && source.Columns.Select(p => p.Name).SequenceEqual(

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1393,8 +1393,7 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
 
     private bool IndexStructureEquals(ITableIndex source, ITableIndex target, DiffContext diffContext)
         => source.IsUnique == target.IsUnique
-            && (
-                (source.IsDescending is null && target.IsDescending is null)
+            && ((source.IsDescending is null && target.IsDescending is null)
                 || (source.IsDescending is not null
                     && target.IsDescending is not null
                     && source.IsDescending.SequenceEqual(target.IsDescending)))

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -601,6 +601,11 @@ public class MigrationBuilder
     /// <param name="schema">The schema that contains the table, or <see langword="null" /> to use the default schema.</param>
     /// <param name="unique">Indicates whether or not the index enforces uniqueness.</param>
     /// <param name="filter">The filter to apply to the index, or <see langword="null" /> for no filter.</param>
+    /// <param name="descending">
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    ///     If <see langword="null" />, all columns will have ascending order.
+    /// </param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual OperationBuilder<CreateIndexOperation> CreateIndex(
         string name,
@@ -608,14 +613,16 @@ public class MigrationBuilder
         string column,
         string? schema = null,
         bool unique = false,
-        string? filter = null)
+        string? filter = null,
+        bool[]? descending = null)
         => CreateIndex(
             name,
             table,
             new[] { Check.NotEmpty(column, nameof(column)) },
             schema,
             unique,
-            filter);
+            filter,
+            descending);
 
     /// <summary>
     ///     Builds a <see cref="CreateIndexOperation" /> to create a new composite (multi-column) index.
@@ -629,6 +636,11 @@ public class MigrationBuilder
     /// <param name="schema">The schema that contains the table, or <see langword="null" /> to use the default schema.</param>
     /// <param name="unique">Indicates whether or not the index enforces uniqueness.</param>
     /// <param name="filter">The filter to apply to the index, or <see langword="null" /> for no filter.</param>
+    /// <param name="descending">
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    ///     If <see langword="null" />, all columns will have ascending order.
+    /// </param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual OperationBuilder<CreateIndexOperation> CreateIndex(
         string name,
@@ -636,7 +648,8 @@ public class MigrationBuilder
         string[] columns,
         string? schema = null,
         bool unique = false,
-        string? filter = null)
+        string? filter = null,
+        bool[]? descending = null)
     {
         Check.NotEmpty(name, nameof(name));
         Check.NotEmpty(table, nameof(table));
@@ -651,6 +664,12 @@ public class MigrationBuilder
             IsUnique = unique,
             Filter = filter
         };
+
+        if (descending is not null)
+        {
+            operation.IsDescending = descending;
+        }
+
         Operations.Add(operation);
 
         return new OperationBuilder<CreateIndexOperation>(operation);

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -603,7 +603,6 @@ public class MigrationBuilder
     /// <param name="filter">The filter to apply to the index, or <see langword="null" /> for no filter.</param>
     /// <param name="descending">
     ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
     ///     If <see langword="null" />, all columns will have ascending order.
     /// </param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
@@ -638,7 +637,6 @@ public class MigrationBuilder
     /// <param name="filter">The filter to apply to the index, or <see langword="null" /> for no filter.</param>
     /// <param name="descending">
     ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
     ///     If <see langword="null" />, all columns will have ascending order.
     /// </param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
@@ -662,13 +660,9 @@ public class MigrationBuilder
             Name = name,
             Columns = columns,
             IsUnique = unique,
+            IsDescending = descending,
             Filter = filter
         };
-
-        if (descending is not null)
-        {
-            operation.IsDescending = descending;
-        }
 
         Operations.Add(operation);
 

--- a/src/EFCore.Relational/Migrations/Operations/CreateIndexOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/CreateIndexOperation.cs
@@ -39,9 +39,8 @@ public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
 
     /// <summary>
     ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
     /// </summary>
-    public virtual bool[] IsDescending { get; set; } = Array.Empty<bool>();
+    public virtual bool[]? IsDescending { get; set; }
 
     /// <summary>
     ///     An expression to use as the index filter.
@@ -64,7 +63,7 @@ public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
             Table = index.Table.Name,
             Columns = index.Columns.Select(p => p.Name).ToArray(),
             IsUnique = index.IsUnique,
-            IsDescending = index.IsDescending.ToArray(),
+            IsDescending = index.IsDescending?.ToArray(),
             Filter = index.Filter
         };
         operation.AddAnnotations(index.GetAnnotations());

--- a/src/EFCore.Relational/Migrations/Operations/CreateIndexOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/CreateIndexOperation.cs
@@ -13,11 +13,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations;
 public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
 {
     /// <summary>
-    ///     Indicates whether or not the index should enforce uniqueness.
-    /// </summary>
-    public virtual bool IsUnique { get; set; }
-
-    /// <summary>
     ///     The name of the index.
     /// </summary>
     public virtual string Name { get; set; } = null!;
@@ -38,6 +33,17 @@ public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
     public virtual string[] Columns { get; set; } = null!;
 
     /// <summary>
+    ///     Indicates whether or not the index should enforce uniqueness.
+    /// </summary>
+    public virtual bool IsUnique { get; set; }
+
+    /// <summary>
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </summary>
+    public virtual bool[] IsDescending { get; set; } = Array.Empty<bool>();
+
+    /// <summary>
     ///     An expression to use as the index filter.
     /// </summary>
     public virtual string? Filter { get; set; }
@@ -53,11 +59,12 @@ public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
 
         var operation = new CreateIndexOperation
         {
-            IsUnique = index.IsUnique,
             Name = index.Name,
             Schema = index.Table.Schema,
             Table = index.Table.Name,
             Columns = index.Columns.Select(p => p.Name).ToArray(),
+            IsUnique = index.IsUnique,
+            IsDescending = index.IsDescending.ToArray(),
             Filter = index.Filter
         };
         operation.AddAnnotations(index.GetAnnotations());

--- a/src/EFCore.Relational/Migrations/Operations/CreateIndexOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/CreateIndexOperation.cs
@@ -12,6 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations;
 [DebuggerDisplay("CREATE INDEX {Name} ON {Table}")]
 public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
 {
+    private string[]? _columns;
+    private bool[]? _isDescending;
+
     /// <summary>
     ///     The name of the index.
     /// </summary>
@@ -30,7 +33,19 @@ public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
     /// <summary>
     ///     The ordered list of column names for the column that make up the index.
     /// </summary>
-    public virtual string[] Columns { get; set; } = null!;
+    public virtual string[] Columns
+    {
+        get => _columns!;
+        set
+        {
+            if (_isDescending is not null && value.Length != _isDescending.Length)
+            {
+                throw new ArgumentException(RelationalStrings.CreateIndexOperationWithInvalidSortOrder(_isDescending.Length, value.Length));
+            }
+
+            _columns = value;
+        }
+    }
 
     /// <summary>
     ///     Indicates whether or not the index should enforce uniqueness.
@@ -40,7 +55,19 @@ public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
     /// <summary>
     ///     A set of values indicating whether each corresponding index column has descending sort order.
     /// </summary>
-    public virtual bool[]? IsDescending { get; set; }
+    public virtual bool[]? IsDescending
+    {
+        get => _isDescending;
+        set
+        {
+            if (value is not null && _columns is not null && value.Length != _columns.Length)
+            {
+                throw new ArgumentException(RelationalStrings.CreateIndexOperationWithInvalidSortOrder(value.Length, _columns.Length));
+            }
+
+            _isDescending = value;
+        }
+    }
 
     /// <summary>
     ///     An expression to use as the index filter.

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -478,44 +478,44 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 foreignKeyProperties1, entityType1, foreignKeyProperties2, entityType2, table, foreignKeyName);
 
         /// <summary>
-        ///     The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different columns ({columnNames1} and {columnNames2}).
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different columns ({columnNames1} and {columnNames2}).
         /// </summary>
-        public static string DuplicateIndexColumnMismatch(object? indexProperties1, object? entityType1, object? indexProperties2, object? entityType2, object? table, object? indexName, object? columnNames1, object? columnNames2)
+        public static string DuplicateIndexColumnMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName, object? columnNames1, object? columnNames2)
             => string.Format(
-                GetString("DuplicateIndexColumnMismatch", nameof(indexProperties1), nameof(entityType1), nameof(indexProperties2), nameof(entityType2), nameof(table), nameof(indexName), nameof(columnNames1), nameof(columnNames2)),
-                indexProperties1, entityType1, indexProperties2, entityType2, table, indexName, columnNames1, columnNames2);
+                GetString("DuplicateIndexColumnMismatch", nameof(index1), nameof(entityType1), nameof(index2), nameof(entityType2), nameof(table), nameof(indexName), nameof(columnNames1), nameof(columnNames2)),
+                index1, entityType1, index2, entityType2, table, indexName, columnNames1, columnNames2);
 
         /// <summary>
-        ///     The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different filters ('{filter1}' and '{filter2}').
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different filters ('{filter1}' and '{filter2}').
         /// </summary>
-        public static string DuplicateIndexFiltersMismatch(object? indexProperties1, object? entityType1, object? indexProperties2, object? entityType2, object? table, object? indexName, object? filter1, object? filter2)
+        public static string DuplicateIndexFiltersMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName, object? filter1, object? filter2)
             => string.Format(
-                GetString("DuplicateIndexFiltersMismatch", nameof(indexProperties1), nameof(entityType1), nameof(indexProperties2), nameof(entityType2), nameof(table), nameof(indexName), nameof(filter1), nameof(filter2)),
-                indexProperties1, entityType1, indexProperties2, entityType2, table, indexName, filter1, filter2);
+                GetString("DuplicateIndexFiltersMismatch", nameof(index1), nameof(entityType1), nameof(index2), nameof(entityType2), nameof(table), nameof(indexName), nameof(filter1), nameof(filter2)),
+                index1, entityType1, index2, entityType2, table, indexName, filter1, filter2);
 
         /// <summary>
-        ///     The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different sort orders.
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different sort orders.
         /// </summary>
-        public static string DuplicateIndexSortOrdersMismatch(object? indexProperties1, object? entityType1, object? indexProperties2, object? entityType2, object? table, object? indexName)
+        public static string DuplicateIndexSortOrdersMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName)
             => string.Format(
-                GetString("DuplicateIndexSortOrdersMismatch", nameof(indexProperties1), nameof(entityType1), nameof(indexProperties2), nameof(entityType2), nameof(table), nameof(indexName)),
-                indexProperties1, entityType1, indexProperties2, entityType2, table, indexName);
+                GetString("DuplicateIndexSortOrdersMismatch", nameof(index1), nameof(entityType1), nameof(index2), nameof(entityType2), nameof(table), nameof(indexName)),
+                index1, entityType1, index2, entityType2, table, indexName);
 
         /// <summary>
-        ///     The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{indexName}', but are declared on different tables ('{table1}' and '{table2}').
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{indexName}', but are declared on different tables ('{table1}' and '{table2}').
         /// </summary>
-        public static string DuplicateIndexTableMismatch(object? indexProperties1, object? entityType1, object? indexProperties2, object? entityType2, object? indexName, object? table1, object? table2)
+        public static string DuplicateIndexTableMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? indexName, object? table1, object? table2)
             => string.Format(
-                GetString("DuplicateIndexTableMismatch", nameof(indexProperties1), nameof(entityType1), nameof(indexProperties2), nameof(entityType2), nameof(indexName), nameof(table1), nameof(table2)),
-                indexProperties1, entityType1, indexProperties2, entityType2, indexName, table1, table2);
+                GetString("DuplicateIndexTableMismatch", nameof(index1), nameof(entityType1), nameof(index2), nameof(entityType2), nameof(indexName), nameof(table1), nameof(table2)),
+                index1, entityType1, index2, entityType2, indexName, table1, table2);
 
         /// <summary>
-        ///     The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different uniqueness configurations.
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different uniqueness configurations.
         /// </summary>
-        public static string DuplicateIndexUniquenessMismatch(object? indexProperties1, object? entityType1, object? indexProperties2, object? entityType2, object? table, object? indexName)
+        public static string DuplicateIndexUniquenessMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName)
             => string.Format(
-                GetString("DuplicateIndexUniquenessMismatch", nameof(indexProperties1), nameof(entityType1), nameof(indexProperties2), nameof(entityType2), nameof(table), nameof(indexName)),
-                indexProperties1, entityType1, indexProperties2, entityType2, table, indexName);
+                GetString("DuplicateIndexUniquenessMismatch", nameof(index1), nameof(entityType1), nameof(index2), nameof(entityType2), nameof(table), nameof(indexName)),
+                index1, entityType1, index2, entityType2, table, indexName);
 
         /// <summary>
         ///     The keys {keyProperties1} on '{entityType1}' and {keyProperties2} on '{entityType2}' are both mapped to '{table}.{keyName}', but with different columns ({columnNames1} and {columnNames2}).

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -152,6 +152,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 firstEntityType, secondEntityType, keyValue, firstConflictingValue, secondConflictingValue, column);
 
         /// <summary>
+        ///     {numSortOrderProperties} values were provided in CreateIndexOperations.IsDescending, but the operation has {numColumns} columns.
+        /// </summary>
+        public static string CreateIndexOperationWithInvalidSortOrder(object? numSortOrderProperties, object? numColumns)
+            => string.Format(
+                GetString("CreateIndexOperationWithInvalidSortOrder", nameof(numSortOrderProperties), nameof(numColumns)),
+                numSortOrderProperties, numColumns);
+
+        /// <summary>
         ///     There is no property mapped to the column '{table}.{column}' which is used in a data operation. Either add a property mapped to this column, or specify the column types in the data operation.
         /// </summary>
         public static string DataOperationNoProperty(object? table, object? column)
@@ -484,6 +492,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("DuplicateIndexFiltersMismatch", nameof(indexProperties1), nameof(entityType1), nameof(indexProperties2), nameof(entityType2), nameof(table), nameof(indexName), nameof(filter1), nameof(filter2)),
                 indexProperties1, entityType1, indexProperties2, entityType2, table, indexName, filter1, filter2);
+
+        /// <summary>
+        ///     The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different sort orders.
+        /// </summary>
+        public static string DuplicateIndexSortOrdersMismatch(object? indexProperties1, object? entityType1, object? indexProperties2, object? entityType2, object? table, object? indexName)
+            => string.Format(
+                GetString("DuplicateIndexSortOrdersMismatch", nameof(indexProperties1), nameof(entityType1), nameof(indexProperties2), nameof(entityType2), nameof(table), nameof(indexName)),
+                indexProperties1, entityType1, indexProperties2, entityType2, table, indexName);
 
         /// <summary>
         ///     The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{indexName}', but are declared on different tables ('{table1}' and '{table2}').

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -293,19 +293,19 @@
     <value>The foreign keys {foreignKeyProperties1} on '{entityType1}' and {foreignKeyProperties2} on '{entityType2}' are both mapped to '{table}.{foreignKeyName}', but with different uniqueness configurations.</value>
   </data>
   <data name="DuplicateIndexColumnMismatch" xml:space="preserve">
-    <value>The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different columns ({columnNames1} and {columnNames2}).</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different columns ({columnNames1} and {columnNames2}).</value>
   </data>
   <data name="DuplicateIndexFiltersMismatch" xml:space="preserve">
-    <value>The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different filters ('{filter1}' and '{filter2}').</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different filters ('{filter1}' and '{filter2}').</value>
   </data>
   <data name="DuplicateIndexSortOrdersMismatch" xml:space="preserve">
-    <value>The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different sort orders.</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different sort orders.</value>
   </data>
   <data name="DuplicateIndexTableMismatch" xml:space="preserve">
-    <value>The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{indexName}', but are declared on different tables ('{table1}' and '{table2}').</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{indexName}', but are declared on different tables ('{table1}' and '{table2}').</value>
   </data>
   <data name="DuplicateIndexUniquenessMismatch" xml:space="preserve">
-    <value>The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different uniqueness configurations.</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different uniqueness configurations.</value>
   </data>
   <data name="DuplicateKeyColumnMismatch" xml:space="preserve">
     <value>The keys {keyProperties1} on '{entityType1}' and {keyProperties2} on '{entityType2}' are both mapped to '{table}.{keyName}', but with different columns ({columnNames1} and {columnNames2}).</value>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -169,6 +169,9 @@
   <data name="ConflictingRowValuesSensitive" xml:space="preserve">
     <value>Instances of entity types '{firstEntityType}' and '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different property values '{firstConflictingValue}' and '{secondConflictingValue}' for the column '{column}'.</value>
   </data>
+  <data name="CreateIndexOperationWithInvalidSortOrder" xml:space="preserve">
+    <value>{numSortOrderProperties} values were provided in CreateIndexOperations.IsDescending, but the operation has {numColumns} columns.</value>
+  </data>
   <data name="DataOperationNoProperty" xml:space="preserve">
     <value>There is no property mapped to the column '{table}.{column}' which is used in a data operation. Either add a property mapped to this column, or specify the column types in the data operation.</value>
   </data>
@@ -294,6 +297,9 @@
   </data>
   <data name="DuplicateIndexFiltersMismatch" xml:space="preserve">
     <value>The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different filters ('{filter1}' and '{filter2}').</value>
+  </data>
+  <data name="DuplicateIndexSortOrdersMismatch" xml:space="preserve">
+    <value>The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{table}.{indexName}', but with different sort orders.</value>
   </data>
   <data name="DuplicateIndexTableMismatch" xml:space="preserve">
     <value>The indexes {indexProperties1} on '{entityType1}' and {indexProperties2} on '{entityType2}' are both mapped to '{indexName}', but are declared on different tables ('{table1}' and '{table2}').</value>

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseIndex.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseIndex.cs
@@ -34,7 +34,6 @@ public class DatabaseIndex : Annotatable
 
     /// <summary>
     ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
     /// </summary>
     public virtual IList<bool> IsDescending { get; set; } = new List<bool>();
 

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseIndex.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseIndex.cs
@@ -28,9 +28,15 @@ public class DatabaseIndex : Annotatable
     public virtual IList<DatabaseColumn> Columns { get; } = new List<DatabaseColumn>();
 
     /// <summary>
-    ///     Indicates whether or not the index constrains uniqueness.
+    ///     Indicates whether or not the index enforces uniqueness.
     /// </summary>
     public virtual bool IsUnique { get; set; }
+
+    /// <summary>
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </summary>
+    public virtual IList<bool> IsDescending { get; set; } = new List<bool>();
 
     /// <summary>
     ///     The filter expression, or <see langword="null" /> if the index has no filter.

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
@@ -163,7 +163,7 @@ public class SqlServerModelValidator : RelationalModelValidator
                     throw new InvalidOperationException(
                         SqlServerStrings.IncludePropertyNotFound(
                             notFound,
-                            index.Name == null ? index.Properties.Format() : "'" + index.Name + "'",
+                            index.DisplayName(),
                             index.DeclaringEntityType.DisplayName()));
                 }
 
@@ -179,7 +179,7 @@ public class SqlServerModelValidator : RelationalModelValidator
                         SqlServerStrings.IncludePropertyDuplicated(
                             index.DeclaringEntityType.DisplayName(),
                             duplicateProperty,
-                            index.Name == null ? index.Properties.Format() : "'" + index.Name + "'"));
+                            index.DisplayName()));
                 }
 
                 var coveredProperty = includeProperties
@@ -191,7 +191,7 @@ public class SqlServerModelValidator : RelationalModelValidator
                         SqlServerStrings.IncludePropertyInIndex(
                             index.DeclaringEntityType.DisplayName(),
                             coveredProperty,
-                            index.Name == null ? index.Properties.Format() : "'" + index.Name + "'"));
+                            index.DisplayName()));
                 }
             }
         }

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerIndexExtensions.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerIndexExtensions.cs
@@ -35,9 +35,9 @@ public static class SqlServerIndexExtensions
                 {
                     throw new InvalidOperationException(
                         SqlServerStrings.DuplicateIndexIncludedMismatch(
-                            index.Properties.Format(),
+                            index.DisplayName(),
                             index.DeclaringEntityType.DisplayName(),
-                            duplicateIndex.Properties.Format(),
+                            duplicateIndex.DisplayName(),
                             duplicateIndex.DeclaringEntityType.DisplayName(),
                             index.DeclaringEntityType.GetSchemaQualifiedTableName(),
                             index.GetDatabaseName(storeObject),
@@ -55,9 +55,9 @@ public static class SqlServerIndexExtensions
             {
                 throw new InvalidOperationException(
                     SqlServerStrings.DuplicateIndexOnlineMismatch(
-                        index.Properties.Format(),
+                        index.DisplayName(),
                         index.DeclaringEntityType.DisplayName(),
-                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DisplayName(),
                         duplicateIndex.DeclaringEntityType.DisplayName(),
                         index.DeclaringEntityType.GetSchemaQualifiedTableName(),
                         index.GetDatabaseName(storeObject)));
@@ -72,9 +72,9 @@ public static class SqlServerIndexExtensions
             {
                 throw new InvalidOperationException(
                     SqlServerStrings.DuplicateIndexClusteredMismatch(
-                        index.Properties.Format(),
+                        index.DisplayName(),
                         index.DeclaringEntityType.DisplayName(),
-                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DisplayName(),
                         duplicateIndex.DeclaringEntityType.DisplayName(),
                         index.DeclaringEntityType.GetSchemaQualifiedTableName(),
                         index.GetDatabaseName(storeObject)));
@@ -89,9 +89,9 @@ public static class SqlServerIndexExtensions
             {
                 throw new InvalidOperationException(
                     SqlServerStrings.DuplicateIndexFillFactorMismatch(
-                        index.Properties.Format(),
+                        index.DisplayName(),
                         index.DeclaringEntityType.DisplayName(),
-                        duplicateIndex.Properties.Format(),
+                        duplicateIndex.DisplayName(),
                         duplicateIndex.DeclaringEntityType.DisplayName(),
                         index.DeclaringEntityType.GetSchemaQualifiedTableName(),
                         index.GetDatabaseName(storeObject)));

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -748,10 +748,9 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 
             IndexTraits(operation, model, builder);
 
-            builder
-                .Append("(")
-                .Append(ColumnList(operation.Columns))
-                .Append(")");
+            builder.Append("(");
+            GenerateIndexColumnList(operation, model, builder);
+            builder.Append(")");
         }
         else
         {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 entityType1, property1, entityType2, property2, columnName, table);
 
         /// <summary>
-        ///     The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different clustered configurations.
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different clustered configurations.
         /// </summary>
         public static string DuplicateIndexClusteredMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName)
             => string.Format(
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 index1, entityType1, index2, entityType2, table, indexName);
 
         /// <summary>
-        ///     The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different fill factor configurations.
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different fill factor configurations.
         /// </summary>
         public static string DuplicateIndexFillFactorMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName)
             => string.Format(
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 index1, entityType1, index2, entityType2, table, indexName);
 
         /// <summary>
-        ///     The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different included columns: {includedColumns1} and {includedColumns2}.
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different included columns: {includedColumns1} and {includedColumns2}.
         /// </summary>
         public static string DuplicateIndexIncludedMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName, object? includedColumns1, object? includedColumns2)
             => string.Format(
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 index1, entityType1, index2, entityType2, table, indexName, includedColumns1, includedColumns2);
 
         /// <summary>
-        ///     The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different online configurations.
+        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different online configurations.
         /// </summary>
         public static string DuplicateIndexOnlineMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName)
             => string.Format(
@@ -132,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 property, entityType, propertyType);
 
         /// <summary>
-        ///     The include property '{entityType}.{property}' was specified multiple times for the index '{index}'.
+        ///     The include property '{entityType}.{property}' was specified multiple times for the index {index}.
         /// </summary>
         public static string IncludePropertyDuplicated(object? entityType, object? property, object? index)
             => string.Format(
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 entityType, property, index);
 
         /// <summary>
-        ///     The include property '{entityType}.{property}' is already part of the index '{index}'.
+        ///     The include property '{entityType}.{property}' is already part of the index {index}.
         /// </summary>
         public static string IncludePropertyInIndex(object? entityType, object? property, object? index)
             => string.Format(
@@ -148,7 +148,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 entityType, property, index);
 
         /// <summary>
-        ///     The include property '{property}' specified on the index '{index}' was not found on entity type '{entityType}'.
+        ///     The include property '{property}' specified on the index {index} was not found on entity type '{entityType}'.
         /// </summary>
         public static string IncludePropertyNotFound(object? property, object? index, object? entityType)
             => string.Format(

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 entityType1, property1, entityType2, property2, columnName, table);
 
         /// <summary>
-        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different clustered configurations.
+        ///     The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different clustered configurations.
         /// </summary>
         public static string DuplicateIndexClusteredMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName)
             => string.Format(
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 index1, entityType1, index2, entityType2, table, indexName);
 
         /// <summary>
-        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different fill factor configurations.
+        ///     The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different fill factor configurations.
         /// </summary>
         public static string DuplicateIndexFillFactorMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName)
             => string.Format(
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 index1, entityType1, index2, entityType2, table, indexName);
 
         /// <summary>
-        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different included columns: {includedColumns1} and {includedColumns2}.
+        ///     The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different included columns: {includedColumns1} and {includedColumns2}.
         /// </summary>
         public static string DuplicateIndexIncludedMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName, object? includedColumns1, object? includedColumns2)
             => string.Format(
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 index1, entityType1, index2, entityType2, table, indexName, includedColumns1, includedColumns2);
 
         /// <summary>
-        ///     The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different online configurations.
+        ///     The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different online configurations.
         /// </summary>
         public static string DuplicateIndexOnlineMismatch(object? index1, object? entityType1, object? index2, object? entityType2, object? table, object? indexName)
             => string.Format(
@@ -132,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 property, entityType, propertyType);
 
         /// <summary>
-        ///     The include property '{entityType}.{property}' was specified multiple times for the index {index}.
+        ///     The include property '{entityType}.{property}' was specified multiple times for the index '{index}'.
         /// </summary>
         public static string IncludePropertyDuplicated(object? entityType, object? property, object? index)
             => string.Format(
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 entityType, property, index);
 
         /// <summary>
-        ///     The include property '{entityType}.{property}' is already part of the index {index}.
+        ///     The include property '{entityType}.{property}' is already part of the index '{index}'.
         /// </summary>
         public static string IncludePropertyInIndex(object? entityType, object? property, object? index)
             => string.Format(
@@ -148,7 +148,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 entityType, property, index);
 
         /// <summary>
-        ///     The include property '{property}' specified on the index {index} was not found on entity type '{entityType}'.
+        ///     The include property '{property}' specified on the index '{index}' was not found on entity type '{entityType}'.
         /// </summary>
         public static string IncludePropertyNotFound(object? property, object? index, object? entityType)
             => string.Format(

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -142,16 +142,16 @@
     <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}', but are configured with different sparseness.</value>
   </data>
   <data name="DuplicateIndexClusteredMismatch" xml:space="preserve">
-    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different clustered configurations.</value>
+    <value>The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different clustered configurations.</value>
   </data>
   <data name="DuplicateIndexFillFactorMismatch" xml:space="preserve">
-    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different fill factor configurations.</value>
+    <value>The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different fill factor configurations.</value>
   </data>
   <data name="DuplicateIndexIncludedMismatch" xml:space="preserve">
-    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different included columns: {includedColumns1} and {includedColumns2}.</value>
+    <value>The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different included columns: {includedColumns1} and {includedColumns2}.</value>
   </data>
   <data name="DuplicateIndexOnlineMismatch" xml:space="preserve">
-    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different online configurations.</value>
+    <value>The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different online configurations.</value>
   </data>
   <data name="DuplicateKeyMismatchedClustering" xml:space="preserve">
     <value>The keys {key1} on '{entityType1}' and {key2} on '{entityType2}' are both mapped to '{table}.{keyName}', but have different clustering configurations.</value>
@@ -160,13 +160,13 @@
     <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.</value>
   </data>
   <data name="IncludePropertyDuplicated" xml:space="preserve">
-    <value>The include property '{entityType}.{property}' was specified multiple times for the index {index}.</value>
+    <value>The include property '{entityType}.{property}' was specified multiple times for the index '{index}'.</value>
   </data>
   <data name="IncludePropertyInIndex" xml:space="preserve">
-    <value>The include property '{entityType}.{property}' is already part of the index {index}.</value>
+    <value>The include property '{entityType}.{property}' is already part of the index '{index}'.</value>
   </data>
   <data name="IncludePropertyNotFound" xml:space="preserve">
-    <value>The include property '{property}' specified on the index {index} was not found on entity type '{entityType}'.</value>
+    <value>The include property '{property}' specified on the index '{index}' was not found on entity type '{entityType}'.</value>
   </data>
   <data name="IncompatibleTableMemoryOptimizedMismatch" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{memoryOptimizedEntityType}' is marked as memory-optimized, but entity type '{nonMemoryOptimizedEntityType}' is not.</value>

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -142,16 +142,16 @@
     <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}', but are configured with different sparseness.</value>
   </data>
   <data name="DuplicateIndexClusteredMismatch" xml:space="preserve">
-    <value>The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different clustered configurations.</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different clustered configurations.</value>
   </data>
   <data name="DuplicateIndexFillFactorMismatch" xml:space="preserve">
-    <value>The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different fill factor configurations.</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different fill factor configurations.</value>
   </data>
   <data name="DuplicateIndexIncludedMismatch" xml:space="preserve">
-    <value>The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different included columns: {includedColumns1} and {includedColumns2}.</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different included columns: {includedColumns1} and {includedColumns2}.</value>
   </data>
   <data name="DuplicateIndexOnlineMismatch" xml:space="preserve">
-    <value>The indexes '{index1}' on '{entityType1}' and '{index2}' on '{entityType2}' are both mapped to '{table}.{indexName}', but have different online configurations.</value>
+    <value>The indexes {index1} on '{entityType1}' and {index2} on '{entityType2}' are both mapped to '{table}.{indexName}', but have different online configurations.</value>
   </data>
   <data name="DuplicateKeyMismatchedClustering" xml:space="preserve">
     <value>The keys {key1} on '{entityType1}' and {key2} on '{entityType2}' are both mapped to '{table}.{keyName}', but have different clustering configurations.</value>
@@ -160,13 +160,13 @@
     <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.</value>
   </data>
   <data name="IncludePropertyDuplicated" xml:space="preserve">
-    <value>The include property '{entityType}.{property}' was specified multiple times for the index '{index}'.</value>
+    <value>The include property '{entityType}.{property}' was specified multiple times for the index {index}.</value>
   </data>
   <data name="IncludePropertyInIndex" xml:space="preserve">
-    <value>The include property '{entityType}.{property}' is already part of the index '{index}'.</value>
+    <value>The include property '{entityType}.{property}' is already part of the index {index}.</value>
   </data>
   <data name="IncludePropertyNotFound" xml:space="preserve">
-    <value>The include property '{property}' specified on the index '{index}' was not found on entity type '{entityType}'.</value>
+    <value>The include property '{property}' specified on the index {index} was not found on entity type '{entityType}'.</value>
   </data>
   <data name="IncompatibleTableMemoryOptimizedMismatch" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{memoryOptimizedEntityType}' is marked as memory-optimized, but entity type '{nonMemoryOptimizedEntityType}' is not.</value>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -932,6 +932,7 @@ SELECT
     [i].[filter_definition],
     [i].[fill_factor],
     COL_NAME([ic].[object_id], [ic].[column_id]) AS [column_name],
+    [ic].[is_descending_key],
     [ic].[is_included_column]
 FROM [sys].[indexes] AS [i]
 JOIN [sys].[tables] AS [t] ON [i].[object_id] = [t].[object_id]
@@ -1136,6 +1137,8 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
                     {
                         return false;
                     }
+
+                    index.IsDescending.Add(dataRecord.GetValueOrDefault<bool>("is_descending_key"));
 
                     index.Columns.Add(column);
                 }

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
@@ -458,8 +458,9 @@ public class SqliteDatabaseModelFactory : DatabaseModelFactory
             using (var command2 = connection.CreateCommand())
             {
                 command2.CommandText = new StringBuilder()
-                    .AppendLine("SELECT \"name\"")
-                    .AppendLine("FROM pragma_index_info(@index)")
+                    .AppendLine("SELECT \"name\", \"desc\"")
+                    .AppendLine("FROM pragma_index_xinfo(@index)")
+                    .AppendLine("WHERE key = 1")
                     .AppendLine("ORDER BY \"seqno\";")
                     .ToString();
 
@@ -477,6 +478,7 @@ public class SqliteDatabaseModelFactory : DatabaseModelFactory
                     Check.DebugAssert(column != null, "column is null.");
 
                     index.Columns.Add(column);
+                    index.IsDescending.Add(reader2.GetBoolean(1));
                 }
             }
 

--- a/src/EFCore/Metadata/Builders/IConventionIndexBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionIndexBuilder.cs
@@ -41,10 +41,7 @@ public interface IConventionIndexBuilder : IConventionAnnotatableBuilder
     /// <summary>
     ///     Configures the sort order(s) for the columns of this index (ascending or descending).
     /// </summary>
-    /// <param name="descending">
-    ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
-    /// </param>
+    /// <param name="descending">A set of values indicating whether each corresponding index column has descending sort order.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The same builder instance if the uniqueness was configured, <see langword="null" /> otherwise.</returns>
     IConventionIndexBuilder? IsDescending(IReadOnlyList<bool>? descending, bool fromDataAnnotation = false);
@@ -52,10 +49,7 @@ public interface IConventionIndexBuilder : IConventionAnnotatableBuilder
     /// <summary>
     ///     Returns a value indicating whether this index sort order can be configured from the current configuration source.
     /// </summary>
-    /// <param name="descending">
-    ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
-    /// </param>
+    /// <param name="descending">A set of values indicating whether each corresponding index column has descending sort order.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the index uniqueness can be configured.</returns>
     bool CanSetIsDescending(IReadOnlyList<bool>? descending, bool fromDataAnnotation = false);

--- a/src/EFCore/Metadata/Builders/IConventionIndexBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionIndexBuilder.cs
@@ -27,18 +27,36 @@ public interface IConventionIndexBuilder : IConventionAnnotatableBuilder
     /// </summary>
     /// <param name="unique">A value indicating whether the index is unique.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>
-    ///     The same builder instance if the uniqueness was configured,
-    ///     <see langword="null" /> otherwise.
-    /// </returns>
+    /// <returns>The same builder instance if the uniqueness was configured, <see langword="null" /> otherwise.</returns>
     IConventionIndexBuilder? IsUnique(bool? unique, bool fromDataAnnotation = false);
 
     /// <summary>
-    ///     Returns a value indicating whether this index uniqueness can be configured
-    ///     from the current configuration source.
+    ///     Returns a value indicating whether this index uniqueness can be configured from the current configuration source.
     /// </summary>
     /// <param name="unique">A value indicating whether the index is unique.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the index uniqueness can be configured.</returns>
     bool CanSetIsUnique(bool? unique, bool fromDataAnnotation = false);
+
+    /// <summary>
+    ///     Configures the sort order(s) for the columns of this index (ascending or descending).
+    /// </summary>
+    /// <param name="descending">
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The same builder instance if the uniqueness was configured, <see langword="null" /> otherwise.</returns>
+    IConventionIndexBuilder? IsDescending(IReadOnlyList<bool>? descending, bool fromDataAnnotation = false);
+
+    /// <summary>
+    ///     Returns a value indicating whether this index sort order can be configured from the current configuration source.
+    /// </summary>
+    /// <param name="descending">
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the index uniqueness can be configured.</returns>
+    bool CanSetIsDescending(IReadOnlyList<bool>? descending, bool fromDataAnnotation = false);
 }

--- a/src/EFCore/Metadata/Builders/IndexBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IndexBuilder.cs
@@ -80,20 +80,10 @@ public class IndexBuilder : IInfrastructure<IConventionIndexBuilder>
     /// <summary>
     ///     Configures the sort order(s) for the columns of this index (ascending or descending).
     /// </summary>
-    /// <param name="descending">
-    ///     If empty, all index columns have descending sort order. Otherwise, each value determines whether the corresponding index
-    ///     column has descending sort order. If less sort order values are provided than there are columns, the remaining columns will have
-    ///     ascending order.
-    /// </param>
+    /// <param name="descending">A set of values indicating whether each corresponding index column has descending sort order.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
     public virtual IndexBuilder IsDescending(params bool[] descending)
     {
-        if (descending.Length == 0)
-        {
-            descending = new bool[Builder.Metadata.Properties.Count];
-            Array.Fill(descending, true);
-        }
-
         Builder.IsDescending(descending, ConfigurationSource.Explicit);
 
         return this;

--- a/src/EFCore/Metadata/Builders/IndexBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IndexBuilder.cs
@@ -77,6 +77,28 @@ public class IndexBuilder : IInfrastructure<IConventionIndexBuilder>
         return this;
     }
 
+    /// <summary>
+    ///     Configures the sort order(s) for the columns of this index (ascending or descending).
+    /// </summary>
+    /// <param name="descending">
+    ///     If empty, all index columns have descending sort order. Otherwise, each value determines whether the corresponding index
+    ///     column has descending sort order. If less sort order values are provided than there are columns, the remaining columns will have
+    ///     ascending order.
+    /// </param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public virtual IndexBuilder IsDescending(params bool[] descending)
+    {
+        if (descending.Length == 0)
+        {
+            descending = new bool[Builder.Metadata.Properties.Count];
+            Array.Fill(descending, true);
+        }
+
+        Builder.IsDescending(descending, ConfigurationSource.Explicit);
+
+        return this;
+    }
+
     #region Hidden System.Object members
 
     /// <summary>

--- a/src/EFCore/Metadata/Builders/IndexBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/IndexBuilder`.cs
@@ -49,4 +49,16 @@ public class IndexBuilder<T> : IndexBuilder
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
     public new virtual IndexBuilder<T> IsUnique(bool unique = true)
         => (IndexBuilder<T>)base.IsUnique(unique);
+
+    /// <summary>
+    ///     Configures the sort order(s) for the columns of this index (ascending or descending).
+    /// </summary>
+    /// <param name="descending">
+    ///     If empty, all index columns have descending sort order. Otherwise, each value determines whether the corresponding index
+    ///     column has descending sort order. If less sort order values are provided than there are columns, the remaining columns will have
+    ///     ascending order.
+    /// </param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public new virtual IndexBuilder<T> IsDescending(params bool[] descending)
+        => (IndexBuilder<T>)base.IsDescending(descending);
 }

--- a/src/EFCore/Metadata/Builders/IndexBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/IndexBuilder`.cs
@@ -53,11 +53,7 @@ public class IndexBuilder<T> : IndexBuilder
     /// <summary>
     ///     Configures the sort order(s) for the columns of this index (ascending or descending).
     /// </summary>
-    /// <param name="descending">
-    ///     If empty, all index columns have descending sort order. Otherwise, each value determines whether the corresponding index
-    ///     column has descending sort order. If less sort order values are provided than there are columns, the remaining columns will have
-    ///     ascending order.
-    /// </param>
+    /// <param name="descending">A set of values indicating whether each corresponding index column has descending sort order.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
     public new virtual IndexBuilder<T> IsDescending(params bool[] descending)
         => (IndexBuilder<T>)base.IsDescending(descending);

--- a/src/EFCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/EFCore/Metadata/Conventions/ConventionSet.cs
@@ -208,6 +208,12 @@ public class ConventionSet
         = new List<IIndexUniquenessChangedConvention>();
 
     /// <summary>
+    ///     Conventions to run when the sort order of an index is changed.
+    /// </summary>
+    public virtual IList<IIndexSortOrderChangedConvention> IndexSortOrderChangedConventions { get; }
+        = new List<IIndexSortOrderChangedConvention>();
+
+    /// <summary>
     ///     Conventions to run when an annotation is changed on an index.
     /// </summary>
     public virtual IList<IIndexAnnotationChangedConvention> IndexAnnotationChangedConventions { get; }

--- a/src/EFCore/Metadata/Conventions/IIndexSortOrderChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IIndexSortOrderChangedConvention.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+///     Represents an operation that should be performed when the sort order of an index is changed.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.
+/// </remarks>
+public interface IIndexSortOrderChangedConvention : IConvention
+{
+    /// <summary>
+    ///     Called after the uniqueness for an index is changed.
+    /// </summary>
+    /// <param name="indexBuilder">The builder for the index.</param>
+    /// <param name="context">Additional information associated with convention execution.</param>
+    void ProcessIndexSortOrderChanged(
+        IConventionIndexBuilder indexBuilder,
+        IConventionContext<IReadOnlyList<bool>?> context);
+}

--- a/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
@@ -110,9 +110,17 @@ public class IndexAttributeConvention : IEntityTypeAddedConvention, IEntityTypeB
             {
                 CheckIgnoredProperties(indexAttribute, entityType);
             }
-            else if (indexAttribute.IsUniqueHasValue)
+            else
             {
-                indexBuilder.IsUnique(indexAttribute.IsUnique, fromDataAnnotation: true);
+                if (indexAttribute.IsUniqueHasValue)
+                {
+                    indexBuilder.IsUnique(indexAttribute.IsUnique, fromDataAnnotation: true);
+                }
+
+                if (indexAttribute.IsDescending is not null)
+                {
+                    indexBuilder.IsDescending(indexAttribute.IsDescending, fromDataAnnotation: true);
+                }
             }
         }
     }

--- a/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
@@ -114,12 +114,12 @@ public class IndexAttributeConvention : IEntityTypeAddedConvention, IEntityTypeB
             {
                 if (indexAttribute.IsUniqueHasValue)
                 {
-                    indexBuilder.IsUnique(indexAttribute.IsUnique, fromDataAnnotation: true);
+                    indexBuilder = indexBuilder.IsUnique(indexAttribute.IsUnique, fromDataAnnotation: true);
                 }
 
-                if (indexAttribute.IsDescending is not null)
+                if (indexBuilder is not null && indexAttribute.IsDescending is not null)
                 {
-                    indexBuilder.IsDescending(indexAttribute.IsDescending, fromDataAnnotation: true);
+                    indexBuilder = indexBuilder.IsDescending(indexAttribute.IsDescending, fromDataAnnotation: true);
                 }
             }
         }

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ConventionScope.cs
@@ -127,6 +127,8 @@ public partial class ConventionDispatcher
             IConventionIndex index);
 
         public abstract bool? OnIndexUniquenessChanged(IConventionIndexBuilder indexBuilder);
+        public abstract IReadOnlyList<bool>? OnIndexSortOrderChanged(IConventionIndexBuilder indexBuilder);
+
         public abstract IConventionKeyBuilder? OnKeyAdded(IConventionKeyBuilder keyBuilder);
 
         public abstract IConventionAnnotation? OnKeyAnnotationChanged(

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.DelayedConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.DelayedConventionScope.cs
@@ -183,6 +183,12 @@ public partial class ConventionDispatcher
             return indexBuilder.Metadata.IsUnique;
         }
 
+        public override IReadOnlyList<bool>? OnIndexSortOrderChanged(IConventionIndexBuilder indexBuilder)
+        {
+            Add(new OnIndexSortOrderChangedNode(indexBuilder));
+            return indexBuilder.Metadata.IsDescending;
+        }
+
         public override IConventionAnnotation? OnIndexAnnotationChanged(
             IConventionIndexBuilder indexBuilder,
             string name,
@@ -899,6 +905,19 @@ public partial class ConventionDispatcher
 
         public override void Run(ConventionDispatcher dispatcher)
             => dispatcher._immediateConventionScope.OnIndexUniquenessChanged(IndexBuilder);
+    }
+
+    private sealed class OnIndexSortOrderChangedNode : ConventionNode
+    {
+        public OnIndexSortOrderChangedNode(IConventionIndexBuilder indexBuilder)
+        {
+            IndexBuilder = indexBuilder;
+        }
+
+        public IConventionIndexBuilder IndexBuilder { get; }
+
+        public override void Run(ConventionDispatcher dispatcher)
+            => dispatcher._immediateConventionScope.OnIndexSortOrderChanged(IndexBuilder);
     }
 
     private sealed class OnIndexAnnotationChangedNode : ConventionNode

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ImmediateConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ImmediateConventionScope.cs
@@ -984,7 +984,7 @@ public partial class ConventionDispatcher
                     }
 
                     indexConvention.ProcessIndexSortOrderChanged(indexBuilder, _boolListConventionContext);
-                    if (_boolConventionContext.ShouldStopProcessing())
+                    if (_boolListConventionContext.ShouldStopProcessing())
                     {
                         return _boolListConventionContext.Result;
                     }

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ImmediateConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ImmediateConventionScope.cs
@@ -29,6 +29,7 @@ public partial class ConventionDispatcher
         private readonly ConventionContext<string> _stringConventionContext;
         private readonly ConventionContext<FieldInfo> _fieldInfoConventionContext;
         private readonly ConventionContext<bool?> _boolConventionContext;
+        private readonly ConventionContext<IReadOnlyList<bool>?> _boolListConventionContext;
 
         public ImmediateConventionScope(ConventionSet conventionSet, ConventionDispatcher dispatcher)
         {
@@ -54,6 +55,7 @@ public partial class ConventionDispatcher
             _stringConventionContext = new ConventionContext<string>(dispatcher);
             _fieldInfoConventionContext = new ConventionContext<FieldInfo>(dispatcher);
             _boolConventionContext = new ConventionContext<bool?>(dispatcher);
+            _boolListConventionContext = new ConventionContext<IReadOnlyList<bool>?>(dispatcher);
         }
 
         public override void Run(ConventionDispatcher dispatcher)
@@ -967,6 +969,29 @@ public partial class ConventionDispatcher
             }
 
             return !indexBuilder.Metadata.IsInModel ? null : _boolConventionContext.Result;
+        }
+
+        public override IReadOnlyList<bool>? OnIndexSortOrderChanged(IConventionIndexBuilder indexBuilder)
+        {
+            using (_dispatcher.DelayConventions())
+            {
+                _boolListConventionContext.ResetState(indexBuilder.Metadata.IsDescending);
+                foreach (var indexConvention in _conventionSet.IndexSortOrderChangedConventions)
+                {
+                    if (!indexBuilder.Metadata.IsInModel)
+                    {
+                        return null;
+                    }
+
+                    indexConvention.ProcessIndexSortOrderChanged(indexBuilder, _boolListConventionContext);
+                    if (_boolConventionContext.ShouldStopProcessing())
+                    {
+                        return _boolListConventionContext.Result;
+                    }
+                }
+            }
+
+            return !indexBuilder.Metadata.IsInModel ? null : _boolListConventionContext.Result;
         }
 
         public override IConventionAnnotation? OnIndexAnnotationChanged(

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -489,6 +489,15 @@ public partial class ConventionDispatcher
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public virtual IReadOnlyList<bool>? OnIndexSortOrderChanged(IConventionIndexBuilder indexBuilder)
+        => _scope.OnIndexSortOrderChanged(indexBuilder);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual IConventionAnnotation? OnIndexAnnotationChanged(
         IConventionIndexBuilder indexBuilder,
         string name,

--- a/src/EFCore/Metadata/IConventionIndex.cs
+++ b/src/EFCore/Metadata/IConventionIndex.cs
@@ -58,10 +58,7 @@ public interface IConventionIndex : IReadOnlyIndex, IConventionAnnotatable
     /// <summary>
     ///     Sets the sort order(s) for this index (ascending or descending).
     /// </summary>
-    /// <param name="descending">
-    ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
-    /// </param>
+    /// <param name="descending">A set of values indicating whether each corresponding index column has descending sort order.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured sort order(s).</returns>
     IReadOnlyList<bool>? SetIsDescending(IReadOnlyList<bool>? descending, bool fromDataAnnotation = false);

--- a/src/EFCore/Metadata/IConventionIndex.cs
+++ b/src/EFCore/Metadata/IConventionIndex.cs
@@ -54,4 +54,21 @@ public interface IConventionIndex : IReadOnlyIndex, IConventionAnnotatable
     /// </summary>
     /// <returns>The configuration source for <see cref="IReadOnlyIndex.IsUnique" />.</returns>
     ConfigurationSource? GetIsUniqueConfigurationSource();
+
+    /// <summary>
+    ///     Sets the sort order(s) for this index (ascending or descending).
+    /// </summary>
+    /// <param name="descending">
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured sort order(s).</returns>
+    IReadOnlyList<bool>? SetIsDescending(IReadOnlyList<bool>? descending, bool fromDataAnnotation = false);
+
+    /// <summary>
+    ///     Returns the configuration source for <see cref="IReadOnlyIndex.IsDescending" />.
+    /// </summary>
+    /// <returns>The configuration source for <see cref="IReadOnlyIndex.IsDescending" />.</returns>
+    ConfigurationSource? GetIsDescendingConfigurationSource();
 }

--- a/src/EFCore/Metadata/IMutableIndex.cs
+++ b/src/EFCore/Metadata/IMutableIndex.cs
@@ -24,6 +24,12 @@ public interface IMutableIndex : IReadOnlyIndex, IMutableAnnotatable
     new bool IsUnique { get; set; }
 
     /// <summary>
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </summary>
+    new IReadOnlyList<bool> IsDescending { get; set; }
+
+    /// <summary>
     ///     Gets the properties that this index is defined on.
     /// </summary>
     new IReadOnlyList<IMutableProperty> Properties { get; }

--- a/src/EFCore/Metadata/IMutableIndex.cs
+++ b/src/EFCore/Metadata/IMutableIndex.cs
@@ -25,9 +25,8 @@ public interface IMutableIndex : IReadOnlyIndex, IMutableAnnotatable
 
     /// <summary>
     ///     A set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
     /// </summary>
-    new IReadOnlyList<bool> IsDescending { get; set; }
+    new IReadOnlyList<bool>? IsDescending { get; set; }
 
     /// <summary>
     ///     Gets the properties that this index is defined on.

--- a/src/EFCore/Metadata/IReadOnlyIndex.cs
+++ b/src/EFCore/Metadata/IReadOnlyIndex.cs
@@ -29,10 +29,9 @@ public interface IReadOnlyIndex : IReadOnlyAnnotatable
     bool IsUnique { get; }
 
     /// <summary>
-    ///     Gets a set of values indicating whether each corresponding index column has descending sort order.
-    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
     /// </summary>
-    IReadOnlyList<bool> IsDescending { get; }
+    IReadOnlyList<bool>? IsDescending { get; }
 
     /// <summary>
     ///     Gets the entity type the index is defined on. This may be different from the type that <see cref="Properties" />

--- a/src/EFCore/Metadata/IReadOnlyIndex.cs
+++ b/src/EFCore/Metadata/IReadOnlyIndex.cs
@@ -47,7 +47,7 @@ public interface IReadOnlyIndex : IReadOnlyAnnotatable
     /// <returns>The display name.</returns>
     [DebuggerStepThrough]
     string DisplayName()
-        => Name ?? Properties.Format();
+        => Name is null ? Properties.Format() : $"'{Name}'";
 
     /// <summary>
     ///     <para>

--- a/src/EFCore/Metadata/IReadOnlyIndex.cs
+++ b/src/EFCore/Metadata/IReadOnlyIndex.cs
@@ -41,6 +41,15 @@ public interface IReadOnlyIndex : IReadOnlyAnnotatable
     IReadOnlyEntityType DeclaringEntityType { get; }
 
     /// <summary>
+    ///     Gets the friendly display name for the given <see cref="IReadOnlyIndex" />, returning its <see cref="Name" /> if one is defined,
+    ///     or a string representation of its <see cref="Properties" /> if this is an unnamed index.
+    /// </summary>
+    /// <returns>The display name.</returns>
+    [DebuggerStepThrough]
+    string DisplayName()
+        => Name ?? Properties.Format();
+
+    /// <summary>
     ///     <para>
     ///         Creates a human-readable representation of the given metadata.
     ///     </para>

--- a/src/EFCore/Metadata/IReadOnlyIndex.cs
+++ b/src/EFCore/Metadata/IReadOnlyIndex.cs
@@ -29,6 +29,12 @@ public interface IReadOnlyIndex : IReadOnlyAnnotatable
     bool IsUnique { get; }
 
     /// <summary>
+    ///     Gets a set of values indicating whether each corresponding index column has descending sort order.
+    ///     If less sort order values are provided than there are columns, the remaining columns will have ascending order.
+    /// </summary>
+    IReadOnlyList<bool> IsDescending { get; }
+
+    /// <summary>
     ///     Gets the entity type the index is defined on. This may be different from the type that <see cref="Properties" />
     ///     are defined on when the index is defined a derived type in an inheritance hierarchy (since the properties
     ///     may be defined on a base type).

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2249,7 +2249,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
             if (!_unnamedIndexes.Remove(index.Properties))
             {
                 throw new InvalidOperationException(
-                    CoreStrings.IndexWrongType(index.Properties.Format(), DisplayName(), index.DeclaringEntityType.DisplayName()));
+                    CoreStrings.IndexWrongType(index.DisplayName(), DisplayName(), index.DeclaringEntityType.DisplayName()));
             }
         }
         else
@@ -2618,7 +2618,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
             throw new InvalidOperationException(
                 CoreStrings.PropertyInUseIndex(
                     property.Name, DisplayName(),
-                    containingIndex.Properties.Format(), containingIndex.DeclaringEntityType.DisplayName()));
+                    containingIndex.DisplayName(), containingIndex.DeclaringEntityType.DisplayName()));
         }
     }
 

--- a/src/EFCore/Metadata/Internal/Index.cs
+++ b/src/EFCore/Metadata/Internal/Index.cs
@@ -221,8 +221,7 @@ public class Index : ConventionAnnotatable, IMutableIndex, IConventionIndex, IIn
         if (descending is not null && descending.Count != Properties.Count)
         {
             throw new ArgumentException(
-                CoreStrings.InvalidNumberOfIndexSortOrderValues(
-                    Properties.Format(), descending.Count, Properties.Count), nameof(descending));
+                CoreStrings.InvalidNumberOfIndexSortOrderValues(DisplayName(), descending.Count, Properties.Count), nameof(descending));
         }
 
         var oldIsDescending = IsDescending;
@@ -307,6 +306,16 @@ public class Index : ConventionAnnotatable, IMutableIndex, IConventionIndex, IIn
         => new(
             () => ((IIndex)this).ToDebugString(),
             () => ((IIndex)this).ToDebugString(MetadataDebugStringOptions.LongDefault));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
+    public virtual string DisplayName()
+        => Name ?? Properties.Format();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Index.cs
+++ b/src/EFCore/Metadata/Internal/Index.cs
@@ -202,7 +202,7 @@ public class Index : ConventionAnnotatable, IMutableIndex, IConventionIndex, IIn
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IReadOnlyList<bool> IsDescending
+    public virtual IReadOnlyList<bool>? IsDescending
     {
         get => _isDescending ?? DefaultIsDescending;
         set => SetIsDescending(value, ConfigurationSource.Explicit);
@@ -218,21 +218,16 @@ public class Index : ConventionAnnotatable, IMutableIndex, IConventionIndex, IIn
     {
         EnsureMutable();
 
-        if (descending is not null && descending.Count > Properties.Count)
+        if (descending is not null && descending.Count != Properties.Count)
         {
             throw new ArgumentException(
-                CoreStrings.TooManyIndexSortOrderValues(descending.Count, Properties.Format(), Properties.Count), nameof(descending));
-        }
-
-        // Normalize all-false array to the simpler empty array representation
-        if (descending is not null && descending.All(d => d == false))
-        {
-            descending = DefaultIsDescending;
+                CoreStrings.InvalidNumberOfIndexSortOrderValues(
+                    Properties.Format(), descending.Count, Properties.Count), nameof(descending));
         }
 
         var oldIsDescending = IsDescending;
         var isChanging = _isDescending is null != descending is null
-            || descending is not null && !oldIsDescending.SequenceEqual(descending);
+            || descending is not null && oldIsDescending is not null && !oldIsDescending.SequenceEqual(descending);
         _isDescending = descending;
 
         if (descending == null)
@@ -249,8 +244,8 @@ public class Index : ConventionAnnotatable, IMutableIndex, IConventionIndex, IIn
             : oldIsDescending;
     }
 
-    private static readonly bool[] DefaultIsDescending
-        = Array.Empty<bool>();
+    private static readonly bool[]? DefaultIsDescending
+        = null;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Index.cs
+++ b/src/EFCore/Metadata/Internal/Index.cs
@@ -226,8 +226,10 @@ public class Index : ConventionAnnotatable, IMutableIndex, IConventionIndex, IIn
         }
 
         var oldIsDescending = IsDescending;
-        var isChanging = _isDescending is null != descending is null
-            || descending is not null && oldIsDescending is not null && !oldIsDescending.SequenceEqual(descending);
+        var isChanging =
+            (_isDescending is null && descending is not null && descending.Any(desc => desc))
+            || (descending is null && _isDescending is not null && _isDescending.Any(desc => desc))
+            || (descending is not null && oldIsDescending is not null && !oldIsDescending.SequenceEqual(descending));
         _isDescending = descending;
 
         if (descending == null)

--- a/src/EFCore/Metadata/Internal/Index.cs
+++ b/src/EFCore/Metadata/Internal/Index.cs
@@ -315,7 +315,7 @@ public class Index : ConventionAnnotatable, IMutableIndex, IConventionIndex, IIn
     /// </summary>
     [DebuggerStepThrough]
     public virtual string DisplayName()
-        => Name ?? Properties.Format();
+        => Name is null ? Properties.Format() : $"'{Name}'";
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/InternalIndexBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalIndexBuilder.cs
@@ -55,6 +55,34 @@ public class InternalIndexBuilder : AnnotatableBuilder<Index, InternalModelBuild
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public virtual InternalIndexBuilder? IsDescending(IReadOnlyList<bool>? descending, ConfigurationSource configurationSource)
+    {
+        if (!CanSetIsDescending(descending, configurationSource))
+        {
+            return null;
+        }
+
+        Metadata.SetIsDescending(descending, configurationSource);
+        return this;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool CanSetIsDescending(IReadOnlyList<bool>? descending, ConfigurationSource? configurationSource)
+        => descending is null
+            || Metadata.IsDescending.SequenceEqual(descending)
+            || configurationSource.Overrides(Metadata.GetIsDescendingConfigurationSource());
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual InternalIndexBuilder? Attach(InternalEntityTypeBuilder entityTypeBuilder)
     {
         var properties = entityTypeBuilder.GetActualProperties(Metadata.Properties, null);
@@ -106,5 +134,27 @@ public class InternalIndexBuilder : AnnotatableBuilder<Index, InternalModelBuild
     bool IConventionIndexBuilder.CanSetIsUnique(bool? unique, bool fromDataAnnotation)
         => CanSetIsUnique(
             unique,
+            fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    IConventionIndexBuilder? IConventionIndexBuilder.IsDescending(IReadOnlyList<bool>? descending, bool fromDataAnnotation)
+        => IsDescending(
+            descending,
+            fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    bool IConventionIndexBuilder.CanSetIsDescending(IReadOnlyList<bool>? descending, bool fromDataAnnotation)
+        => CanSetIsDescending(
+            descending,
             fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 }

--- a/src/EFCore/Metadata/Internal/InternalIndexBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalIndexBuilder.cs
@@ -73,8 +73,8 @@ public class InternalIndexBuilder : AnnotatableBuilder<Index, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool CanSetIsDescending(IReadOnlyList<bool>? descending, ConfigurationSource? configurationSource)
-        => descending is null
-            || Metadata.IsDescending.SequenceEqual(descending)
+        => descending is null && Metadata.IsDescending is null
+            || descending is not null && Metadata.IsDescending is not null && Metadata.IsDescending.SequenceEqual(descending)
             || configurationSource.Overrides(Metadata.GetIsDescendingConfigurationSource());
 
     /// <summary>

--- a/src/EFCore/Metadata/RuntimeIndex.cs
+++ b/src/EFCore/Metadata/RuntimeIndex.cs
@@ -56,6 +56,15 @@ public class RuntimeIndex : AnnotatableBase, IIndex
     public virtual RuntimeEntityType DeclaringEntityType { get; }
 
     /// <summary>
+    ///     Always returns an empty array for <see cref="RuntimeIndex" />.
+    /// </summary>
+    IReadOnlyList<bool> IReadOnlyIndex.IsDescending
+    {
+        [DebuggerStepThrough]
+        get => Array.Empty<bool>();
+    }
+
+    /// <summary>
     ///     Returns a string that represents the current object.
     /// </summary>
     /// <returns>A string that represents the current object.</returns>

--- a/src/EFCore/Metadata/RuntimeIndex.cs
+++ b/src/EFCore/Metadata/RuntimeIndex.cs
@@ -61,7 +61,7 @@ public class RuntimeIndex : AnnotatableBase, IIndex
     IReadOnlyList<bool> IReadOnlyIndex.IsDescending
     {
         [DebuggerStepThrough]
-        get => Array.Empty<bool>();
+        get => throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData);
     }
 
     /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1118,7 +1118,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 indexProperties, entityType);
 
         /// <summary>
-        ///     The index '{index}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
+        ///     The index {index} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
         /// </summary>
         public static string IndexWrongType(object? index, object? entityType, object? otherEntityType)
             => string.Format(
@@ -2038,7 +2038,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, foreignKeyProperties, foreignKeyType);
 
         /// <summary>
-        ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index '{index}' on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.
+        ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index {index} on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.
         /// </summary>
         public static string PropertyInUseIndex(object? property, object? entityType, object? index, object? indexType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1118,12 +1118,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 indexProperties, entityType);
 
         /// <summary>
-        ///     The index {indexProperties} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
+        ///     The index '{index}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
         /// </summary>
-        public static string IndexWrongType(object? indexProperties, object? entityType, object? otherEntityType)
+        public static string IndexWrongType(object? index, object? entityType, object? otherEntityType)
             => string.Format(
-                GetString("IndexWrongType", nameof(indexProperties), nameof(entityType), nameof(otherEntityType)),
-                indexProperties, entityType, otherEntityType);
+                GetString("IndexWrongType", nameof(index), nameof(entityType), nameof(otherEntityType)),
+                index, entityType, otherEntityType);
 
         /// <summary>
         ///     The property '{property}' cannot be ignored on entity type '{entityType}' because it's declared on the base entity type '{baseEntityType}'. To exclude this property from your model, use the [NotMapped] attribute or 'Ignore' on the base type in 'OnModelCreating'.
@@ -2038,7 +2038,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, foreignKeyProperties, foreignKeyType);
 
         /// <summary>
-        ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index {index} on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.
+        ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index '{index}' on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.
         /// </summary>
         public static string PropertyInUseIndex(object? property, object? entityType, object? index, object? indexType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1220,6 +1220,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, referencedProperty, referencedEntityType);
 
         /// <summary>
+        ///     Invalid number of index sort order values provided for {indexProperties}: {numValues} values were provided, but the index has {numProperties} properties.
+        /// </summary>
+        public static string InvalidNumberOfIndexSortOrderValues(object? indexProperties, object? numValues, object? numProperties)
+            => string.Format(
+                GetString("InvalidNumberOfIndexSortOrderValues", nameof(indexProperties), nameof(numValues), nameof(numProperties)),
+                indexProperties, numValues, numProperties);
+
+        /// <summary>
         ///     The specified poolSize must be greater than 0.
         /// </summary>
         public static string InvalidPoolSize
@@ -2584,14 +2592,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("TempValuePersists", "0_property", "1_entityType", nameof(state)),
                 property, entityType, state);
-
-        /// <summary>
-        ///     Too many index sort order values ({numDescendingValues}) specified for index {indexProperties}, which has only {numProperties} properties.
-        /// </summary>
-        public static string TooManyIndexSortOrderValues(object? numDescendingValues, object? indexProperties, object? numProperties)
-            => string.Format(
-                GetString("TooManyIndexSortOrderValues", nameof(numDescendingValues), nameof(indexProperties), nameof(numProperties)),
-                numDescendingValues, indexProperties, numProperties);
 
         /// <summary>
         ///     The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because the two types are not in the same hierarchy.

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2586,6 +2586,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, state);
 
         /// <summary>
+        ///     Too many index sort order values ({numDescendingValues}) specified for index {indexProperties}, which has only {numProperties} properties.
+        /// </summary>
+        public static string TooManyIndexSortOrderValues(object? numDescendingValues, object? indexProperties, object? numProperties)
+            => string.Format(
+                GetString("TooManyIndexSortOrderValues", nameof(numDescendingValues), nameof(indexProperties), nameof(numProperties)),
+                numDescendingValues, indexProperties, numProperties);
+
+        /// <summary>
         ///     The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because the two types are not in the same hierarchy.
         /// </summary>
         public static string TrackingTypeMismatch(object? runtimeEntityType, object? entityType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1397,6 +1397,9 @@
   <data name="TempValuePersists" xml:space="preserve">
     <value>The property '{1_entityType}.{0_property}' has a temporary value while attempting to change the entity's state to '{state}'. Either set a permanent value explicitly, or ensure that the database is configured to generate values for this property.</value>
   </data>
+  <data name="TooManyIndexSortOrderValues" xml:space="preserve">
+    <value>Too many index sort order values ({numDescendingValues}) specified for {indexProperties}, which has only {numProperties} properties.</value>
+  </data>
   <data name="TrackingTypeMismatch" xml:space="preserve">
     <value>The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because the two types are not in the same hierarchy.</value>
   </data>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -574,6 +574,9 @@
   <data name="InvalidNavigationWithInverseProperty" xml:space="preserve">
     <value>The [InverseProperty] attribute on property '{1_entityType}.{0_property}' is not valid. The property '{referencedProperty}' is not a valid navigation on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation.</value>
   </data>
+  <data name="InvalidNumberOfIndexSortOrderValues" xml:space="preserve">
+    <value>Invalid number of index sort order values provided for {indexProperties}: {numValues} values were provided, but the index has {numProperties} properties.</value>
+  </data>
   <data name="InvalidPoolSize" xml:space="preserve">
     <value>The specified poolSize must be greater than 0.</value>
   </data>
@@ -1396,9 +1399,6 @@
   </data>
   <data name="TempValuePersists" xml:space="preserve">
     <value>The property '{1_entityType}.{0_property}' has a temporary value while attempting to change the entity's state to '{state}'. Either set a permanent value explicitly, or ensure that the database is configured to generate values for this property.</value>
-  </data>
-  <data name="TooManyIndexSortOrderValues" xml:space="preserve">
-    <value>Too many index sort order values ({numDescendingValues}) specified for {indexProperties}, which has only {numProperties} properties.</value>
   </data>
   <data name="TrackingTypeMismatch" xml:space="preserve">
     <value>The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because the two types are not in the same hierarchy.</value>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -536,7 +536,7 @@
     <value>The specified index properties {indexProperties} are not declared on the entity type '{entityType}'. Ensure that index properties are declared on the target entity type.</value>
   </data>
   <data name="IndexWrongType" xml:space="preserve">
-    <value>The index {indexProperties} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
+    <value>The index '{index}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
   </data>
   <data name="InheritedPropertyCannotBeIgnored" xml:space="preserve">
     <value>The property '{property}' cannot be ignored on entity type '{entityType}' because it's declared on the base entity type '{baseEntityType}'. To exclude this property from your model, use the [NotMapped] attribute or 'Ignore' on the base type in 'OnModelCreating'.</value>
@@ -1182,7 +1182,7 @@
     <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the foreign key {foreignKeyProperties} on '{foreignKeyType}'. All containing foreign keys must be removed or redefined before the property can be removed.</value>
   </data>
   <data name="PropertyInUseIndex" xml:space="preserve">
-    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index {index} on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.</value>
+    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index '{index}' on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.</value>
   </data>
   <data name="PropertyInUseKey" xml:space="preserve">
     <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the key {keyProperties}. All containing keys must be removed or redefined before the property can be removed.</value>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -536,7 +536,7 @@
     <value>The specified index properties {indexProperties} are not declared on the entity type '{entityType}'. Ensure that index properties are declared on the target entity type.</value>
   </data>
   <data name="IndexWrongType" xml:space="preserve">
-    <value>The index '{index}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
+    <value>The index {index} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
   </data>
   <data name="InheritedPropertyCannotBeIgnored" xml:space="preserve">
     <value>The property '{property}' cannot be ignored on entity type '{entityType}' because it's declared on the base entity type '{baseEntityType}'. To exclude this property from your model, use the [NotMapped] attribute or 'Ignore' on the base type in 'OnModelCreating'.</value>
@@ -1182,7 +1182,7 @@
     <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the foreign key {foreignKeyProperties} on '{foreignKeyType}'. All containing foreign keys must be removed or redefined before the property can be removed.</value>
   </data>
   <data name="PropertyInUseIndex" xml:space="preserve">
-    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index '{index}' on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.</value>
+    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index {index} on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.</value>
   </data>
   <data name="PropertyInUseKey" xml:space="preserve">
     <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the key {keyProperties}. All containing keys must be removed or redefined before the property can be removed.</value>

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -963,6 +963,9 @@ public class CSharpMigrationOperationGeneratorTest
                 Assert.Equal("IX_Post_Title", o.Name);
                 Assert.Equal("Post", o.Table);
                 Assert.Equal(new[] { "Title" }, o.Columns);
+                Assert.False(o.IsUnique);
+                Assert.Empty(o.IsDescending);
+                Assert.Null(o.Filter);
             });
 
     [ConditionalFact]
@@ -973,8 +976,9 @@ public class CSharpMigrationOperationGeneratorTest
                 Name = "IX_Post_Title",
                 Schema = "dbo",
                 Table = "Post",
-                Columns = new[] { "Title" },
+                Columns = new[] { "Title", "Name" },
                 IsUnique = true,
+                IsDescending = new[] { true, false },
                 Filter = "[Title] IS NOT NULL"
             },
             "mb.CreateIndex("
@@ -985,9 +989,11 @@ public class CSharpMigrationOperationGeneratorTest
             + _eol
             + "    table: \"Post\","
             + _eol
-            + "    column: \"Title\","
+            + "    columns: new[] { \"Title\", \"Name\" },"
             + _eol
             + "    unique: true,"
+            + _eol
+            + "    descending: new[] { true, false },"
             + _eol
             + "    filter: \"[Title] IS NOT NULL\");",
             o =>
@@ -995,8 +1001,10 @@ public class CSharpMigrationOperationGeneratorTest
                 Assert.Equal("IX_Post_Title", o.Name);
                 Assert.Equal("dbo", o.Schema);
                 Assert.Equal("Post", o.Table);
-                Assert.Equal(new[] { "Title" }, o.Columns);
+                Assert.Equal(new[] { "Title", "Name" }, o.Columns);
                 Assert.True(o.IsUnique);
+                Assert.Equal(new[] { true, false }, o.IsDescending);
+                Assert.Equal("[Title] IS NOT NULL", o.Filter);
             });
 
     [ConditionalFact]

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -964,7 +964,7 @@ public class CSharpMigrationOperationGeneratorTest
                 Assert.Equal("Post", o.Table);
                 Assert.Equal(new[] { "Title" }, o.Columns);
                 Assert.False(o.IsUnique);
-                Assert.Empty(o.IsDescending);
+                Assert.Null(o.IsDescending);
                 Assert.Null(o.Filter);
             });
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -4308,7 +4308,8 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_all_ascending"");
+                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_all_ascending"")
+                        .IsDescending(false, false, false);
 
                     b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_all_descending"")
                         .IsDescending(true, true, true);
@@ -4326,10 +4327,10 @@ namespace RootNamespace
                 Assert.Equal(4, entityType.GetIndexes().Count());
 
                 var emptyIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_empty");
-                Assert.Equal(Array.Empty<bool>(), emptyIndex.IsDescending);
+                Assert.Null(emptyIndex.IsDescending);
 
                 var allAscendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_ascending");
-                Assert.Equal(Array.Empty<bool>(), allAscendingIndex.IsDescending);
+                Assert.Equal(new[] { false, false, false}, allAscendingIndex.IsDescending);
 
                 var allDescendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_descending");
                 Assert.Equal(new[] { true, true, true }, allDescendingIndex.IsDescending);

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -164,6 +164,14 @@ public class ModelSnapshotSqlServerTest
         public TProperty Property { get; set; }
     }
 
+    private class EntityWithThreeProperties
+    {
+        public int Id { get; set; }
+        public int X { get; set; }
+        public int Y { get; set; }
+        public int Z { get; set; }
+    }
+
     [Index(nameof(FirstName), nameof(LastName))]
     private class EntityWithIndexAttribute
     {
@@ -4231,7 +4239,7 @@ namespace RootNamespace
             o => Assert.True(o.GetEntityTypes().Single().GetIndexes().Single().IsClustered()));
 
     [ConditionalFact]
-    public virtual void Index_isUnique_is_stored_in_snapshot()
+    public virtual void Index_IsUnique_is_stored_in_snapshot()
         => Test(
             builder =>
             {
@@ -4260,6 +4268,75 @@ namespace RootNamespace
                     b.ToTable(""EntityWithTwoProperties"");
                 });"),
             o => Assert.True(o.GetEntityTypes().First().GetIndexes().First().IsUnique));
+
+    [ConditionalFact]
+    public virtual void Index_IsDescending_is_stored_in_snapshot()
+        => Test(
+            builder =>
+            {
+                builder.Entity<EntityWithThreeProperties>(
+                    e =>
+                    {
+                        e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_empty");
+                        e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_all_ascending")
+                            .IsDescending(false, false, false);
+                        e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_all_descending")
+                            .IsDescending(true, true, true);
+                        e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_mixed")
+                            .IsDescending(false, true, false);
+                    });
+            },
+            AddBoilerPlate(
+                GetHeading()
+                + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithThreeProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
+
+                    b.Property<int>(""X"")
+                        .HasColumnType(""int"");
+
+                    b.Property<int>(""Y"")
+                        .HasColumnType(""int"");
+
+                    b.Property<int>(""Z"")
+                        .HasColumnType(""int"");
+
+                    b.HasKey(""Id"");
+
+                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_all_ascending"");
+
+                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_all_descending"")
+                        .IsDescending(true, true, true);
+
+                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_empty"");
+
+                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_mixed"")
+                        .IsDescending(false, true, false);
+
+                    b.ToTable(""EntityWithThreeProperties"");
+                });"),
+            o =>
+            {
+                var entityType = o.GetEntityTypes().Single();
+                Assert.Equal(4, entityType.GetIndexes().Count());
+
+                var emptyIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_empty");
+                Assert.Equal(Array.Empty<bool>(), emptyIndex.IsDescending);
+
+                var allAscendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_ascending");
+                Assert.Equal(Array.Empty<bool>(), allAscendingIndex.IsDescending);
+
+                var allDescendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_descending");
+                Assert.Equal(new[] { true, true, true }, allDescendingIndex.IsDescending);
+
+                var mixedIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_mixed");
+                Assert.Equal(new[] { false, true, false }, mixedIndex.IsDescending);
+            });
 
     [ConditionalFact]
     public virtual void Index_database_name_annotation_is_stored_in_snapshot_as_fluent_api()

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -553,7 +553,8 @@ namespace TestNamespace
                             x.Property<int>("C");
                             x.HasKey("Id");
                             x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
-                                .IsUnique();
+                                .IsUnique()
+                                .IsDescending();
                             x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC")
                                 .HasFilter("Filter SQL")
                                 .HasAnnotation("AnnotationName", "AnnotationValue");
@@ -598,7 +599,8 @@ namespace TestNamespace
             modelBuilder.Entity<EntityWithIndexes>(entity =>
             {
                 entity.HasIndex(e => new { e.A, e.B }, ""IndexOnAAndB"")
-                    .IsUnique();
+                    .IsUnique()
+                    .IsDescending();
 
                 entity.HasIndex(e => new { e.B, e.C }, ""IndexOnBAndC"")
                     .HasFilter(""Filter SQL"")
@@ -633,7 +635,8 @@ namespace TestNamespace
                             x.Property<int>("C");
                             x.HasKey("Id");
                             x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
-                                .IsUnique();
+                                .IsUnique()
+                                .IsDescending();
                             x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC")
                                 .HasFilter("Filter SQL")
                                 .HasAnnotation("AnnotationName", "AnnotationValue");
@@ -695,6 +698,106 @@ namespace TestNamespace
                 },
                 model =>
                     Assert.Equal(2, model.FindEntityType("TestNamespace.EntityWithIndexes").GetIndexes().Count()));
+
+        [ConditionalFact]
+        public void Indexes_with_descending()
+            => Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "EntityWithIndexes",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<int>("X");
+                            x.Property<int>("Y");
+                            x.Property<int>("Z");
+                            x.HasKey("Id");
+                            x.HasIndex(new[] { "X", "Y", "Z" }, "IX_empty");
+                            x.HasIndex(new[] { "X", "Y", "Z" }, "IX_all_ascending")
+                                .IsDescending(false, false, false);
+                            x.HasIndex(new[] { "X", "Y", "Z" }, "IX_all_descending")
+                                .IsDescending(true, true, true);
+                            x.HasIndex(new[] { "X", "Y", "Z" }, "IX_mixed")
+                                .IsDescending(false, true, false);
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = false },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<EntityWithIndexes> EntityWithIndexes { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<EntityWithIndexes>(entity =>
+            {
+                entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_all_ascending"");
+
+                entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_all_descending"")
+                    .IsDescending();
+
+                entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_empty"");
+
+                entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_mixed"")
+                    .IsDescending(false, true);
+
+                entity.Property(e => e.Id).UseIdentityColumn();
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.EntityWithIndexes")!;
+                    Assert.Equal(4, entityType.GetIndexes().Count());
+
+                    var emptyIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_empty");
+                    Assert.Equal(Array.Empty<bool>(), emptyIndex.IsDescending);
+
+                    var allAscendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_ascending");
+                    Assert.Equal(Array.Empty<bool>(), allAscendingIndex.IsDescending);
+
+                    var allDescendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_descending");
+                    Assert.Equal(new[] { true, true, true }, allDescendingIndex.IsDescending);
+
+                    var mixedIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_mixed");
+                    Assert.Equal(new[] { false, true }, mixedIndex.IsDescending);
+                });
 
         [ConditionalFact]
         public void Entity_lambda_uses_correct_identifiers()

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -554,7 +554,7 @@ namespace TestNamespace
                             x.HasKey("Id");
                             x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
                                 .IsUnique()
-                                .IsDescending();
+                                .IsDescending(false, true);
                             x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC")
                                 .HasFilter("Filter SQL")
                                 .HasAnnotation("AnnotationName", "AnnotationValue");
@@ -600,7 +600,7 @@ namespace TestNamespace
             {
                 entity.HasIndex(e => new { e.A, e.B }, ""IndexOnAAndB"")
                     .IsUnique()
-                    .IsDescending();
+                    .IsDescending(false, true);
 
                 entity.HasIndex(e => new { e.B, e.C }, ""IndexOnBAndC"")
                     .HasFilter(""Filter SQL"")
@@ -636,7 +636,7 @@ namespace TestNamespace
                             x.HasKey("Id");
                             x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
                                 .IsUnique()
-                                .IsDescending();
+                                .IsDescending(false, true);
                             x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC")
                                 .HasFilter("Filter SQL")
                                 .HasAnnotation("AnnotationName", "AnnotationValue");
@@ -759,15 +759,16 @@ namespace TestNamespace
         {
             modelBuilder.Entity<EntityWithIndexes>(entity =>
             {
-                entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_all_ascending"");
+                entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_all_ascending"")
+                    .IsDescending(false, false, false);
 
                 entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_all_descending"")
-                    .IsDescending();
+                    .IsDescending(true, true, true);
 
                 entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_empty"");
 
                 entity.HasIndex(e => new { e.X, e.Y, e.Z }, ""IX_mixed"")
-                    .IsDescending(false, true);
+                    .IsDescending(false, true, false);
 
                 entity.Property(e => e.Id).UseIdentityColumn();
             });
@@ -787,16 +788,16 @@ namespace TestNamespace
                     Assert.Equal(4, entityType.GetIndexes().Count());
 
                     var emptyIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_empty");
-                    Assert.Equal(Array.Empty<bool>(), emptyIndex.IsDescending);
+                    Assert.Null(emptyIndex.IsDescending);
 
                     var allAscendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_ascending");
-                    Assert.Equal(Array.Empty<bool>(), allAscendingIndex.IsDescending);
+                    Assert.Equal(new[] { false, false, false }, allAscendingIndex.IsDescending);
 
                     var allDescendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_descending");
                     Assert.Equal(new[] { true, true, true }, allDescendingIndex.IsDescending);
 
                     var mixedIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_mixed");
-                    Assert.Equal(new[] { false, true }, mixedIndex.IsDescending);
+                    Assert.Equal(new[] { false, true, false }, mixedIndex.IsDescending);
                 });
 
         [ConditionalFact]

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -247,7 +247,7 @@ namespace TestNamespace
             });
 
     [ConditionalFact]
-    public void IndexAttribute_is_generated_for_multiple_indexes_with_name_unique()
+    public void IndexAttribute_is_generated_for_multiple_indexes_with_name_unique_descending()
         => Test(
             modelBuilder => modelBuilder
                 .Entity(
@@ -260,7 +260,8 @@ namespace TestNamespace
                         x.Property<int>("C");
                         x.HasKey("Id");
                         x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
-                            .IsUnique();
+                            .IsUnique()
+                            .IsDescending();
                         x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC");
                         x.HasIndex("C");
                     }),
@@ -277,7 +278,7 @@ using Microsoft.EntityFrameworkCore;
 namespace TestNamespace
 {
     [Index(""C"")]
-    [Index(""A"", ""B"", Name = ""IndexOnAAndB"", IsUnique = true)]
+    [Index(""A"", ""B"", Name = ""IndexOnAAndB"", IsUnique = true, IsDescending = new[] { true, true })]
     [Index(""B"", ""C"", Name = ""IndexOnBAndC"")]
     public partial class EntityWithIndexes
     {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -261,7 +261,7 @@ namespace TestNamespace
                         x.HasKey("Id");
                         x.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
                             .IsUnique()
-                            .IsDescending();
+                            .IsDescending(true, false);
                         x.HasIndex(new[] { "B", "C" }, "IndexOnBAndC");
                         x.HasIndex("C");
                     }),
@@ -278,7 +278,7 @@ using Microsoft.EntityFrameworkCore;
 namespace TestNamespace
 {
     [Index(""C"")]
-    [Index(""A"", ""B"", Name = ""IndexOnAAndB"", IsUnique = true, IsDescending = new[] { true, true })]
+    [Index(""A"", ""B"", Name = ""IndexOnAAndB"", IsUnique = true, IsDescending = new[] { true, false })]
     [Index(""B"", ""C"", Name = ""IndexOnBAndC"")]
     public partial class EntityWithIndexes
     {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -1448,10 +1448,10 @@ public class RelationalScaffoldingModelFactoryTest
         var entityType = model.FindEntityType("SomeTable")!;
 
         var emptyIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_empty");
-        Assert.Equal(Array.Empty<bool>(), emptyIndex.IsDescending);
+        Assert.Null(emptyIndex.IsDescending);
 
         var allAscendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_ascending");
-        Assert.Equal(Array.Empty<bool>(), allAscendingIndex.IsDescending);
+        Assert.Null(allAscendingIndex.IsDescending);
 
         var allDescendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_descending");
         Assert.Equal(new[] { true, true, true }, allDescendingIndex.IsDescending);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -1377,6 +1377,90 @@ public class RelationalScaffoldingModelFactoryTest
     }
 
     [ConditionalFact]
+    public void Index_descending()
+    {
+        var table = new DatabaseTable
+        {
+            Database = Database,
+            Name = "SomeTable",
+            Columns =
+            {
+                new DatabaseColumn
+                {
+                    Table = Table,
+                    Name = "X",
+                    StoreType = "int"
+                },
+                new DatabaseColumn
+                {
+                    Table = Table,
+                    Name = "Y",
+                    StoreType = "int"
+                },
+                new DatabaseColumn
+                {
+                    Table = Table,
+                    Name = "Z",
+                    StoreType = "int"
+                }
+            }
+        };
+
+        table.Indexes.Add(
+            new DatabaseIndex
+            {
+                Table = Table,
+                Name = "IX_empty",
+                Columns = { table.Columns[0], table.Columns[1], table.Columns[2] }
+            });
+
+        table.Indexes.Add(
+            new DatabaseIndex
+            {
+                Table = Table,
+                Name = "IX_all_ascending",
+                Columns = { table.Columns[0], table.Columns[1], table.Columns[2] },
+                IsDescending = { false, false, false }
+            });
+
+        table.Indexes.Add(
+            new DatabaseIndex
+            {
+                Table = Table,
+                Name = "IX_all_descending",
+                Columns = { table.Columns[0], table.Columns[1], table.Columns[2] },
+                IsDescending = { true, true, true }
+            });
+
+        table.Indexes.Add(
+            new DatabaseIndex
+            {
+                Table = Table,
+                Name = "IX_mixed",
+                Columns = { table.Columns[0], table.Columns[1], table.Columns[2] },
+                IsDescending = { false, true, false }
+            });
+
+        var model = _factory.Create(
+            new DatabaseModel { Tables = { table } },
+            new ModelReverseEngineerOptions { NoPluralize = true });
+
+        var entityType = model.FindEntityType("SomeTable")!;
+
+        var emptyIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_empty");
+        Assert.Equal(Array.Empty<bool>(), emptyIndex.IsDescending);
+
+        var allAscendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_ascending");
+        Assert.Equal(Array.Empty<bool>(), allAscendingIndex.IsDescending);
+
+        var allDescendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_descending");
+        Assert.Equal(new[] { true, true, true }, allDescendingIndex.IsDescending);
+
+        var mixedIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_mixed");
+        Assert.Equal(new[] { false, true, false }, mixedIndex.IsDescending);
+    }
+
+    [ConditionalFact]
     public void Unique_names()
     {
         var info = new DatabaseModel

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -1042,6 +1042,12 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 Assert.Same(table.Columns.Single(c => c.Name == "FirstName"), Assert.Single(index.Columns));
                 Assert.Equal("IX_People_FirstName", index.Name);
                 Assert.False(index.IsUnique);
+
+                if (index.IsDescending.Count > 0)
+                {
+                    Assert.Collection(index.IsDescending, descending => Assert.False(descending));
+                }
+
                 Assert.Null(index.Filter);
             });
 
@@ -1062,6 +1068,46 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                 var table = Assert.Single(model.Tables);
                 var index = Assert.Single(table.Indexes);
                 Assert.True(index.IsUnique);
+            });
+
+    [ConditionalFact]
+    public virtual Task Create_index_descending()
+        => Test(
+            builder => builder.Entity(
+                "People", e =>
+                {
+                    e.Property<int>("Id");
+                    e.Property<int>("X");
+                }),
+            builder => { },
+            builder => builder.Entity("People").HasIndex("X").IsDescending(),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                var index = Assert.Single(table.Indexes);
+                Assert.Collection(index.IsDescending, Assert.True);
+            });
+
+    [ConditionalFact]
+    public virtual Task Create_index_descending_mixed()
+        => Test(
+            builder => builder.Entity(
+                "People", e =>
+                {
+                    e.Property<int>("Id");
+                    e.Property<int>("X");
+                    e.Property<int>("Y");
+                    e.Property<int>("Z");
+                }),
+            builder => { },
+            builder => builder.Entity("People")
+                .HasIndex("X", "Y", "Z")
+                .IsDescending(false, true),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                var index = Assert.Single(table.Indexes);
+                Assert.Collection(index.IsDescending, Assert.False, Assert.True, Assert.False);
             });
 
     [ConditionalFact]

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -1080,7 +1080,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                     e.Property<int>("X");
                 }),
             builder => { },
-            builder => builder.Entity("People").HasIndex("X").IsDescending(),
+            builder => builder.Entity("People").HasIndex("X").IsDescending(true),
             model =>
             {
                 var table = Assert.Single(model.Tables);
@@ -1102,7 +1102,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             builder => { },
             builder => builder.Entity("People")
                 .HasIndex("X", "Y", "Z")
-                .IsDescending(false, true),
+                .IsDescending(false, true, false),
             model =>
             {
                 var table = Assert.Single(model.Tables);

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -1111,6 +1111,48 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             });
 
     [ConditionalFact]
+    public virtual Task Alter_index_make_unique()
+        => Test(
+            builder => builder.Entity(
+                "People", e =>
+                {
+                    e.Property<int>("Id");
+                    e.Property<int>("X");
+                }),
+            builder => builder.Entity("People").HasIndex("X"),
+            builder => builder.Entity("People").HasIndex("X").IsUnique(),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                var index = Assert.Single(table.Indexes);
+                Assert.True(index.IsUnique);
+            });
+
+    [ConditionalFact]
+    public virtual Task Alter_index_change_sort_order()
+        => Test(
+            builder => builder.Entity(
+                "People", e =>
+                {
+                    e.Property<int>("Id");
+                    e.Property<int>("X");
+                    e.Property<int>("Y");
+                    e.Property<int>("Z");
+                }),
+            builder => builder.Entity("People")
+                .HasIndex("X", "Y", "Z")
+                .IsDescending(true, false, true),
+            builder => builder.Entity("People")
+                .HasIndex("X", "Y", "Z")
+                .IsDescending(false, true, false),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                var index = Assert.Single(table.Indexes);
+                // Assert.Collection(index.IsDescending, Assert.False, Assert.True, Assert.False);
+            });
+
+    [ConditionalFact]
     public virtual Task Create_index_with_filter()
         => Test(
             builder => builder.Entity(

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -1149,7 +1149,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
             {
                 var table = Assert.Single(model.Tables);
                 var index = Assert.Single(table.Indexes);
-                // Assert.Collection(index.IsDescending, Assert.False, Assert.True, Assert.False);
+                Assert.Collection(index.IsDescending, Assert.False, Assert.True, Assert.False);
             });
 
     [ConditionalFact]

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -1309,6 +1309,24 @@ public partial class RelationalModelValidatorTest : ModelValidatorTest
     }
 
     [ConditionalFact]
+    public virtual void Detects_duplicate_index_names_within_hierarchy_with_different_sort_orders()
+    {
+        var modelBuilder = CreateConventionalModelBuilder();
+        modelBuilder.Entity<Animal>();
+        modelBuilder.Entity<Cat>().HasIndex(c => c.Name).HasDatabaseName("IX_Animal_Name")
+            .IsDescending(true);
+        modelBuilder.Entity<Dog>().HasIndex(d => d.Name).HasDatabaseName("IX_Animal_Name")
+            .IsDescending(false);
+
+        VerifyError(
+            RelationalStrings.DuplicateIndexSortOrdersMismatch(
+                "{'" + nameof(Dog.Name) + "'}", nameof(Dog),
+                "{'" + nameof(Cat.Name) + "'}", nameof(Cat),
+                nameof(Animal), "IX_Animal_Name"),
+            modelBuilder);
+    }
+
+    [ConditionalFact]
     public virtual void Detects_duplicate_index_names_within_hierarchy_with_different_filters()
     {
         var modelBuilder = CreateConventionalModelBuilder();

--- a/test/EFCore.Relational.Tests/Migrations/Operations/CreateIndexOperationTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Operations/CreateIndexOperationTest.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Operations;
+
+public class CreateIndexOperationTest
+{
+    [Fact]
+    public void IsDescending_count_matches_column_count()
+    {
+        var operation = new CreateIndexOperation();
+
+        operation.IsDescending = new[] { true };
+        Assert.Throws<ArgumentException>(() => operation.Columns = new[] { "X", "Y" });
+
+        operation.IsDescending = null;
+
+        operation.Columns = new[] { "X", "Y" };
+        Assert.Throws<ArgumentException>(() => operation.IsDescending = new[] { true });
+    }
+}

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -505,6 +505,7 @@ public abstract class TestHelpers
             Conventions.IndexAnnotationChangedConventions.Clear();
             Conventions.IndexRemovedConventions.Clear();
             Conventions.IndexUniquenessChangedConventions.Clear();
+            Conventions.IndexSortOrderChangedConventions.Clear();
             Conventions.KeyAddedConventions.Clear();
             Conventions.KeyAnnotationChangedConventions.Clear();
             Conventions.KeyRemovedConventions.Clear();

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -19,7 +19,7 @@ public class MigrationsSqlServerTest : MigrationsTestBase<MigrationsSqlServerTes
         : base(fixture)
     {
         Fixture.TestSqlLoggerFactory.Clear();
-        // Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
     public override async Task Create_table()
@@ -1259,6 +1259,26 @@ ALTER TABLE [People] ALTER COLUMN [FirstName] nvarchar(450) NULL;",
         await base.Create_index_descending_mixed();
 
         AssertSql(
+            @"CREATE INDEX [IX_People_X_Y_Z] ON [People] ([X], [Y] DESC, [Z]);");
+    }
+
+    public override async Task Alter_index_make_unique()
+    {
+        await base.Alter_index_make_unique();
+
+        AssertSql(
+            @"DROP INDEX [IX_People_X] ON [People];",
+            //
+            @"CREATE UNIQUE INDEX [IX_People_X] ON [People] ([X]);");
+    }
+
+    public override async Task Alter_index_change_sort_order()
+    {
+        await base.Alter_index_change_sort_order();
+
+        AssertSql(
+            @"DROP INDEX [IX_People_X_Y_Z] ON [People];",
+            //
             @"CREATE INDEX [IX_People_X_Y_Z] ON [People] ([X], [Y] DESC, [Z]);");
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -1246,6 +1246,22 @@ ALTER TABLE [People] ALTER COLUMN [FirstName] nvarchar(450) NULL;",
             @"CREATE UNIQUE INDEX [IX_People_FirstName_LastName] ON [People] ([FirstName], [LastName]) WHERE [FirstName] IS NOT NULL AND [LastName] IS NOT NULL;");
     }
 
+    public override async Task Create_index_descending()
+    {
+        await base.Create_index_descending();
+
+        AssertSql(
+            @"CREATE INDEX [IX_People_X] ON [People] ([X] DESC);");
+    }
+
+    public override async Task Create_index_descending_mixed()
+    {
+        await base.Create_index_descending_mixed();
+
+        AssertSql(
+            @"CREATE INDEX [IX_People_X_Y_Z] ON [People] ([X], [Y] DESC, [Z]);");
+    }
+
     public override async Task Create_index_with_filter()
     {
         await base.Create_index_with_filter();

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -19,7 +19,7 @@ public class MigrationsSqlServerTest : MigrationsTestBase<MigrationsSqlServerTes
         : base(fixture)
     {
         Fixture.TestSqlLoggerFactory.Clear();
-        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
     public override async Task Create_table()

--- a/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
@@ -28,6 +28,7 @@ public class IndexAttributeConventionTest
         var indexProperties = new List<string> { propABuilder.Metadata.Name, propBBuilder.Metadata.Name };
         var indexBuilder = entityBuilder.HasIndex(indexProperties, "IndexOnAAndB", ConfigurationSource.Convention);
         indexBuilder.IsUnique(false, ConfigurationSource.Convention);
+        indexBuilder.IsDescending(new[] { false, true }, ConfigurationSource.Convention);
 
         RunConvention(entityBuilder);
         RunConvention(modelBuilder);
@@ -35,8 +36,11 @@ public class IndexAttributeConventionTest
         var index = entityBuilder.Metadata.GetIndexes().Single();
         Assert.Equal(ConfigurationSource.DataAnnotation, index.GetConfigurationSource());
         Assert.Equal("IndexOnAAndB", index.Name);
+
         Assert.True(index.IsUnique);
         Assert.Equal(ConfigurationSource.DataAnnotation, index.GetIsUniqueConfigurationSource());
+        Assert.Equal(new[] { true, false }, index.IsDescending);
+        Assert.Equal(ConfigurationSource.DataAnnotation, index.GetIsDescendingConfigurationSource());
         Assert.Collection(
             index.Properties,
             prop0 => Assert.Equal("A", prop0.Name),
@@ -50,7 +54,8 @@ public class IndexAttributeConventionTest
         var entityBuilder = modelBuilder.Entity<EntityWithIndex>();
 
         entityBuilder.HasIndex(new[] { "A", "B" }, "IndexOnAAndB")
-            .IsUnique(false);
+            .IsUnique(false)
+            .IsDescending(false, true);
 
         modelBuilder.Model.FinalizeModel();
 
@@ -59,6 +64,8 @@ public class IndexAttributeConventionTest
         Assert.Equal("IndexOnAAndB", index.Name);
         Assert.False(index.IsUnique);
         Assert.Equal(ConfigurationSource.Explicit, index.GetIsUniqueConfigurationSource());
+        Assert.Equal(new[] { false, true }, index.IsDescending);
+        Assert.Equal(ConfigurationSource.Explicit, index.GetIsDescendingConfigurationSource());
         Assert.Collection(
             index.Properties,
             prop0 => Assert.Equal("A", prop0.Name),
@@ -316,7 +323,7 @@ public class IndexAttributeConventionTest
     private ProviderConventionSetBuilderDependencies CreateDependencies()
         => InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
 
-    [Index(nameof(A), nameof(B), Name = "IndexOnAAndB", IsUnique = true)]
+    [Index(nameof(A), nameof(B), Name = "IndexOnAAndB", IsUnique = true, IsDescending = new[] { true, false })]
     private class EntityWithIndex
     {
         public int Id { get; set; }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -581,6 +581,9 @@ public class ModelBuilderGenericTest : ModelBuilderTest
         public override TestIndexBuilder<TEntity> IsUnique(bool isUnique = true)
             => new GenericTestIndexBuilder<TEntity>(IndexBuilder.IsUnique(isUnique));
 
+        public override TestIndexBuilder<TEntity> IsDescending(params bool[] isDescending)
+            => new GenericTestIndexBuilder<TEntity>(IndexBuilder.IsDescending(isDescending));
+
         IndexBuilder<TEntity> IInfrastructure<IndexBuilder<TEntity>>.Instance
             => IndexBuilder;
     }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -686,6 +686,9 @@ public class ModelBuilderNonGenericTest : ModelBuilderTest
         public override TestIndexBuilder<TEntity> IsUnique(bool isUnique = true)
             => new NonGenericTestIndexBuilder<TEntity>(IndexBuilder.IsUnique(isUnique));
 
+        public override TestIndexBuilder<TEntity> IsDescending(params bool[] isDescending)
+            => new NonGenericTestIndexBuilder<TEntity>(IndexBuilder.IsDescending(isDescending));
+
         IndexBuilder IInfrastructure<IndexBuilder>.Instance
             => IndexBuilder;
     }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -362,6 +362,7 @@ public abstract partial class ModelBuilderTest
 
         public abstract TestIndexBuilder<TEntity> HasAnnotation(string annotation, object? value);
         public abstract TestIndexBuilder<TEntity> IsUnique(bool isUnique = true);
+        public abstract TestIndexBuilder<TEntity> IsDescending(params bool[] isDescending);
     }
 
     public abstract class TestPropertyBuilder<TProperty>

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -1722,6 +1722,7 @@ public abstract partial class ModelBuilderTest
             entityBuilder.HasIndex(ix => ix.Id).IsUnique();
             entityBuilder.HasIndex(ix => ix.Name).HasAnnotation("A1", "V1");
             entityBuilder.HasIndex(ix => ix.Id, "Named");
+            entityBuilder.HasIndex(ix => ix.Id, "Descending").IsDescending();
 
             var model = modelBuilder.FinalizeModel();
 
@@ -1729,7 +1730,7 @@ public abstract partial class ModelBuilderTest
             var idProperty = entityType.FindProperty(nameof(Customer.Id));
             var nameProperty = entityType.FindProperty(nameof(Customer.Name));
 
-            Assert.Equal(3, entityType.GetIndexes().Count());
+            Assert.Equal(4, entityType.GetIndexes().Count());
             var firstIndex = entityType.FindIndex(idProperty);
             Assert.True(firstIndex.IsUnique);
             var secondIndex = entityType.FindIndex(nameProperty);
@@ -1737,6 +1738,8 @@ public abstract partial class ModelBuilderTest
             Assert.Equal("V1", secondIndex["A1"]);
             var namedIndex = entityType.FindIndex("Named");
             Assert.False(namedIndex.IsUnique);
+            var descendingIndex = entityType.FindIndex("Descending");
+            Assert.Equal(new[] { true }, descendingIndex.IsDescending);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -1722,7 +1722,7 @@ public abstract partial class ModelBuilderTest
             entityBuilder.HasIndex(ix => ix.Id).IsUnique();
             entityBuilder.HasIndex(ix => ix.Name).HasAnnotation("A1", "V1");
             entityBuilder.HasIndex(ix => ix.Id, "Named");
-            entityBuilder.HasIndex(ix => ix.Id, "Descending").IsDescending();
+            entityBuilder.HasIndex(ix => ix.Id, "Descending").IsDescending(true);
 
             var model = modelBuilder.FinalizeModel();
 


### PR DESCRIPTION
* Added a new IsDescending Fluent API and Data Annotation.
* It's implemented as a property on Index and not as an annotation, since it's a core concept. One downside is that it has to be on RuntimeIndex, though it's not a runtime feature (I made it always return Array.Empty).
* I simplified the implementation: if IsDescending is specified, it must explicitly specify all values for all properties.

/cc @AndriySvyryd would appreciate a good review as this touches upon lots of metadata/model stuff, and is non-annotation array metadata property.

Closes #4150

