### PR TITLE
[release/6.0] RevEng: Don't use nameof syntax (#26622)

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -214,7 +214,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     var indexAttribute = new AttributeWriter(nameof(IndexAttribute));
                     foreach (var property in index.Properties)
                     {
-                        indexAttribute.AddParameter($"nameof({property.Name})");
+                        // Do NOT use nameof for property.Name
+                        indexAttribute.AddParameter(_code.Literal(property.Name));
                     }
 
                     if (index.Name != null)
@@ -496,11 +497,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     var inversePropertyAttribute = new AttributeWriter(nameof(InversePropertyAttribute));
 
-                    inversePropertyAttribute.AddParameter(
-                        !navigation.DeclaringEntityType.GetPropertiesAndNavigations().Any(
-                            m => m.Name == inverseNavigation.DeclaringEntityType.Name)
-                            ? $"nameof({inverseNavigation.DeclaringEntityType.Name}.{inverseNavigation.Name})"
-                            : _code.Literal(inverseNavigation.Name));
+                    // Do NOT use nameof for inverseNavigation.Name
+                    inversePropertyAttribute.AddParameter(_code.Literal(inverseNavigation.Name));
 
                     _sb.AppendLine(inversePropertyAttribute.ToString());
                 }
@@ -557,16 +555,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     var foreignKeyAttribute = new AttributeWriter(nameof(ForeignKeyAttribute));
 
-                    if (navigation.ForeignKey.Properties.Count > 1)
-                    {
-                        foreignKeyAttribute.AddParameter(
-                            _code.Literal(
-                                string.Join(",", navigation.ForeignKey.Properties.Select(p => p.Name))));
-                    }
-                    else
-                    {
-                        foreignKeyAttribute.AddParameter($"nameof({navigation.ForeignKey.Properties.First().Name})");
-                    }
+                    // Do NOT use nameof syntax
+                    foreignKeyAttribute.AddParameter(
+                        _code.Literal(
+                            string.Join(",", navigation.ForeignKey.Properties.Select(p => p.Name))));
 
                     _sb.AppendLine(foreignKeyAttribute.ToString());
                 }
@@ -583,11 +575,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     var inversePropertyAttribute = new AttributeWriter(nameof(InversePropertyAttribute));
 
-                    inversePropertyAttribute.AddParameter(
-                        !navigation.DeclaringEntityType.GetPropertiesAndNavigations().Any(
-                            m => m.Name == inverseNavigation.DeclaringEntityType.Name)
-                            ? $"nameof({inverseNavigation.DeclaringEntityType.Name}.{inverseNavigation.Name})"
-                            : _code.Literal(inverseNavigation.Name));
+                    // Do NOT use nameof for inverseNavigation.Name
+                    inversePropertyAttribute.AddParameter(_code.Literal(inverseNavigation.Name));
 
                     _sb.AppendLine(inversePropertyAttribute.ToString());
                 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -296,9 +296,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace TestNamespace
 {
-    [Index(nameof(C))]
-    [Index(nameof(A), nameof(B), Name = ""IndexOnAAndB"", IsUnique = true)]
-    [Index(nameof(B), nameof(C), Name = ""IndexOnBAndC"")]
+    [Index(""C"")]
+    [Index(""A"", ""B"", Name = ""IndexOnAAndB"", IsUnique = true)]
+    [Index(""B"", ""C"", Name = ""IndexOnBAndC"")]
     public partial class EntityWithIndexes
     {
         [Key]
@@ -354,7 +354,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace TestNamespace
 {
-    [Index(nameof(A), nameof(B), Name = ""IndexOnAAndB"", IsUnique = true)]
+    [Index(""A"", ""B"", Name = ""IndexOnAAndB"", IsUnique = true)]
     public partial class EntityWithIndexes
     {
         [Key]
@@ -741,17 +741,17 @@ namespace TestNamespace
         public string RequiredReferenceNavigationId { get; set; }
         public int RequiredValueNavigationId { get; set; }
 
-        [ForeignKey(nameof(OptionalReferenceNavigationId))]
-        [InverseProperty(nameof(Dependent2.Entity))]
+        [ForeignKey(""OptionalReferenceNavigationId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent2 OptionalReferenceNavigation { get; set; }
-        [ForeignKey(nameof(OptionalValueNavigationId))]
-        [InverseProperty(nameof(Dependent4.Entity))]
+        [ForeignKey(""OptionalValueNavigationId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent4 OptionalValueNavigation { get; set; }
-        [ForeignKey(nameof(RequiredReferenceNavigationId))]
-        [InverseProperty(nameof(Dependent1.Entity))]
+        [ForeignKey(""RequiredReferenceNavigationId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent1 RequiredReferenceNavigation { get; set; }
-        [ForeignKey(nameof(RequiredValueNavigationId))]
-        [InverseProperty(nameof(Dependent3.Entity))]
+        [ForeignKey(""RequiredValueNavigationId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent3 RequiredValueNavigation { get; set; }
     }
 }
@@ -815,17 +815,17 @@ namespace TestNamespace
         public string RequiredNavigationWithReferenceForeignKeyId { get; set; } = null!;
         public int RequiredNavigationWithValueForeignKeyId { get; set; }
 
-        [ForeignKey(nameof(OptionalNavigationWithReferenceForeignKeyId))]
-        [InverseProperty(nameof(Dependent2.Entity))]
+        [ForeignKey(""OptionalNavigationWithReferenceForeignKeyId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent2? OptionalNavigationWithReferenceForeignKey { get; set; }
-        [ForeignKey(nameof(OptionalNavigationWithValueForeignKeyId))]
-        [InverseProperty(nameof(Dependent4.Entity))]
+        [ForeignKey(""OptionalNavigationWithValueForeignKeyId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent4? OptionalNavigationWithValueForeignKey { get; set; }
-        [ForeignKey(nameof(RequiredNavigationWithReferenceForeignKeyId))]
-        [InverseProperty(nameof(Dependent1.Entity))]
+        [ForeignKey(""RequiredNavigationWithReferenceForeignKeyId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent1 RequiredNavigationWithReferenceForeignKey { get; set; } = null!;
-        [ForeignKey(nameof(RequiredNavigationWithValueForeignKeyId))]
-        [InverseProperty(nameof(Dependent3.Entity))]
+        [ForeignKey(""RequiredNavigationWithValueForeignKeyId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent3 RequiredNavigationWithValueForeignKey { get; set; } = null!;
     }
 }
@@ -889,17 +889,17 @@ namespace TestNamespace
         public string RequiredNavigationWithReferenceForeignKeyId { get; set; } = null!;
         public int RequiredNavigationWithValueForeignKeyId { get; set; }
 
-        [ForeignKey(nameof(OptionalNavigationWithReferenceForeignKeyId))]
-        [InverseProperty(nameof(Dependent2.Entity))]
+        [ForeignKey(""OptionalNavigationWithReferenceForeignKeyId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent2? OptionalNavigationWithReferenceForeignKey { get; set; }
-        [ForeignKey(nameof(OptionalNavigationWithValueForeignKeyId))]
-        [InverseProperty(nameof(Dependent4.Entity))]
+        [ForeignKey(""OptionalNavigationWithValueForeignKeyId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent4? OptionalNavigationWithValueForeignKey { get; set; }
-        [ForeignKey(nameof(RequiredNavigationWithReferenceForeignKeyId))]
-        [InverseProperty(nameof(Dependent1.Entity))]
+        [ForeignKey(""RequiredNavigationWithReferenceForeignKeyId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent1 RequiredNavigationWithReferenceForeignKey { get; set; } = null!;
-        [ForeignKey(nameof(RequiredNavigationWithValueForeignKeyId))]
-        [InverseProperty(nameof(Dependent3.Entity))]
+        [ForeignKey(""RequiredNavigationWithValueForeignKeyId"")]
+        [InverseProperty(""Entity"")]
         public virtual Dependent3 RequiredNavigationWithValueForeignKey { get; set; } = null!;
     }
 }
@@ -1401,8 +1401,8 @@ namespace TestNamespace
         public int Id { get; set; }
         public int? AuthorId { get; set; }
 
-        [ForeignKey(nameof(AuthorId))]
-        [InverseProperty(nameof(Person.Posts))]
+        [ForeignKey(""AuthorId"")]
+        [InverseProperty(""Posts"")]
         public virtual Person Author { get; set; }
         public virtual ICollection<Contribution> Contributions { get; set; }
     }
@@ -1429,7 +1429,7 @@ namespace TestNamespace
         [Key]
         public int Id { get; set; }
 
-        [InverseProperty(nameof(Post.Author))]
+        [InverseProperty(""Author"")]
         public virtual ICollection<Post> Posts { get; set; }
     }
 }
@@ -1490,7 +1490,7 @@ namespace TestNamespace
         public int? BlogId2 { get; set; }
 
         [ForeignKey(""BlogId1,BlogId2"")]
-        [InverseProperty(nameof(Blog.Posts))]
+        [InverseProperty(""Posts"")]
         public virtual Blog BlogNavigation { get; set; }
     }
 }
@@ -1710,7 +1710,7 @@ namespace TestNamespace
         public int Id { get; set; }
         public int? BlogId { get; set; }
 
-        [ForeignKey(nameof(BlogId))]
+        [ForeignKey(""BlogId"")]
         [InverseProperty(""Posts"")]
         public virtual Blog Blog { get; set; }
     }
@@ -1765,7 +1765,7 @@ namespace TestNamespace
         public int Id { get; set; }
         public int? Blog { get; set; }
 
-        [ForeignKey(nameof(Blog))]
+        [ForeignKey(""Blog"")]
         [InverseProperty(""Posts"")]
         public virtual Blog BlogNavigation { get; set; }
     }
@@ -1822,10 +1822,10 @@ namespace TestNamespace
         public int? BlogId { get; set; }
         public int? OriginalBlogId { get; set; }
 
-        [ForeignKey(nameof(BlogId))]
+        [ForeignKey(""BlogId"")]
         [InverseProperty(""Posts"")]
         public virtual Blog Blog { get; set; }
-        [ForeignKey(nameof(OriginalBlogId))]
+        [ForeignKey(""OriginalBlogId"")]
         [InverseProperty(""OriginalPosts"")]
         public virtual Blog OriginalBlog { get; set; }
     }
@@ -2430,7 +2430,7 @@ namespace TestNamespace
         public int Id { get; set; }
 
         [ForeignKey(""BlogsId"")]
-        [InverseProperty(nameof(Post.Blogs))]
+        [InverseProperty(""Blogs"")]
         public virtual ICollection<Post> Posts { get; set; }
     }
 }
@@ -2456,7 +2456,7 @@ namespace TestNamespace
         public int Id { get; set; }
 
         [ForeignKey(""PostsId"")]
-        [InverseProperty(nameof(Blog.Posts))]
+        [InverseProperty(""Posts"")]
         public virtual ICollection<Blog> Blogs { get; set; }
     }
 }


### PR DESCRIPTION
Scoping causes clash in names.

Resolves #26588

**Description**
Don't generate `nameof` syntax when generating attributes during scaffolding a database as it can cause clash with types/members.

**Customer impact**
Customers scaffolding database where this can cause issue will run into code with compilation failure or invalid model created.

**How found**
Customers reported 6.0.

**Regression**
Yes. Use of `nameof` sytanx was new feature in 6.0.

**Testing**
There is existing testing for scenario. Fix here is reverting the feature added in 6.0

**Risk**
Low risk. The fix has been merged to main and this is cherry-pick of it. The generated code is same as what was in 5.0.