### PR TITLE
Attribute for configuring composite primary keys

### DIFF
--- a/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
+++ b/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
@@ -30,7 +30,7 @@ public sealed class PrimaryKeyAttribute : Attribute
     }
 
     /// <summary>
-    ///     The properties which constitute the index, in order.
+    ///     The properties which constitute the primary key, in order.
     /// </summary>
     public IReadOnlyList<string> PropertyNames { get; }
 }

--- a/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
+++ b/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore;
 public sealed class PrimaryKeyAttribute : Attribute
 {
     /// <summary>
-    ///     Initializes a new instance of the <see cref="IndexAttribute" /> class.
+    ///     Initializes a new instance of the <see cref="PrimaryKeyAttribute" /> class.
     /// </summary>
     /// <param name="propertyNames">The properties which constitute the index, in order (there must be at least one).</param>
     public PrimaryKeyAttribute(params string[] propertyNames)

--- a/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
+++ b/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore;
@@ -11,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore;
 /// <remarks>
 ///     <para>
 ///         This attribute can be used for both keys made up of a
-///         single property, and for composite keys made up of multiple properties. `System.ComponentModel.DataAnnotations.KeyAttribute`
+///         single property, and for composite keys made up of multiple properties. <see cref="KeyAttribute" />
 ///         can be used instead for single-property keys, in which case the behavior is identical. If both attributes are used, then
 ///         this attribute takes precedence.
 ///     </para>

--- a/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
+++ b/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
@@ -20,7 +20,7 @@ public sealed class PrimaryKeyAttribute : Attribute
     /// <summary>
     ///     Initializes a new instance of the <see cref="PrimaryKeyAttribute" /> class.
     /// </summary>
-    /// <param name="propertyNames">The properties which constitute the index, in order (there must be at least one).</param>
+    /// <param name="propertyNames">The properties which constitute the primary key, in order (there must be at least one).</param>
     public PrimaryKeyAttribute(params string[] propertyNames)
     {
         Check.NotEmpty(propertyNames, nameof(propertyNames));

--- a/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
+++ b/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
@@ -6,13 +6,19 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
-///     Specifies a primary key for the entity type mapped to this CLR type. This attribute can be used for both keys made up of a
-///     single property, and for composite keys made up of multiple properties. `System.ComponentModel.DataAnnotations.KeyAttribute`
-///     can be used instead for single-property keys, in which case the behavior is identical. If both attributes are used, then
-///     this attribute takes precedence.
+///     Specifies a primary key for the entity type mapped to this CLR type.
 /// </summary>
 /// <remarks>
-///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+///     <para>
+///         This attribute can be used for both keys made up of a
+///         single property, and for composite keys made up of multiple properties. `System.ComponentModel.DataAnnotations.KeyAttribute`
+///         can be used instead for single-property keys, in which case the behavior is identical. If both attributes are used, then
+///         this attribute takes precedence.
+///     </para>
+///     <para>
+///         See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and
+///         examples.
+///     </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class PrimaryKeyAttribute : Attribute
@@ -20,13 +26,15 @@ public sealed class PrimaryKeyAttribute : Attribute
     /// <summary>
     ///     Initializes a new instance of the <see cref="PrimaryKeyAttribute" /> class.
     /// </summary>
-    /// <param name="propertyNames">The properties which constitute the primary key, in order (there must be at least one).</param>
-    public PrimaryKeyAttribute(params string[] propertyNames)
+    /// <param name="propertyName">The first (or only) property in the primary key.</param>
+    /// <param name="additionalPropertyNames">The additional properties which constitute the primary key, if any, in order.</param>
+    public PrimaryKeyAttribute(string propertyName, params string[] additionalPropertyNames)
     {
-        Check.NotEmpty(propertyNames, nameof(propertyNames));
-        Check.HasNoEmptyElements(propertyNames, nameof(propertyNames));
+        Check.NotEmpty(propertyName, nameof(propertyName));
+        Check.HasNoEmptyElements(additionalPropertyNames, nameof(additionalPropertyNames));
 
-        PropertyNames = propertyNames.ToList();
+        PropertyNames = new List<string> { propertyName };
+        ((List<string>)PropertyNames).AddRange(additionalPropertyNames);
     }
 
     /// <summary>

--- a/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
+++ b/src/EFCore.Abstractions/PrimaryKeyAttribute.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Specifies a primary key for the entity type mapped to this CLR type. This attribute can be used for both keys made up of a
+///     single property, and for composite keys made up of multiple properties. `System.ComponentModel.DataAnnotations.KeyAttribute`
+///     can be used instead for single-property keys, in which case the behavior is identical. If both attributes are used, then
+///     this attribute takes precedence.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class PrimaryKeyAttribute : Attribute
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="IndexAttribute" /> class.
+    /// </summary>
+    /// <param name="propertyNames">The properties which constitute the index, in order (there must be at least one).</param>
+    public PrimaryKeyAttribute(params string[] propertyNames)
+    {
+        Check.NotEmpty(propertyNames, nameof(propertyNames));
+        Check.HasNoEmptyElements(propertyNames, nameof(propertyNames));
+
+        PropertyNames = propertyNames.ToList();
+    }
+
+    /// <summary>
+    ///     The properties which constitute the index, in order.
+    /// </summary>
+    public IReadOnlyList<string> PropertyNames { get; }
+}

--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -231,6 +231,18 @@ public interface IConventionEntityTypeBuilder : IConventionAnnotatableBuilder
     IConventionKeyBuilder? PrimaryKey(IReadOnlyList<IConventionProperty>? properties, bool fromDataAnnotation = false);
 
     /// <summary>
+    ///     Sets the properties that make up the primary key for this entity type.
+    /// </summary>
+    /// <param name="propertyNames">The names of the properties that make up the primary key.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>An object that can be used to configure the primary key.</returns>
+    /// <returns>
+    ///     An object that can be used to configure the primary key if it was set on the entity type,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    IConventionKeyBuilder? PrimaryKey(IReadOnlyList<string> propertyNames, bool fromDataAnnotation = false);
+
+    /// <summary>
     ///     Returns a value indicating whether the given properties can be set as the primary key for this entity type.
     /// </summary>
     /// <param name="properties">The properties that make up the primary key.</param>

--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -240,7 +240,7 @@ public interface IConventionEntityTypeBuilder : IConventionAnnotatableBuilder
     ///     An object that can be used to configure the primary key if it was set on the entity type,
     ///     <see langword="null" /> otherwise.
     /// </returns>
-    IConventionKeyBuilder? PrimaryKey(IReadOnlyList<string> propertyNames, bool fromDataAnnotation = false);
+    IConventionKeyBuilder? PrimaryKey(IReadOnlyList<string>? propertyNames, bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns a value indicating whether the given properties can be set as the primary key for this entity type.

--- a/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
@@ -100,30 +100,7 @@ public class IndexAttributeConvention : IEntityTypeAddedConvention, IEntityTypeB
                 }
                 catch (InvalidOperationException exception)
                 {
-                    foreach (var propertyName in indexAttribute.PropertyNames)
-                    {
-                        var property = entityType.FindProperty(propertyName);
-                        if (property == null)
-                        {
-                            if (indexAttribute.Name == null)
-                            {
-                                throw new InvalidOperationException(
-                                    CoreStrings.UnnamedIndexDefinedOnNonExistentProperty(
-                                        entityType.DisplayName(),
-                                        indexAttribute.PropertyNames.Format(),
-                                        propertyName),
-                                    exception);
-                            }
-
-                            throw new InvalidOperationException(
-                                CoreStrings.NamedIndexDefinedOnNonExistentProperty(
-                                    indexAttribute.Name,
-                                    entityType.DisplayName(),
-                                    indexAttribute.PropertyNames.Format(),
-                                    propertyName),
-                                exception);
-                        }
-                    }
+                    CheckMissingProperties(entityType, indexAttribute, exception);
 
                     throw;
                 }
@@ -133,27 +110,7 @@ public class IndexAttributeConvention : IEntityTypeAddedConvention, IEntityTypeB
             {
                 if (shouldThrow)
                 {
-                    foreach (var propertyName in indexAttribute.PropertyNames)
-                    {
-                        if (entityType.Builder.IsIgnored(propertyName, fromDataAnnotation: true))
-                        {
-                            if (indexAttribute.Name == null)
-                            {
-                                throw new InvalidOperationException(
-                                    CoreStrings.UnnamedIndexDefinedOnIgnoredProperty(
-                                        entityType.DisplayName(),
-                                        indexAttribute.PropertyNames.Format(),
-                                        propertyName));
-                            }
-
-                            throw new InvalidOperationException(
-                                CoreStrings.NamedIndexDefinedOnIgnoredProperty(
-                                    indexAttribute.Name,
-                                    entityType.DisplayName(),
-                                    indexAttribute.PropertyNames.Format(),
-                                    propertyName));
-                        }
-                    }
+                    CheckIgnoredProperties(entityType, indexAttribute);
                 }
             }
             else
@@ -167,6 +124,62 @@ public class IndexAttributeConvention : IEntityTypeAddedConvention, IEntityTypeB
                 {
                     indexBuilder.IsDescending(indexAttribute.IsDescending, fromDataAnnotation: true);
                 }
+            }
+        }
+    }
+
+    private static void CheckIgnoredProperties(IConventionEntityType entityType, IndexAttribute indexAttribute)
+    {
+        foreach (var propertyName in indexAttribute.PropertyNames)
+        {
+            if (entityType.Builder.IsIgnored(propertyName, fromDataAnnotation: true))
+            {
+                if (indexAttribute.Name == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.UnnamedIndexDefinedOnIgnoredProperty(
+                            entityType.DisplayName(),
+                            indexAttribute.PropertyNames.Format(),
+                            propertyName));
+                }
+
+                throw new InvalidOperationException(
+                    CoreStrings.NamedIndexDefinedOnIgnoredProperty(
+                        indexAttribute.Name,
+                        entityType.DisplayName(),
+                        indexAttribute.PropertyNames.Format(),
+                        propertyName));
+            }
+        }
+    }
+
+    private static void CheckMissingProperties(
+        IConventionEntityType entityType,
+        IndexAttribute indexAttribute,
+        InvalidOperationException exception)
+    {
+        foreach (var propertyName in indexAttribute.PropertyNames)
+        {
+            var property = entityType.FindProperty(propertyName);
+            if (property == null)
+            {
+                if (indexAttribute.Name == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.UnnamedIndexDefinedOnNonExistentProperty(
+                            entityType.DisplayName(),
+                            indexAttribute.PropertyNames.Format(),
+                            propertyName),
+                        exception);
+                }
+
+                throw new InvalidOperationException(
+                    CoreStrings.NamedIndexDefinedOnNonExistentProperty(
+                        indexAttribute.Name,
+                        entityType.DisplayName(),
+                        indexAttribute.PropertyNames.Format(),
+                        propertyName),
+                    exception);
             }
         }
     }

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -89,8 +89,8 @@ public class ProviderConventionSetBuilder : IProviderConventionSetBuilder
 
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(propertyDiscoveryConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(servicePropertyDiscoveryConvention);
-        conventionSet.EntityTypeBaseTypeChangedConventions.Add(keyDiscoveryConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(keyAttributeConvention);
+        conventionSet.EntityTypeBaseTypeChangedConventions.Add(keyDiscoveryConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(indexAttributeConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(inversePropertyAttributeConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(relationshipDiscoveryConvention);

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -60,6 +60,7 @@ public class ProviderConventionSetBuilder : IProviderConventionSetBuilder
         var foreignKeyAttributeConvention = new ForeignKeyAttributeConvention(Dependencies);
         var relationshipDiscoveryConvention = new RelationshipDiscoveryConvention(Dependencies);
         var servicePropertyDiscoveryConvention = new ServicePropertyDiscoveryConvention(Dependencies);
+        var keyAttributeConvention = new KeyAttributeConvention(Dependencies);
         var indexAttributeConvention = new IndexAttributeConvention(Dependencies);
         var baseTypeDiscoveryConvention = new BaseTypeDiscoveryConvention(Dependencies);
         conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention(Dependencies));
@@ -70,6 +71,7 @@ public class ProviderConventionSetBuilder : IProviderConventionSetBuilder
         conventionSet.EntityTypeAddedConventions.Add(baseTypeDiscoveryConvention);
         conventionSet.EntityTypeAddedConventions.Add(propertyDiscoveryConvention);
         conventionSet.EntityTypeAddedConventions.Add(servicePropertyDiscoveryConvention);
+        conventionSet.EntityTypeAddedConventions.Add(keyAttributeConvention);
         conventionSet.EntityTypeAddedConventions.Add(keyDiscoveryConvention);
         conventionSet.EntityTypeAddedConventions.Add(indexAttributeConvention);
         conventionSet.EntityTypeAddedConventions.Add(inversePropertyAttributeConvention);
@@ -88,6 +90,7 @@ public class ProviderConventionSetBuilder : IProviderConventionSetBuilder
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(propertyDiscoveryConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(servicePropertyDiscoveryConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(keyDiscoveryConvention);
+        conventionSet.EntityTypeBaseTypeChangedConventions.Add(keyAttributeConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(indexAttributeConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(inversePropertyAttributeConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(relationshipDiscoveryConvention);
@@ -102,7 +105,6 @@ public class ProviderConventionSetBuilder : IProviderConventionSetBuilder
         conventionSet.EntityTypeMemberIgnoredConventions.Add(keyDiscoveryConvention);
         conventionSet.EntityTypeMemberIgnoredConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
-        var keyAttributeConvention = new KeyAttributeConvention(Dependencies);
         var backingFieldConvention = new BackingFieldConvention(Dependencies);
         var concurrencyCheckAttributeConvention = new ConcurrencyCheckAttributeConvention(Dependencies);
         var databaseGeneratedAttributeConvention = new DatabaseGeneratedAttributeConvention(Dependencies);

--- a/src/EFCore/Metadata/Conventions/KeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyAttributeConvention.cs
@@ -7,12 +7,17 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
-///     A convention that configures the entity type key based on the <see cref="KeyAttribute" /> specified on a property.
+///     A convention that configures the entity type key based on the <see cref="KeyAttribute" /> specified on a property or
+///     <see cref="PrimaryKeyAttribute"/> specified on a CLR type.
 /// </summary>
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.
 /// </remarks>
-public class KeyAttributeConvention : PropertyAttributeConventionBase<KeyAttribute>, IModelFinalizingConvention
+public class KeyAttributeConvention
+    : PropertyAttributeConventionBase<KeyAttribute>,
+        IModelFinalizingConvention,
+        IEntityTypeAddedConvention,
+        IEntityTypeBaseTypeChangedConvention
 {
     /// <summary>
     ///     Creates a new instance of <see cref="KeyAttributeConvention" />.
@@ -23,13 +28,28 @@ public class KeyAttributeConvention : PropertyAttributeConventionBase<KeyAttribu
     {
     }
 
-    /// <summary>
-    ///     Called after a property is added to the entity type with an attribute on the associated CLR property or field.
-    /// </summary>
-    /// <param name="propertyBuilder">The builder for the property.</param>
-    /// <param name="attribute">The attribute.</param>
-    /// <param name="clrMember">The member that has the attribute.</param>
-    /// <param name="context">Additional information associated with convention execution.</param>
+    /// <inheritdoc />
+    public virtual void ProcessEntityTypeAdded(
+        IConventionEntityTypeBuilder entityTypeBuilder,
+        IConventionContext<IConventionEntityTypeBuilder> context)
+        => CheckAttributesAndEnsurePrimaryKey((EntityType)entityTypeBuilder.Metadata, null, false);
+
+    /// <inheritdoc />
+    public virtual void ProcessEntityTypeBaseTypeChanged(
+        IConventionEntityTypeBuilder entityTypeBuilder,
+        IConventionEntityType? newBaseType,
+        IConventionEntityType? oldBaseType,
+        IConventionContext<IConventionEntityType> context)
+    {
+        if (oldBaseType == null)
+        {
+            return;
+        }
+
+        CheckAttributesAndEnsurePrimaryKey((EntityType)entityTypeBuilder.Metadata, null, false);
+    }
+
+    /// <inheritdoc />
     protected override void ProcessPropertyAdded(
         IConventionPropertyBuilder propertyBuilder,
         KeyAttribute attribute,
@@ -42,8 +62,7 @@ public class KeyAttributeConvention : PropertyAttributeConventionBase<KeyAttribu
             switch (entityType.GetIsKeylessConfigurationSource())
             {
                 case ConfigurationSource.DataAnnotation:
-                    Dependencies.Logger
-                        .ConflictingKeylessAndKeyAttributesWarning(propertyBuilder.Metadata);
+                    Dependencies.Logger.ConflictingKeylessAndKeyAttributesWarning(propertyBuilder.Metadata);
                     return;
 
                 case ConfigurationSource.Explicit:
@@ -52,39 +71,49 @@ public class KeyAttributeConvention : PropertyAttributeConventionBase<KeyAttribu
             }
         }
 
+        CheckAttributesAndEnsurePrimaryKey(
+            (EntityType)propertyBuilder.Metadata.DeclaringEntityType,
+            propertyBuilder,
+            shouldThrow: false);
+    }
+
+    private bool CheckAttributesAndEnsurePrimaryKey(
+        EntityType entityType,
+        IConventionPropertyBuilder? propertyBuilder,
+        bool shouldThrow)
+    {
         if (entityType.BaseType != null)
         {
-            return;
+            return false;
         }
 
-        if (entityType.IsKeyless
-            && entityType.GetIsKeylessConfigurationSource().Overrides(ConfigurationSource.DataAnnotation))
-        {
-            // TODO: Log a warning that KeyAttribute is being ignored. See issue#20014
-            // This code path will also be hit when entity is marked as Keyless explicitly
-            return;
-        }
+        var primaryKeyAttributeExists = CheckPrimaryKeyAttributesAndEnsurePrimaryKey(entityType, shouldThrow);
+        var currentKey = entityType.FindPrimaryKey();
 
-        var entityTypeBuilder = entityType.Builder;
-        var currentKey = entityTypeBuilder.Metadata.FindPrimaryKey();
-        var properties = new List<string> { propertyBuilder.Metadata.Name };
-
-        if (currentKey != null
-            && entityType.GetPrimaryKeyConfigurationSource() == ConfigurationSource.DataAnnotation)
+        if (!primaryKeyAttributeExists
+            && propertyBuilder != null)
         {
-            properties.AddRange(
-                currentKey.Properties
-                    .Where(p => !p.Name.Equals(propertyBuilder.Metadata.Name, StringComparison.OrdinalIgnoreCase))
-                    .Select(p => p.Name));
-            if (properties.Count > 1)
+            var properties = new List<string> { propertyBuilder.Metadata.Name };
+
+            if (currentKey != null
+                && entityType.GetPrimaryKeyConfigurationSource() == ConfigurationSource.DataAnnotation)
             {
-                properties.Sort(StringComparer.OrdinalIgnoreCase);
-                entityTypeBuilder.HasNoKey(currentKey, fromDataAnnotation: true);
+                properties.AddRange(
+                    currentKey.Properties
+                        .Where(p => !p.Name.Equals(propertyBuilder.Metadata.Name, StringComparison.OrdinalIgnoreCase))
+                        .Select(p => p.Name));
+
+                if (properties.Count > 1)
+                {
+                    properties.Sort(StringComparer.OrdinalIgnoreCase);
+                    entityType.Builder.HasNoKey(currentKey, ConfigurationSource.DataAnnotation);
+                }
             }
+
+            entityType.Builder.PrimaryKey(properties, ConfigurationSource.DataAnnotation);
         }
 
-        entityTypeBuilder.PrimaryKey(
-            entityTypeBuilder.GetOrCreateProperties(properties, fromDataAnnotation: true), fromDataAnnotation: true);
+        return primaryKeyAttributeExists;
     }
 
     /// <inheritdoc />
@@ -95,17 +124,29 @@ public class KeyAttributeConvention : PropertyAttributeConventionBase<KeyAttribu
         var entityTypes = modelBuilder.Metadata.GetEntityTypes();
         foreach (var entityType in entityTypes)
         {
+            var primaryKeyAttributeExits = CheckAttributesAndEnsurePrimaryKey((EntityType)entityType, null, true);
+
             if (entityType.BaseType == null)
             {
-                var currentPrimaryKey = entityType.FindPrimaryKey();
-                if (currentPrimaryKey?.Properties.Count > 1
-                    && entityType.GetPrimaryKeyConfigurationSource() == ConfigurationSource.DataAnnotation)
+                if (!primaryKeyAttributeExits)
                 {
-                    throw new InvalidOperationException(CoreStrings.CompositePKWithDataAnnotation(entityType.DisplayName()));
+                    var currentPrimaryKey = entityType.FindPrimaryKey();
+                    if (currentPrimaryKey?.Properties.Count > 1
+                        && entityType.GetPrimaryKeyConfigurationSource() == ConfigurationSource.DataAnnotation)
+                    {
+                        throw new InvalidOperationException(CoreStrings.CompositePKWithDataAnnotation(entityType.DisplayName()));
+                    }
                 }
             }
             else
             {
+                if (Attribute.IsDefined(entityType.ClrType, typeof(PrimaryKeyAttribute), inherit: false))
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.PrimaryKeyAttributeOnDerivedEntity(
+                            entityType.DisplayName(), entityType.GetRootType().DisplayName()));
+                }
+
                 foreach (var declaredProperty in entityType.GetDeclaredProperties())
                 {
                     var memberInfo = declaredProperty.GetIdentifyingMemberInfo();
@@ -118,6 +159,99 @@ public class KeyAttributeConvention : PropertyAttributeConventionBase<KeyAttribu
                                 entityType.DisplayName(), declaredProperty.Name, entityType.GetRootType().DisplayName()));
                     }
                 }
+            }
+        }
+    }
+
+    private static bool CheckPrimaryKeyAttributesAndEnsurePrimaryKey(
+        IConventionEntityType entityType,
+        bool shouldThrow)
+    {
+        var primaryKeyAttribute = entityType.ClrType.GetCustomAttributes<PrimaryKeyAttribute>(true).FirstOrDefault();
+        if (primaryKeyAttribute == null)
+        {
+            return false;
+        }
+
+        if (entityType.ClrType.GetCustomAttributes<KeylessAttribute>(true).Any())
+        {
+            throw new InvalidOperationException(
+                CoreStrings.ConflictingKeylessAndPrimaryKeyAttributes(entityType.DisplayName()));
+        }
+
+        IConventionKeyBuilder? keyBuilder;
+        if (!shouldThrow)
+        {
+            var keyProperties = new List<IConventionProperty>();
+            foreach (var propertyName in primaryKeyAttribute.PropertyNames)
+            {
+                var property = entityType.FindProperty(propertyName);
+                if (property == null)
+                {
+                    return true;
+                }
+
+                keyProperties.Add(property);
+            }
+
+            keyBuilder = entityType.Builder.PrimaryKey(keyProperties, fromDataAnnotation: true);
+        }
+        else
+        {
+            try
+            {
+                // Using the PrimaryKey(propertyNames) overload gives us a chance to create a missing property
+                // e.g. if the CLR property existed but was non-public.
+                keyBuilder = entityType.Builder.PrimaryKey(primaryKeyAttribute.PropertyNames, fromDataAnnotation: true);
+            }
+            catch (InvalidOperationException exception)
+            {
+                CheckMissingProperties(primaryKeyAttribute, entityType, exception);
+
+                throw;
+            }
+        }
+
+        if (keyBuilder == null)
+        {
+            CheckIgnoredProperties(primaryKeyAttribute, entityType);
+        }
+
+        return true;
+    }
+
+    private static void CheckIgnoredProperties(
+        PrimaryKeyAttribute primaryKeyAttribute,
+        IConventionEntityType entityType)
+    {
+        foreach (var propertyName in primaryKeyAttribute.PropertyNames)
+        {
+            if (entityType.Builder.IsIgnored(propertyName, fromDataAnnotation: true))
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.PrimaryKeyDefinedOnIgnoredProperty(
+                        entityType.DisplayName(),
+                        propertyName));
+            }
+        }
+    }
+
+    private static void CheckMissingProperties(
+        PrimaryKeyAttribute primaryKeyAttribute,
+        IConventionEntityType entityType,
+        InvalidOperationException innerException)
+    {
+        foreach (var propertyName in primaryKeyAttribute.PropertyNames)
+        {
+            var property = entityType.FindProperty(propertyName);
+            if (property == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.PrimaryKeyDefinedOnNonExistentProperty(
+                        entityType.DisplayName(),
+                        primaryKeyAttribute.PropertyNames.Format(),
+                        propertyName),
+                    innerException);
             }
         }
     }

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -33,7 +33,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     /// </summary>
     [DebuggerStepThrough]
     IConventionKeyBuilder? IConventionEntityTypeBuilder.PrimaryKey(
-        IReadOnlyList<string> propertyNames,
+        IReadOnlyList<string>? propertyNames,
         bool fromDataAnnotation)
         => PrimaryKey(
             propertyNames,

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -31,6 +31,20 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DebuggerStepThrough]
+    IConventionKeyBuilder? IConventionEntityTypeBuilder.PrimaryKey(
+        IReadOnlyList<string> propertyNames,
+        bool fromDataAnnotation)
+        => PrimaryKey(
+            propertyNames,
+            fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual InternalKeyBuilder? PrimaryKey(
         IReadOnlyList<string>? propertyNames,
         ConfigurationSource configurationSource)

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -433,7 +433,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType);
 
         /// <summary>
-        ///     The entity type '{entityType}' has multiple properties with the [Key] attribute. Composite primary keys configured by placing the [PrimaryKey] on the entity type class, or by using 'HasKey' in 'OnModelCreating'.
+        ///     The entity type '{entityType}' has multiple properties with the [Key] attribute. Composite primary keys configured by placing the [PrimaryKey] attribute on the entity type class, or by using 'HasKey' in 'OnModelCreating'.
         /// </summary>
         public static string CompositePKWithDataAnnotation(object? entityType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -433,7 +433,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType);
 
         /// <summary>
-        ///     The entity type '{entityType}' has multiple properties with the [Key] attribute. Composite primary keys can only be set using 'HasKey' in 'OnModelCreating'.
+        ///     The entity type '{entityType}' has multiple properties with the [Key] attribute. Composite primary keys configured by placing the [PrimaryKey] on the entity type class, or by using 'HasKey' in 'OnModelCreating'.
         /// </summary>
         public static string CompositePKWithDataAnnotation(object? entityType)
             => string.Format(
@@ -461,6 +461,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("ConflictingForeignKeyAttributes", nameof(propertyList), nameof(entityType), nameof(principalEntityType)),
                 propertyList, entityType, principalEntityType);
+
+        /// <summary>
+        ///     The entity type '{entity}' has both [Keyless] and [PrimaryKey] attributes; one must be removed.
+        /// </summary>
+        public static string ConflictingKeylessAndPrimaryKeyAttributes(object? entity)
+            => string.Format(
+                GetString("ConflictingKeylessAndPrimaryKeyAttributes", nameof(entity)),
+                entity);
 
         /// <summary>
         ///     The property or navigation '{member}' cannot be added to the entity type '{entityType}' because a property or navigation with the same name already exists on entity type '{conflictingEntityType}'.
@@ -1988,6 +1996,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("PrincipalOwnedType", nameof(referencingEntityTypeOrNavigation), nameof(referencedEntityTypeOrNavigation), nameof(ownedType)),
                 referencingEntityTypeOrNavigation, referencedEntityTypeOrNavigation, ownedType);
+
+        /// <summary>
+        ///     The derived type '{derivedType}' cannot have the [PrimaryKey] attribute since primary keys may only be declared on the root type. Move the attribute to '{rootType}', or remove '{rootType}' from the model by using [NotMapped] attribute or calling 'EntityTypeBuilder.Ignore' on the base type in 'OnModelCreating'.
+        /// </summary>
+        public static string PrimaryKeyAttributeOnDerivedEntity(object? derivedType, object? rootType)
+            => string.Format(
+                GetString("PrimaryKeyAttributeOnDerivedEntity", nameof(derivedType), nameof(rootType)),
+                derivedType, rootType);
+
+        /// <summary>
+        ///     The [PrimaryKey] attribute on the entity type '{entityType}' is invalid because the property '{propertyName}' was marked as unmapped by [NotMapped] attribute or 'Ignore()' in 'OnModelCreating'. A primary key cannot use unmapped properties.
+        /// </summary>
+        public static string PrimaryKeyDefinedOnIgnoredProperty(object? entityType, object? propertyName)
+            => string.Format(
+                GetString("PrimaryKeyDefinedOnIgnoredProperty", nameof(entityType), nameof(propertyName)),
+                entityType, propertyName);
+
+        /// <summary>
+        ///     The [PrimaryKey] attribute on the entity type '{entityType}' references properties {properties}, but no property with name '{propertyName}' exists on that entity type or any of its base types.
+        /// </summary>
+        public static string PrimaryKeyDefinedOnNonExistentProperty(object? entityType, object? properties, object? propertyName)
+            => string.Format(
+                GetString("PrimaryKeyDefinedOnNonExistentProperty", nameof(entityType), nameof(properties), nameof(propertyName)),
+                entityType, properties, propertyName);
 
         /// <summary>
         ///     '{property}' cannot be used as a property on entity type '{entityType}' because it is configured as a navigation.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -271,7 +271,7 @@
     <value>There are multiple properties with the [ForeignKey] attribute pointing to navigation '{1_entityType}.{0_navigation}'. To define a composite foreign key using data annotations, use the [ForeignKey] attribute on the navigation.</value>
   </data>
   <data name="CompositePKWithDataAnnotation" xml:space="preserve">
-    <value>The entity type '{entityType}' has multiple properties with the [Key] attribute. Composite primary keys can only be set using 'HasKey' in 'OnModelCreating'.</value>
+    <value>The entity type '{entityType}' has multiple properties with the [Key] attribute. Composite primary keys configured by placing the [PrimaryKey] on the entity type class, or by using 'HasKey' in 'OnModelCreating'.</value>
   </data>
   <data name="ConcurrentMethodInvocation" xml:space="preserve">
     <value>A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext. For more information on how to avoid threading issues with DbContext, see https://go.microsoft.com/fwlink/?linkid=2097913.</value>
@@ -281,6 +281,9 @@
   </data>
   <data name="ConflictingForeignKeyAttributes" xml:space="preserve">
     <value>There are multiple [ForeignKey] attributes which are pointing to same set of properties '{propertyList}' on entity type '{entityType}' and targeting the principal entity type '{principalEntityType}'.</value>
+  </data>
+  <data name="ConflictingKeylessAndPrimaryKeyAttributes" xml:space="preserve">
+    <value>The entity type '{entity}' has both [Keyless] and [PrimaryKey] attributes; one must be removed.</value>
   </data>
   <data name="ConflictingPropertyOrNavigation" xml:space="preserve">
     <value>The property or navigation '{member}' cannot be added to the entity type '{entityType}' because a property or navigation with the same name already exists on entity type '{conflictingEntityType}'.</value>
@@ -1162,6 +1165,15 @@
   </data>
   <data name="PrincipalOwnedType" xml:space="preserve">
     <value>The relationship from '{referencingEntityTypeOrNavigation}' to '{referencedEntityTypeOrNavigation}' is not supported because the owned entity type '{ownedType}' cannot be on the principal side of a non-ownership relationship. Remove the relationship or configure the foreign key to be on '{ownedType}'.</value>
+  </data>
+  <data name="PrimaryKeyAttributeOnDerivedEntity" xml:space="preserve">
+    <value>The derived type '{derivedType}' cannot have the [PrimaryKey] attribute since primary keys may only be declared on the root type. Move the attribute to '{rootType}', or remove '{rootType}' from the model by using [NotMapped] attribute or calling 'EntityTypeBuilder.Ignore' on the base type in 'OnModelCreating'.</value>
+  </data>
+  <data name="PrimaryKeyDefinedOnIgnoredProperty" xml:space="preserve">
+    <value>The [PrimaryKey] attribute on the entity type '{entityType}' is invalid because the property '{propertyName}' was marked as unmapped by [NotMapped] attribute or 'Ignore()' in 'OnModelCreating'. A primary key cannot use unmapped properties.</value>
+  </data>
+  <data name="PrimaryKeyDefinedOnNonExistentProperty" xml:space="preserve">
+    <value>The [PrimaryKey] attribute on the entity type '{entityType}' references properties {properties}, but no property with name '{propertyName}' exists on that entity type or any of its base types.</value>
   </data>
   <data name="PropertyCalledOnNavigation" xml:space="preserve">
     <value>'{property}' cannot be used as a property on entity type '{entityType}' because it is configured as a navigation.</value>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -271,7 +271,7 @@
     <value>There are multiple properties with the [ForeignKey] attribute pointing to navigation '{1_entityType}.{0_navigation}'. To define a composite foreign key using data annotations, use the [ForeignKey] attribute on the navigation.</value>
   </data>
   <data name="CompositePKWithDataAnnotation" xml:space="preserve">
-    <value>The entity type '{entityType}' has multiple properties with the [Key] attribute. Composite primary keys configured by placing the [PrimaryKey] on the entity type class, or by using 'HasKey' in 'OnModelCreating'.</value>
+    <value>The entity type '{entityType}' has multiple properties with the [Key] attribute. Composite primary keys configured by placing the [PrimaryKey] attribute on the entity type class, or by using 'HasKey' in 'OnModelCreating'.</value>
   </data>
   <data name="ConcurrentMethodInvocation" xml:space="preserve">
     <value>A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext. For more information on how to avoid threading issues with DbContext, see https://go.microsoft.com/fwlink/?linkid=2097913.</value>

--- a/test/EFCore.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -199,23 +199,9 @@ public class CompositeKeyEndToEndTest
                         b.Property(e => e.Id2).ValueGeneratedOnAdd();
                     });
 
-            modelBuilder.Entity<Unicorn>().HasKey(
-                e => new
-                {
-                    e.Id1,
-                    e.Id2,
-                    e.Id3
-                });
             modelBuilder.Entity<Unicorn>(
                 b =>
                 {
-                    b.HasKey(
-                        e => new
-                        {
-                            e.Id1,
-                            e.Id2,
-                            e.Id3
-                        });
                     b.Property(e => e.Id1).ValueGeneratedOnAdd();
                     b.Property(e => e.Id3).ValueGeneratedOnAdd();
                 });
@@ -240,6 +226,7 @@ public class CompositeKeyEndToEndTest
         public string Name { get; set; }
     }
 
+    [PrimaryKey(nameof(Id1), nameof(Id2), nameof(Id3))]
     private class Unicorn
     {
         public int Id1 { get; set; }

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -1314,6 +1314,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
         public string B { get; set; }
     }
 
+    [PrimaryKey(nameof(Id1), nameof(Id2))]
     private class Root23687
     {
         public int Id1 { get; set; }
@@ -1331,7 +1332,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
                 .UseInMemoryDatabase("23687");
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.Entity<Root23687>().HasKey(e => new { e.Id1, e.Id2 });
+            => modelBuilder.Entity<Root23687>();
     }
 
     #endregion

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -1561,6 +1561,7 @@ public abstract class FieldMappingTestBase<TFixture> : IClassFixture<TFixture>
         }
     }
 
+    [PrimaryKey(nameof(Id))]
     protected class PostWriteOnly : IPostAccessor
     {
         private int _id;
@@ -2073,7 +2074,6 @@ public abstract class FieldMappingTestBase<TFixture> : IClassFixture<TFixture>
                 modelBuilder.Entity<PostWriteOnly>(
                     b =>
                     {
-                        b.HasKey("Id");
                         b.Property("Title");
                         b.Property("BlogId");
                     });

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -3309,6 +3309,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture> : IClassFixture<TFi
         }
     }
 
+    [PrimaryKey("PartnerId", "ProviderId")]
     protected abstract class ProviderContract : NotifyingEntity
     {
         private Partner _partner;

--- a/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -754,6 +754,7 @@ public abstract class WithConstructorsTestBase<TFixture> : IClassFixture<TFixtur
         }
     }
 
+    [PrimaryKey(nameof(_blogId))]
     protected class Blog
     {
         private readonly int _blogId;
@@ -1615,7 +1616,6 @@ public abstract class WithConstructorsTestBase<TFixture> : IClassFixture<TFixtur
             modelBuilder.Entity<Blog>(
                 b =>
                 {
-                    b.HasKey("_blogId");
                     b.Property(e => e.Title);
                 });
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -493,8 +493,6 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
                     b.HasDiscriminator<string>("ProviderId")
                         .HasValue<ProviderContract1>("prov1")
                         .HasValue<ProviderContract2>("prov2");
-
-                    b.HasKey("PartnerId", "ProviderId");
                 });
 
             modelBuilder.Entity<EventDescriptorZ>(

--- a/test/EFCore.Tests/Metadata/Conventions/PrimaryKeyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PrimaryKeyAttributeConventionTest.cs
@@ -55,17 +55,14 @@ public class PrimaryKeyAttributeConventionTest
     }
 
     [ConditionalFact]
-    public void PrimaryKeyAttribute_with_no_property_names_throws()
+    public void PrimaryKeyAttribute_with_null_properties_array_throws()
     {
         var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
 
-        Assert.Equal(
-            AbstractionsStrings.CollectionArgumentIsEmpty("propertyNames"),
-            Assert.Throws<ArgumentException>(
-                () => modelBuilder.Entity<EntityWithInvalidEmptyPrimaryKey>()).Message);
+        Assert.Throws<ArgumentNullException>(() => modelBuilder.Entity<EntityWithInvalidNullAdditionalProperties>());
     }
 
-    [InlineData(typeof(EntityWithInvalidNullPrimaryKeyProperty))]
+    [InlineData(typeof(EntityWithInvalidNullAdditionalProperty))]
     [InlineData(typeof(EntityWithInvalidEmptyPrimaryKeyProperty))]
     [InlineData(typeof(EntityWithInvalidWhiteSpacePrimaryKeyProperty))]
     [ConditionalTheory]
@@ -74,7 +71,7 @@ public class PrimaryKeyAttributeConventionTest
         var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
 
         Assert.Equal(
-            AbstractionsStrings.CollectionArgumentHasEmptyElements("propertyNames"),
+            AbstractionsStrings.CollectionArgumentHasEmptyElements("additionalPropertyNames"),
             Assert.Throws<ArgumentException>(
                 () => modelBuilder.Entity(entityTypeWithInvalidPrimaryKey)).Message);
     }
@@ -254,16 +251,16 @@ public class PrimaryKeyAttributeConventionTest
         public int D { get; set; }
     }
 
-    [PrimaryKey]
-    private class EntityWithInvalidEmptyPrimaryKey
+    [PrimaryKey(nameof(A), null!)]
+    private class EntityWithInvalidNullAdditionalProperties
     {
         public int Id { get; set; }
         public int A { get; set; }
         public int B { get; set; }
     }
 
-    [PrimaryKey(nameof(A), null!)]
-    private class EntityWithInvalidNullPrimaryKeyProperty
+    [PrimaryKey(nameof(A), nameof(B), null!)]
+    private class EntityWithInvalidNullAdditionalProperty
     {
         public int Id { get; set; }
         public int A { get; set; }

--- a/test/EFCore.Tests/Metadata/Conventions/PrimaryKeyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PrimaryKeyAttributeConventionTest.cs
@@ -1,0 +1,349 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+#nullable enable
+
+public class PrimaryKeyAttributeConventionTest
+{
+    [ConditionalFact]
+    public void PrimaryKeyAttribute_overrides_configuration_from_convention()
+    {
+        var modelBuilder = new InternalModelBuilder(new Model());
+
+        var entityBuilder = modelBuilder.Entity(typeof(EntityWithPrimaryKey), ConfigurationSource.Convention)!;
+        entityBuilder.Property("Id", ConfigurationSource.Convention);
+        var propABuilder = entityBuilder.Property("A", ConfigurationSource.Convention)!;
+        var propBBuilder = entityBuilder.Property("B", ConfigurationSource.Convention)!;
+        entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
+
+        var primaryKeyProperties = new List<string> { propABuilder.Metadata.Name, propBBuilder.Metadata.Name };
+        entityBuilder.PrimaryKey(primaryKeyProperties, ConfigurationSource.Convention);
+
+        RunConvention(entityBuilder);
+        RunConvention(modelBuilder);
+
+        var primaryKey = entityBuilder.Metadata.FindPrimaryKey()!;
+        Assert.Same(primaryKey, entityBuilder.Metadata.GetKeys().Single());
+        Assert.Equal(ConfigurationSource.DataAnnotation, primaryKey.GetConfigurationSource());
+        Assert.Collection(
+            primaryKey.Properties,
+            prop0 => Assert.Equal("A", prop0.Name),
+            prop1 => Assert.Equal("B", prop1.Name));
+    }
+
+    [ConditionalFact]
+    public void PrimaryKeyAttribute_can_be_overriden_using_explicit_configuration()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+        var entityBuilder = modelBuilder.Entity<EntityWithPrimaryKey>();
+
+        entityBuilder.HasKey(e => e.A);
+
+        modelBuilder.Model.FinalizeModel();
+
+        var primaryKey = (Key)entityBuilder.Metadata.FindPrimaryKey()!;
+        Assert.Equal(ConfigurationSource.Explicit, primaryKey.GetConfigurationSource());
+        Assert.Collection(
+            primaryKey.Properties,
+            prop0 => Assert.Equal("A", prop0.Name));
+    }
+
+    [ConditionalFact]
+    public void PrimaryKeyAttribute_with_no_property_names_throws()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+        Assert.Equal(
+            AbstractionsStrings.CollectionArgumentIsEmpty("propertyNames"),
+            Assert.Throws<ArgumentException>(
+                () => modelBuilder.Entity<EntityWithInvalidEmptyPrimaryKey>()).Message);
+    }
+
+    [InlineData(typeof(EntityWithInvalidNullPrimaryKeyProperty))]
+    [InlineData(typeof(EntityWithInvalidEmptyPrimaryKeyProperty))]
+    [InlineData(typeof(EntityWithInvalidWhiteSpacePrimaryKeyProperty))]
+    [ConditionalTheory]
+    public void PrimaryKeyAttribute_properties_cannot_include_whitespace(Type entityTypeWithInvalidPrimaryKey)
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+        Assert.Equal(
+            AbstractionsStrings.CollectionArgumentHasEmptyElements("propertyNames"),
+            Assert.Throws<ArgumentException>(
+                () => modelBuilder.Entity(entityTypeWithInvalidPrimaryKey)).Message);
+    }
+
+    [ConditionalFact]
+    public void PrimaryKeyAttribute_can_be_inherited_from_base_entity_type()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+        var entityBuilder = modelBuilder.Entity<EntityWithPrimaryKeyFromBaseType>();
+        modelBuilder.Model.FinalizeModel();
+
+        // assert that the base type is not part of the model
+        Assert.Empty(
+            modelBuilder.Model.GetEntityTypes()
+                .Where(e => e.ClrType == typeof(BaseUnmappedEntityWithPrimaryKey)));
+
+        // assert that we see the primaryKey anyway
+        var primaryKey = (Key)entityBuilder.Metadata.FindPrimaryKey()!;
+        Assert.Equal(ConfigurationSource.DataAnnotation, primaryKey.GetConfigurationSource());
+        Assert.Collection(
+            primaryKey.Properties,
+            prop0 => Assert.Equal("A", prop0.Name),
+            prop1 => Assert.Equal("B", prop1.Name));
+    }
+
+    [ConditionalFact]
+    public virtual void PrimaryKeyAttribute_on_ignored_property_causes_error()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+        modelBuilder.Entity<EntityPrimaryKeyWithIgnoredProperty>();
+
+        Assert.Equal(
+            CoreStrings.PrimaryKeyDefinedOnIgnoredProperty(nameof(EntityPrimaryKeyWithIgnoredProperty), "B"),
+            Assert.Throws<InvalidOperationException>(
+                () => modelBuilder.Model.FinalizeModel()).Message);
+    }
+
+    [ConditionalFact]
+    public virtual void PrimaryKeyAttribute_with_non_existent_property_causes_error()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+        modelBuilder.Entity<EntityPrimaryKeyWithNonExistentProperty>();
+
+        Assert.Equal(
+            CoreStrings.PrimaryKeyDefinedOnNonExistentProperty(
+                nameof(EntityPrimaryKeyWithNonExistentProperty),
+                "{'A', 'DoesNotExist'}",
+                "DoesNotExist"),
+            Assert.Throws<InvalidOperationException>(
+                () => modelBuilder.Model.FinalizeModel()).Message);
+    }
+
+    [ConditionalFact]
+    public virtual void PrimaryKeyAttribute_and_KeylessAttribute_on_same_type()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+        Assert.Equal(
+            CoreStrings.ConflictingKeylessAndPrimaryKeyAttributes(nameof(EntityPrimaryKeyAndKeyless)),
+            Assert.Throws<InvalidOperationException>(
+                () => modelBuilder.Entity<EntityPrimaryKeyAndKeyless>()).Message);
+    }
+
+    [ConditionalFact]
+    public void PrimaryKeyAttribute_primaryKey_replicated_to_derived_type_when_base_type_changes()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+        var grandparentEntityBuilder = modelBuilder.Entity(typeof(GrandparentEntityWithPrimaryKey));
+        var parentEntityBuilder = modelBuilder.Entity<ParentEntity>();
+        var childEntityBuilder = modelBuilder.Entity<ChildEntity>();
+
+        Assert.NotNull(parentEntityBuilder.Metadata.BaseType);
+        Assert.NotNull(childEntityBuilder.Metadata.BaseType);
+        Assert.Single(grandparentEntityBuilder.Metadata.GetDeclaredKeys());
+        Assert.Empty(parentEntityBuilder.Metadata.GetDeclaredKeys());
+        Assert.Empty(childEntityBuilder.Metadata.GetDeclaredKeys());
+
+        parentEntityBuilder.HasBaseType((string)null!);
+
+        Assert.Null(parentEntityBuilder.Metadata.BaseType);
+        Assert.NotNull(childEntityBuilder.Metadata.BaseType);
+
+        var basePrimaryKey = (Key)grandparentEntityBuilder.Metadata.FindPrimaryKey()!;
+        Assert.Equal(ConfigurationSource.DataAnnotation, basePrimaryKey.GetConfigurationSource());
+        var basePrimaryKeyProperty = Assert.Single(basePrimaryKey.Properties);
+        Assert.Equal("B", basePrimaryKeyProperty.Name);
+
+        var primaryKey = (Key)parentEntityBuilder.Metadata.FindPrimaryKey()!;
+        Assert.Equal(ConfigurationSource.DataAnnotation, primaryKey.GetConfigurationSource());
+        var primaryKeyProperty = Assert.Single(primaryKey.Properties);
+        Assert.Equal("A", primaryKeyProperty.Name);
+
+        var childPrimaryKey = (Key)childEntityBuilder.Metadata.FindPrimaryKey()!;
+        Assert.Equal(ConfigurationSource.DataAnnotation, childPrimaryKey.GetConfigurationSource());
+        var childPrimaryKeyProperty = Assert.Single(childPrimaryKey.Properties);
+        Assert.Equal("A", childPrimaryKeyProperty.Name);
+
+        // Check there are no errors.
+        modelBuilder.Model.FinalizeModel();
+    }
+
+    [ConditionalFact]
+    public void PrimaryKeyAttribute_primaryKey_is_created_when_missing_property_added()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+        var entityBuilder = modelBuilder.Entity(typeof(EntityWithPrimaryKeyOnShadowProperty));
+
+        Assert.Equal("Id", entityBuilder.Metadata.FindPrimaryKey()!.Properties.Single().Name);
+
+        entityBuilder.Property<int>("Y");
+        modelBuilder.Model.FinalizeModel();
+
+        var primaryKey = (Key)entityBuilder.Metadata.FindPrimaryKey()!;
+        Assert.Equal(ConfigurationSource.DataAnnotation, primaryKey.GetConfigurationSource());
+        Assert.Collection(
+            primaryKey.Properties,
+            prop0 => Assert.Equal("X", prop0.Name),
+            prop1 => Assert.Equal("Y", prop1.Name));
+    }
+
+    [ConditionalFact]
+    public void PrimaryKeyAttribute_primaryKey_is_created_when_primaryKey_on_private_property()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+        var entityBuilder = modelBuilder.Entity(typeof(EntityWithPrimaryKeyOnPrivateProperty));
+        modelBuilder.Model.FinalizeModel();
+
+        var primaryKey = (Key)entityBuilder.Metadata.FindPrimaryKey()!;
+        Assert.Equal(ConfigurationSource.DataAnnotation, primaryKey.GetConfigurationSource());
+        Assert.Collection(
+            primaryKey.Properties,
+            prop0 => Assert.Equal("X", prop0.Name),
+            prop1 => Assert.Equal("Y", prop1.Name));
+    }
+
+    private void RunConvention(InternalEntityTypeBuilder entityTypeBuilder)
+    {
+        var context = new ConventionContext<IConventionEntityTypeBuilder>(
+            entityTypeBuilder.Metadata.Model.ConventionDispatcher);
+
+        CreatePrimaryKeyAttributeConvention().ProcessEntityTypeAdded(entityTypeBuilder, context);
+    }
+
+    private void RunConvention(InternalModelBuilder modelBuilder)
+    {
+        var context = new ConventionContext<IConventionModelBuilder>(modelBuilder.Metadata.ConventionDispatcher);
+
+        CreatePrimaryKeyAttributeConvention().ProcessModelFinalizing(modelBuilder, context);
+    }
+
+    private KeyAttributeConvention CreatePrimaryKeyAttributeConvention()
+        => new(CreateDependencies());
+
+    private ProviderConventionSetBuilderDependencies CreateDependencies()
+        => InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
+
+    [PrimaryKey(nameof(A), nameof(B))]
+    private class EntityWithPrimaryKey
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+
+    [PrimaryKey(nameof(A), nameof(B))]
+    [NotMapped]
+    private class BaseUnmappedEntityWithPrimaryKey
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+
+    private class EntityWithPrimaryKeyFromBaseType : BaseUnmappedEntityWithPrimaryKey
+    {
+        public int C { get; set; }
+        public int D { get; set; }
+    }
+
+    [PrimaryKey]
+    private class EntityWithInvalidEmptyPrimaryKey
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+
+    [PrimaryKey(nameof(A), null!)]
+    private class EntityWithInvalidNullPrimaryKeyProperty
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+
+    [PrimaryKey(nameof(A), "")]
+    private class EntityWithInvalidEmptyPrimaryKeyProperty
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+
+    [PrimaryKey(nameof(A), " \r\n\t")]
+    private class EntityWithInvalidWhiteSpacePrimaryKeyProperty
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+
+    [PrimaryKey(nameof(A), nameof(B))]
+    private class EntityPrimaryKeyWithIgnoredProperty
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+
+        [NotMapped]
+        public int B { get; set; }
+    }
+
+    [PrimaryKey(nameof(A), "DoesNotExist")]
+    private class EntityPrimaryKeyWithNonExistentProperty
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+
+    [PrimaryKey(nameof(B))]
+    private class GrandparentEntityWithPrimaryKey
+    {
+        public int Id { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+    }
+
+    [PrimaryKey(nameof(A))]
+    private class ParentEntity : GrandparentEntityWithPrimaryKey
+    {
+        public int C { get; set; }
+        public int D { get; set; }
+    }
+
+    private class ChildEntity : ParentEntity
+    {
+        public int E { get; set; }
+        public int F { get; set; }
+    }
+
+    [PrimaryKey(nameof(X), "Y")]
+    private class EntityWithPrimaryKeyOnShadowProperty
+    {
+        public int Id { get; set; }
+        public int X { get; set; }
+    }
+
+    [PrimaryKey(nameof(X), nameof(Y))]
+    private class EntityWithPrimaryKeyOnPrivateProperty
+    {
+        public int Id { get; set; }
+        public int X { get; set; }
+        private int Y { get; set; }
+    }
+
+    [PrimaryKey("Id")]
+    [Keyless]
+    private class EntityPrimaryKeyAndKeyless
+    {
+        public int Id { get; set; }
+    }
+}

--- a/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
@@ -224,6 +224,18 @@ public class PropertyAttributeConventionTest
     }
 
     [ConditionalFact]
+    public void KeyAttribute_does_not_throw_when_setting_key_in_derived_type_when_base_has_PrimaryKeyAttribute()
+    {
+        var derivedEntityTypeBuilder = CreateInternalEntityTypeBuilder<DerivedEntity2>();
+        var baseEntityType = derivedEntityTypeBuilder.ModelBuilder.Entity(typeof(BaseEntity2), ConfigurationSource.Explicit).Metadata;
+        derivedEntityTypeBuilder.HasBaseType(baseEntityType, ConfigurationSource.Explicit);
+
+        derivedEntityTypeBuilder.Property(typeof(int), "Number", ConfigurationSource.Explicit);
+
+        Validate(derivedEntityTypeBuilder);
+    }
+
+    [ConditionalFact]
     public void KeyAttribute_allows_composite_key_with_inheritance()
     {
         var derivedEntityTypeBuilder = CreateInternalEntityTypeBuilder<CompositeKeyDerivedEntity>();
@@ -860,6 +872,20 @@ public class PropertyAttributeConventionTest
 
     private class CompositeKeyDerivedEntity : BaseEntity
     {
+    }
+
+    [PrimaryKey(nameof(Name))]
+    private class BaseEntity2
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    private class DerivedEntity2 : BaseEntity2
+    {
+        [Key]
+        public int Number { get; set; }
     }
 
     private static ModelBuilder CreateModelBuilder()

--- a/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
@@ -198,6 +198,16 @@ public class PropertyAttributeConventionTest
     }
 
     [ConditionalFact]
+    public void KeyAttribute_does_not_throw_when_setting_composite_primary_key_with_PrimaryKey_attribute()
+    {
+        var model = new MyContext().Model;
+
+        Assert.Equal(2, model.FindEntityType(typeof(B2)).FindPrimaryKey().Properties.Count);
+        Assert.Equal("MyPrimaryKey", model.FindEntityType(typeof(B2)).FindPrimaryKey().Properties[0].Name);
+        Assert.Equal("Id", model.FindEntityType(typeof(B2)).FindPrimaryKey().Properties[1].Name);
+    }
+
+    [ConditionalFact]
     public void KeyAttribute_throws_when_setting_key_in_derived_type()
     {
         var derivedEntityTypeBuilder = CreateInternalEntityTypeBuilder<DerivedEntity>();
@@ -789,6 +799,16 @@ public class PropertyAttributeConventionTest
         public int MyPrimaryKey { get; set; }
     }
 
+    [PrimaryKey(nameof(MyPrimaryKey), nameof(Id))]
+    private class B2
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Key]
+        public int MyPrimaryKey { get; set; }
+    }
+
     public class F
     {
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
@@ -853,7 +873,9 @@ public class PropertyAttributeConventionTest
                 .UseInMemoryDatabase(nameof(MyContext));
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.Entity<B>().HasKey(
-                e => new { e.MyPrimaryKey, e.Id });
+        {
+            modelBuilder.Entity<B>().HasKey(e => new { e.MyPrimaryKey, e.Id });
+            modelBuilder.Entity<B2>();
+        }
     }
 }


### PR DESCRIPTION
Fixes #11003

This PR introduces a new `[PrimaryKey]` which follows the same pattern as `[Index]` in that it is applied to the entity type class and takes an ordered list of property names. It takes precedence over any `[Key]` attributes on properties, since these may still be needed for OData or other technologies. `PrimaryKey` and `Keyless` cannot be used on the same type.


