### PR TITLE
Check for updates on nuget.org

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+registries:
+  nuget.org:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
 updates:
   - package-ecosystem: nuget
     directory: /
@@ -29,3 +33,4 @@ updates:
     labels:
       - area-infrastructure
       - 'type-dependency update :arrow_up_small:'
+    registries: '*'


### PR DESCRIPTION
This should enable Dependabot to send PRs once an update is available on nuget.org. From there, we can request that the package be mirrored on the dotnet-public feed. Today, I manually watch for updates on nuget.org. This will automate that part of our workflow.