### PR TITLE
[release/6.0] Tools: Target .NET 6 to improve compatibility with osx-arm64

### DIFF
--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -12,10 +12,10 @@ dotnet ef dbcontext scaffold
 dotnet ef database drop
 dotnet ef database update
     </Description>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;win-arm64</PackAsToolShimRuntimeIdentifiers>
     <!-- Because this project uses a custom nuspec, this is necessary to ensure the generated shims are in the publish directory. -->
     <PackagedShimOutputRootDirectory>$(OutDir)</PackagedShimOutputRootDirectory>
     <RootNamespace>Microsoft.EntityFrameworkCore.Tools</RootNamespace>

--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Microsoft.EntityFrameworkCore.Tools</RootNamespace>
     <CheckEolTargetFramework>False</CheckEolTargetFramework>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For tools targeting versions below 6.0, the `dotnet tool install` command creates an **x64** shim. When users try to run `dotnet ef`, it errors with *The required library libhostfxr.dylib could not be found.*

For tools targeting 6.0 or higher, it will generate an **arm64** shim. This enables the tool to work as expected.

Fixes #27787, fixes #27827

### Customer impact

Without this, users are required to specify `-a arm64` when installing the tool on osx-arm64 before it will work.

### Regression?

Sort of. The `dotnet tool install` behavior changed in 6.0.1 causing our tool to stop working.

### Risk

Low. EF Core 6.0 already requires .NET 6.0, so users already have it installed, and because we specify RollForward= Major, it's already being used to run dotnet-ef.