### PR TITLE
[release/6.0] Query: Convert single result subquery comparison to null to Any operation

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -32,6 +32,24 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
     {
         private const string RuntimeParameterPrefix = QueryCompilationContext.QueryParameterPrefix + "entity_equality_";
 
+        private static readonly List<MethodInfo> _singleResultMethodInfos = new()
+        {
+            QueryableMethods.FirstWithPredicate,
+            QueryableMethods.FirstWithoutPredicate,
+            QueryableMethods.FirstOrDefaultWithPredicate,
+            QueryableMethods.FirstOrDefaultWithoutPredicate,
+            QueryableMethods.SingleWithPredicate,
+            QueryableMethods.SingleWithoutPredicate,
+            QueryableMethods.SingleOrDefaultWithPredicate,
+            QueryableMethods.SingleOrDefaultWithoutPredicate,
+            QueryableMethods.LastWithPredicate,
+            QueryableMethods.LastWithoutPredicate,
+            QueryableMethods.LastOrDefaultWithPredicate,
+            QueryableMethods.LastOrDefaultWithoutPredicate
+            //QueryableMethodProvider.ElementAtMethodInfo,
+            //QueryableMethodProvider.ElementAtOrDefaultMethodInfo
+        };
+
         private static readonly MemberInfo _valueBufferIsEmpty = typeof(ValueBuffer).GetMember(nameof(ValueBuffer.IsEmpty))[0];
 
         private static readonly MethodInfo _parameterValueExtractor =
@@ -159,6 +177,51 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 && binaryExpression.NodeType == ExpressionType.Equal)
             {
                 return Visit(ConvertObjectArrayEqualityComparison(binaryExpression.Left, binaryExpression.Right));
+            }
+
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26744", out var enabled) && enabled))
+            {
+                if ((binaryExpression.NodeType == ExpressionType.Equal || binaryExpression.NodeType == ExpressionType.NotEqual)
+                && (binaryExpression.Left.IsNullConstantExpression() || binaryExpression.Right.IsNullConstantExpression()))
+                {
+                    var nonNullExpression = binaryExpression.Left.IsNullConstantExpression() ? binaryExpression.Right : binaryExpression.Left;
+                    if (nonNullExpression is MethodCallExpression nonNullMethodCallExpression
+                        && nonNullMethodCallExpression.Method.DeclaringType == typeof(Queryable)
+                        && nonNullMethodCallExpression.Method.IsGenericMethod
+                        && _singleResultMethodInfos.Contains(nonNullMethodCallExpression.Method.GetGenericMethodDefinition()))
+                    {
+                        var source = nonNullMethodCallExpression.Arguments[0];
+                        if (nonNullMethodCallExpression.Arguments.Count == 2)
+                        {
+                            source = Expression.Call(
+                                QueryableMethods.Where.MakeGenericMethod(source.Type.GetSequenceType()),
+                                source,
+                                nonNullMethodCallExpression.Arguments[1]);
+                        }
+
+                        var translatedSubquery = _queryableMethodTranslatingExpressionVisitor.TranslateSubquery(source);
+                        if (translatedSubquery != null)
+                        {
+                            var projection = translatedSubquery.ShaperExpression;
+                            if (projection is NewExpression
+                                || RemoveConvert(projection) is EntityShaperExpression { IsNullable: false })
+                            {
+                                var anySubquery = Expression.Call(
+                                    QueryableMethods.AnyWithoutPredicate.MakeGenericMethod(translatedSubquery.Type.GetSequenceType()),
+                                    translatedSubquery);
+
+                                return Visit(binaryExpression.NodeType == ExpressionType.Equal
+                                    ? Expression.Not(anySubquery)
+                                    : anySubquery);
+                            }
+
+                            static Expression RemoveConvert(Expression e)
+                                => e is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary
+                                    ? RemoveConvert(unary.Operand)
+                                    : e;
+                        }
+                    }
+                }
             }
 
             var newLeft = Visit(binaryExpression.Left);

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -31,6 +31,24 @@ namespace Microsoft.EntityFrameworkCore.Query
     {
         private const string RuntimeParameterPrefix = QueryCompilationContext.QueryParameterPrefix + "entity_equality_";
 
+        private static readonly List<MethodInfo> _singleResultMethodInfos = new()
+        {
+            QueryableMethods.FirstWithPredicate,
+            QueryableMethods.FirstWithoutPredicate,
+            QueryableMethods.FirstOrDefaultWithPredicate,
+            QueryableMethods.FirstOrDefaultWithoutPredicate,
+            QueryableMethods.SingleWithPredicate,
+            QueryableMethods.SingleWithoutPredicate,
+            QueryableMethods.SingleOrDefaultWithPredicate,
+            QueryableMethods.SingleOrDefaultWithoutPredicate,
+            QueryableMethods.LastWithPredicate,
+            QueryableMethods.LastWithoutPredicate,
+            QueryableMethods.LastOrDefaultWithPredicate,
+            QueryableMethods.LastOrDefaultWithoutPredicate
+            //QueryableMethodProvider.ElementAtMethodInfo,
+            //QueryableMethodProvider.ElementAtOrDefaultMethodInfo
+        };
+
         private static readonly MethodInfo _parameterValueExtractor =
             typeof(RelationalSqlTranslatingExpressionVisitor).GetRequiredDeclaredMethod(nameof(ParameterValueExtractor));
 
@@ -322,6 +340,51 @@ namespace Microsoft.EntityFrameworkCore.Query
             else if (isRightConvertToObject && left.IsNullConstantExpression())
             {
                 right = rightOperand!;
+            }
+
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue26744", out var enabled) && enabled))
+            {
+                if ((binaryExpression.NodeType == ExpressionType.Equal || binaryExpression.NodeType == ExpressionType.NotEqual)
+                    && (left.IsNullConstantExpression() || right.IsNullConstantExpression()))
+                {
+                    var nonNullExpression = left.IsNullConstantExpression() ? right : left;
+                    if (nonNullExpression is MethodCallExpression nonNullMethodCallExpression
+                        && nonNullMethodCallExpression.Method.DeclaringType == typeof(Queryable)
+                        && nonNullMethodCallExpression.Method.IsGenericMethod
+                        && _singleResultMethodInfos.Contains(nonNullMethodCallExpression.Method.GetGenericMethodDefinition()))
+                    {
+                        var source = nonNullMethodCallExpression.Arguments[0];
+                        if (nonNullMethodCallExpression.Arguments.Count == 2)
+                        {
+                            source = Expression.Call(
+                                QueryableMethods.Where.MakeGenericMethod(source.Type.GetSequenceType()),
+                                source,
+                                nonNullMethodCallExpression.Arguments[1]);
+                        }
+
+                        var translatedSubquery = _queryableMethodTranslatingExpressionVisitor.TranslateSubquery(source);
+                        if (translatedSubquery != null)
+                        {
+                            var projection = translatedSubquery.ShaperExpression;
+                            if (projection is NewExpression
+                                || RemoveConvert(projection) is EntityShaperExpression { IsNullable: false })
+                            {
+                                var anySubquery = Expression.Call(
+                                    QueryableMethods.AnyWithoutPredicate.MakeGenericMethod(translatedSubquery.Type.GetSequenceType()),
+                                    translatedSubquery);
+
+                                return Visit(binaryExpression.NodeType == ExpressionType.Equal
+                                    ? Expression.Not(anySubquery)
+                                    : anySubquery);
+                            }
+
+                            static Expression RemoveConvert(Expression e)
+                                => e is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary
+                                    ? RemoveConvert(unary.Operand)
+                                    : e;
+                        }
+                    }
+                }
             }
 
             var visitedLeft = Visit(left);

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -9138,6 +9138,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Mission>().Where(m => m.Rating.Equals(null)));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_subquery_equality_to_null_with_composite_key(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>().Where(s => s.Members.OrderBy(e => e.Nickname).FirstOrDefault() == null));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_subquery_equality_to_null_without_composite_key(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>().Where(s => s.Weapons.OrderBy(e => e.Name).FirstOrDefault() == null));
+        }
+
         protected GearsOfWarContext CreateContext()
             => Fixture.CreateContext();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3213,10 +3213,11 @@ ORDER BY [l].[Id]");
                 @"SELECT (
     SELECT TOP(1) [l0].[Name]
     FROM [LevelThree] AS [l0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE ((
+        SELECT TOP(1) [l1].[Id]
         FROM [LevelTwo] AS [l1]
-        WHERE [l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND (((
+        WHERE [l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]
+        ORDER BY [l1].[Id]) IS NOT NULL) AND (((
         SELECT TOP(1) [l2].[Id]
         FROM [LevelTwo] AS [l2]
         WHERE [l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]
@@ -3699,10 +3700,10 @@ ORDER BY [l].[Id], [t0].[Id]");
                 @"SELECT [l].[Id], (
     SELECT TOP(1) [l0].[Name]
     FROM [LevelThree] AS [l0]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE ((
+        SELECT TOP(1) [l1].[Id]
         FROM [LevelTwo] AS [l1]
-        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND ([l1].[Name] = N'L2 02')) AND (((
+        WHERE ([l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]) AND ([l1].[Name] = N'L2 02')) IS NOT NULL) AND (((
         SELECT TOP(1) [l2].[Id]
         FROM [LevelTwo] AS [l2]
         WHERE ([l].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND ([l2].[Name] = N'L2 02')) = [l0].[OneToMany_Optional_Inverse3Id]) OR (((

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -8223,6 +8223,32 @@ LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
 ORDER BY [t0].[Nickname], [t0].[SquadId], [t0].[HasSoulPatch0]");
         }
 
+        public override async Task Where_subquery_equality_to_null_with_composite_key(bool async)
+        {
+            await base.Where_subquery_equality_to_null_with_composite_key(async);
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+WHERE NOT (EXISTS (
+    SELECT 1
+    FROM [Gears] AS [g]
+    WHERE [s].[Id] = [g].[SquadId]))");
+        }
+
+        public override async Task Where_subquery_equality_to_null_without_composite_key(bool async)
+        {
+            await base.Where_subquery_equality_to_null_without_composite_key(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE NOT (EXISTS (
+    SELECT 1
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -591,10 +591,11 @@ FROM [Customers] AS [c]
 OUTER APPLY (
     SELECT TOP(1) [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
     FROM [Order Details] AS [o]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE ((
+        SELECT TOP(1) [o0].[OrderID]
         FROM [Orders] AS [o0]
-        WHERE [c].[CustomerID] = [o0].[CustomerID]) AND ((
+        WHERE [c].[CustomerID] = [o0].[CustomerID]
+        ORDER BY [o0].[OrderID]) IS NOT NULL) AND ((
         SELECT TOP(1) [o1].[OrderID]
         FROM [Orders] AS [o1]
         WHERE [c].[CustomerID] = [o1].[CustomerID]
@@ -613,10 +614,11 @@ ORDER BY [c].[CustomerID]");
                 @"SELECT (
     SELECT TOP(1) [o].[ProductID]
     FROM [Order Details] AS [o]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE ((
+        SELECT TOP(1) [o0].[OrderID]
         FROM [Orders] AS [o0]
-        WHERE [c].[CustomerID] = [o0].[CustomerID]) AND ((
+        WHERE [c].[CustomerID] = [o0].[CustomerID]
+        ORDER BY [o0].[OrderID]) IS NOT NULL) AND ((
         SELECT TOP(1) [o1].[OrderID]
         FROM [Orders] AS [o1]
         WHERE [c].[CustomerID] = [o1].[CustomerID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -3889,10 +3889,11 @@ WHERE [o].[OrderID] = 10300");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE NOT (EXISTS (
-    SELECT 1
+WHERE (
+    SELECT TOP(1) [o].[CustomerID]
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID]))");
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID] DESC) IS NULL");
         }
 
         public override async Task Subquery_is_not_null_translated_correctly(bool async)
@@ -3902,10 +3903,11 @@ WHERE NOT (EXISTS (
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE EXISTS (
-    SELECT 1
+WHERE (
+    SELECT TOP(1) [o].[CustomerID]
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID])");
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID] DESC) IS NOT NULL");
         }
 
         public override async Task Select_take_average(bool async)
@@ -4601,11 +4603,12 @@ WHERE (
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE NOT (EXISTS (
-    SELECT 1
+WHERE (
+    SELECT TOP(1) [c0].[CustomerID]
     FROM [Orders] AS [o]
     LEFT JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-    WHERE [c].[CustomerID] = [o].[CustomerID]))");
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID]) IS NULL");
         }
 
         public override async Task Collection_navigation_equality_rewrite_for_subquery(bool async)
@@ -5128,11 +5131,12 @@ ORDER BY [c].[CustomerID]");
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o]
-        WHERE (EXISTS (
-            SELECT 1
+        WHERE (((
+            SELECT TOP(1) [c0].[CustomerID]
             FROM [Orders] AS [o0]
             LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-            WHERE [c].[CustomerID] = [o0].[CustomerID]) AND (((
+            WHERE [c].[CustomerID] = [o0].[CustomerID]
+            ORDER BY [o0].[OrderDate]) IS NOT NULL) AND (((
             SELECT TOP(1) [c1].[CustomerID]
             FROM [Orders] AS [o1]
             LEFT JOIN [Customers] AS [c1] ON [o1].[CustomerID] = [c1].[CustomerID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -2295,10 +2295,10 @@ WHERE [c].[CustomerID] = N'ALFKI'");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE NOT (EXISTS (
-    SELECT 1
+WHERE (
+    SELECT TOP(1) [o].[OrderID]
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID]))");
+    WHERE [c].[CustomerID] = [o].[CustomerID]) IS NULL");
         }
 
         public override async Task FirstOrDefault_over_scalar_projection_compared_to_not_null(bool async)
@@ -2308,10 +2308,10 @@ WHERE NOT (EXISTS (
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE EXISTS (
-    SELECT 1
+WHERE (
+    SELECT TOP(1) [o].[OrderID]
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID])");
+    WHERE [c].[CustomerID] = [o].[CustomerID]) IS NOT NULL");
         }
 
         public override async Task FirstOrDefault_over_custom_projection_compared_to_null(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -5348,10 +5348,10 @@ OUTER APPLY (
     SELECT [s].[ThingId], [t].[Id], [s].[Id] AS [Id0]
     FROM [Things] AS [t]
     LEFT JOIN [Subthings] AS [s] ON [t].[Id] = [s].[ThingId]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE ((
+        SELECT TOP(1) [v].[Id]
         FROM [Values] AS [v]
-        WHERE [e].[Id] = [v].[Entity11023Id]) AND (((
+        WHERE [e].[Id] = [v].[Entity11023Id]) IS NOT NULL) AND (((
         SELECT TOP(1) [v0].[Id]
         FROM [Values] AS [v0]
         WHERE [e].[Id] = [v0].[Entity11023Id]) = [t].[Value11023Id]) OR (((

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -257,5 +257,44 @@ LEFT JOIN (
 ) AS [t0] ON [t].[ChildFilter1Id] = [t0].[Id]
 GROUP BY [t].[Key]");
         }
+
+        public override async Task Subquery_first_member_compared_to_null(bool async)
+        {
+            await base.Subquery_first_member_compared_to_null(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT TOP(1) [c1].[SomeOtherNullableDateTime]
+    FROM [Child26744] AS [c1]
+    WHERE ([p].[Id] = [c1].[ParentId]) AND ([c1].[SomeNullableDateTime] IS NULL)
+    ORDER BY [c1].[SomeInteger])
+FROM [Parents] AS [p]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Child26744] AS [c]
+    WHERE ([p].[Id] = [c].[ParentId]) AND ([c].[SomeNullableDateTime] IS NULL)) AND ((
+    SELECT TOP(1) [c0].[SomeOtherNullableDateTime]
+    FROM [Child26744] AS [c0]
+    WHERE ([p].[Id] = [c0].[ParentId]) AND ([c0].[SomeNullableDateTime] IS NULL)
+    ORDER BY [c0].[SomeInteger]) IS NOT NULL)");
+        }
+
+        public override async Task SelectMany_where_Select(bool async)
+        {
+            await base.SelectMany_where_Select(async);
+
+            AssertSql(
+                @"SELECT [t0].[SomeNullableDateTime]
+FROM [Parents] AS [p]
+INNER JOIN (
+    SELECT [t].[ParentId], [t].[SomeNullableDateTime], [t].[SomeOtherNullableDateTime]
+    FROM (
+        SELECT [c].[ParentId], [c].[SomeNullableDateTime], [c].[SomeOtherNullableDateTime], ROW_NUMBER() OVER(PARTITION BY [c].[ParentId], [c].[SomeNullableDateTime] ORDER BY [c].[SomeInteger]) AS [row]
+        FROM [Child] AS [c]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON ([p].[Id] = [t0].[ParentId]) AND [t0].[SomeNullableDateTime] IS NULL
+WHERE [t0].[SomeOtherNullableDateTime] IS NOT NULL");
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -9173,6 +9173,36 @@ LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
 ORDER BY [t0].[Nickname], [t0].[SquadId], [t0].[HasSoulPatch0]");
         }
 
+        public override async Task Where_subquery_equality_to_null_with_composite_key(bool async)
+        {
+            await base.Where_subquery_equality_to_null_with_composite_key(async);
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+WHERE NOT (EXISTS (
+    SELECT 1
+    FROM [Gears] AS [g]
+    LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
+    WHERE [s].[Id] = [g].[SquadId]))");
+        }
+
+        public override async Task Where_subquery_equality_to_null_without_composite_key(bool async)
+        {
+            await base.Where_subquery_equality_to_null_without_composite_key(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
+    WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
+END AS [Discriminator]
+FROM [Gears] AS [g]
+LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
+WHERE NOT (EXISTS (
+    SELECT 1
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -385,6 +385,32 @@ WHERE [g0].[Discriminator] = N'Officer'");
             Assert.Equal(SqlServerStrings.TemporalSetOperationOnMismatchedSources(nameof(Gear)), message);
         }
 
+        public override async Task Where_subquery_equality_to_null_with_composite_key(bool async)
+        {
+            await base.Where_subquery_equality_to_null_with_composite_key(async);
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [s].[PeriodEnd], [s].[PeriodStart]
+FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
+WHERE NOT (EXISTS (
+    SELECT 1
+    FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
+    WHERE [s].[Id] = [g].[SquadId]))");
+        }
+
+        public override async Task Where_subquery_equality_to_null_without_composite_key(bool async)
+        {
+            await base.Where_subquery_equality_to_null_without_composite_key(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
+FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
+WHERE NOT (EXISTS (
+    SELECT 1
+    FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
Resolves #26744
A better fix for #18476

Initial fix for #18476 (in 6.0) assumed that whenever we have single result operation compared to null, it will only be true if the result of single result is default when sequence is empty. This was correct for the query in the issue tracker which had anonymous type projection.

Anonymous type is never null as long as there is data, it can be only null value when default is invoked i.e. empty sequence. Hence we added optimization for that but it didn't restrict to just anonymous type.

For entity type projection when entity is not nullable, the same logic holds true. This helped us translate queries which wouldn't work with entity equality due to composite key from a subquery. But optimization was incorrect for the result which can be null (nullable scalar or nullable entity) as an non-empty sequence can have first result to be null which can match.

The improved fix avoids doing the unrestricted optimization during preprocessing phase. Instead we moved the logic to translation phase where we can evaluate the shape of the projection coming out subquery. Now we only apply optimization for non-nullable entity and anonymous type. Scalar comparison will work by comparing to null and nullable entity will work if entity equality covers it. It will start throwing error if composite key though earlier version possibly generated wrong results for it.

**Description**

A faulty optimization in EF Core converts a subquery comparison to null to any operation making it sequence check. In case when the sequence can return null value as element, the optimization is incorrect.

**Customer impact**

Users running a query where this optimization would incorrectly kick in, will get incorrect results.

**How found**

Customer reported on 6.0

**Regression**

Yes. From 5.0 The regression was caused by faulty optimization added in 6.0 as enhancement.

**Testing**

There are existing test verifying the optimization (in correct scenario), Added additional tests for user scenario where optimization was incorrect. Some tests have different SQL now as optimization was incorrect but due to the data, it was still giving correct results.

**Risk**

Low risk. Optimization is applied accurately in the cases where it is correct. This has potential to break some queries though they are supposed to be giving incorrect results. Also added quirk to revert to earlier behavior.
