### PR TITLE
Update tool to roll forward to latest major version of runtime installed.

### DIFF
--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Microsoft.EntityFrameworkCore.Tools</RootNamespace>
     <CheckEolTargetFramework>False</CheckEolTargetFramework>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is needed otherwise it will try to require ".NET 2.0 Runtime" to be installed, which will cause roll forward to fail to load 6.0.0's System.Runtime when used on devices with newer versions of the .NET SDK and runtimes.

Fixes: https://github.com/dotnet/efcore/issues/27660.
Discovered at: https://github.com/dotnet/efcore/issues/27660#issuecomment-1073184551

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features) **N/A**
- [x] Code follows the same patterns and style as existing code in this repo **(tool projects TFM change)**

