### PR TITLE
Stop deleting orphans for optional relationships configured for cascade deletes

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1250,7 +1250,8 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
                 && valueType == CurrentValueType.Normal
                 && (!asProperty.ClrType.IsNullableType()
                     || asProperty.GetContainingForeignKeys().Any(
-                        fk => (fk.DeleteBehavior == DeleteBehavior.Cascade
+                        fk => fk.IsRequired
+                                && (fk.DeleteBehavior == DeleteBehavior.Cascade
                                 || fk.DeleteBehavior == DeleteBehavior.ClientCascade)
                             && fk.DeclaringEntityType.IsAssignableFrom(EntityType))))
             {


### PR DESCRIPTION
Fixes #27217
Fixes #27218

The 5.0/6.0 behavior here is:
- Orphans are deleted if the relationship is severed by navigation property
- Orphans are not deleted if the relationship is severed by setting the FK to null

This change means orphans are not deleted in either case. The change that causes this to happen is to not set a conceptual null for a nullable FK property. Deletion can still be forced by explicitly forcing a conceptual null or just by setting the dependent state explicitly to Deleted.
