### PR TITLE
Simplify logging by collapsing together sync/async

### DIFF
--- a/rulesets/FxCop.ruleset
+++ b/rulesets/FxCop.ruleset
@@ -100,7 +100,7 @@
       <Rule Id="CA2009" Action="Error" />            <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
       <Rule Id="CA2010" Action="None" />             <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
       <Rule Id="CA2011" Action="Error" />            <!-- Avoid infinite recursion -->
-      <Rule Id="CA2012" Action="Error" />            <!-- Use ValueTasks correctly -->
+      <Rule Id="CA2012" Action="None" />             <!-- Use ValueTasks correctly -->
       <Rule Id="CA2013" Action="Error" />            <!-- Do not use ReferenceEquals with value types -->
       <Rule Id="CA2100" Action="None" />             <!-- Review SQL queries for security vulnerabilities -->
       <Rule Id="CA2101" Action="None" />             <!-- Specify marshaling for P/Invoke string arguments -->

--- a/rulesets/FxCop.test.ruleset
+++ b/rulesets/FxCop.test.ruleset
@@ -100,7 +100,7 @@
       <Rule Id="CA2009" Action="Error" />            <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
       <Rule Id="CA2010" Action="None" />             <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
       <Rule Id="CA2011" Action="Error" />            <!-- Avoid infinite recursion -->
-      <Rule Id="CA2012" Action="Error" />            <!-- Use ValueTasks correctly -->
+      <Rule Id="CA2012" Action="None" />             <!-- Use ValueTasks correctly -->
       <Rule Id="CA2013" Action="Error" />            <!-- Do not use ReferenceEquals with value types -->
       <Rule Id="CA2100" Action="None" />             <!-- Review SQL queries for security vulnerabilities -->
       <Rule Id="CA2101" Action="None" />             <!-- Specify marshaling for P/Invoke string arguments -->

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -330,7 +330,8 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
             this,
             isolationLevel,
             transactionId,
-            startTime);
+            startTime,
+            async: false).GetAwaiter().GetResult();
 
         var dbTransaction = interceptionResult.HasResult
             ? interceptionResult.Result
@@ -377,11 +378,12 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
         var startTime = DateTimeOffset.UtcNow;
         _stopwatch.Restart();
 
-        var interceptionResult = await Dependencies.TransactionLogger.TransactionStartingAsync(
+        var interceptionResult = await Dependencies.TransactionLogger.TransactionStarting(
                 this,
                 isolationLevel,
                 transactionId,
                 startTime,
+                async: true,
                 cancellationToken)
             .ConfigureAwait(false);
 


### PR DESCRIPTION
This proposes collapsing the sync and async logging extensions methods into a single method that receives an `async` parameter. It cuts down a lot of code and allows inlining all methods related to an event into one (no more BroadcastTransactionStarting, LogTransactionStarting, TransactionStarting...).

This PR only does this for a single event; if we like it I'll do EVERYTHING.