### PR TITLE
[main] Update build and test machines

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -19,7 +19,7 @@ stages:
             enablePublishTestResults: true
             pool:
               name: NetCore1ESPool-Public
-              demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
+              demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
             steps:
               - task: NuGetCommand@2
                 displayName: 'Clear NuGet caches'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,10 +63,10 @@ stages:
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Public
-                demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
+                demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Internal
-                demands: ImageOverride -equals Build.Server.Amd64.VS2017
+                demands: ImageOverride -equals Build.Server.Amd64.VS2019
             variables:
               - _InternalBuildArgs: ''
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -147,10 +147,14 @@ stages:
             timeoutInMinutes: 120
             enablePublishTestResults: true
             pool:
-              vmImage: ubuntu-18.04
+              - ${{ if or(ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
+                vmImage: ubuntu-18.04
+              - ${{ if and(ne(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
+                name: NetCore1ESPool-Internal
+                demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
             variables:
               - _runCounter: $[counter(variables['Build.Reason'], 0)]
-              - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['system.pullrequest.isfork'], false), notin(variables['Build.Reason'], 'PullRequest', 'Schedule', 'BuildCompletion')) }}:
+              - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['system.pullrequest.isfork'], false), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
                 - _CosmosConnectionUrl: 'true'
             steps:
               - bash: sudo apt-get install -y libsqlite3-mod-spatialite
@@ -194,21 +198,21 @@ stages:
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Public
-                demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
+                demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Internal
-                demands: ImageOverride -equals Build.Server.Amd64.VS2017
+                demands: ImageOverride -equals Build.Server.Amd64.VS2019
             variables:
               - name: _HelixBuildConfig
                 value: $(_BuildConfig)
               - ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 - name: HelixTargetQueues
-                  value: OSX.1100.Amd64.Open;(Ubuntu.1804.Amd64.SqlServer)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20201109180804-3069967
+                  value: OSX.1100.Amd64.Open;(Ubuntu.1804.Amd64.SqlServer)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20220118141424-3069967
                 - name: _HelixAccessToken
                   value: '' # Needed for public queues
               - ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 - name: HelixTargetQueues
-                  value: OSX.1100.Amd64;(Ubuntu.1804.Amd64.SqlServer)Ubuntu.1604.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20201109180804-3069967
+                  value: OSX.1100.Amd64;(Ubuntu.1804.Amd64.SqlServer)Ubuntu.1804.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20220118141424-3069967
                 - name: _HelixAccessToken
                   value: $(HelixApiAccessToken) # Needed for internal queues
             steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,7 +154,7 @@ stages:
                 demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
             variables:
               - _runCounter: $[counter(variables['Build.Reason'], 0)]
-              - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['system.pullrequest.isfork'], false), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
+              - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest', 'Schedule')) }}:
                 - _CosmosConnectionUrl: 'true'
             steps:
               - bash: sudo apt-get install -y libsqlite3-mod-spatialite

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,7 +149,7 @@ stages:
             pool:
               - ${{ if or(ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
                 vmImage: ubuntu-18.04
-              - ${{ if and(ne(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
+              - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
                 name: NetCore1ESPool-Internal
                 demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
             variables:


### PR DESCRIPTION
- stop building w/ VS2017 in CI
    - version of VisualStudio is out of support
- use 1ES machines for official builds
- use Ubuntu 18.04 Helix queue under Ubuntu Docker image

nits:
- move to latest Ubuntu Docker image