### PR TITLE
Generate temp values for key properties contained in optional FKs

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1459,6 +1459,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
         }
 
+        private readonly static bool _useOldBehavior27455 =
+            AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27455", out var enabled27455) && enabled27455;
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -1485,7 +1488,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                     if (property.IsKey()
                         && property.IsForeignKey()
-                        && _stateData.IsPropertyFlagged(property.GetIndex(), PropertyFlag.Unknown))
+                        && _stateData.IsPropertyFlagged(property.GetIndex(), PropertyFlag.Unknown)
+                        && (_useOldBehavior27455 || !IsStoreGenerated(property)))
                     {
                         throw new InvalidOperationException(CoreStrings.UnknownKeyValue(entityType.DisplayName(), property.Name));
                     }

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
@@ -228,6 +228,8 @@ namespace Microsoft.EntityFrameworkCore
 
                 modelBuilder.Entity<NonStoreGenDependent>().Property(e => e.HasTemp).HasDefaultValue(777);
 
+                modelBuilder.Entity<CompositePrincipal>().Property(e => e.Id).UseIdentityColumn();
+
                 base.OnModelCreating(modelBuilder, context);
             }
         }


### PR DESCRIPTION
Fixes #27455

**Description**

We stopped marking properties as store-generated when they are contained in an FK cycle to avoid stack overflows. However, this also affected cycles that contain an optional composite FK that can be used to break the cycle.

**Customer impact**

For models that contain an FK cycle with an optional composite FK `SaveChanges` will throw an exception when propagating the store-generated value.

**How found**

Reported by a customer.

**Regression**

Yes, in 6.0.0

**Testing**

Added a test for the given scenario.

**Risk**

Low, also added a quirk mode.
