### PR TITLE
[6.0.x] Ignore a failing Cosmos test to unblock builds

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -782,7 +782,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(Skip = "Fails on CI #27688")]
         public override async Task Distinct_Scalar(bool async)
         {
             await base.Distinct_Scalar(async);


### PR DESCRIPTION
- backport of 5df9bcf1d716