### PR TITLE
Update to Roslyn 4.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,6 +28,6 @@
     <MicrosoftExtensionsLoggingVersion>7.0.0-alpha.1.22073.5</MicrosoftExtensionsLoggingVersion>
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
-    <MicrosoftCodeAnalysisVersion>3.7.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>4.0.1</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
 </Project>

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -69,7 +69,11 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
                 AnalyzeMember(context, ((IMethodReferenceOperation)context.Operation).Method);
                 break;
             case OperationKind.ObjectCreation:
-                AnalyzeMember(context, ((IObjectCreationOperation)context.Operation).Constructor);
+                var constructor = ((IObjectCreationOperation)context.Operation).Constructor;
+                if (constructor is not null)
+                {
+                    AnalyzeMember(context, constructor);
+                }
                 break;
             case OperationKind.Invocation:
                 AnalyzeInvocation(context, (IInvocationOperation)context.Operation);

--- a/src/Shared/ReferenceEqualityComparer.cs
+++ b/src/Shared/ReferenceEqualityComparer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 #nullable enable
+#pragma warning disable RS1024
 
 namespace Microsoft.EntityFrameworkCore.Internal;
 


### PR DESCRIPTION
Since .NET 6 only works on VS 2022, we can update the version of Roslyn we use. This gives our analyzers the ability to work with new expressions added in C# 9 and 10.