### PR TITLE
[6.0.x] Reset read count on RelationalDataReader

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -61,6 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             _reader = reader;
             _commandId = commandId;
             _logger = logger;
+            _readCount = 0;
             _disposed = false;
             _startTime = DateTimeOffset.UtcNow;
             _stopwatch.Restart();


### PR DESCRIPTION
**Description**
As part of the EF Core 6.0 query perf optimization cycle, RelationalDataReader started to get recycled across executions, but the read count value wasn't properly reset.

**Customer impact**
When tracking how many reader reads were performed via DataReaderDisposingEventData.ReadCount, users got incorrect values since the count wasn't properly reset across usages of RelationalDataReader. No known workaround.

**How found**
Customer reported on 6.0.

**Regression**
Yes, From 5.0.

**Testing**
Added test.

**Risk**
Very low risk, one-line fix.

Backports #27845
Fixes #27652

