### PR TITLE
Refactor ReaderModificationCommandBatch

### DIFF
--- a/src/EFCore.Relational/Storage/IRelationalCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommandBuilder.cs
@@ -31,6 +31,13 @@ public interface IRelationalCommandBuilder
     IRelationalCommandBuilder AddParameter(IRelationalParameter parameter);
 
     /// <summary>
+    ///     Removes the parameter with the given index from this command.
+    /// </summary>
+    /// <param name="index">The index of the parameter to be removed.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    IRelationalCommandBuilder RemoveParameterAt(int index);
+
+    /// <summary>
     ///     The source for <see cref="RelationalTypeMapping" />s to use.
     /// </summary>
     [Obsolete("Code trying to add parameter should add type mapped parameter using TypeMappingSource directly.")]

--- a/src/EFCore.Relational/Storage/RelationalCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandBuilder.cs
@@ -3,19 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Storage;
 
-/// <summary>
-///     <para>
-///         Builds a command to be executed against a relational database.
-///     </para>
-///     <para>
-///         This type is typically used by database providers (and other extensions). It is generally
-///         not used in application code.
-///     </para>
-/// </summary>
-/// <remarks>
-///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
-///     for more information and examples.
-/// </remarks>
+/// <inheritdoc />
 public class RelationalCommandBuilder : IRelationalCommandBuilder
 {
     private readonly List<IRelationalParameter> _parameters = new();
@@ -42,17 +30,12 @@ public class RelationalCommandBuilder : IRelationalCommandBuilder
     /// </summary>
     protected virtual RelationalCommandBuilderDependencies Dependencies { get; }
 
-    /// <summary>
-    ///     The source for <see cref="RelationalTypeMapping" />s to use.
-    /// </summary>
+    /// <inheritdoc />
     [Obsolete("Code trying to add parameter should add type mapped parameter using TypeMappingSource directly.")]
     public virtual IRelationalTypeMappingSource TypeMappingSource
         => Dependencies.TypeMappingSource;
 
-    /// <summary>
-    ///     Creates the command.
-    /// </summary>
-    /// <returns>The newly created command.</returns>
+    /// <inheritdoc />
     public virtual IRelationalCommand Build()
         => new RelationalCommand(Dependencies, _commandTextBuilder.ToString(), Parameters);
 
@@ -62,17 +45,11 @@ public class RelationalCommandBuilder : IRelationalCommandBuilder
     public override string ToString()
         => _commandTextBuilder.ToString();
 
-    /// <summary>
-    ///     The collection of parameters.
-    /// </summary>
+    /// <inheritdoc />
     public virtual IReadOnlyList<IRelationalParameter> Parameters
         => _parameters;
 
-    /// <summary>
-    ///     Adds the given parameter to this command.
-    /// </summary>
-    /// <param name="parameter">The parameter.</param>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    /// <inheritdoc />
     public virtual IRelationalCommandBuilder AddParameter(IRelationalParameter parameter)
     {
         _parameters.Add(parameter);
@@ -80,11 +57,15 @@ public class RelationalCommandBuilder : IRelationalCommandBuilder
         return this;
     }
 
-    /// <summary>
-    ///     Appends an object to the command text.
-    /// </summary>
-    /// <param name="value">The object to be written.</param>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    /// <inheritdoc />
+    public virtual IRelationalCommandBuilder RemoveParameterAt(int index)
+    {
+        _parameters.RemoveAt(index);
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public virtual IRelationalCommandBuilder Append(string value)
     {
         _commandTextBuilder.Append(value);
@@ -92,10 +73,7 @@ public class RelationalCommandBuilder : IRelationalCommandBuilder
         return this;
     }
 
-    /// <summary>
-    ///     Appends a blank line to the command text.
-    /// </summary>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    /// <inheritdoc />
     public virtual IRelationalCommandBuilder AppendLine()
     {
         _commandTextBuilder.AppendLine();
@@ -103,10 +81,7 @@ public class RelationalCommandBuilder : IRelationalCommandBuilder
         return this;
     }
 
-    /// <summary>
-    ///     Increments the indent of subsequent lines.
-    /// </summary>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    /// <inheritdoc />
     public virtual IRelationalCommandBuilder IncrementIndent()
     {
         _commandTextBuilder.IncrementIndent();
@@ -114,10 +89,7 @@ public class RelationalCommandBuilder : IRelationalCommandBuilder
         return this;
     }
 
-    /// <summary>
-    ///     Decrements the indent of subsequent lines.
-    /// </summary>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    /// <inheritdoc />
     public virtual IRelationalCommandBuilder DecrementIndent()
     {
         _commandTextBuilder.DecrementIndent();
@@ -125,9 +97,7 @@ public class RelationalCommandBuilder : IRelationalCommandBuilder
         return this;
     }
 
-    /// <summary>
-    ///     Gets the length of the command text.
-    /// </summary>
+    /// <inheritdoc />
     public virtual int CommandTextLength
         => _commandTextBuilder.Length;
 }

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -55,100 +55,64 @@ public class ColumnModification : IColumnModification
         UseParameter = _generateParameterName != null;
     }
 
-    /// <summary>
-    ///     The <see cref="IUpdateEntry" /> that represents the entity that is being modified.
-    /// </summary>
+    /// <inheritdoc />
     public virtual IUpdateEntry? Entry { get; }
 
-    /// <summary>
-    ///     The property that maps to the column.
-    /// </summary>
+    /// <inheritdoc />
     public virtual IProperty? Property { get; }
 
-    /// <summary>
-    ///     The relational type mapping for the column.
-    /// </summary>
+    /// <inheritdoc />
     public virtual RelationalTypeMapping? TypeMapping { get; }
 
-    /// <summary>
-    ///     A value indicating whether the column could contain a null value.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool? IsNullable { get; }
 
-    /// <summary>
-    ///     Indicates whether a value must be read from the database for the column.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool IsRead { get; }
 
-    /// <summary>
-    ///     Indicates whether a value must be written to the database for the column.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool IsWrite { get; }
 
-    /// <summary>
-    ///     Indicates whether the column is used in the <c>WHERE</c> clause when updating.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool IsCondition { get; }
 
-    /// <summary>
-    ///     Indicates whether the column is part of a primary or alternate key.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool IsKey { get; }
 
-    /// <summary>
-    ///     Indicates whether the original value of the property must be passed as a parameter to the SQL.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool UseOriginalValueParameter
         => UseParameter && UseOriginalValue;
 
-    /// <summary>
-    ///     Indicates whether the current value of the property must be passed as a parameter to the SQL.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool UseCurrentValueParameter
         => UseParameter && UseCurrentValue;
 
-    /// <summary>
-    ///     Indicates whether the original value of the property should be used.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool UseOriginalValue
         => IsCondition;
 
-    /// <summary>
-    ///     Indicates whether the current value of the property should be used.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool UseCurrentValue
         => IsWrite;
 
-    /// <summary>
-    ///     Indicates whether the value of the property must be passed as a parameter to the SQL as opposed to being inlined.
-    /// </summary>
+    /// <inheritdoc />
     public virtual bool UseParameter { get; }
 
-    /// <summary>
-    ///     The parameter name to use for the current value parameter (<see cref="UseCurrentValueParameter" />), if needed.
-    /// </summary>
+    /// <inheritdoc />
     public virtual string? ParameterName
         => _parameterName ??= UseCurrentValueParameter ? _generateParameterName!() : null;
 
-    /// <summary>
-    ///     The parameter name to use for the original value parameter (<see cref="UseOriginalValueParameter" />), if needed.
-    /// </summary>
+    /// <inheritdoc />
     public virtual string? OriginalParameterName
         => _originalParameterName ??= UseOriginalValueParameter ? _generateParameterName!() : null;
 
-    /// <summary>
-    ///     The name of the column.
-    /// </summary>
+    /// <inheritdoc />
     public virtual string ColumnName { get; }
 
-    /// <summary>
-    ///     The database type of the column.
-    /// </summary>
+    /// <inheritdoc />
     public virtual string? ColumnType { get; }
 
-    /// <summary>
-    ///     The original value of the property mapped to this column.
-    /// </summary>
+    /// <inheritdoc />
     public virtual object? OriginalValue
         => Entry == null
             ? _originalValue
@@ -156,9 +120,7 @@ public class ColumnModification : IColumnModification
                 ? Entry.GetOriginalValue(Property!)
                 : Entry.SharedIdentityEntry.GetOriginalValue(Property!);
 
-    /// <summary>
-    ///     Gets or sets the current value of the property mapped to this column.
-    /// </summary>
+    /// <inheritdoc />
     public virtual object? Value
     {
         get => Entry == null
@@ -186,10 +148,7 @@ public class ColumnModification : IColumnModification
         }
     }
 
-    /// <summary>
-    ///     Adds a modification affecting the same database value.
-    /// </summary>
-    /// <param name="modification">The modification for the shared column.</param>
+    /// <inheritdoc />
     public virtual void AddSharedColumnModification(IColumnModification modification)
     {
         Check.DebugAssert(Entry is not null, "Entry is not null");
@@ -258,4 +217,8 @@ public class ColumnModification : IColumnModification
 
         _sharedColumnModifications.Add(modification);
     }
+
+    /// <inheritdoc />
+    public virtual void ResetParameterNames()
+        => _parameterName = _originalParameterName = null;
 }

--- a/src/EFCore.Relational/Update/IColumnModification.cs
+++ b/src/EFCore.Relational/Update/IColumnModification.cs
@@ -122,4 +122,9 @@ public interface IColumnModification
     /// </summary>
     /// <param name="modification">The modification for the shared column.</param>
     public void AddSharedColumnModification(IColumnModification modification);
+
+    /// <summary>
+    ///     Resets parameter names, so they can be regenerated if the command needs to be re-added to a new batch.
+    /// </summary>
+    public void ResetParameterNames();
 }

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -74,7 +74,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                     continue;
                 }
 
-                if (!batch.AddCommand(modificationCommand))
+                if (!batch.TryAddCommand(modificationCommand))
                 {
                     if (batch.ModificationCommands.Count == 1
                         || batch.ModificationCommands.Count >= _minBatchSize)
@@ -144,7 +144,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
     {
         parameterNameGenerator.Reset();
         var batch = Dependencies.ModificationCommandBatchFactory.Create();
-        batch.AddCommand(modificationCommand);
+        batch.TryAddCommand(modificationCommand);
         return batch;
     }
 

--- a/src/EFCore.Relational/Update/ModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ModificationCommandBatch.cs
@@ -24,14 +24,14 @@ public abstract class ModificationCommandBatch
     public abstract IReadOnlyList<IReadOnlyModificationCommand> ModificationCommands { get; }
 
     /// <summary>
-    ///     Adds the given insert/update/delete <see cref="ModificationCommands" /> to the batch.
+    ///     Attempts to adds the given insert/update/delete <paramref name="modificationCommand" /> to the batch.
     /// </summary>
     /// <param name="modificationCommand">The command to add.</param>
     /// <returns>
     ///     <see langword="true" /> if the command was successfully added; <see langword="false" /> if there was no
     ///     room in the current batch to add the command and it must instead be added to a new batch.
     /// </returns>
-    public abstract bool AddCommand(IReadOnlyModificationCommand modificationCommand);
+    public abstract bool TryAddCommand(IReadOnlyModificationCommand modificationCommand);
 
     /// <summary>
     ///     Indicates that no more commands will be added to this batch, and prepares it for execution.

--- a/src/EFCore.Relational/Update/SingularModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/SingularModificationCommandBatch.cs
@@ -28,19 +28,11 @@ public class SingularModificationCommandBatch : AffectedCountModificationCommand
     }
 
     /// <summary>
-    ///     Only returns <see langword="true" /> if the no command has already been added.
-    /// </summary>
-    /// <param name="modificationCommand">The command to potentially add.</param>
-    /// <returns><see langword="true" /> if no command has already been added.</returns>
-    protected override bool CanAddCommand(IReadOnlyModificationCommand modificationCommand)
-        => ModificationCommands.Count == 0;
-
-    /// <summary>
-    ///     Returns <see langword="true" /> since only a single command is generated so the command text must be valid.
+    ///     Returns <see langword="true" /> only when the batch contains a single command.
     /// </summary>
     /// <returns>
-    ///     <see langword="true" />
+    ///     <see langword="true" /> when the batch contains a single command, <see langword="false" /> otherwise.
     /// </returns>
-    protected override bool IsCommandTextValid()
-        => true;
+    protected override bool IsValid()
+        => ModificationCommands.Count == 1;
 }

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Text;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 
@@ -20,10 +19,8 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
     private const int MaxScriptLength = 65536 * DefaultNetworkPacketSizeBytes / 2;
     private const int MaxParameterCount = 2100;
     private const int MaxRowCount = 1000;
-    private int _parameterCount = 1; // Implicit parameter for the command text
     private readonly int _maxBatchSize;
-    private readonly List<IReadOnlyModificationCommand> _bulkInsertCommands = new();
-    private int _commandsLeftToLengthCheck = 50;
+    private readonly List<IReadOnlyModificationCommand> _pendingBulkInsertCommands = new();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -36,8 +33,7 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
         int? maxBatchSize)
         : base(dependencies)
     {
-        if (maxBatchSize.HasValue
-            && maxBatchSize.Value <= 0)
+        if (maxBatchSize is <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(maxBatchSize), RelationalStrings.InvalidMaxBatchSize(maxBatchSize.Value));
         }
@@ -60,22 +56,15 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override bool CanAddCommand(IReadOnlyModificationCommand modificationCommand)
+    protected override void RollbackLastCommand()
     {
-        if (ModificationCommands.Count >= _maxBatchSize)
+        if (_pendingBulkInsertCommands.Count > 0)
         {
-            return false;
+            _pendingBulkInsertCommands.RemoveAt(_pendingBulkInsertCommands.Count - 1);
+            return;
         }
 
-        var additionalParameterCount = CountParameters(modificationCommand);
-
-        if (_parameterCount + additionalParameterCount >= MaxParameterCount)
-        {
-            return false;
-        }
-
-        _parameterCount += additionalParameterCount;
-        return true;
+        base.RollbackLastCommand();
     }
 
     /// <summary>
@@ -84,79 +73,25 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override bool IsCommandTextValid()
+    protected override bool IsValid()
+        => ModificationCommands.Count <= _maxBatchSize
+            && SqlBuilder.Length < MaxScriptLength
+            // A single implicit parameter for the command text itself
+            && ParameterValues.Count + 1 < MaxParameterCount;
+
+    private void ApplyPendingBulkInsertCommands()
     {
-        if (--_commandsLeftToLengthCheck < 0)
-        {
-            UpdateCachedCommandText();
-            var commandTextLength = CachedCommandText.Length;
-            if (commandTextLength >= MaxScriptLength)
-            {
-                return false;
-            }
-
-            var averageCommandLength = commandTextLength / ModificationCommands.Count;
-            var expectedAdditionalCommandCapacity = (MaxScriptLength - commandTextLength) / averageCommandLength;
-            _commandsLeftToLengthCheck = Math.Max(1, expectedAdditionalCommandCapacity / 4);
-        }
-
-        return true;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    protected override int GetParameterCount()
-        => _parameterCount;
-
-    private static int CountParameters(IReadOnlyModificationCommand modificationCommand)
-    {
-        var parameterCount = 0;
-        // ReSharper disable once ForCanBeConvertedToForeach
-        for (var columnIndex = 0; columnIndex < modificationCommand.ColumnModifications.Count; columnIndex++)
-        {
-            var columnModification = modificationCommand.ColumnModifications[columnIndex];
-            if (columnModification.UseCurrentValueParameter)
-            {
-                parameterCount++;
-            }
-
-            if (columnModification.UseOriginalValueParameter)
-            {
-                parameterCount++;
-            }
-        }
-
-        return parameterCount;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    protected override void ResetCommandText()
-    {
-        base.ResetCommandText();
-
-        _bulkInsertCommands.Clear();
-    }
-
-    private void AppendBulkInsertCommandText(int lastIndex)
-    {
-        if (_bulkInsertCommands.Count == 0)
+        if (_pendingBulkInsertCommands.Count == 0)
         {
             return;
         }
 
-        var wasCachedCommandTextEmpty = IsCachedCommandTextEmpty;
+        var commandPosition = CommandResultSet.Count;
+
+        var wasCachedCommandTextEmpty = IsCommandTextEmpty;
 
         var resultSetMapping = UpdateSqlGenerator.AppendBulkInsertOperation(
-            CachedCommandText, _bulkInsertCommands, lastIndex - _bulkInsertCommands.Count, out var resultsContainPositionMapping,
+            SqlBuilder, _pendingBulkInsertCommands, commandPosition, out var resultsContainPositionMapping,
             out var requiresTransaction);
 
         SetRequiresTransaction(!wasCachedCommandTextEmpty || requiresTransaction);
@@ -165,27 +100,29 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
         {
             if (ResultsPositionalMappingEnabled is null)
             {
-                ResultsPositionalMappingEnabled = new BitArray(CommandResultSet.Count);
+                ResultsPositionalMappingEnabled = new BitArray(CommandResultSet.Count + _pendingBulkInsertCommands.Count);
             }
             else
             {
-                ResultsPositionalMappingEnabled.Length = CommandResultSet.Count;
+                ResultsPositionalMappingEnabled.Length = CommandResultSet.Count + _pendingBulkInsertCommands.Count;
             }
 
-            for (var i = lastIndex - _bulkInsertCommands.Count; i < lastIndex; i++)
+            for (var i = commandPosition; i < commandPosition + _pendingBulkInsertCommands.Count; i++)
             {
                 ResultsPositionalMappingEnabled![i] = true;
             }
         }
 
-        for (var i = lastIndex - _bulkInsertCommands.Count; i < lastIndex; i++)
+        foreach (var pendingCommand in _pendingBulkInsertCommands)
         {
-            CommandResultSet[i] = resultSetMapping;
+            AddParameters(pendingCommand);
+
+            CommandResultSet.Add(resultSetMapping);
         }
 
         if (resultSetMapping != ResultSetMapping.NoResultSet)
         {
-            CommandResultSet[lastIndex - 1] = ResultSetMapping.LastInResultSet;
+            CommandResultSet[^1] = ResultSetMapping.LastInResultSet;
         }
     }
 
@@ -195,50 +132,33 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override void UpdateCachedCommandText()
+    protected override void AddCommand(IReadOnlyModificationCommand modificationCommand)
     {
-        base.UpdateCachedCommandText();
-
-        AppendBulkInsertCommandText(ModificationCommands.Count);
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    protected override void UpdateCachedCommandText(int commandPosition)
-    {
-        var newModificationCommand = ModificationCommands[commandPosition];
-
-        if (newModificationCommand.EntityState == EntityState.Added)
+        if (modificationCommand.EntityState == EntityState.Added)
         {
-            if (_bulkInsertCommands.Count > 0
-                && !CanBeInsertedInSameStatement(_bulkInsertCommands[0], newModificationCommand))
+            if (_pendingBulkInsertCommands.Count > 0
+                && !CanBeInsertedInSameStatement(_pendingBulkInsertCommands[0], modificationCommand))
             {
                 // The new Add command cannot be added to the pending bulk insert commands (e.g. different table).
                 // Write out the pending commands before starting a new pending chain.
-                AppendBulkInsertCommandText(commandPosition);
-                _bulkInsertCommands.Clear();
+                ApplyPendingBulkInsertCommands();
+                _pendingBulkInsertCommands.Clear();
             }
 
-            _bulkInsertCommands.Add(newModificationCommand);
-
-            LastCachedCommandIndex = commandPosition;
+            _pendingBulkInsertCommands.Add(modificationCommand);
         }
         else
         {
             // If we have any pending bulk insert commands, write them out before the next non-Add command
-            if (_bulkInsertCommands.Count > 0)
+            if (_pendingBulkInsertCommands.Count > 0)
             {
                 // Note that we don't care about the transactionality of the bulk insert SQL, since there's the additional non-Add
                 // command coming right afterwards, and so a transaction is required in any case.
-                AppendBulkInsertCommandText(commandPosition);
-                _bulkInsertCommands.Clear();
+                ApplyPendingBulkInsertCommands();
+                _pendingBulkInsertCommands.Clear();
             }
 
-            base.UpdateCachedCommandText(commandPosition);
+            base.AddCommand(modificationCommand);
         }
     }
 
@@ -251,6 +171,19 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
                 secondCommand.ColumnModifications.Where(o => o.IsWrite).Select(o => o.ColumnName))
             && firstCommand.ColumnModifications.Where(o => o.IsRead).Select(o => o.ColumnName).SequenceEqual(
                 secondCommand.ColumnModifications.Where(o => o.IsRead).Select(o => o.ColumnName));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override void Complete()
+    {
+        ApplyPendingBulkInsertCommands();
+
+        base.Complete();
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Relational.Tests/TestUtilities/TestModificationCommandBatch.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestModificationCommandBatch.cs
@@ -15,6 +15,6 @@ public class TestModificationCommandBatch : SingularModificationCommandBatch
         _maxBatchSize = maxBatchSize ?? 1;
     }
 
-    protected override bool CanAddCommand(IReadOnlyModificationCommand modificationCommand)
-        => ModificationCommands.Count < _maxBatchSize;
+    protected override bool IsValid()
+        => ModificationCommands.Count <= _maxBatchSize;
 }

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -15,55 +15,116 @@ namespace Microsoft.EntityFrameworkCore.Update;
 public class ReaderModificationCommandBatchTest
 {
     [ConditionalFact]
-    public void AddCommand_adds_command_if_possible()
+    public void AddCommand_adds_command_if_batch_is_valid()
     {
-        var command = CreateModificationCommand("T1", null, true, columnModifications: null);
+        var parameterNameGenerator = new ParameterNameGenerator();
+
+        var entry1 = CreateEntry(EntityState.Modified);
+        var property1 = entry1.EntityType.FindProperty("Name")!;
+        var command1 = CreateModificationCommand(
+            "T1",
+            null,
+            true,
+            new[]
+            {
+                new ColumnModificationParameters(
+                    entry1,
+                    property1,
+                    property1.GetTableColumnMappings().Single().Column,
+                    parameterNameGenerator.GenerateNext,
+                    property1.GetTableColumnMappings().Single().TypeMapping,
+                    false, true, false, false, true)
+            });
+
+        var entry2 = CreateEntry(EntityState.Modified);
+        var property2 = entry1.EntityType.FindProperty("Name")!;
+        var command2 = CreateModificationCommand(
+            "T2",
+            null,
+            true,
+            new[]
+            {
+                new ColumnModificationParameters(
+                    entry2,
+                    property2,
+                    property2.GetTableColumnMappings().Single().Column,
+                    parameterNameGenerator.GenerateNext,
+                    property2.GetTableColumnMappings().Single().TypeMapping,
+                    false, true, false, false, true)
+            });
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
-        batch.ShouldAddCommand = true;
-        batch.ShouldValidateSql = true;
-
-        batch.AddCommand(command);
+        batch.ShouldBeValid = true;
+        Assert.True(batch.TryAddCommand(command1));
+        Assert.True(batch.TryAddCommand(command2));
         batch.Complete();
 
-        Assert.Equal(2, batch.ModificationCommands.Count);
-        Assert.Same(command, batch.ModificationCommands[0]);
-        Assert.Equal("..", batch.CommandText);
+        Assert.Collection(batch.ModificationCommands,
+            m => Assert.Same(command1, m),
+            m => Assert.Same(command2, m));
+
+        Assert.Equal(@"UPDATE ""T1"" SET ""Col2"" = @p0
+RETURNING 1;
+UPDATE ""T2"" SET ""Col2"" = @p1
+RETURNING 1;
+",
+            batch.CommandText,
+            ignoreLineEndingDifferences: true);
     }
 
     [ConditionalFact]
-    public void AddCommand_does_not_add_command_if_not_possible()
+    public void AddCommand_does_not_add_command_batch_is_invalid()
     {
-        var command = CreateModificationCommand("T1", null, true, columnModifications: null);
+        var parameterNameGenerator = new ParameterNameGenerator();
+
+        var entry1 = CreateEntry(EntityState.Modified);
+        var property1 = entry1.EntityType.FindProperty("Name")!;
+        var command1 = CreateModificationCommand(
+            "T1",
+            null,
+            true,
+            new[]
+            {
+                new ColumnModificationParameters(
+                    entry1,
+                    property1,
+                    property1.GetTableColumnMappings().Single().Column,
+                    parameterNameGenerator.GenerateNext,
+                    property1.GetTableColumnMappings().Single().TypeMapping,
+                    false, true, false, false, true)
+            });
+
+        var entry2 = CreateEntry(EntityState.Modified);
+        var property2 = entry1.EntityType.FindProperty("Name")!;
+        var command2 = CreateModificationCommand(
+            "T2",
+            null,
+            true,
+            new[]
+            {
+                new ColumnModificationParameters(
+                    entry2,
+                    property2,
+                    property2.GetTableColumnMappings().Single().Column,
+                    parameterNameGenerator.GenerateNext,
+                    property2.GetTableColumnMappings().Single().TypeMapping,
+                    false, true, false, false, true)
+            });
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
-        batch.ShouldAddCommand = false;
-        batch.ShouldValidateSql = true;
+        Assert.True(batch.TryAddCommand(command1));
+        batch.ShouldBeValid = false;
 
-        batch.AddCommand(command);
+        Assert.False(batch.TryAddCommand(command2));
         batch.Complete();
 
-        Assert.Equal(1, batch.ModificationCommands.Count);
-        Assert.Equal(".", batch.CommandText);
-    }
+        Assert.Same(command1, Assert.Single(batch.ModificationCommands));
 
-    [ConditionalFact]
-    public void AddCommand_does_not_add_command_if_resulting_sql_is_invalid()
-    {
-        var command = CreateModificationCommand("T1", null, true, columnModifications: null);
-
-        var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
-        batch.ShouldAddCommand = true;
-        batch.ShouldValidateSql = false;
-
-        batch.AddCommand(command);
-        batch.Complete();
-
-        Assert.Equal(1, batch.ModificationCommands.Count);
-        Assert.Equal(".", batch.CommandText);
+        Assert.Equal(@"UPDATE ""T1"" SET ""Col2"" = @p0
+RETURNING 1;
+",
+            batch.CommandText,
+            ignoreLineEndingDifferences: true);
     }
 
     [ConditionalFact]
@@ -74,16 +135,12 @@ public class ReaderModificationCommandBatchTest
         var command = CreateModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, true, null);
         command.AddEntry(entry, true);
 
-        var fakeSqlGenerator = new FakeSqlGenerator(
-            RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<UpdateSqlGeneratorDependencies>());
-        var batch = new ModificationCommandBatchFake(fakeSqlGenerator);
-        batch.AddCommand(command);
+        var batch = new ModificationCommandBatchFake();
+        batch.TryAddCommand(command);
         batch.Complete();
 
-        batch.UpdateCachedCommandTextBase(0);
-
-        Assert.Equal(1, fakeSqlGenerator.AppendBatchHeaderCalls);
-        Assert.Equal(1, fakeSqlGenerator.AppendInsertOperationCalls);
+        Assert.Equal(1, batch.FakeSqlGenerator.AppendBatchHeaderCalls);
+        Assert.Equal(1, batch.FakeSqlGenerator.AppendInsertOperationCalls);
     }
 
     [ConditionalFact]
@@ -94,16 +151,12 @@ public class ReaderModificationCommandBatchTest
         var command = CreateModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, true, null);
         command.AddEntry(entry, true);
 
-        var fakeSqlGenerator = new FakeSqlGenerator(
-            RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<UpdateSqlGeneratorDependencies>());
-        var batch = new ModificationCommandBatchFake(fakeSqlGenerator);
-        batch.AddCommand(command);
-
-        batch.UpdateCachedCommandTextBase(0);
+        var batch = new ModificationCommandBatchFake();
+        batch.TryAddCommand(command);
         batch.Complete();
 
-        Assert.Equal(1, fakeSqlGenerator.AppendBatchHeaderCalls);
-        Assert.Equal(1, fakeSqlGenerator.AppendUpdateOperationCalls);
+        Assert.Equal(1, batch.FakeSqlGenerator.AppendBatchHeaderCalls);
+        Assert.Equal(1, batch.FakeSqlGenerator.AppendUpdateOperationCalls);
     }
 
     [ConditionalFact]
@@ -114,16 +167,12 @@ public class ReaderModificationCommandBatchTest
         var command = CreateModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, true, null);
         command.AddEntry(entry, true);
 
-        var fakeSqlGenerator = new FakeSqlGenerator(
-            RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<UpdateSqlGeneratorDependencies>());
-        var batch = new ModificationCommandBatchFake(fakeSqlGenerator);
-        batch.AddCommand(command);
-
-        batch.UpdateCachedCommandTextBase(0);
+        var batch = new ModificationCommandBatchFake();
+        batch.TryAddCommand(command);
         batch.Complete();
 
-        Assert.Equal(1, fakeSqlGenerator.AppendBatchHeaderCalls);
-        Assert.Equal(1, fakeSqlGenerator.AppendDeleteOperationCalls);
+        Assert.Equal(1, batch.FakeSqlGenerator.AppendBatchHeaderCalls);
+        Assert.Equal(1, batch.FakeSqlGenerator.AppendDeleteOperationCalls);
     }
 
     [ConditionalFact]
@@ -131,25 +180,25 @@ public class ReaderModificationCommandBatchTest
     {
         var entry = CreateEntry(EntityState.Added);
 
-        var command = CreateModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, true, null);
-        command.AddEntry(entry, true);
+        var parameterNameGenerator = new ParameterNameGenerator();
+        var command1 = CreateModificationCommand("T1", null, parameterNameGenerator.GenerateNext, true, null);
+        command1.AddEntry(entry, true);
+        var command2 = CreateModificationCommand("T1", null, parameterNameGenerator.GenerateNext, true, null);
+        command2.AddEntry(entry, true);
 
-        var fakeSqlGenerator = new FakeSqlGenerator(
-            RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<UpdateSqlGeneratorDependencies>());
-        var batch = new ModificationCommandBatchFake(fakeSqlGenerator);
-        batch.AddCommand(command);
-        batch.AddCommand(command);
+        var batch = new ModificationCommandBatchFake();
+        batch.TryAddCommand(command1);
+        batch.TryAddCommand(command2);
         batch.Complete();
 
-        Assert.Equal("..", batch.CommandText);
-
-        Assert.Equal(1, fakeSqlGenerator.AppendBatchHeaderCalls);
+        Assert.Equal(1, batch.FakeSqlGenerator.AppendBatchHeaderCalls);
+        Assert.Equal(2, batch.FakeSqlGenerator.AppendInsertOperationCalls);
     }
 
     [ConditionalFact]
     public async Task ExecuteAsync_executes_batch_commands_and_consumes_reader()
     {
-        var entry = CreateEntry(EntityState.Added);
+        var entry = CreateEntry(EntityState.Added, generateKeyValues: true);
 
         var command = CreateModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, true, null);
         command.AddEntry(entry, true);
@@ -159,7 +208,7 @@ public class ReaderModificationCommandBatchTest
         var connection = CreateConnection(dbDataReader);
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         await batch.ExecuteAsync(connection);
@@ -182,7 +231,7 @@ public class ReaderModificationCommandBatchTest
                 new[] { "Col1" }, new List<object[]> { new object[] { 42 } }));
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         await batch.ExecuteAsync(connection);
@@ -206,7 +255,7 @@ public class ReaderModificationCommandBatchTest
                 new[] { "Col1", "Col2" }, new List<object[]> { new object[] { 42, "FortyTwo" } }));
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         await batch.ExecuteAsync(connection);
@@ -219,7 +268,7 @@ public class ReaderModificationCommandBatchTest
     public async Task ExecuteAsync_saves_store_generated_values_when_updating()
     {
         var entry = CreateEntry(
-            EntityState.Modified, generateKeyValues: true, computeNonKeyValue: true);
+            EntityState.Modified, generateKeyValues: true, overrideKeyValues: true, computeNonKeyValue: true);
 
         var command = CreateModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, true, null);
         command.AddEntry(entry, true);
@@ -229,7 +278,7 @@ public class ReaderModificationCommandBatchTest
                 new[] { "Col2" }, new List<object[]> { new object[] { "FortyTwo" } }));
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         await batch.ExecuteAsync(connection);
@@ -253,7 +302,7 @@ public class ReaderModificationCommandBatchTest
                 new List<object[]> { new object[] { 42 }, new object[] { 43 } }));
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         await batch.ExecuteAsync(connection);
@@ -266,7 +315,7 @@ public class ReaderModificationCommandBatchTest
     [InlineData(true)]
     public async Task Exception_thrown_if_rows_returned_for_command_without_store_generated_values_is_not_1(bool async)
     {
-        var entry = CreateEntry(EntityState.Added);
+        var entry = CreateEntry(EntityState.Modified);
 
         var command = CreateModificationCommand("T1", null, new ParameterNameGenerator().GenerateNext, true, null);
         command.AddEntry(entry, true);
@@ -276,7 +325,7 @@ public class ReaderModificationCommandBatchTest
                 new[] { "Col1" }, new List<object[]> { new object[] { 42 } }));
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         var exception = async
@@ -301,7 +350,7 @@ public class ReaderModificationCommandBatchTest
             CreateFakeDataReader(new[] { "Col1" }, new List<object[]>()));
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         var exception = async
@@ -329,7 +378,7 @@ public class ReaderModificationCommandBatchTest
                 executeReader: (c, b) => throw originalException));
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         var actualException = async
@@ -357,7 +406,7 @@ public class ReaderModificationCommandBatchTest
                 executeReader: (c, b) => throw originalException));
 
         var batch = new ModificationCommandBatchFake();
-        batch.AddCommand(command);
+        batch.TryAddCommand(command);
         batch.Complete();
 
         var actualException = async
@@ -377,7 +426,7 @@ public class ReaderModificationCommandBatchTest
         var batch = new ModificationCommandBatchFake();
         var parameterNameGenerator = new ParameterNameGenerator();
 
-        batch.AddCommand(
+        batch.TryAddCommand(
             CreateModificationCommand(
                 "T1",
                 null,
@@ -393,7 +442,7 @@ public class ReaderModificationCommandBatchTest
                         false, true, false, false, true)
                 }));
 
-        batch.AddCommand(
+        batch.TryAddCommand(
             CreateModificationCommand(
                 "T1",
                 null,
@@ -411,7 +460,7 @@ public class ReaderModificationCommandBatchTest
 
         batch.Complete();
 
-        var storeCommand = batch.CreateStoreCommandBase();
+        var storeCommand = batch.StoreCommand;
 
         Assert.Equal(2, storeCommand.RelationalCommand.Parameters.Count);
         Assert.Equal("p0", storeCommand.RelationalCommand.Parameters[0].InvariantName);
@@ -431,7 +480,7 @@ public class ReaderModificationCommandBatchTest
 
         var batch = new ModificationCommandBatchFake();
         var parameterNameGenerator = new ParameterNameGenerator();
-        batch.AddCommand(
+        batch.TryAddCommand(
             CreateModificationCommand(
                 "T1",
                 null,
@@ -450,7 +499,7 @@ public class ReaderModificationCommandBatchTest
 
         batch.Complete();
 
-        var storeCommand = batch.CreateStoreCommandBase();
+        var storeCommand = batch.StoreCommand;
 
         Assert.Equal(1, storeCommand.RelationalCommand.Parameters.Count);
         Assert.Equal("p0", storeCommand.RelationalCommand.Parameters[0].InvariantName);
@@ -468,7 +517,7 @@ public class ReaderModificationCommandBatchTest
 
         var batch = new ModificationCommandBatchFake();
         var parameterNameGenerator = new ParameterNameGenerator();
-        batch.AddCommand(
+        batch.TryAddCommand(
             CreateModificationCommand(
                 "T1",
                 null,
@@ -487,7 +536,7 @@ public class ReaderModificationCommandBatchTest
 
         batch.Complete();
 
-        var storeCommand = batch.CreateStoreCommandBase();
+        var storeCommand = batch.StoreCommand;
 
         Assert.Equal(1, storeCommand.RelationalCommand.Parameters.Count);
         Assert.Equal("p0", storeCommand.RelationalCommand.Parameters[0].InvariantName);
@@ -505,7 +554,7 @@ public class ReaderModificationCommandBatchTest
 
         var batch = new ModificationCommandBatchFake();
         var parameterNameGenerator = new ParameterNameGenerator();
-        batch.AddCommand(
+        batch.TryAddCommand(
             CreateModificationCommand(
                 "T1",
                 null,
@@ -524,7 +573,7 @@ public class ReaderModificationCommandBatchTest
 
         batch.Complete();
 
-        var storeCommand = batch.CreateStoreCommandBase();
+        var storeCommand = batch.StoreCommand;
 
         Assert.Equal(2, storeCommand.RelationalCommand.Parameters.Count);
         Assert.Equal("p0", storeCommand.RelationalCommand.Parameters[0].InvariantName);
@@ -544,7 +593,7 @@ public class ReaderModificationCommandBatchTest
 
         var batch = new ModificationCommandBatchFake();
         var parameterNameGenerator = new ParameterNameGenerator();
-        batch.AddCommand(
+        batch.TryAddCommand(
             CreateModificationCommand(
                 "T1",
                 null,
@@ -563,7 +612,7 @@ public class ReaderModificationCommandBatchTest
 
         batch.Complete();
 
-        var storeCommand = batch.CreateStoreCommandBase();
+        var storeCommand = batch.StoreCommand;
 
         Assert.Equal(0, storeCommand.RelationalCommand.Parameters.Count);
     }
@@ -597,12 +646,17 @@ public class ReaderModificationCommandBatchTest
     private static InternalEntityEntry CreateEntry(
         EntityState entityState,
         bool generateKeyValues = false,
+        bool overrideKeyValues = false,
         bool computeNonKeyValue = false)
     {
         var model = BuildModel(generateKeyValues, computeNonKeyValue);
 
         return RelationalTestHelpers.Instance.CreateInternalEntry(
-            model, entityState, new T1 { Id = 1, Name = computeNonKeyValue ? null : "Test" });
+            model, entityState, new T1
+            {
+                Id = overrideKeyValues ? 1 : default,
+                Name = computeNonKeyValue ? null : "Test"
+            });
     }
 
     private static FakeDbDataReader CreateFakeDataReader(string[] columnNames = null, IList<object[]> results = null)
@@ -615,12 +669,14 @@ public class ReaderModificationCommandBatchTest
 
     private class ModificationCommandBatchFake : AffectedCountModificationCommandBatch
     {
-        public ModificationCommandBatchFake(
-            IUpdateSqlGenerator sqlGenerator = null)
+        private readonly FakeSqlGenerator _fakeSqlGenerator;
+
+        public ModificationCommandBatchFake(IUpdateSqlGenerator sqlGenerator = null)
             : base(CreateDependencies(sqlGenerator))
         {
-            ShouldAddCommand = true;
-            ShouldValidateSql = true;
+            ShouldBeValid = true;
+
+            _fakeSqlGenerator = Dependencies.UpdateSqlGenerator as FakeSqlGenerator;
         }
 
         private static ModificationCommandBatchFactoryDependencies CreateDependencies(
@@ -632,6 +688,10 @@ public class ReaderModificationCommandBatchTest
 
             var logger = new FakeRelationalCommandDiagnosticsLogger();
 
+            sqlGenerator ??= new FakeSqlGenerator(
+                RelationalTestHelpers.Instance.CreateContextServices()
+                    .GetRequiredService<UpdateSqlGeneratorDependencies>());
+
             return new ModificationCommandBatchFactoryDependencies(
                 new RelationalCommandBuilderFactory(
                     new RelationalCommandBuilderDependencies(
@@ -639,10 +699,7 @@ public class ReaderModificationCommandBatchTest
                         new ExceptionDetector())),
                 new RelationalSqlGenerationHelper(
                     new RelationalSqlGenerationHelperDependencies()),
-                sqlGenerator
-                ?? new FakeSqlGenerator(
-                    RelationalTestHelpers.Instance.CreateContextServices()
-                        .GetRequiredService<UpdateSqlGeneratorDependencies>()),
+                sqlGenerator,
                 new TypedRelationalValueBufferFactoryFactory(
                     new RelationalValueBufferFactoryDependencies(
                         typeMappingSource,
@@ -651,27 +708,20 @@ public class ReaderModificationCommandBatchTest
                 logger);
         }
 
+
         public string CommandText
-            => CachedCommandText.ToString();
+            => SqlBuilder.ToString();
 
-        public bool ShouldAddCommand { get; set; }
+        public bool ShouldBeValid { get; set; }
 
-        protected override bool CanAddCommand(IReadOnlyModificationCommand modificationCommand)
-            => ShouldAddCommand;
+        protected override bool IsValid()
+            => ShouldBeValid;
 
-        public bool ShouldValidateSql { get; set; }
+        public new RawSqlCommand StoreCommand
+            => base.StoreCommand;
 
-        protected override bool IsCommandTextValid()
-            => ShouldValidateSql;
-
-        protected override void UpdateCachedCommandText(int commandIndex)
-            => CachedCommandText.Append(".");
-
-        public void UpdateCachedCommandTextBase(int commandIndex)
-            => base.UpdateCachedCommandText(commandIndex);
-
-        public RawSqlCommand CreateStoreCommandBase()
-            => CreateStoreCommand();
+        public FakeSqlGenerator FakeSqlGenerator
+            => _fakeSqlGenerator ?? throw new InvalidOperationException("Not using FakeSqlGenerator");
     }
 
     private class FakeDbContext : DbContext

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -40,6 +40,13 @@ public class TestRelationalCommandBuilderFactory : IRelationalCommandBuilderFact
             return this;
         }
 
+        public IRelationalCommandBuilder RemoveParameterAt(int index)
+        {
+            _parameters.RemoveAt(index);
+
+            return this;
+        }
+
         [Obsolete("Code trying to add parameter should add type mapped parameter using TypeMappingSource directly.")]
         public IRelationalTypeMappingSource TypeMappingSource
             => Dependencies.TypeMappingSource;

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -184,6 +184,13 @@ public class SqlServerDatabaseCreatorTest
             return this;
         }
 
+        public IRelationalCommandBuilder RemoveParameterAt(int index)
+        {
+            _parameters.RemoveAt(index);
+
+            return this;
+        }
+
         public IRelationalTypeMappingSource TypeMappingSource
             => null;
 

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -45,8 +45,8 @@ public class SqlServerModificationCommandBatchFactoryTest
 
         var batch = factory.Create();
 
-        Assert.True(batch.AddCommand(CreateModificationCommand("T1", null, false)));
-        Assert.False(batch.AddCommand(CreateModificationCommand("T1", null, false)));
+        Assert.True(batch.TryAddCommand(CreateModificationCommand("T1", null, false)));
+        Assert.False(batch.TryAddCommand(CreateModificationCommand("T1", null, false)));
     }
 
     [ConditionalFact]
@@ -83,8 +83,8 @@ public class SqlServerModificationCommandBatchFactoryTest
 
         var batch = factory.Create();
 
-        Assert.True(batch.AddCommand(CreateModificationCommand("T1", null, false)));
-        Assert.True(batch.AddCommand(CreateModificationCommand("T1", null, false)));
+        Assert.True(batch.TryAddCommand(CreateModificationCommand("T1", null, false)));
+        Assert.True(batch.TryAddCommand(CreateModificationCommand("T1", null, false)));
     }
 
     private class FakeDbContext : DbContext


### PR DESCRIPTION
~Note: this PR is based on #27573, review only the last commit.~

This refactors ReaderModificationCommandBatch to simplify the adding of ModificationCommands, applying them directly to the batch's SQL and parameters rather than deferring that for later.

* Since SQL now gets add with every command, the SQL Server length check is now very cheap, and so I've removed the heuristic for doing it (we simply check every time). If we've gone over, we simply restart and re-add all the previous commands.
* I don't think that the scenario where we go over the SQL length is perf-critical, but if it is, we can optimize it by just rolling back the last command instead of replaying the entire batch.
* Note in our previous design, if a IsCommandTextValid occured in the middle of a pending bulk insert (eg. after 50 rows), that would cause that bulk insert to be terminated, resulting in multiple MERGE commands instead of one.
