### PR TITLE
[release/6.0] SQLite: Don't modify collection while enumerating inside ReclaimLeakedConnections

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionPool.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionPool.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 
 namespace Microsoft.Data.Sqlite
@@ -157,17 +158,17 @@ namespace Microsoft.Data.Sqlite
         {
             var leakedConnectionsFound = false;
 
+            List<SqliteConnectionInternal> leakedConnections;
             lock (_connections)
             {
-                foreach (var connection in _connections)
-                {
-                    if (connection.Leaked)
-                    {
-                        Return(connection);
+                leakedConnections = _connections.Where(c => c.Leaked).ToList();
+            }
 
-                        leakedConnectionsFound = true;
-                    }
-                }
+            foreach (var connection in leakedConnections)
+            {
+                leakedConnectionsFound = true;
+
+                Return(connection);
             }
 
             return leakedConnectionsFound;

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionFactoryTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionFactoryTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using System.IO;
+using System.Runtime.CompilerServices;
 using SQLitePCL;
 using Xunit;
 
@@ -216,6 +217,26 @@ namespace Microsoft.Data.Sqlite
             ex = Assert.Throws<SqliteException>(
                 () => connection2.ExecuteNonQuery("SELECT load_extension('unknown');"));
             Assert.Equal(disabledMessage, ex.Message);
+        }
+
+        [Fact]
+        public void Clear_works_when_connection_leaked()
+        {
+            using var connection = new SqliteConnection(ConnectionString);
+            connection.Open();
+
+            LeakConnection();
+            GC.Collect();
+
+            SqliteConnection.ClearPool(connection);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void LeakConnection()
+            {
+                // Don't add using!
+                var connection = new SqliteConnection(ConnectionString);
+                connection.Open();
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
The existing code to reclaim leaked connections inadvertently modifies a collection while enumerating.

Fixes #27168

### Customer impact

Because of this defect, calling methods like `SqliteConnection.ClearAllPools()` currently throws when an application fails to dispose connection objects.

### Regression

Yes. Pooling was added in 6.0 and is enabled by default. There's a new Timer that calls this code on a background thread every 2-4 minutes.

### Risk

Low. The updated code more closely mirrors the existing code used by the [ODBC](https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbConnectionPool.cs#L1073), [OLE DB](https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPool.cs#L1610), and [SqlClient](https://github.com/dotnet/corefx/blob/v3.1.0/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs#L1497) providers.

### Verification

Added a new automated test to cover the scenario.