### PR TITLE
Fix to #27423 - Renaming and dropping columns with Temporal Tables generates faulty migration

### DIFF
--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -264,13 +264,12 @@ public class SqlServerAnnotationProvider : RelationalAnnotationProvider
                 ? periodEndProperty.GetColumnName(storeObjectIdentifier)
                 : periodEndPropertyName;
 
-            if (column.Name == periodStartColumnName
-                || column.Name == periodEndColumnName)
-            {
-                yield return new Annotation(SqlServerAnnotationNames.IsTemporal, true);
-                yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodStartColumnName, periodStartColumnName);
-                yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodEndColumnName, periodEndColumnName);
-            }
+            // TODO: issue #27459 - we want to avoid having those annotations on every column
+            yield return new Annotation(SqlServerAnnotationNames.IsTemporal, true);
+            yield return new Annotation(SqlServerAnnotationNames.TemporalHistoryTableName, entityType.GetHistoryTableName());
+            yield return new Annotation(SqlServerAnnotationNames.TemporalHistoryTableSchema, entityType.GetHistoryTableSchema());
+            yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodStartColumnName, periodStartColumnName);
+            yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodEndColumnName, periodEndColumnName);
         }
     }
 }

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -104,4 +104,35 @@ public class SqlServerMigrationsAnnotationProvider : MigrationsAnnotationProvide
                 table[SqlServerAnnotationNames.TemporalHistoryTableSchema]);
         }
     }
+
+    /// <inheritdoc />
+    public override IEnumerable<IAnnotation> ForRename(IColumn column)
+    {
+        if (column.Table[SqlServerAnnotationNames.IsTemporal] as bool? == true)
+        {
+            yield return new Annotation(SqlServerAnnotationNames.IsTemporal, true);
+
+            yield return new Annotation(
+                SqlServerAnnotationNames.TemporalHistoryTableName,
+                column.Table[SqlServerAnnotationNames.TemporalHistoryTableName]);
+
+            yield return new Annotation(
+                SqlServerAnnotationNames.TemporalHistoryTableSchema,
+                column.Table[SqlServerAnnotationNames.TemporalHistoryTableSchema]);
+
+            if (column[SqlServerAnnotationNames.TemporalPeriodStartColumnName] is string periodStartColumnName)
+            {
+                yield return new Annotation(
+                    SqlServerAnnotationNames.TemporalPeriodStartColumnName,
+                    periodStartColumnName);
+            }
+
+            if (column[SqlServerAnnotationNames.TemporalPeriodEndColumnName] is string periodEndColumnName)
+            {
+                yield return new Annotation(
+                    SqlServerAnnotationNames.TemporalPeriodEndColumnName,
+                    periodEndColumnName);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Problem is that when we drop column from the history table we need to disable versioning (and drop columns in both tables separately). However, since we have disabled the period, renaming (and other operations) also needs to happen for both tables now and we don't do it. So the column is only renamed for the temporal table and the name in history table stays the same. When we try to switch versioning back on the exception is thrown.

Fix is to flow the information to ColumnOperations that the column is part of a temporal table and when we process the migrations, if the versioning for the temporal table has been disabled, mirror the necessary operation(s) to the history table also.

Fixes #27423