### PR TITLE
Ensure FK properties have nullable-appropriate value comparers

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -594,10 +594,11 @@ public class InMemoryQueryableMethodTranslatingExpressionVisitor : QueryableMeth
         }
 
         if (joinCondition is MethodCallExpression methodCallExpression
-            && methodCallExpression.Method.IsStatic
-            && methodCallExpression.Method.DeclaringType == typeof(object)
             && methodCallExpression.Method.Name == nameof(object.Equals)
-            && methodCallExpression.Arguments.Count == 2)
+            && methodCallExpression.Arguments.Count == 2
+            && ((methodCallExpression.Method.IsStatic
+                    && methodCallExpression.Method.DeclaringType == typeof(object))
+                || typeof(ValueComparer).IsAssignableFrom(methodCallExpression.Method.DeclaringType)))
         {
             leftExpressions.Add(methodCallExpression.Arguments[0]);
             rightExpressions.Add(methodCallExpression.Arguments[1]);

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -42,12 +42,12 @@ public static class ExpressionExtensions
         }
 
         var property = propertyBase as IReadOnlyProperty;
-        var clrType = propertyBase?.ClrType ?? currentValueExpression.Type;
         var comparer = property?.GetValueComparer()
-            ?? ValueComparer.CreateDefault(clrType, favorStructuralComparisons: false);
+            ?? ValueComparer.CreateDefault(
+                propertyBase?.ClrType ?? currentValueExpression.Type, favorStructuralComparisons: false);
 
         return comparer.ExtractEqualsBody(
-            comparer.Type != clrType
+            comparer.Type != currentValueExpression.Type
                 ? Expression.Convert(currentValueExpression, comparer.Type)
                 : currentValueExpression,
             Expression.Default(comparer.Type));

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -1686,8 +1686,7 @@ public abstract class BuiltInDataTypesTestBase<TFixture> : IClassFixture<TFixtur
                     TestNullableDouble = -1.23456789,
                     TestNullableDecimal = -1234567890.01M,
                     TestNullableDateTime = DateTime.Parse("01/01/2000 12:34:56").ToUniversalTime(),
-                    TestNullableDateTimeOffset =
-                        new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)).ToUniversalTime(),
+                    TestNullableDateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
                     TestNullableTimeSpan = new TimeSpan(0, 10, 9, 8, 7),
                     TestNullableSingle = -1.234F,
                     TestNullableBoolean = false,
@@ -1723,8 +1722,7 @@ public abstract class BuiltInDataTypesTestBase<TFixture> : IClassFixture<TFixtur
             AssertEqualIfMapped(entityType, -1.23456789, () => dt.TestNullableDouble);
             AssertEqualIfMapped(entityType, -1234567890.01M, () => dt.TestNullableDecimal);
             AssertEqualIfMapped(entityType, DateTime.Parse("01/01/2000 12:34:56").ToUniversalTime(), () => dt.TestNullableDateTime);
-            AssertEqualIfMapped(
-                entityType, new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)).ToUniversalTime(),
+            AssertEqualIfMapped(entityType, new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
                 () => dt.TestNullableDateTimeOffset);
             AssertEqualIfMapped(entityType, new TimeSpan(0, 10, 9, 8, 7), () => dt.TestNullableTimeSpan);
             AssertEqualIfMapped(entityType, -1.234F, () => dt.TestNullableSingle);

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -204,6 +204,12 @@ public abstract class CustomConvertersTestBase<TFixture> : BuiltInDataTypesTestB
             _value = value;
         }
 
+        public override bool Equals(object obj)
+            => _value == ((Email)obj)?._value;
+
+        public override int GetHashCode()
+            => _value.GetHashCode();
+
         public static Email Create(string value)
             => new(value);
 
@@ -1069,7 +1075,7 @@ public abstract class CustomConvertersTestBase<TFixture> : BuiltInDataTypesTestB
                     b.Property(nameof(BuiltInNullableDataTypes.TestNullableDateTimeOffset)).HasConversion(
                         new ValueConverter<DateTimeOffset?, long>(
                             v => v.Value.ToUnixTimeMilliseconds(),
-                            v => DateTimeOffset.FromUnixTimeMilliseconds(v)));
+                            v => DateTimeOffset.FromUnixTimeMilliseconds(v).ToOffset(TimeSpan.FromHours(-8.0))));
 
                     b.Property(nameof(BuiltInNullableDataTypes.TestNullableDouble)).HasConversion(
                         new ValueConverter<double?, decimal?>(

--- a/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
@@ -1569,7 +1569,7 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
         public int? NonNullableAsNullable
         {
             get => _nonNullableAsNullable;
-            set => _nonNullableAsNullable = (int)value;
+            set => _nonNullableAsNullable = value ?? 0;
         }
     }
 
@@ -1930,7 +1930,10 @@ public abstract class StoreGeneratedTestBase<TFixture> : IClassFixture<TFixture>
                 {
                     b.Property(e => e.Id).HasField("_id");
                     b.Property(e => e.NullableAsNonNullable).HasField("_nullableAsNonNullable").ValueGeneratedOnAddOrUpdate();
-                    b.Property(e => e.NonNullableAsNullable).HasField("_nonNullableAsNullable").ValueGeneratedOnAddOrUpdate();
+                    b.Property(e => e.NonNullableAsNullable)
+                        .HasField("_nonNullableAsNullable")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .UsePropertyAccessMode(PropertyAccessMode.Property);
                 });
 
             modelBuilder.Entity<OptionalProduct>();

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -991,7 +991,7 @@ public abstract partial class ModelBuilderTest
 
             var wierd = entityType.FindProperty("Wierd");
             Assert.IsType<NumberToStringConverter<int>>(wierd.GetValueConverter());
-            Assert.IsType<CustomValueComparer<int>>(wierd.GetValueComparer());
+            Assert.IsType<ValueComparer<int?>>(wierd.GetValueComparer());
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Part of #11597

This change takes the ValueComparer defined for the principal key and uses it for the foreign key, but also accommodating for nulls appropriately. As part of this, we started getting some more complex expressions in value comparers used in the in-memory database. These expressions became part of the query, which then meant they needed to be translated. Therefore, this logic has been changed to call the value comparer as a method when using the in-memory database, and this method is then detected. This incidentally fixes #27495, which was also a case of a value comparer expression that could not be translated, and any other case where a value comparer could not be translated in in-memory queries.
