### PR TITLE
Map check constraints only to the tables for which they are declared

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/RandomTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/RandomTranslator.cs
@@ -43,7 +43,7 @@ public class RandomTranslator : IMethodCallTranslator
         => MethodInfo.Equals(method)
             ? _sqlExpressionFactory.Function(
                 "RAND",
-                Array.Empty<SqlExpression>(),
+                Enumerable.Empty<SqlExpression>(),
                 method.ReturnType)
             : null;
 }

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -931,7 +931,8 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
             .Append(", ")
             .Append(Code.Literal(checkConstraint.Sql));
 
-        if (checkConstraint.Name != (checkConstraint.GetDefaultName() ?? checkConstraint.ModelName))
+        if (checkConstraint.Name != null
+            && checkConstraint.Name != (checkConstraint.GetDefaultName() ?? checkConstraint.ModelName))
         {
             stringBuilder
                 .Append(", c => c.HasName(")

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -558,7 +558,7 @@ public class CSharpDbContextGenerator : ICSharpDbContextGenerator
 
         var lines = new List<string>
         {
-            $".{nameof(EntityTypeBuilder.HasIndex)}({_code.Lambda(index.Properties, "e")}, {_code.Literal(index.GetDatabaseName())})"
+            $".{nameof(EntityTypeBuilder.HasIndex)}({_code.Lambda(index.Properties, "e")}, {_code.Literal(index.GetDatabaseName()!)})"
         };
         annotations.Remove(RelationalAnnotationNames.Name);
 
@@ -845,7 +845,7 @@ public class CSharpDbContextGenerator : ICSharpDbContextGenerator
                             _annotationCodeGenerator.RemoveAnnotationsHandledByConventions(index, indexAnnotations);
 
                             lines.Add(
-                                $"j.{nameof(EntityTypeBuilder.HasIndex)}({_code.Literal(index.Properties.Select(e => e.Name).ToArray())}, {_code.Literal(index.GetDatabaseName())})");
+                                $"j.{nameof(EntityTypeBuilder.HasIndex)}({_code.Literal(index.Properties.Select(e => e.Name).ToArray())}, {_code.Literal(index.GetDatabaseName()!)})");
                             indexAnnotations.Remove(RelationalAnnotationNames.Name);
 
                             if (index.IsUnique)

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -39,7 +39,7 @@ public static class RelationalEntityTypeExtensions
             return entityType.GetRootType().GetTableName();
         }
 
-        return (entityType as IConventionEntityType)?.GetViewNameConfigurationSource() == null
+        return ((entityType as IConventionEntityType)?.GetViewNameConfigurationSource() == null)
             && ((entityType as IConventionEntityType)?.GetFunctionNameConfigurationSource() == null)
 #pragma warning disable CS0618 // Type or member is obsolete
             && ((entityType as IConventionEntityType)?.GetDefiningQueryConfigurationSource() == null)
@@ -254,7 +254,7 @@ public static class RelationalEntityTypeExtensions
     public static IEnumerable<ITableMappingBase> GetDefaultMappings(this IEntityType entityType)
         => (IEnumerable<ITableMappingBase>?)entityType.FindRuntimeAnnotationValue(
                 RelationalAnnotationNames.DefaultMappings)
-            ?? Array.Empty<ITableMappingBase>();
+            ?? Enumerable.Empty<ITableMappingBase>();
 
     /// <summary>
     ///     Returns the tables to which the entity type is mapped.
@@ -264,7 +264,7 @@ public static class RelationalEntityTypeExtensions
     public static IEnumerable<ITableMapping> GetTableMappings(this IEntityType entityType)
         => (IEnumerable<ITableMapping>?)entityType.FindRuntimeAnnotationValue(
                 RelationalAnnotationNames.TableMappings)
-            ?? Array.Empty<ITableMapping>();
+            ?? Enumerable.Empty<ITableMapping>();
 
     /// <summary>
     ///     Returns the name of the view to which the entity type is mapped or <see langword="null" /> if not mapped to a view.
@@ -286,7 +286,7 @@ public static class RelationalEntityTypeExtensions
 
         return ((entityType as IConventionEntityType)?.GetFunctionNameConfigurationSource() == null)
 #pragma warning disable CS0618 // Type or member is obsolete
-            && (entityType as IConventionEntityType)?.GetDefiningQueryConfigurationSource() == null
+            && ((entityType as IConventionEntityType)?.GetDefiningQueryConfigurationSource() == null)
 #pragma warning restore CS0618 // Type or member is obsolete
             && ((entityType as IConventionEntityType)?.GetSqlQueryConfigurationSource() == null)
                 ? GetDefaultViewName(entityType)
@@ -428,7 +428,7 @@ public static class RelationalEntityTypeExtensions
     public static IEnumerable<IViewMapping> GetViewMappings(this IEntityType entityType)
         => (IEnumerable<IViewMapping>?)entityType.FindRuntimeAnnotationValue(
                 RelationalAnnotationNames.ViewMappings)
-            ?? Array.Empty<IViewMapping>();
+            ?? Enumerable.Empty<IViewMapping>();
 
     /// <summary>
     ///     Gets the default SQL query name that would be used for this entity type when mapped using
@@ -493,7 +493,7 @@ public static class RelationalEntityTypeExtensions
     public static IEnumerable<ISqlQueryMapping> GetSqlQueryMappings(this IEntityType entityType)
         => (IEnumerable<ISqlQueryMapping>?)entityType.FindRuntimeAnnotationValue(
                 RelationalAnnotationNames.SqlQueryMappings)
-            ?? Array.Empty<ISqlQueryMapping>();
+            ?? Enumerable.Empty<ISqlQueryMapping>();
 
     /// <summary>
     ///     Returns the name of the function to which the entity type is mapped or <see langword="null" /> if not mapped to a function.
@@ -549,7 +549,7 @@ public static class RelationalEntityTypeExtensions
     public static IEnumerable<IFunctionMapping> GetFunctionMappings(this IEntityType entityType)
         => (IEnumerable<IFunctionMapping>?)entityType.FindRuntimeAnnotationValue(
                 RelationalAnnotationNames.FunctionMappings)
-            ?? Array.Empty<IFunctionMapping>();
+            ?? Enumerable.Empty<IFunctionMapping>();
 
     /// <summary>
     ///     Finds an <see cref="IReadOnlyCheckConstraint" /> with the given name.

--- a/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
@@ -21,6 +21,12 @@ public static class RelationalForeignKeyExtensions
     /// <returns>The foreign key constraint name.</returns>
     public static string? GetConstraintName(this IReadOnlyForeignKey foreignKey)
     {
+        var tableName = foreignKey.DeclaringEntityType.GetTableName();
+        if (tableName == null)
+        {
+            return null;
+        }
+
         var annotation = foreignKey.FindAnnotation(RelationalAnnotationNames.Name);
         return annotation != null
             ? (string?)annotation.Value
@@ -39,6 +45,12 @@ public static class RelationalForeignKeyExtensions
         in StoreObjectIdentifier storeObject,
         in StoreObjectIdentifier principalStoreObject)
     {
+        if (storeObject.StoreObjectType != StoreObjectType.Table
+            || principalStoreObject.StoreObjectType != StoreObjectType.Table)
+        {
+            return null;
+        }
+
         var annotation = foreignKey.FindAnnotation(RelationalAnnotationNames.Name);
         return annotation != null
             ? (string?)annotation.Value
@@ -50,10 +62,15 @@ public static class RelationalForeignKeyExtensions
     /// </summary>
     /// <param name="foreignKey">The foreign key.</param>
     /// <returns>The default constraint name that would be used for this foreign key.</returns>
-    public static string GetDefaultName(this IReadOnlyForeignKey foreignKey)
+    public static string? GetDefaultName(this IReadOnlyForeignKey foreignKey)
     {
         var tableName = foreignKey.DeclaringEntityType.GetTableName();
         var principalTableName = foreignKey.PrincipalEntityType.GetTableName();
+        if (tableName == null
+            || principalTableName == null)
+        {
+            return null;
+        }
 
         var name = new StringBuilder()
             .Append("FK_")
@@ -79,6 +96,12 @@ public static class RelationalForeignKeyExtensions
         in StoreObjectIdentifier storeObject,
         in StoreObjectIdentifier principalStoreObject)
     {
+        if (storeObject.StoreObjectType != StoreObjectType.Table
+            || principalStoreObject.StoreObjectType != StoreObjectType.Table)
+        {
+            return null;
+        }
+
         var propertyNames = foreignKey.Properties.GetColumnNames(storeObject);
         var principalPropertyNames = foreignKey.PrincipalKey.Properties.GetColumnNames(principalStoreObject);
         if (propertyNames == null

--- a/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
@@ -20,7 +20,10 @@ public static class RelationalKeyExtensions
     /// <param name="key">The key.</param>
     /// <returns>The key constraint name for this key.</returns>
     public static string? GetName(this IReadOnlyKey key)
-        => key.GetName(StoreObjectIdentifier.Table(key.DeclaringEntityType.GetTableName()!, key.DeclaringEntityType.GetSchema()));
+    {
+        var table = StoreObjectIdentifier.Create(key.DeclaringEntityType, StoreObjectType.Table);
+        return !table.HasValue ? null : key.GetName(table.Value);
+    }
 
     /// <summary>
     ///     Returns the key constraint name for this key for a particular table.
@@ -29,17 +32,36 @@ public static class RelationalKeyExtensions
     /// <param name="storeObject">The identifier of the containing store object.</param>
     /// <returns>The key constraint name for this key.</returns>
     public static string? GetName(this IReadOnlyKey key, in StoreObjectIdentifier storeObject)
-        => (string?)key[RelationalAnnotationNames.Name]
-            ?? key.GetDefaultName(storeObject);
+    {
+        if (storeObject.StoreObjectType != StoreObjectType.Table)
+        {
+            return null;
+        }
+
+        foreach (var containingType in key.DeclaringEntityType.GetDerivedTypesInclusive())
+        {
+            if (StoreObjectIdentifier.Create(containingType, storeObject.StoreObjectType) == storeObject)
+            {
+                return (string?)key[RelationalAnnotationNames.Name] ?? key.GetDefaultName(storeObject);
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     ///     Returns the default key constraint name that would be used for this key.
     /// </summary>
     /// <param name="key">The key.</param>
     /// <returns>The default key constraint name that would be used for this key.</returns>
-    public static string GetDefaultName(this IReadOnlyKey key)
+    public static string? GetDefaultName(this IReadOnlyKey key)
     {
         var tableName = key.DeclaringEntityType.GetTableName();
+        if (tableName == null)
+        {
+            return null;
+        }
+
         var name = key.IsPrimaryKey()
             ? "PK_" + tableName
             : new StringBuilder()
@@ -60,6 +82,11 @@ public static class RelationalKeyExtensions
     /// <returns>The default key constraint name that would be used for this key.</returns>
     public static string? GetDefaultName(this IReadOnlyKey key, in StoreObjectIdentifier storeObject)
     {
+        if (storeObject.StoreObjectType != StoreObjectType.Table)
+        {
+            return null;
+        }
+
         string? name;
         if (key.IsPrimaryKey())
         {

--- a/src/EFCore.Relational/Metadata/IMutableCheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IMutableCheckConstraint.cs
@@ -19,5 +19,5 @@ public interface IMutableCheckConstraint : IReadOnlyCheckConstraint, IMutableAnn
     /// <summary>
     ///     Gets or sets the name of the check constraint in the database.
     /// </summary>
-    new string Name { get; set; }
+    new string? Name { get; set; }
 }

--- a/src/EFCore.Relational/Metadata/IReadOnlyCheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlyCheckConstraint.cs
@@ -19,7 +19,7 @@ public interface IReadOnlyCheckConstraint : IReadOnlyAnnotatable
     /// <summary>
     ///     Gets the database name of the check constraint.
     /// </summary>
-    string Name { get; }
+    string? Name { get; }
 
     /// <summary>
     ///     Returns the default database name that would be used for this check constraint.
@@ -43,8 +43,10 @@ public interface IReadOnlyCheckConstraint : IReadOnlyAnnotatable
     /// </summary>
     /// <param name="storeObject">The identifier of the store object.</param>
     /// <returns>The default name that would be used for this check constraint.</returns>
-    string GetDefaultName(in StoreObjectIdentifier storeObject)
-        => Uniquifier.Truncate(ModelName, EntityType.Model.GetMaxIdentifierLength());
+    string? GetDefaultName(in StoreObjectIdentifier storeObject)
+        => storeObject.StoreObjectType == StoreObjectType.Table
+        ? Uniquifier.Truncate(ModelName, EntityType.Model.GetMaxIdentifierLength())
+        : null;
 
     /// <summary>
     ///     Gets the entity type on which this check constraint is defined.

--- a/src/EFCore.Relational/Metadata/ITable.cs
+++ b/src/EFCore.Relational/Metadata/ITable.cs
@@ -51,9 +51,7 @@ public interface ITable : ITableBase
     /// <summary>
     ///     Gets the check constraints for this table.
     /// </summary>
-    IEnumerable<ICheckConstraint> CheckConstraints
-        => EntityTypeMappings.SelectMany(m => m.EntityType.GetDeclaredCheckConstraints())
-            .Distinct((x, y) => x!.Name == y!.Name);
+    IEnumerable<ICheckConstraint> CheckConstraints { get; }
 
     /// <summary>
     ///     Gets the comment for this table.

--- a/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
@@ -280,15 +280,32 @@ public class CheckConstraint : ConventionAnnotatable, IMutableCheckConstraint, I
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual string Name
+    public virtual string? Name
     {
-        get => _name ?? ((IReadOnlyCheckConstraint)this).GetDefaultName() ?? ModelName;
+        get => EntityType.GetTableName() == null
+            ? null
+            : _name ?? ((IReadOnlyCheckConstraint)this).GetDefaultName();
         set => SetName(value, ConfigurationSource.Explicit);
     }
 
     /// <inheritdoc />
     public virtual string? GetName(in StoreObjectIdentifier storeObject)
-        => _name ?? ((IReadOnlyCheckConstraint)this).GetDefaultName(storeObject) ?? ModelName;
+    {
+        if (storeObject.StoreObjectType != StoreObjectType.Table)
+        {
+            return null;
+        }
+
+        foreach (var containingType in EntityType.GetDerivedTypesInclusive())
+        {
+            if (StoreObjectIdentifier.Create(containingType, storeObject.StoreObjectType) == storeObject)
+            {
+                return _name ?? ((IReadOnlyCheckConstraint)this).GetDefaultName(storeObject);
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/Table.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Table.cs
@@ -113,6 +113,15 @@ public class Table : TableBase, ITable
     public virtual SortedDictionary<string, TableIndex> Indexes { get; }
         = new();
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SortedDictionary<string, CheckConstraint> CheckConstraints { get; }
+        = new();
+
     /// <inheritdoc />
     public virtual bool IsExcludedFromMigrations
         => EntityTypeMappings.First().EntityType.IsTableExcludedFromMigrations();
@@ -174,6 +183,15 @@ public class Table : TableBase, ITable
         get => Indexes.Values;
     }
 
+    /// <inheritdoc />
+    IEnumerable<ICheckConstraint> ITable.CheckConstraints
+    {
+        [DebuggerStepThrough]
+        get => EntityTypeMappings.First().EntityType is RuntimeEntityType
+            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+            : CheckConstraints.Values;
+    }
+    
     /// <inheritdoc />
     [DebuggerStepThrough]
     IColumn? ITable.FindColumn(string name)

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1527,7 +1527,7 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
 
         var operation = new DropCheckConstraintOperation
         {
-            Name = source.Name,
+            Name = source.Name!,
             Schema = sourceEntityType.GetSchema(),
             Table = sourceEntityType.GetTableName()!
         };

--- a/src/EFCore.Relational/Migrations/Operations/AddCheckConstraintOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/AddCheckConstraintOperation.cs
@@ -46,7 +46,7 @@ public class AddCheckConstraintOperation : MigrationOperation, ITableMigrationOp
 
         var operation = new AddCheckConstraintOperation
         {
-            Name = checkConstraint.Name,
+            Name = checkConstraint.Name!,
             Sql = checkConstraint.Sql,
             Schema = checkConstraint.EntityType.GetSchema(),
             Table = checkConstraint.EntityType.GetTableName()!

--- a/src/EFCore.Relational/Query/Internal/RandomTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/RandomTranslator.cs
@@ -43,9 +43,9 @@ public class RandomTranslator : IMethodCallTranslator
         => MethodInfo.Equals(method)
             ? _sqlExpressionFactory.Function(
                 "RAND",
-                Array.Empty<SqlExpression>(),
+                Enumerable.Empty<SqlExpression>(),
                 nullable: false,
-                argumentsPropagateNullability: Array.Empty<bool>(),
+                argumentsPropagateNullability: Enumerable.Empty<bool>(),
                 method.ReturnType)
             : null;
 }

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -156,7 +156,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                 continue;
             }
 
-            var mappings = (IReadOnlyCollection<ITableMapping>)entry.EntityType.GetTableMappings();
+            var mappings = entry.EntityType.GetTableMappings();
             IModificationCommand? firstCommands = null;
             foreach (var mapping in mappings)
             {

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryCollectionMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryCollectionMemberTranslator.cs
@@ -46,10 +46,10 @@ public class SqlServerGeometryCollectionMemberTranslator : IMemberTranslator
             return _sqlExpressionFactory.Function(
                 instance!,
                 "STNumGeometries",
-                Array.Empty<SqlExpression>(),
+                Enumerable.Empty<SqlExpression>(),
                 nullable: true,
                 instancePropagatesNullability: true,
-                argumentsPropagateNullability: Array.Empty<bool>(),
+                argumentsPropagateNullability: Enumerable.Empty<bool>(),
                 returnType);
         }
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMemberTranslator.cs
@@ -86,10 +86,10 @@ public class SqlServerGeometryMemberTranslator : IMemberTranslator
                 return _sqlExpressionFactory.Function(
                     instance,
                     functionName,
-                    Array.Empty<SqlExpression>(),
+                    Enumerable.Empty<SqlExpression>(),
                     nullable: true,
                     instancePropagatesNullability: true,
-                    argumentsPropagateNullability: Array.Empty<bool>(),
+                    argumentsPropagateNullability: Enumerable.Empty<bool>(),
                     returnType,
                     resultTypeMapping);
             }
@@ -131,10 +131,10 @@ public class SqlServerGeometryMemberTranslator : IMemberTranslator
                     _sqlExpressionFactory.Function(
                         instance,
                         "STGeometryType",
-                        Array.Empty<SqlExpression>(),
+                        Enumerable.Empty<SqlExpression>(),
                         nullable: true,
                         instancePropagatesNullability: true,
-                        argumentsPropagateNullability: Array.Empty<bool>(),
+                        argumentsPropagateNullability: Enumerable.Empty<bool>(),
                         typeof(string)),
                     whenClauses,
                     null);

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerMultiLineStringMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerMultiLineStringMemberTranslator.cs
@@ -46,10 +46,10 @@ public class SqlServerMultiLineStringMemberTranslator : IMemberTranslator
             return _sqlExpressionFactory.Function(
                 instance!,
                 "STIsClosed",
-                Array.Empty<SqlExpression>(),
+                Enumerable.Empty<SqlExpression>(),
                 nullable: true,
                 instancePropagatesNullability: true,
-                argumentsPropagateNullability: Array.Empty<bool>(),
+                argumentsPropagateNullability: Enumerable.Empty<bool>(),
                 returnType);
         }
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPolygonMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPolygonMemberTranslator.cs
@@ -80,10 +80,10 @@ public class SqlServerPolygonMemberTranslator : IMemberTranslator
                         _sqlExpressionFactory.Function(
                             instance,
                             "NumRings",
-                            Array.Empty<SqlExpression>(),
+                            Enumerable.Empty<SqlExpression>(),
                             nullable: true,
                             instancePropagatesNullability: true,
-                            argumentsPropagateNullability: Array.Empty<bool>(),
+                            argumentsPropagateNullability: Enumerable.Empty<bool>(),
                             returnType),
                         _sqlExpressionFactory.Constant(1));
                 }
@@ -98,10 +98,10 @@ public class SqlServerPolygonMemberTranslator : IMemberTranslator
                 return _sqlExpressionFactory.Function(
                     instance,
                     functionName,
-                    Array.Empty<SqlExpression>(),
+                    Enumerable.Empty<SqlExpression>(),
                     nullable: true,
                     instancePropagatesNullability: true,
-                    argumentsPropagateNullability: Array.Empty<bool>(),
+                    argumentsPropagateNullability: Enumerable.Empty<bool>(),
                     returnType,
                     resultTypeMapping);
             }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMemberTranslator.cs
@@ -96,17 +96,17 @@ public class SqlServerDateTimeMemberTranslator : IMemberTranslator
                 case nameof(DateTime.Now):
                     return _sqlExpressionFactory.Function(
                         declaringType == typeof(DateTime) ? "GETDATE" : "SYSDATETIMEOFFSET",
-                        Array.Empty<SqlExpression>(),
+                        Enumerable.Empty<SqlExpression>(),
                         nullable: false,
-                        argumentsPropagateNullability: Array.Empty<bool>(),
+                        argumentsPropagateNullability: Enumerable.Empty<bool>(),
                         returnType);
 
                 case nameof(DateTime.UtcNow):
                     var serverTranslation = _sqlExpressionFactory.Function(
                         declaringType == typeof(DateTime) ? "GETUTCDATE" : "SYSUTCDATETIME",
-                        Array.Empty<SqlExpression>(),
+                        Enumerable.Empty<SqlExpression>(),
                         nullable: false,
-                        argumentsPropagateNullability: Array.Empty<bool>(),
+                        argumentsPropagateNullability: Enumerable.Empty<bool>(),
                         returnType);
 
                     return declaringType == typeof(DateTime)
@@ -121,9 +121,9 @@ public class SqlServerDateTimeMemberTranslator : IMemberTranslator
                             _sqlExpressionFactory.Fragment("date"),
                             _sqlExpressionFactory.Function(
                                 "GETDATE",
-                                Array.Empty<SqlExpression>(),
+                                Enumerable.Empty<SqlExpression>(),
                                 nullable: false,
-                                argumentsPropagateNullability: Array.Empty<bool>(),
+                                argumentsPropagateNullability: Enumerable.Empty<bool>(),
                                 typeof(DateTime))
                         },
                         nullable: true,

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerNewGuidTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerNewGuidTranslator.cs
@@ -41,9 +41,9 @@ public class SqlServerNewGuidTranslator : IMethodCallTranslator
         => MethodInfo.Equals(method)
             ? _sqlExpressionFactory.Function(
                 "NEWID",
-                Array.Empty<SqlExpression>(),
+                Enumerable.Empty<SqlExpression>(),
                 nullable: false,
-                argumentsPropagateNullability: Array.Empty<bool>(),
+                argumentsPropagateNullability: Enumerable.Empty<bool>(),
                 method.ReturnType)
             : null;
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteRandomTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteRandomTranslator.cs
@@ -49,14 +49,14 @@ public class SqliteRandomTranslator : IMethodCallTranslator
                     _sqlExpressionFactory.Divide(
                         _sqlExpressionFactory.Function(
                             "random",
-                            Array.Empty<SqlExpression>(),
+                            Enumerable.Empty<SqlExpression>(),
                             nullable: false,
-                            argumentsPropagateNullability: Array.Empty<bool>(),
+                            argumentsPropagateNullability: Enumerable.Empty<bool>(),
                             method.ReturnType),
                         _sqlExpressionFactory.Constant(9223372036854780000.0))
                 },
                 nullable: false,
-                argumentsPropagateNullability: Array.Empty<bool>(),
+                argumentsPropagateNullability: Enumerable.Empty<bool>(),
                 method.ReturnType)
             : null;
 }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -482,7 +482,7 @@ public class DbContext :
     /// <remarks>
     ///     <para>
     ///         If a model is explicitly set on the options for this context (via <see cref="DbContextOptionsBuilder.UseModel(IModel)" />)
-    ///         then this method will not be run.
+    ///         then this method will not be run. However, it will still run when creating a compiled model.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-pre-convention">Pre-convention model building in EF Core</see> for more information and
@@ -504,7 +504,7 @@ public class DbContext :
     /// <remarks>
     ///     <para>
     ///         If a model is explicitly set on the options for this context (via <see cref="DbContextOptionsBuilder.UseModel(IModel)" />)
-    ///         then this method will not be run.
+    ///         then this method will not be run. However, it will still run when creating a compiled model.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and

--- a/src/EFCore/Metadata/IReadOnlyEntityType.cs
+++ b/src/EFCore/Metadata/IReadOnlyEntityType.cs
@@ -159,7 +159,17 @@ public interface IReadOnlyEntityType : IReadOnlyTypeBase
     {
         Check.NotNull(derivedType, nameof(derivedType));
 
-        var baseType = derivedType;
+        if (derivedType == this)
+        {
+            return true;
+        }
+
+        if (!GetDirectlyDerivedTypes().Any())
+        {
+            return false;
+        }
+
+        var baseType = derivedType.BaseType;
         while (baseType != null)
         {
             if (baseType == this)

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -458,11 +458,11 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IReadOnlyCollection<EntityType> GetEntityTypes(string name)
+    public virtual IEnumerable<EntityType> GetEntityTypes(string name)
     {
         var entityType = FindEntityType(name);
         return entityType == null
-            ? Array.Empty<EntityType>()
+            ? Enumerable.Empty<EntityType>()
             : new[] { entityType };
     }
 

--- a/src/EFCore/Metadata/RuntimeModel.cs
+++ b/src/EFCore/Metadata/RuntimeModel.cs
@@ -126,7 +126,7 @@ public class RuntimeModel : AnnotatableBase, IRuntimeModel
     {
         var entityType = FindEntityType(GetDisplayName(type));
         var result = entityType == null
-            ? Array.Empty<RuntimeEntityType>()
+            ? Enumerable.Empty<RuntimeEntityType>()
             : new[] { entityType };
 
         return _sharedTypes.TryGetValue(type, out var sharedTypes)

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -980,7 +980,9 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
 
     public enum Grade
     {
+#pragma warning disable SA1602 // Enumeration items should be documented
         A, B, C, D, F
+#pragma warning restore SA1602 // Enumeration items should be documented
     }
 
     public class Enrollment


### PR DESCRIPTION
Return null name for constraints on entity types not mapped to a table
Change calls from Array.Empty to Enumerable.Empty

Fixes #24219