### PR TITLE
Reduce SaveChanges roundtrips

### DIFF
--- a/src/EFCore/Metadata/IReadOnlyEntityType.cs
+++ b/src/EFCore/Metadata/IReadOnlyEntityType.cs
@@ -125,7 +125,7 @@ public interface IReadOnlyEntityType : IReadOnlyTypeBase
         => new[] { this }.Concat(GetDerivedTypes());
 
     /// <summary>
-    ///     Gets all types in the model that directly derive from a given entity type.
+    ///     Gets all types in the model that directly derive from a given entity type, in a deterministic top-to-bottom ordering.
     /// </summary>
     /// <returns>The derived types.</returns>
     IEnumerable<IReadOnlyEntityType> GetDirectlyDerivedTypes();

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -427,9 +427,8 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    // Note this is ISet because there is no suitable readonly interface in the profiles we are using
     [DebuggerStepThrough]
-    public virtual ISet<EntityType> GetDirectlyDerivedTypes()
+    public virtual IReadOnlySet<EntityType> GetDirectlyDerivedTypes()
         => _directlyDerivedTypes;
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/ModelExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ModelExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 /// <summary>
@@ -36,18 +38,25 @@ public static class ModelExtensions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public static IEnumerable<IEntityType> GetEntityTypesInHierarchicalOrder(this IModel model)
-        => Sort(model.GetEntityTypes());
-
-    private static IEnumerable<IEntityType> Sort(IEnumerable<IEntityType> entityTypes)
     {
-        var entityTypeGraph = new Multigraph<IEntityType, int>();
-        entityTypeGraph.AddVertices(entityTypes);
-        foreach (var entityType in entityTypes.Where(et => et.BaseType != null))
+        var entityTypes = new Queue<IEntityType>();
+
+        foreach (var root in model.GetRootEntityTypes())
         {
-            entityTypeGraph.AddEdge(entityType.BaseType!, entityType, 0);
+            entityTypes.Enqueue(root);
         }
 
-        return entityTypeGraph.BatchingTopologicalSort().SelectMany(b => b.OrderBy(et => et.Name));
+        while (entityTypes.Count > 0)
+        {
+            var current = entityTypes.Dequeue();
+
+            yield return current;
+
+            foreach (var descendant in current.GetDirectlyDerivedTypes())
+            {
+                entityTypes.Enqueue(descendant);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Shared/Multigraph.cs
+++ b/src/Shared/Multigraph.cs
@@ -8,9 +8,22 @@ namespace Microsoft.EntityFrameworkCore.Utilities;
 internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
     where TVertex : notnull
 {
+    private readonly IComparer<TVertex>? _secondarySortComparer;
     private readonly HashSet<TVertex> _vertices = new();
     private readonly Dictionary<TVertex, Dictionary<TVertex, object?>> _successorMap = new();
-    private readonly Dictionary<TVertex, HashSet<TVertex>> _predecessorMap = new();
+    private readonly Dictionary<TVertex, Dictionary<TVertex, object?>> _predecessorMap = new();
+
+    public Multigraph()
+    {
+    }
+
+    public Multigraph(IComparer<TVertex> secondarySortComparer)
+        => _secondarySortComparer = secondarySortComparer;
+
+    public Multigraph(Comparison<TVertex> secondarySortComparer)
+        : this(Comparer<TVertex>.Create(secondarySortComparer))
+    {
+    }
 
     public IEnumerable<TEdge> GetEdges(TVertex from, TVertex to)
     {
@@ -18,7 +31,7 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
         {
             if (successorSet.TryGetValue(to, out var edges))
             {
-                return edges is IEnumerable<TEdge> edgeList ? edgeList : (new[] { (TEdge)edges! });
+                return edges is IEnumerable<Edge> edgeList ? edgeList.Select(e => e.Payload) : (new[] { ((Edge)edges!).Payload });
             }
         }
 
@@ -31,7 +44,7 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
     public void AddVertices(IEnumerable<TVertex> vertices)
         => _vertices.UnionWith(vertices);
 
-    public void AddEdge(TVertex from, TVertex to, TEdge edge)
+    public void AddEdge(TVertex from, TVertex to, TEdge payload, bool requiresBatchingBoundary = false)
     {
 #if DEBUG
         if (!_vertices.Contains(from))
@@ -45,6 +58,8 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
         }
 #endif
 
+        var edge = new Edge(payload, requiresBatchingBoundary);
+
         if (!_successorMap.TryGetValue(from, out var successorEdges))
         {
             successorEdges = new Dictionary<TVertex, object?>();
@@ -53,9 +68,9 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
 
         if (successorEdges.TryGetValue(to, out var edges))
         {
-            if (edges is not List<TEdge> edgeList)
+            if (edges is not List<Edge> edgeList)
             {
-                edgeList = new List<TEdge> { (TEdge)edges! };
+                edgeList = new List<Edge> { (Edge)edges! };
                 successorEdges[to] = edgeList;
             }
 
@@ -66,13 +81,26 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
             successorEdges.Add(to, edge);
         }
 
-        if (!_predecessorMap.TryGetValue(to, out var predecessors))
+        if (!_predecessorMap.TryGetValue(to, out var predecessorEdges))
         {
-            predecessors = new HashSet<TVertex>();
-            _predecessorMap.Add(to, predecessors);
+            predecessorEdges = new Dictionary<TVertex, object?>();
+            _predecessorMap.Add(to, predecessorEdges);
         }
 
-        predecessors.Add(from);
+        if (predecessorEdges.TryGetValue(from, out edges))
+        {
+            if (edges is not List<Edge> edgeList)
+            {
+                edgeList = new List<Edge> { (Edge)edges! };
+                predecessorEdges[from] = edgeList;
+            }
+
+            edgeList.Add(edge);
+        }
+        else
+        {
+            predecessorEdges.Add(from, edge);
+        }
     }
 
     public override void Clear()
@@ -98,41 +126,121 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
         Func<IReadOnlyList<Tuple<TVertex, TVertex, IEnumerable<TEdge>>>, string>? formatCycle,
         Func<string, string>? formatException = null)
     {
-        var queue = new List<TVertex>();
+        var batches = TopologicalSortCore(withBatching: false, tryBreakEdge, formatCycle, formatException);
+
+        Check.DebugAssert(batches.Count < 2, "TopologicalSortCore did batching but withBatching was false");
+
+        return batches.Count == 1
+            ? batches[0]
+            : Array.Empty<TVertex>();
+    }
+
+    protected virtual string? ToString(TVertex vertex)
+        => vertex.ToString();
+
+    public IReadOnlyList<List<TVertex>> BatchingTopologicalSort()
+        => BatchingTopologicalSort(null, null);
+
+    public IReadOnlyList<List<TVertex>> BatchingTopologicalSort(
+        Func<TVertex, TVertex, IEnumerable<TEdge>, bool>? tryBreakEdge,
+        Func<IReadOnlyList<Tuple<TVertex, TVertex, IEnumerable<TEdge>>>, string>? formatCycle,
+        Func<string, string>? formatException = null)
+        => TopologicalSortCore(withBatching: true, tryBreakEdge, formatCycle, formatException);
+
+    private IReadOnlyList<List<TVertex>> TopologicalSortCore(
+        bool withBatching,
+        Func<TVertex, TVertex, IEnumerable<TEdge>, bool>? tryBreakEdge,
+        Func<IReadOnlyList<Tuple<TVertex, TVertex, IEnumerable<TEdge>>>, string>? formatCycle,
+        Func<string, string>? formatException = null)
+    {
+        // Performs a breadth-first topological sort (Kahn's algorithm)
+        var result = new List<List<TVertex>>();
+        var currentRootsQueue = new List<TVertex>();
+        var nextRootsQueue = new List<TVertex>();
+        var vertexesProcessed = 0;
+        var batchBoundaryRequired = false;
+        var currentBatch = new List<TVertex>();
+        var currentBatchSet = new HashSet<TVertex>();
+
         var predecessorCounts = new Dictionary<TVertex, int>(_predecessorMap.Count);
         foreach (var (vertex, vertices) in _predecessorMap)
         {
             predecessorCounts[vertex] = vertices.Count;
         }
 
+        // Bootstrap the topological sort by finding all vertexes which have no predecessors
         foreach (var vertex in _vertices)
         {
             if (!predecessorCounts.ContainsKey(vertex))
             {
-                queue.Add(vertex);
+                currentRootsQueue.Add(vertex);
             }
         }
 
-        var index = 0;
-        while (queue.Count < _vertices.Count)
-        {
-            while (index < queue.Count)
-            {
-                var currentRoot = queue[index];
-                index++;
+        result.Add(currentBatch);
 
-                foreach (var successor in GetOutgoingNeighbors(currentRoot))
+        while (vertexesProcessed < _vertices.Count)
+        {
+            while (currentRootsQueue.Count > 0)
+            {
+                // Secondary sorting: after the first topological sorting (according to dependencies between the commands as expressed in
+                // the graph), we apply an optional secondary sort.
+                // When sorting modification commands, this ensures a deterministic ordering and prevents deadlocks between concurrent
+                // transactions locking the same rows in different orders.
+                if (_secondarySortComparer is not null)
                 {
-                    predecessorCounts[successor]--;
-                    if (predecessorCounts[successor] == 0)
+                    currentRootsQueue.Sort(_secondarySortComparer);
+                }
+
+                // If we detected in the last roots pass that a batch boundary is required, close the current batch and start a new one.
+                if (batchBoundaryRequired)
+                {
+                    currentBatch = new();
+                    result.Add(currentBatch);
+                    currentBatchSet.Clear();
+
+                    batchBoundaryRequired = false;
+                }
+
+                foreach (var currentRoot in currentRootsQueue)
+                {
+                    currentBatch.Add(currentRoot);
+                    currentBatchSet.Add(currentRoot);
+                    vertexesProcessed++;
+
+                    foreach (var successor in GetOutgoingNeighbors(currentRoot))
                     {
-                        queue.Add(successor);
+                        predecessorCounts[successor]--;
+
+                        // If the successor has no other predecessors, add it for processing in the next roots pass.
+                        if (predecessorCounts[successor] == 0)
+                        {
+                            nextRootsQueue.Add(successor);
+
+                            // Detect batch boundary (if batching is enabled).
+                            // If the successor has any predecessor where the edge requires a batching boundary, and that predecessor is
+                            // already in the current batch, then the next batch will have to be executed in a separate batch.
+                            // TODO: Optimization: Instead of currentBatchSet, store a batch counter on each vertex, and check if later
+                            // vertexes have a boundary-requiring dependency on a vertex with the same batch counter.
+                            if (withBatching && _predecessorMap[successor].Any(
+                                    kv =>
+                                        (kv.Value is Edge { RequiresBatchingBoundary: true }
+                                            || kv.Value is IEnumerable<Edge> edges && edges.Any(e => e.RequiresBatchingBoundary))
+                                        && currentBatchSet.Contains(kv.Key)))
+                            {
+                                batchBoundaryRequired = true;
+                            }
+                        }
                     }
                 }
+
+                // Finished passing over the current roots, move on to the next set.
+                (currentRootsQueue, nextRootsQueue) = (nextRootsQueue, currentRootsQueue);
+                nextRootsQueue.Clear();
             }
 
-            // Cycle breaking
-            if (queue.Count < _vertices.Count)
+            // We have no more roots to process. That either means we're done, or that there's a cycle which we need to break
+            if (vertexesProcessed < _vertices.Count)
             {
                 var broken = false;
 
@@ -158,12 +266,15 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
 
                     if (tryBreakEdge(incomingNeighbor, candidateVertex, GetEdges(incomingNeighbor, candidateVertex)))
                     {
-                        _successorMap[incomingNeighbor].Remove(candidateVertex);
-                        _predecessorMap[candidateVertex].Remove(incomingNeighbor);
+                        var removed = _successorMap[incomingNeighbor].Remove(candidateVertex);
+                        Check.DebugAssert(removed, "Candidate vertex not found in successor map");
+                        removed = _predecessorMap[candidateVertex].Remove(incomingNeighbor);
+                        Check.DebugAssert(removed, "Incoming neighbor not found in predecessor map");
+
                         predecessorCounts[candidateVertex]--;
                         if (predecessorCounts[candidateVertex] == 0)
                         {
-                            queue.Add(candidateVertex);
+                            currentRootsQueue.Add(candidateVertex);
                             broken = true;
                         }
 
@@ -219,7 +330,7 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
             }
         }
 
-        return queue;
+        return result;
     }
 
     private void ThrowCycle(
@@ -250,158 +361,6 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
         throw new InvalidOperationException(message);
     }
 
-    protected virtual string? ToString(TVertex vertex)
-        => vertex.ToString();
-
-    public IReadOnlyList<List<TVertex>> BatchingTopologicalSort()
-        => BatchingTopologicalSort(null, null);
-
-    public IReadOnlyList<List<TVertex>> BatchingTopologicalSort(
-        Func<TVertex, TVertex, IEnumerable<TEdge>, bool>? tryBreakEdge,
-        Func<IReadOnlyList<Tuple<TVertex, TVertex, IEnumerable<TEdge>>>, string>? formatCycle)
-    {
-        var currentRootsQueue = new List<TVertex>();
-        var predecessorCounts = new Dictionary<TVertex, int>(_predecessorMap.Count);
-        foreach (var (vertex, vertices) in _predecessorMap)
-        {
-            predecessorCounts[vertex] = vertices.Count;
-        }
-
-        foreach (var vertex in _vertices)
-        {
-            if (!predecessorCounts.ContainsKey(vertex))
-            {
-                currentRootsQueue.Add(vertex);
-            }
-        }
-
-        var result = new List<List<TVertex>>();
-        var nextRootsQueue = new List<TVertex>();
-
-        while (result.Sum(b => b.Count) != _vertices.Count)
-        {
-            var currentRootIndex = 0;
-            while (currentRootIndex < currentRootsQueue.Count)
-            {
-                var currentRoot = currentRootsQueue[currentRootIndex];
-                currentRootIndex++;
-
-                foreach (var successor in GetOutgoingNeighbors(currentRoot))
-                {
-                    predecessorCounts[successor]--;
-                    if (predecessorCounts[successor] == 0)
-                    {
-                        nextRootsQueue.Add(successor);
-                    }
-                }
-
-                // Roll lists over for next batch
-                if (currentRootIndex == currentRootsQueue.Count)
-                {
-                    result.Add(currentRootsQueue);
-
-                    currentRootsQueue = nextRootsQueue;
-                    currentRootIndex = 0;
-
-                    if (currentRootsQueue.Count != 0)
-                    {
-                        nextRootsQueue = new List<TVertex>();
-                    }
-                }
-            }
-
-            // Cycle breaking
-            if (result.Sum(b => b.Count) != _vertices.Count)
-            {
-                var broken = false;
-
-                var candidateVertices = predecessorCounts.Keys.ToList();
-                var candidateIndex = 0;
-
-                while ((candidateIndex < candidateVertices.Count)
-                       && !broken
-                       && tryBreakEdge != null)
-                {
-                    var candidateVertex = candidateVertices[candidateIndex];
-                    if (predecessorCounts[candidateVertex] == 0)
-                    {
-                        candidateIndex++;
-                        continue;
-                    }
-
-                    // Find a vertex in the unsorted portion of the graph that has edges to the candidate
-                    var incomingNeighbor = GetIncomingNeighbors(candidateVertex)
-                        .First(
-                            neighbor => predecessorCounts.TryGetValue(neighbor, out var neighborPredecessors)
-                                && neighborPredecessors > 0);
-
-                    if (tryBreakEdge(incomingNeighbor, candidateVertex, GetEdges(incomingNeighbor, candidateVertex)))
-                    {
-                        _successorMap[incomingNeighbor].Remove(candidateVertex);
-                        _predecessorMap[candidateVertex].Remove(incomingNeighbor);
-                        predecessorCounts[candidateVertex]--;
-                        if (predecessorCounts[candidateVertex] == 0)
-                        {
-                            currentRootsQueue.Add(candidateVertex);
-                            nextRootsQueue = new List<TVertex>();
-                            broken = true;
-                        }
-
-                        continue;
-                    }
-
-                    candidateIndex++;
-                }
-
-                if (broken)
-                {
-                    continue;
-                }
-
-                var currentCycleVertex = _vertices.First(
-                    v => predecessorCounts.TryGetValue(v, out var predecessorCount) && predecessorCount != 0);
-                var cycle = new List<TVertex> { currentCycleVertex };
-                var finished = false;
-                while (!finished)
-                {
-                    foreach (var predecessor in GetIncomingNeighbors(currentCycleVertex))
-                    {
-                        if (!predecessorCounts.TryGetValue(predecessor, out var predecessorCount)
-                            || predecessorCount == 0)
-                        {
-                            continue;
-                        }
-
-                        predecessorCounts[currentCycleVertex] = -1;
-
-                        currentCycleVertex = predecessor;
-                        cycle.Add(currentCycleVertex);
-                        finished = predecessorCounts[predecessor] == -1;
-                        break;
-                    }
-                }
-
-                cycle.Reverse();
-
-                // Remove any tail that's not part of the cycle
-                var startingVertex = cycle[0];
-                for (var i = cycle.Count - 1; i >= 0; i--)
-                {
-                    if (cycle[i].Equals(startingVertex))
-                    {
-                        break;
-                    }
-
-                    cycle.RemoveAt(i);
-                }
-
-                ThrowCycle(cycle, formatCycle);
-            }
-        }
-
-        return result;
-    }
-
     public override IEnumerable<TVertex> Vertices
         => _vertices;
 
@@ -412,6 +371,8 @@ internal class Multigraph<TVertex, TEdge> : Graph<TVertex>
 
     public override IEnumerable<TVertex> GetIncomingNeighbors(TVertex to)
         => _predecessorMap.TryGetValue(to, out var predecessors)
-            ? predecessors
+            ? predecessors.Keys
             : Enumerable.Empty<TVertex>();
+
+    private record struct Edge(TEdge Payload, bool RequiresBatchingBoundary);
 }

--- a/test/EFCore.Relational.Specification.Tests/Update/StoreValueGenerationTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoreValueGenerationTestBase.cs
@@ -53,7 +53,7 @@ public abstract class StoreValueGenerationTestBase<TFixture> : IClassFixture<TFi
 
     #endregion Single operation
 
-    #region Two operations with same entity type
+    #region Same two operations with same entity type
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -85,9 +85,9 @@ public abstract class StoreValueGenerationTestBase<TFixture> : IClassFixture<TFi
     public virtual Task Delete_Delete_with_same_entity_type(bool async)
         => Test(EntityState.Deleted, EntityState.Deleted, GeneratedValues.Some, async, withSameEntityType: true);
 
-    #endregion Two operations with same entity type
+    #endregion Same two operations with same entity type
 
-    #region Two operations with different entity types
+    #region Same two operations with different entity types
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -119,7 +119,16 @@ public abstract class StoreValueGenerationTestBase<TFixture> : IClassFixture<TFi
     public virtual Task Delete_Delete_with_different_entity_types(bool async)
         => Test(EntityState.Deleted, EntityState.Deleted, GeneratedValues.Some, async, withSameEntityType: false);
 
-    #endregion Two operations with different entity types
+    #endregion Same two operations with different entity types
+
+    #region Different two operations
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Delete_Add_with_same_entity_types(bool async)
+        => Test(EntityState.Deleted, EntityState.Added, GeneratedValues.Some, async, withSameEntityType: true);
+
+    #endregion Different two operations
 
     protected virtual async Task Test(
         EntityState firstOperationType,

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -2525,13 +2525,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                     var m = Assert.IsType<InsertDataOperation>(o);
                     AssertMultidimensionalArray(
                         m.Values,
-                        v => Assert.Equal(42, v));
-                },
-                o =>
-                {
-                    var m = Assert.IsType<InsertDataOperation>(o);
-                    AssertMultidimensionalArray(
-                        m.Values,
+                        v => Assert.Equal(42, v),
                         v => Assert.Equal(43, v));
                 }));
 
@@ -5822,15 +5816,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                     AssertMultidimensionalArray(
                         operation.Values,
                         v => Assert.Equal(23, v),
-                        v => Assert.Null(v));
-                },
-                o =>
-                {
-                    var operation = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal(new[] { "Id", "MouseId" }, operation.Columns);
-                    AssertMultidimensionalArray(
-                        operation.Values,
+                        v => Assert.Null(v),
                         v => Assert.Equal(33, v),
                         v => Assert.Null(v));
                 },
@@ -5856,15 +5842,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                     AssertMultidimensionalArray(
                         operation.Values,
                         v => Assert.Equal(22, v),
-                        v => Assert.Equal(33, v));
-                },
-                o =>
-                {
-                    var operation = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Dogs", operation.Table);
-                    Assert.Equal(new[] { "Id", "PreyId" }, operation.Columns);
-                    AssertMultidimensionalArray(
-                        operation.Values,
+                        v => Assert.Equal(33, v),
                         v => Assert.Equal(23, v),
                         v => Assert.Null(v));
                 },
@@ -6461,15 +6439,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                     AssertMultidimensionalArray(
                         operation.Values,
                         v => Assert.Equal(23, v),
-                        v => Assert.Null(v));
-                },
-                o =>
-                {
-                    var operation = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal(new[] { "Id", "MouseId" }, operation.Columns);
-                    AssertMultidimensionalArray(
-                        operation.Values,
+                        v => Assert.Null(v),
                         v => Assert.Equal(33, v),
                         v => Assert.Null(v));
                 },
@@ -6495,15 +6465,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                     AssertMultidimensionalArray(
                         operation.Values,
                         v => Assert.Equal(22, v),
-                        v => Assert.Equal(33, v));
-                },
-                o =>
-                {
-                    var operation = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Dogs", operation.Table);
-                    Assert.Equal(new[] { "Id", "PreyId" }, operation.Columns);
-                    AssertMultidimensionalArray(
-                        operation.Values,
+                        v => Assert.Equal(33, v),
                         v => Assert.Equal(23, v),
                         v => Assert.Null(v));
                 },
@@ -6747,15 +6709,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                         operation.Values,
                         v => Assert.Equal(31, v),
                         v => Assert.Equal("Mouse", v),
-                        v => Assert.Null(v));
-                },
-                o =>
-                {
-                    var operation = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal(new[] { "Id", "Discriminator", "MouseId" }, operation.Columns);
-                    AssertMultidimensionalArray(
-                        operation.Values,
+                        v => Assert.Null(v),
                         v => Assert.Equal(32, v),
                         v => Assert.Equal("Mouse", v),
                         v => Assert.Null(v));
@@ -6771,42 +6725,15 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                         v => Assert.Equal(11, v),
                         v => Assert.Equal("Cat", v),
                         v => Assert.Equal(31, v),
-                        v => Assert.Null(v));
-                },
-                o =>
-                {
-                    var operation = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal(new[] { "Id", "Discriminator", "MouseId", "PreyId" }, operation.Columns);
-                    Assert.Null(operation.ColumnTypes);
-                    AssertMultidimensionalArray(
-                        operation.Values,
+                        v => Assert.Null(v),
                         v => Assert.Equal(12, v),
                         v => Assert.Equal("Cat", v),
                         v => Assert.Equal(32, v),
-                        v => Assert.Null(v));
-                },
-                o =>
-                {
-                    var operation = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal(new[] { "Id", "Discriminator", "MouseId", "PreyId" }, operation.Columns);
-                    Assert.Null(operation.ColumnTypes);
-                    AssertMultidimensionalArray(
-                        operation.Values,
+                        v => Assert.Null(v),
                         v => Assert.Equal(21, v),
                         v => Assert.Equal("Dog", v),
                         v => Assert.Null(v),
-                        v => Assert.Equal(31, v));
-                },
-                o =>
-                {
-                    var operation = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal(new[] { "Id", "Discriminator", "MouseId", "PreyId" }, operation.Columns);
-                    Assert.Null(operation.ColumnTypes);
-                    AssertMultidimensionalArray(
-                        operation.Values,
+                        v => Assert.Equal(31, v),
                         v => Assert.Equal(22, v),
                         v => Assert.Equal("Dog", v),
                         v => Assert.Null(v),
@@ -10352,14 +10279,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                         m.Values,
                         v => Assert.Equal(11111, v),
                         v => Assert.Equal(0, v),
-                        v => Assert.Equal("", v));
-                },
-                o =>
-                {
-                    var m = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Null(m.ColumnTypes);
-                    AssertMultidimensionalArray(
-                        m.Values,
+                        v => Assert.Equal("", v),
                         v => Assert.Equal(11112, v),
                         v => Assert.Equal(1, v),
                         v => Assert.Equal("new", v));
@@ -10751,14 +10671,7 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
                     AssertMultidimensionalArray(
                         m.Values,
                         v => Assert.Equal(38, v),
-                        v => Assert.Equal("newblog.url", v));
-                },
-                o =>
-                {
-                    var m = Assert.IsType<InsertDataOperation>(o);
-                    Assert.Equal("Blog", m.Table);
-                    AssertMultidimensionalArray(
-                        m.Values,
+                        v => Assert.Equal("newblog.url", v),
                         v => Assert.Equal(316, v),
                         v => Assert.Equal("nowitexists.blog", v));
                 },

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -82,24 +82,7 @@ public abstract class MigrationsModelDifferTestBase
     }
 
     protected void AssertMultidimensionalArray<T>(T[,] values, params Action<T>[] assertions)
-        => Assert.Collection(ToOnedimensionalArray(values), assertions);
-
-    protected static T[] ToOnedimensionalArray<T>(T[,] values, bool firstDimension = false)
-    {
-        Check.DebugAssert(
-            values.GetLength(firstDimension ? 1 : 0) == 1,
-            $"Length of dimension {(firstDimension ? 1 : 0)} is not 1.");
-
-        var result = new T[values.Length];
-        for (var i = 0; i < values.Length; i++)
-        {
-            result[i] = firstDimension
-                ? values[i, 0]
-                : values[0, i];
-        }
-
-        return result;
-    }
+        => Assert.Collection(values.Cast<T>(), assertions);
 
     protected static T[][] ToJaggedArray<T>(T[,] twoDimensionalArray, bool firstDimension = false)
     {

--- a/test/EFCore.Relational.Tests/TestUtilities/TestModificationCommandBatch.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestModificationCommandBatch.cs
@@ -9,7 +9,7 @@ public class TestModificationCommandBatch : SingularModificationCommandBatch
         ModificationCommandBatchFactoryDependencies dependencies,
         int? maxBatchSize)
         : base(dependencies)
-        => MaxBatchSize = maxBatchSize ?? 1;
+        => MaxBatchSize = maxBatchSize ?? 42;
 
     protected override int MaxBatchSize { get; }
 }

--- a/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -127,6 +127,51 @@ public class CommandBatchPreparerTest
     }
 
     [ConditionalFact]
+    public void BatchCommands_does_not_create_separate_batch_without_principal_key_database_generation()
+    {
+        var configuration = CreateContextServices(CreateFKOneToManyModelWithGeneratedIds());
+        var stateManager = configuration.GetRequiredService<IStateManager>();
+
+        var entry = stateManager.GetOrCreateEntry(new FakeEntity { Id = 42, Value = "Test" });
+        var relatedEntry1 = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 100, RelatedId = 42 });
+        var relatedEntry2 = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 101, RelatedId = 42 });
+        entry.SetEntityState(EntityState.Added);
+        relatedEntry1.SetEntityState(EntityState.Added);
+        relatedEntry2.SetEntityState(EntityState.Added);
+
+        var batches = CreateBatches(new[] { relatedEntry1, entry, relatedEntry2 }, new UpdateAdapter(stateManager));
+        var batch = Assert.Single(batches);
+
+        Assert.Equal(
+            new[] { entry, relatedEntry1, relatedEntry2 },
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
+    }
+
+    [ConditionalFact]
+    public void BatchCommands_creates_separate_batch_with_principal_key_database_generation()
+    {
+        var configuration = CreateContextServices(CreateFKOneToManyModelWithGeneratedIds());
+        var stateManager = configuration.GetRequiredService<IStateManager>();
+
+        var entry = stateManager.GetOrCreateEntry(new FakeEntity { Value = "Test" });
+        entry.SetEntityState(EntityState.Added);
+
+        var temporaryIdValue = entry.GetCurrentValue<int>(entry.EntityType.GetProperty(nameof(FakeEntity.Id)));
+
+        var relatedEntry1 = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 1, RelatedId = temporaryIdValue });
+        var relatedEntry2 = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 2, RelatedId = temporaryIdValue });
+        relatedEntry1.SetEntityState(EntityState.Added);
+        relatedEntry2.SetEntityState(EntityState.Added);
+
+        var batches = CreateBatches(new[] { relatedEntry1, entry, relatedEntry2 }, new UpdateAdapter(stateManager));
+
+        Assert.Collection(
+            batches,
+            b => Assert.Same(entry, b.ModificationCommands.Single().Entries.Single()),
+            b => Assert.Equal(new[] { relatedEntry1, relatedEntry2 }, b.ModificationCommands.Select(m => m.Entries.Single())));
+    }
+
+    [ConditionalFact]
     public void BatchCommands_sorts_related_added_entities()
     {
         var configuration = CreateContextServices(CreateSimpleFKModel());
@@ -142,11 +187,12 @@ public class CommandBatchPreparerTest
             new RelatedFakeEntity { Id = 42 });
         relatedEntry.SetEntityState(EntityState.Added);
 
-        var commandBatches = CreateBatches(new[] { relatedEntry, entry }, modelData);
+        var batches = CreateBatches(new[] { relatedEntry, entry }, modelData);
+        var batch = Assert.Single(batches);
 
         Assert.Equal(
             new[] { entry, relatedEntry },
-            commandBatches.Select(cb => cb.ModificationCommands.Single()).Select(mc => mc.Entries.Single()));
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
     }
 
     [ConditionalFact]
@@ -165,11 +211,12 @@ public class CommandBatchPreparerTest
             new RelatedFakeEntity { Id = 42 });
         relatedEntry.SetEntityState(EntityState.Modified);
 
-        var commandBatches = CreateBatches(new[] { relatedEntry, entry }, modelData);
+        var batches = CreateBatches(new[] { relatedEntry, entry }, modelData);
+        var batch = Assert.Single(batches);
 
         Assert.Equal(
             new[] { entry, relatedEntry },
-            commandBatches.Select(cb => cb.ModificationCommands.Single()).Select(mc => mc.Entries.Single()));
+            batch.ModificationCommands.Select(mc => mc.Entries.Single()));
     }
 
     [ConditionalFact]
@@ -188,11 +235,12 @@ public class CommandBatchPreparerTest
 
         var modelData = new UpdateAdapter(stateManager);
 
-        var commandBatches = CreateBatches(new[] { secondEntry, firstEntry }, modelData);
+        var batches = CreateBatches(new[] { secondEntry, firstEntry }, modelData);
+        var batch = Assert.Single(batches);
 
         Assert.Equal(
             new[] { firstEntry, secondEntry },
-            commandBatches.Select(cb => cb.ModificationCommands.Single()).Select(mc => mc.Entries.Single()));
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
     }
 
     [ConditionalFact]
@@ -216,11 +264,12 @@ public class CommandBatchPreparerTest
 
         var modelData = new UpdateAdapter(stateManager);
 
-        var commandBatches = CreateBatches(new[] { relatedEntry, previousParent, newParent }, modelData);
+        var batches = CreateBatches(new[] { relatedEntry, previousParent, newParent }, modelData);
+        var batch = Assert.Single(batches);
 
         Assert.Equal(
             new[] { newParent, relatedEntry, previousParent },
-            commandBatches.Select(cb => cb.ModificationCommands.Single()).Select(mc => mc.Entries.Single()));
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
     }
 
     [ConditionalFact]
@@ -243,11 +292,12 @@ public class CommandBatchPreparerTest
 
         var modelData = new UpdateAdapter(stateManager);
 
-        var commandBatches = CreateBatches(new[] { newChild, previousChild }, modelData);
+        var batches = CreateBatches(new[] { newChild, previousChild }, modelData);
+        var batch = Assert.Single(batches);
 
         Assert.Equal(
             new[] { previousChild, newChild },
-            commandBatches.Select(cb => cb.ModificationCommands.Single()).Select(mc => mc.Entries.Single()));
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
     }
 
     [ConditionalFact]
@@ -278,12 +328,12 @@ public class CommandBatchPreparerTest
 
         var modelData = new UpdateAdapter(stateManager);
 
-        var sortedEntities = CreateBatches(new[] { newEntity, newChildEntity, oldEntity, oldChildEntity }, modelData)
-            .Select(cb => cb.ModificationCommands.Single()).Select(mc => mc.Entries.Single()).ToArray();
+        var batches = CreateBatches(new[] { newEntity, newChildEntity, oldEntity, oldChildEntity }, modelData);
+        var batch = Assert.Single(batches);
 
         Assert.Equal(
-            new IUpdateEntry[] { oldChildEntity, oldEntity, newEntity, newChildEntity },
-            sortedEntities);
+            new[] { oldChildEntity, oldEntity, newEntity, newChildEntity },
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
     }
 
     [ConditionalFact]
@@ -291,30 +341,27 @@ public class CommandBatchPreparerTest
     {
         var configuration = RelationalTestHelpers.Instance.CreateContextServices(
             new ServiceCollection().AddScoped<IModificationCommandBatchFactory, TestModificationCommandBatchFactory>(),
-            CreateSimpleFKModel());
+            CreateFKOneToManyModelWithGeneratedIds());
 
         var stateManager = configuration.GetRequiredService<IStateManager>();
 
-        var fakeEntity = new FakeEntity { Id = 42, Value = "Test" };
-        var entry = stateManager.GetOrCreateEntry(fakeEntity);
+        var entry = stateManager.GetOrCreateEntry(new FakeEntity { Value = "Test" });
         entry.SetEntityState(EntityState.Added);
 
-        var relatedEntry = stateManager.GetOrCreateEntry(
-            new RelatedFakeEntity { Id = 42 });
+        var temporaryIdValue = entry.GetCurrentValue<int>(entry.EntityType.GetProperty(nameof(FakeEntity.Id)));
+        var relatedEntry = stateManager.GetOrCreateEntry(new RelatedFakeEntity { RelatedId = temporaryIdValue });
         relatedEntry.SetEntityState(EntityState.Added);
 
         var factory = (TestModificationCommandBatchFactory)configuration.GetService<IModificationCommandBatchFactory>();
 
-        var modelData = new UpdateAdapter(stateManager);
+        var batches = CreateCommandBatchPreparer(factory).BatchCommands(new[] { relatedEntry, entry }, new UpdateAdapter(stateManager));
 
-        var commandBatches = CreateCommandBatchPreparer(factory).BatchCommands(new[] { relatedEntry, entry }, modelData);
-
-        using var commandBatchesEnumerator = commandBatches.GetEnumerator();
-        commandBatchesEnumerator.MoveNext();
+        using var commandBatchesEnumerator = batches.GetEnumerator();
+        Assert.True(commandBatchesEnumerator.MoveNext());
 
         Assert.Equal(1, factory.CreateCount);
 
-        commandBatchesEnumerator.MoveNext();
+        Assert.True(commandBatchesEnumerator.MoveNext());
 
         Assert.Equal(2, factory.CreateCount);
     }
@@ -346,13 +393,12 @@ public class CommandBatchPreparerTest
 
         var modelData = new UpdateAdapter(stateManager);
 
-        var sortedEntities =
-            CreateBatches(new[] { fakeEntry, fakeEntry2, relatedFakeEntry }, modelData)
-            .Select(cb => cb.ModificationCommands.Single()).Select(mc => mc.Entries.Single()).ToArray();
+        var batches = CreateBatches(new[] { fakeEntry, fakeEntry2, relatedFakeEntry }, modelData);
+        var batch = Assert.Single(batches);
 
         Assert.Equal(
             new IUpdateEntry[] { fakeEntry, relatedFakeEntry, fakeEntry2 },
-            sortedEntities);
+            batch.ModificationCommands.Select(c => c.Entries.Single()));
     }
 
     [ConditionalFact]
@@ -508,9 +554,14 @@ FakeEntity [Deleted]"
 
         var modelData = new UpdateAdapter(stateManager);
 
-        var batches = CreateBatches(new[] { fakeEntry, fakeEntry2 }, modelData);
+        var batches = CreateBatches(new[] { fakeEntry2, fakeEntry }, modelData);
+        var batch = Assert.Single(batches);
 
-        Assert.Equal(2, batches.Count);
+        // The DELETE must be ordered before the UPDATE, otherwise we'd get a unique constraint violation.
+        Assert.Collection(
+            batch.ModificationCommands,
+            e => Assert.Equal(EntityState.Deleted, e.EntityState),
+            e => Assert.Equal(EntityState.Modified, e.EntityState));
     }
 
     [ConditionalFact]
@@ -914,15 +965,15 @@ FakeEntity [Deleted]"
         }
         else
         {
-            Assert.Equal(2, commandBatches.Count);
-            Assert.Equal(1, commandBatches.First().ModificationCommands.Count);
+            var batch = Assert.Single(commandBatches);
+            Assert.Equal(2, batch.ModificationCommands.Count);
 
-            var command = commandBatches.First().ModificationCommands.Single();
-            Assert.Equal(EntityState.Modified, command.EntityState);
+            var firstCommand = batch.ModificationCommands[0];
+            Assert.Equal(EntityState.Modified, firstCommand.EntityState);
 
-            Assert.Equal(2, command.ColumnModifications.Count);
+            Assert.Equal(2, firstCommand.ColumnModifications.Count);
 
-            var columnMod = command.ColumnModifications[0];
+            var columnMod = firstCommand.ColumnModifications[0];
 
             Assert.Equal(nameof(DerivedRelatedFakeEntity.Id), columnMod.ColumnName);
             Assert.Equal(first.Id, columnMod.Value);
@@ -932,7 +983,7 @@ FakeEntity [Deleted]"
             Assert.False(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
 
-            columnMod = command.ColumnModifications[1];
+            columnMod = firstCommand.ColumnModifications[1];
 
             Assert.Equal(nameof(AnotherFakeEntity.AnotherId), columnMod.ColumnName);
             Assert.Equal(second.AnotherId, columnMod.Value);
@@ -999,6 +1050,28 @@ FakeEntity [Deleted]"
                     .WithOne()
                     .HasForeignKey<RelatedFakeEntity>(c => c.Id);
             });
+
+        return modelBuilder.Model.FinalizeModel();
+    }
+
+    private static IModel CreateFKOneToManyModelWithGeneratedIds()
+    {
+        var modelBuilder = RelationalTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity<FakeEntity>(
+            b =>
+            {
+                b.Property(c => c.Id).ValueGeneratedOnAdd();
+                b.Ignore(c => c.UniqueValue);
+                b.Ignore(c => c.RelatedId);
+
+                b.HasMany<RelatedFakeEntity>()
+                    .WithOne()
+                    .HasForeignKey(c => c.RelatedId);
+            });
+
+        modelBuilder.Entity<RelatedFakeEntity>(
+            b => b.Property(c => c.Id).ValueGeneratedOnAdd());
 
         return modelBuilder.Model.FinalizeModel();
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
@@ -305,7 +305,7 @@ public class BatchingTest : IClassFixture<BatchingTest.BatchingTestFixture>
                 var owner = new Owner();
                 context.Owners.Add(owner);
 
-                for (var i = 1; i < 4; i++)
+                for (var i = 1; i < 3; i++)
                 {
                     var blog = new Blog { Id = Guid.NewGuid(), Owner = owner };
 
@@ -325,7 +325,7 @@ public class BatchingTest : IClassFixture<BatchingTest.BatchingTestFixture>
                             .GenerateMessage(3, 4),
                     Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
 
-                Assert.Equal(minBatchSize <= 3 ? 2 : 4, Fixture.TestSqlLoggerFactory.SqlStatements.Count);
+                Assert.Equal(minBatchSize <= 3 ? 1 : 3, Fixture.TestSqlLoggerFactory.SqlStatements.Count);
             }, context => AssertDatabaseState(context, false, expectedBlogs));
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
@@ -101,26 +101,17 @@ WHERE [c].[Id] = 1",
             @"@p0='Apteryx owenii' (Nullable = false) (Size = 100)
 @p1='1'
 @p2='Little spotted kiwi' (Size = 4000)
-
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-INSERT INTO [Animals] ([Species], [CountryId], [Name])
-VALUES (@p0, @p1, @p2);",
-            //
-            @"@p3='Apteryx owenii' (Nullable = false) (Size = 100)
+@p3='Apteryx owenii' (Nullable = false) (Size = 100)
 @p4=NULL (Size = 100)
 @p5='True'
-
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-INSERT INTO [Birds] ([Species], [EagleId], [IsFlightless])
-VALUES (@p3, @p4, @p5);",
-            //
-            @"@p6='Apteryx owenii' (Nullable = false) (Size = 100)
+@p6='Apteryx owenii' (Nullable = false) (Size = 100)
 @p7='0' (Size = 1)
 
-SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
+INSERT INTO [Animals] ([Species], [CountryId], [Name])
+VALUES (@p0, @p1, @p2);
+INSERT INTO [Birds] ([Species], [EagleId], [IsFlightless])
+VALUES (@p3, @p4, @p5);
 INSERT INTO [Kiwi] ([Species], [FoundOn])
 VALUES (@p6, @p7);",
             //
@@ -146,25 +137,16 @@ INNER JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
 WHERE [a].[Species] LIKE N'%owenii'",
             //
             @"@p0='Apteryx owenii' (Nullable = false) (Size = 100)
+@p1='Apteryx owenii' (Nullable = false) (Size = 100)
+@p2='Apteryx owenii' (Nullable = false) (Size = 100)
 
-SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
 DELETE FROM [Kiwi]
 OUTPUT 1
-WHERE [Species] = @p0;",
-            //
-            @"@p1='Apteryx owenii' (Nullable = false) (Size = 100)
-
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
+WHERE [Species] = @p0;
 DELETE FROM [Birds]
 OUTPUT 1
-WHERE [Species] = @p1;",
-            //
-            @"@p2='Apteryx owenii' (Nullable = false) (Size = 100)
-
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
+WHERE [Species] = @p1;
 DELETE FROM [Animals]
 OUTPUT 1
 WHERE [Species] = @p2;",
@@ -533,11 +515,19 @@ INNER JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]",
             @"@p0='Haliaeetus leucocephalus' (Nullable = false) (Size = 100)
 @p1='0'
 @p2='Bald eagle' (Size = 4000)
+@p3='Haliaeetus leucocephalus' (Nullable = false) (Size = 100)
+@p4='Apteryx haastii' (Size = 100)
+@p5='False'
+@p6='Haliaeetus leucocephalus' (Nullable = false) (Size = 100)
+@p7='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
 INSERT INTO [Animals] ([Species], [CountryId], [Name])
-VALUES (@p0, @p1, @p2);");
+VALUES (@p0, @p1, @p2);
+INSERT INTO [Birds] ([Species], [EagleId], [IsFlightless])
+VALUES (@p3, @p4, @p5);
+INSERT INTO [Eagle] ([Species], [Group])
+VALUES (@p6, @p7);");
     }
 
     public override async Task Subquery_OfType(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -707,13 +707,13 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
             Assert.Equal(EntityState.Unchanged, db.Entry(toAdd).State);
             Assert.DoesNotContain(toDelete, db.ChangeTracker.Entries().Select(e => e.Entity));
 
-            Assert.Equal(4, Fixture.TestSqlLoggerFactory.SqlStatements.Count);
+            Assert.Equal(3, Fixture.TestSqlLoggerFactory.SqlStatements.Count);
             Assert.Contains("SELECT", Fixture.TestSqlLoggerFactory.SqlStatements[0]);
             Assert.Contains("SELECT", Fixture.TestSqlLoggerFactory.SqlStatements[1]);
             Assert.Contains("@p0='" + deletedId, Fixture.TestSqlLoggerFactory.SqlStatements[2]);
             Assert.Contains("DELETE", Fixture.TestSqlLoggerFactory.SqlStatements[2]);
             Assert.Contains("UPDATE", Fixture.TestSqlLoggerFactory.SqlStatements[2]);
-            Assert.Contains("INSERT", Fixture.TestSqlLoggerFactory.SqlStatements[3]);
+            Assert.Contains("INSERT", Fixture.TestSqlLoggerFactory.SqlStatements[2]);
 
             var rows = await testDatabase.ExecuteScalarAsync<int>(
                 $"SELECT Count(*) FROM [dbo].[Blog] WHERE Id = {updatedId} AND Name = 'Blog is Updated'");

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentitySqlServerTest.cs
@@ -127,7 +127,7 @@ WHERE [Id] = @p0;");
 
     #endregion Single operation
 
-    #region Two operations with same entity type
+    #region Same two operations with same entity type
 
     public override async Task Add_Add_with_same_entity_type_and_generated_values(bool async)
     {
@@ -238,9 +238,9 @@ OUTPUT 1
 WHERE [Id] = @p1;");
     }
 
-    #endregion Two operations with same entity type
+    #endregion Same two operations with same entity type
 
-    #region Two operations with different entity types
+    #region Same two operations with different entity types
 
     public override async Task Add_Add_with_different_entity_types_and_generated_values(bool async)
     {
@@ -349,7 +349,30 @@ OUTPUT 1
 WHERE [Id] = @p1;");
     }
 
-    #endregion Two operations with different entity types
+    #endregion Same two operations with different entity types
+
+    #region Different two operations
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public override async Task Delete_Add_with_same_entity_types(bool async)
+    {
+        await Test(EntityState.Deleted, EntityState.Added, GeneratedValues.Some, async, withSameEntityType: true);
+
+        AssertSql(
+            @"@p0='1'
+@p1='1001'
+
+SET NOCOUNT ON;
+DELETE FROM [WithSomeDatabaseGenerated]
+OUTPUT 1
+WHERE [Id] = @p0;
+INSERT INTO [WithSomeDatabaseGenerated] ([Data2])
+OUTPUT INSERTED.[Id], INSERTED.[Data1]
+VALUES (@p1);");
+    }
+
+    #endregion Different two operations
 
     protected override async Task Test(
         EntityState firstOperationType,

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentityTriggerSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentityTriggerSqlServerTest.cs
@@ -133,7 +133,7 @@ SELECT @@ROWCOUNT;");
 
     #endregion Single operation
 
-    #region Two operations with same entity type
+    #region Same two operations with same entity type
 
     public override async Task Add_Add_with_same_entity_type_and_generated_values(bool async)
     {
@@ -259,9 +259,9 @@ WHERE [Id] = @p1;
 SELECT @@ROWCOUNT;");
     }
 
-    #endregion Two operations with same entity type
+    #endregion Same two operations with same entity type
 
-    #region Two operations with different entity types
+    #region Same two operations with different entity types
 
     public override async Task Add_Add_with_different_entity_types_and_generated_values(bool async)
     {
@@ -322,7 +322,6 @@ SELECT [Id], [Data1], [Data2]
 FROM [WithAllDatabaseGenerated2]
 WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();");
     }
-
 
     public override async Task Modify_Modify_with_different_entity_types_and_generated_values(bool async)
     {
@@ -388,7 +387,7 @@ WHERE [Id] = @p1;
 SELECT @@ROWCOUNT;");
     }
 
-    #endregion Two operations with different entity types
+    #endregion Same two operations with different entity types
 
     public override async Task Three_Add_use_batched_inserts(bool async)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSequenceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSequenceSqlServerTest.cs
@@ -129,7 +129,7 @@ WHERE [Id] = @p0;");
 
     #endregion Single operation
 
-    #region Two operations with same entity type
+    #region Same two operations with same entity type
 
     public override async Task Add_Add_with_same_entity_type_and_generated_values(bool async)
     {
@@ -242,9 +242,9 @@ OUTPUT 1
 WHERE [Id] = @p1;");
     }
 
-    #endregion Two operations with same entity type
+    #endregion Same two operations with same entity type
 
-    #region Two operations with different entity types
+    #region Same two operations with different entity types
 
     public override async Task Add_Add_with_different_entity_types_and_generated_values(bool async)
     {
@@ -352,7 +352,7 @@ OUTPUT 1
 WHERE [Id] = @p1;");
     }
 
-    #endregion Two operations with different entity types
+    #endregion Same two operations with different entity types
 
     protected override async Task Test(
         EntityState firstOperationType,

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSequenceTriggerSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSequenceTriggerSqlServerTest.cs
@@ -141,7 +141,7 @@ SELECT @@ROWCOUNT;");
 
     #endregion Single operation
 
-    #region Two operations with same entity type
+    #region Same two operations with same entity type
 
     public override async Task Add_Add_with_same_entity_type_and_generated_values(bool async)
     {
@@ -266,9 +266,9 @@ WHERE [Id] = @p1;
 SELECT @@ROWCOUNT;");
     }
 
-    #endregion Two operations with same entity type
+    #endregion Same two operations with same entity type
 
-    #region Two operations with different entity types
+    #region Same two operations with different entity types
 
     public override async Task Add_Add_with_different_entity_types_and_generated_values(bool async)
     {
@@ -402,7 +402,7 @@ WHERE [Id] = @p1;
 SELECT @@ROWCOUNT;");
     }
 
-    #endregion Two operations with different entity types
+    #endregion Same two operations with different entity types
 
     public override async Task Three_Add_use_batched_inserts(bool async)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Update/StoreValueGenerationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/StoreValueGenerationSqliteTest.cs
@@ -100,7 +100,7 @@ RETURNING 1;");
 
     #endregion Single operation
 
-    #region Two operations with same entity type
+    #region Same two operations with same entity type
 
     public override async Task Add_Add_with_same_entity_type_and_generated_values(bool async)
     {
@@ -214,9 +214,9 @@ WHERE ""Id"" = @p0
 RETURNING 1;");
     }
 
-    #endregion Two operations with same entity type
+    #endregion Same two operations with same entity type
 
-    #region Two operations with different entity types
+    #region Same two operations with different entity types
 
     public override async Task Add_Add_with_different_entity_types_and_generated_values(bool async)
     {
@@ -330,7 +330,7 @@ WHERE ""Id"" = @p0
 RETURNING 1;");
     }
 
-    #endregion Two operations with different entity types
+    #endregion Same two operations with different entity types
 
     public class StoreValueGenerationSqliteFixture : StoreValueGenerationFixtureBase
     {

--- a/test/EFCore.Tests/Utilities/MultigraphTest.cs
+++ b/test/EFCore.Tests/Utilities/MultigraphTest.cs
@@ -393,6 +393,54 @@ public class MultigraphTest
     }
 
     [ConditionalFact]
+    public void TopologicalSort_with_secondary_sort()
+    {
+        var vertexOne = new Vertex { Id = 1 };
+        var vertexTwo = new Vertex { Id = 2 };
+        var vertexThree = new Vertex { Id = 3 };
+        var vertexFour = new Vertex { Id = 4 };
+
+        var edgeOne = new Edge { Id = 1 };
+        var edgeTwo = new Edge { Id = 2 };
+
+        var graph = new Multigraph<Vertex, Edge>((v1, v2) => Comparer<int>.Default.Compare(v1.Id, v2.Id));
+        graph.AddVertices(new[] { vertexFour, vertexThree, vertexTwo, vertexOne });
+
+        // 1 -> {3}
+        graph.AddEdge(vertexOne, vertexThree, edgeOne);
+        // 2 -> {4}
+        graph.AddEdge(vertexTwo, vertexFour, edgeTwo);
+
+        Assert.Equal(
+            new[] { vertexOne, vertexTwo, vertexThree, vertexFour },
+            graph.TopologicalSort().ToArray());
+    }
+
+    [ConditionalFact]
+    public void TopologicalSort_without_secondary_sort()
+    {
+        var vertexOne = new Vertex { Id = 1 };
+        var vertexTwo = new Vertex { Id = 2 };
+        var vertexThree = new Vertex { Id = 3 };
+        var vertexFour = new Vertex { Id = 4 };
+
+        var edgeOne = new Edge { Id = 1 };
+        var edgeTwo = new Edge { Id = 2 };
+
+        var graph = new Multigraph<Vertex, Edge>();
+        graph.AddVertices(new[] { vertexFour, vertexThree, vertexTwo, vertexOne });
+
+        // 1 -> {3}
+        graph.AddEdge(vertexOne, vertexThree, edgeOne);
+        // 2 -> {4}
+        graph.AddEdge(vertexTwo, vertexFour, edgeTwo);
+
+        Assert.Equal(
+            new[] { vertexTwo, vertexOne, vertexFour, vertexThree },
+            graph.TopologicalSort().ToArray());
+    }
+
+    [ConditionalFact]
     public void BatchingTopologicalSort_throws_with_formatted_message_when_cycle_cannot_be_broken()
     {
         const string message = "Formatted cycle";
@@ -789,6 +837,81 @@ public class MultigraphTest
             CoreStrings.CircularDependency(
                 nameof(C) + " ->" + Environment.NewLine + nameof(B) + " ->" + Environment.NewLine + nameof(C)),
             Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort()).Message);
+    }
+
+    [ConditionalFact]
+    public void BatchingTopologicalSort_with_secondary_sort()
+    {
+        var vertexOne = new Vertex { Id = 1 };
+        var vertexTwo = new Vertex { Id = 2 };
+        var vertexThree = new Vertex { Id = 3 };
+        var vertexFour = new Vertex { Id = 4 };
+
+        var edgeOne = new Edge { Id = 1 };
+        var edgeTwo = new Edge { Id = 2 };
+
+        var graph = new Multigraph<Vertex, Edge>((v1, v2) => Comparer<int>.Default.Compare(v1.Id, v2.Id));
+        graph.AddVertices(new[] { vertexFour, vertexThree, vertexTwo, vertexOne });
+
+        // 1 -> {3}
+        graph.AddEdge(vertexOne, vertexThree, edgeOne);
+        // 2 -> {4}
+        graph.AddEdge(vertexTwo, vertexFour, edgeTwo);
+
+        Assert.Equal(
+            new[] { vertexOne, vertexTwo, vertexThree, vertexFour },
+            graph.BatchingTopologicalSort().Single().ToArray());
+    }
+
+    [ConditionalFact]
+    public void BatchingTopologicalSort_without_secondary_sort()
+    {
+        var vertexOne = new Vertex { Id = 1 };
+        var vertexTwo = new Vertex { Id = 2 };
+        var vertexThree = new Vertex { Id = 3 };
+        var vertexFour = new Vertex { Id = 4 };
+
+        var edgeOne = new Edge { Id = 1 };
+        var edgeTwo = new Edge { Id = 2 };
+
+        var graph = new Multigraph<Vertex, Edge>();
+        graph.AddVertices(new[] { vertexFour, vertexThree, vertexTwo, vertexOne });
+
+        // 1 -> {3}
+        graph.AddEdge(vertexOne, vertexThree, edgeOne);
+        // 2 -> {4}
+        graph.AddEdge(vertexTwo, vertexFour, edgeTwo);
+
+        Assert.Equal(
+            new[] { vertexTwo, vertexOne, vertexFour, vertexThree },
+            graph.BatchingTopologicalSort().Single().ToArray());
+    }
+
+    [ConditionalFact]
+    public void BatchingTopologicalSort_with_batching_boundary_edge()
+    {
+        var vertexOne = new Vertex { Id = 1 };
+        var vertexTwo = new Vertex { Id = 2 };
+        var vertexThree = new Vertex { Id = 3 };
+        var vertexFour = new Vertex { Id = 4 };
+
+        var edgeOne = new Edge { Id = 1 };
+        var edgeTwo = new Edge { Id = 2 };
+
+        var graph = new Multigraph<Vertex, Edge>((v1, v2) => Comparer<int>.Default.Compare(v1.Id, v2.Id));
+        graph.AddVertices(new[] { vertexFour, vertexThree, vertexTwo, vertexOne });
+
+        // 1 -> {3}
+        graph.AddEdge(vertexOne, vertexThree, edgeOne, requiresBatchingBoundary: true);
+        // 2 -> {4}
+        graph.AddEdge(vertexTwo, vertexFour, edgeTwo);
+
+        var batches = graph.BatchingTopologicalSort();
+
+        Assert.Collection(
+            batches,
+            b => Assert.Equal(new[] { vertexOne, vertexTwo }, b.ToArray()),
+            b => Assert.Equal(new[] { vertexThree, vertexFour }, b.ToArray()));
     }
 
     private static IMutableModel CreateModel()


### PR DESCRIPTION
This is a draft for allowing batching in more cases by only applying a batch boundary for foreign keys where a principal key property is database-generated. There's still work and failing tests, but it seems like a good point to get feedback on the general approach.

* Multigraph edges now have an additional flag - RequiresBatchBoundary.
* The batching topological sort continuously adds to the same batch, unless it sees an edge with RequiresBatchBoundary=true pointing to a vertex that's in the current batch.
* Since we now mix commands with dependencies in the same batch (as long as the dependency doesn't require a batch boundary), we can no longer do "secondary" sorting within the batch (ModificationCommandComparer). For now that's removed, I'm not sure of the exact importance of this.

See tests BatchCommands_does_not_create_batch_without_principal_key_database_generation, BatchCommands_creates_batch_with_principal_key_database_generation, Delete_Add_with_same_entity_types. 

Closes #20664