### PR TITLE
Remove DisableImplicitNamespaceImports config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,10 +35,6 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn.Replace(';1591', ''))</NoWarn>
   </PropertyGroup>
-  
-  <PropertyGroup>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />


### PR DESCRIPTION
Remove `DisableImplicitNamespaceImports` config, since .NET 6 RC 1 `ImplicitUsings` is used and disabled by default