### PR TITLE
[release/6.0] Revert change to delete dependent when optional FK with cascade delete is set to null

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -38,6 +38,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private readonly bool _useOldBehavior26779
             = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26779", out var enabled) && enabled;
 
+        private readonly bool _useOldBehavior27174
+            = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27174", out var enabled) && enabled;
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -504,6 +507,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
 
                     if (newValue == null
+                        && (foreignKey.IsRequired
+                            || _useOldBehavior27174)
                         && (foreignKey.DeleteBehavior == DeleteBehavior.Cascade
                             || foreignKey.DeleteBehavior == DeleteBehavior.ClientCascade))
                     {

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1943,7 +1943,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             }
         }
 
-        [ConditionalTheory] // Issues #16546 #25360
+        [ConditionalTheory] // Issues #16546 #25360; Change reverted in #27174.
         [InlineData(false, false, false, true, false)]
         [InlineData(true, false, false, true, false)]
         [InlineData(false, true, false, true, false)]
@@ -2043,7 +2043,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(EntityState.Unchanged, context.Entry(attachedContainer).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(attachedTroduct).State);
 
-                if (delayCascade)
+                if (delayCascade
+                    || (useForeignKey && setProperty))
                 {
                     Assert.Equal(EntityState.Modified, context.Entry(attachedRoom).State);
                 }
@@ -2058,7 +2059,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 Assert.Equal(3, context.ChangeTracker.Entries().Count());
                 Assert.Equal(EntityState.Unchanged, context.Entry(attachedContainer).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(attachedTroduct).State);
-                Assert.Equal(EntityState.Deleted, context.Entry(attachedRoom).State);
+
+
+                Assert.Equal(
+                    useForeignKey && setProperty ? EntityState.Modified : EntityState.Deleted,
+                    context.Entry(attachedRoom).State);
 
                 context.SaveChanges();
             }


### PR DESCRIPTION
Fixes #27174.

**Description**

In 6.0, we made a change to fix a "bug" (#25360) where setting the foreign key of an optional relationship to null did not trigger deletion of orphans when the relationship was configured for cascade delete. It turns out that people have been relying on this behavior--i.e. to our users, this was a feature, not a bug.

In addition, the people reporting this a breaking their apps have made a compelling case that orphans should _not_ automatically be deleted for optional relationships with cascade delete enabled. We have discussed this, and have a three-step plan to address this:

1. Revert the change that is breaking apps from updating to 6.0. (This PR.)
2. Stop throwing for optional FKs if delete orphans timing is set to Never. (Setting the timing could have been a workaround, except that it still causes an exception to be thrown.) This is tracked by #27218.
3. The change in this PR reverts the behavior when a foreign key is explicitly set to null. However, it may make sense to stop automatically deleting orphans in general for optional relationships with cascade delete configured. This is tracked by #27217.

**Customer impact**

Several customers have reported apps being broken when updating to EF Core 6.0.

**How found**

Multiple customer reports on 6.0.

**Regression**

Yes; regressed by #25360.

**Testing**

Test added in 6.0 changed to match reverted behavior.

**Risk**

Low. This reverts the behavior to that of 6.0 for optional relationships. Also quirked.