### PR TITLE
Fix for the optimizer when an entity has a collection property that references itself.

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -1376,7 +1376,7 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
         }
 
         var sequenceType = type.TryGetSequenceType();
-        if (sequenceType != null)
+        if (sequenceType != null && sequenceType.Namespace != null && !namespaces.Contains(sequenceType.Namespace))
         {
             AddNamespace(sequenceType, namespaces);
         }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -1376,7 +1376,7 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
         }
 
         var sequenceType = type.TryGetSequenceType();
-        if (sequenceType != null && sequenceType.Namespace != null && !namespaces.Contains(sequenceType.Namespace))
+        if (sequenceType != null && sequenceType != type)
         {
             AddNamespace(sequenceType, namespaces);
         }


### PR DESCRIPTION
Fix for the optimizer when an entity has a collection property that references itself. An example would be a Json.Net's [JArray](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Linq/JArray.cs#L41). It implements IEnumerable&lt;JToken&gt;, which in turn implements IEnumerable&lt;JToken&gt;. This caused an infinite loop and stack overflow exception in [`CSharpRuntimeModelCodeGenerator.AddNamespace`](https://github.com/dotnet/efcore/blob/main/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs#L1381)

- Added a check if the sequence type matches the parameter type to break the inifinite loop.
- Added unit test with self-referential collection type. If the unit test doesn't stack overflow, can be considered successful.

Fixes #27301

