### PR TITLE
[release/6.0] Fix to #27356 - Collection_navigation_equal_to_null_for_subquery fails after merging from release/6.0

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -204,7 +204,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                         {
                             var projection = translatedSubquery.ShaperExpression;
                             if (projection is NewExpression
-                                || RemoveConvert(projection) is EntityShaperExpression { IsNullable: false })
+                                || RemoveConvert(projection) is EntityShaperExpression { IsNullable: false }
+                                || RemoveConvert(projection) is CollectionResultShaperExpression)
                             {
                                 var anySubquery = Expression.Call(
                                     QueryableMethods.AnyWithoutPredicate.MakeGenericMethod(translatedSubquery.Type.GetSequenceType()),

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -367,7 +367,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         {
                             var projection = translatedSubquery.ShaperExpression;
                             if (projection is NewExpression
-                                || RemoveConvert(projection) is EntityShaperExpression { IsNullable: false })
+                                || RemoveConvert(projection) is EntityShaperExpression { IsNullable: false }
+                                || RemoveConvert(projection) is CollectionResultExpression)
                             {
                                 var anySubquery = Expression.Call(
                                     QueryableMethods.AnyWithoutPredicate.MakeGenericMethod(translatedSubquery.Type.GetSequenceType()),

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5546,7 +5546,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected internal uint ClientEvalSelector(Order order)
             => order.EmployeeID % 10 ?? 0;
 
-        [ConditionalTheory(Skip = "Issue#20445")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_navigation_equal_to_null_for_subquery(bool async)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -4589,11 +4589,10 @@ WHERE ([c].[CustomerID] LIKE N'A%') AND (((
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (
-    SELECT TOP(1) [o].[OrderID]
+WHERE NOT (EXISTS (
+    SELECT 1
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID]
-    ORDER BY [o].[OrderID]) IS NULL");
+    WHERE [c].[CustomerID] = [o].[CustomerID]))");
         }
 
         public override async Task Dependent_to_principal_navigation_equal_to_null_for_subquery(bool async)


### PR DESCRIPTION
Improvement on the previous patch fix (#26744). We were not taking into the account scenario where collection projected from FirstOrDefault was compared to null. Collection can only be null if the parent entity is null, so we can safely apply the same optimization we do for anonymous types and required entities.

Fixes #27356

----------------------------------------------

**Description**

Problem was that we were scaled down the optimization for comparing complex expressions to null, but we scaled it down too much. Scenario involving collection projection could also be optimized (and was being optimized in the too eager version before the previous fix), but now the optimization wouldn't apply causing query compilation error.

**Customer impact**

Customer executing the query in the scenario would see query compilation error now, whereas before query worked correctly. The scenario is quite niche/contrived (projecting collection navigation, then composing First/Single/etc and then projecting another collection and comparing that to null)

**How found**

We found it after merging patch to main - we have test coverage for this scenario but it was (incorrectly) disabled with another issue on release 6.0 branch.

**Regression**

Yes. Optimization before #26744 was too aggressive, but this scenario would have been optimized correctly. Comments in #26744 predicts these breaks could happen. Most of the time it would just lead to worse sql, but here its a scenario enabling optimization, since we are unable to translate the query in it's original form.

**Testing**

Re-enabled the test case covering this, that we already had.

**Risk**

Low. Extended the optimization to another (straightforward) scenario. Code path affected is very isolated. Quirk already present.