### PR TITLE
Fix for the optimizer when an entity has a collection property that references itself.

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -1400,7 +1400,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             var sequenceType = type.TryGetSequenceType();
-            if (sequenceType != null)
+            if (sequenceType != null && sequenceType != type)
             {
                 AddNamespace(sequenceType, namespaces);
             }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -56,6 +56,20 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
     public class CSharpRuntimeModelCodeGeneratorTest
     {
+
+        [ConditionalFact]
+        public void Self_referential_property()
+            => Test(
+                new TestModel.Internal.SelfReferentialDbContext(),
+                new CompiledModelCodeGenerationOptions(),
+                assertModel: model =>
+                {
+                    Assert.Single(model.GetEntityTypes());
+                    Assert.Same(model, model.FindRuntimeAnnotationValue("ReadOnlyModel"));
+                }
+            );
+
+
         [ConditionalFact]
         public void Empty_model()
         {
@@ -3659,6 +3673,18 @@ namespace TestNamespace
     {
 
     }
+
+
+    public class SelfReferentialEntity
+    {
+        public long Id { get; set; }
+
+        public SelfReferentialProperty Collection { get; set; }
+    }
+
+    public class SelfReferentialProperty : List<SelfReferentialProperty>
+    {
+    }
 }
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.TestModel.Internal
@@ -3677,5 +3703,30 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.TestModel.Internal
             });
             modelBuilder.Entity<Scaffolding.Internal.Internal>();
         }
+    }
+
+    public class SelfReferentialDbContext : ContextBase
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Scaffolding.Internal.SelfReferentialEntity>(
+                eb =>
+                {
+                    eb.Property(e => e.Collection).HasConversion(typeof(SelfReferentialPropertyValueConverter));
+                });
+        }
+    }
+
+    public class SelfReferentialPropertyValueConverter : ValueConverter<Scaffolding.Internal.SelfReferentialProperty, string>
+    {
+        public SelfReferentialPropertyValueConverter()
+          : this(null)
+        { }
+
+        public SelfReferentialPropertyValueConverter(ConverterMappingHints hints)
+           : base(v => null, v => null, hints)
+        { }
     }
 }


### PR DESCRIPTION
Fixes #27301

Port of https://github.com/dotnet/efcore/pull/27350

**Description**

The code that ensures all the needed namespaces have been added recurses into generic collections, but didn't have a check for types that implent a collection of themselves.

**Customer impact**

Using `dotnet ef dbcontext optimize` will hang without any error messages for affected models.

**How found**

Reported by a customer on 6.0

**Regression**

No. Compiled models is a new feature in 6.0

**Testing**

Added a test for the affected scenario.

**Risk**

Low. The fix is very straightforward and localized. Also, only design-time tooling is affected.