### PR TITLE
Reimplement MaxBatchSize as a pre-check

### DIFF
--- a/src/EFCore.Relational/Update/ModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ModificationCommandBatch.cs
@@ -56,7 +56,5 @@ public abstract class ModificationCommandBatch
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous save operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public abstract Task ExecuteAsync(
-        IRelationalConnection connection,
-        CancellationToken cancellationToken = default);
+    public abstract Task ExecuteAsync(IRelationalConnection connection, CancellationToken cancellationToken = default);
 }

--- a/src/EFCore.Relational/Update/SingularModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/SingularModificationCommandBatch.cs
@@ -28,11 +28,8 @@ public class SingularModificationCommandBatch : AffectedCountModificationCommand
     }
 
     /// <summary>
-    ///     Returns <see langword="true" /> only when the batch contains a single command.
+    ///     The maximum number of <see cref="ModificationCommand"/> instances that can be added to a single batch; always returns 1.
     /// </summary>
-    /// <returns>
-    ///     <see langword="true" /> when the batch contains a single command, <see langword="false" /> otherwise.
-    /// </returns>
-    protected override bool IsValid()
-        => ModificationCommands.Count == 1;
+    protected override int MaxBatchSize
+        => 1;
 }

--- a/test/EFCore.Relational.Tests/TestUtilities/TestModificationCommandBatch.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestModificationCommandBatch.cs
@@ -5,16 +5,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 public class TestModificationCommandBatch : SingularModificationCommandBatch
 {
-    private readonly int _maxBatchSize;
-
     public TestModificationCommandBatch(
         ModificationCommandBatchFactoryDependencies dependencies,
         int? maxBatchSize)
         : base(dependencies)
-    {
-        _maxBatchSize = maxBatchSize ?? 1;
-    }
+        => MaxBatchSize = maxBatchSize ?? 1;
 
-    protected override bool IsValid()
-        => ModificationCommands.Count <= _maxBatchSize;
+    protected override int MaxBatchSize { get; }
 }

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -125,6 +125,9 @@ RETURNING 1;
 ",
             batch.CommandText,
             ignoreLineEndingDifferences: true);
+
+        Assert.Equal(1, batch.StoreCommand.RelationalCommand.Parameters.Count);
+        Assert.Equal(1, batch.StoreCommand.ParameterValues.Count);
     }
 
     [ConditionalFact]

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -61,7 +61,7 @@ public class SqlServerModificationCommandBatchTest
     {
     }
 
-    private static TestSqlServerModificationCommandBatch CreateBatch(int? maxBatchSize = null)
+    private static TestSqlServerModificationCommandBatch CreateBatch(int maxBatchSize = 42)
     {
         var typeMapper = CreateTypeMappingSource();
 
@@ -100,7 +100,7 @@ public class SqlServerModificationCommandBatchTest
 
     private class TestSqlServerModificationCommandBatch : SqlServerModificationCommandBatch
     {
-        public TestSqlServerModificationCommandBatch(ModificationCommandBatchFactoryDependencies dependencies, int? maxBatchSize)
+        public TestSqlServerModificationCommandBatch(ModificationCommandBatchFactoryDependencies dependencies, int maxBatchSize)
             : base(dependencies, maxBatchSize)
         {
         }


### PR DESCRIPTION
For better perf on SQLite (#27681)

Also moves the handling of MaxBatchSize to ReaderModificationCommandBatch and does some cleanup.
