### PR TITLE
[6.0.x] Return null constraint names for keys and FKs on entity types not mapped to a table.

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
@@ -26,6 +26,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>The foreign key constraint name.</returns>
         public static string? GetConstraintName(this IReadOnlyForeignKey foreignKey)
         {
+            var tableName = foreignKey.DeclaringEntityType.GetTableName();
+            if (tableName == null)
+            {
+                return null;
+            }
+
             var annotation = foreignKey.FindAnnotation(RelationalAnnotationNames.Name);
             return annotation != null
                 ? (string?)annotation.Value
@@ -44,6 +50,12 @@ namespace Microsoft.EntityFrameworkCore
             in StoreObjectIdentifier storeObject,
             in StoreObjectIdentifier principalStoreObject)
         {
+            if (storeObject.StoreObjectType != StoreObjectType.Table
+                || principalStoreObject.StoreObjectType != StoreObjectType.Table)
+            {
+                return null;
+            }
+
             var annotation = foreignKey.FindAnnotation(RelationalAnnotationNames.Name);
             return annotation != null
                 ? (string?)annotation.Value
@@ -85,6 +97,12 @@ namespace Microsoft.EntityFrameworkCore
             in StoreObjectIdentifier storeObject,
             in StoreObjectIdentifier principalStoreObject)
         {
+            if (storeObject.StoreObjectType != StoreObjectType.Table
+                || principalStoreObject.StoreObjectType != StoreObjectType.Table)
+            {
+                return null;
+            }
+
             var propertyNames = foreignKey.Properties.GetColumnNames(storeObject);
             var principalPropertyNames = foreignKey.PrincipalKey.Properties.GetColumnNames(principalStoreObject);
             if (propertyNames == null

--- a/test/EFCore.Relational.Tests/ModelBuilding/RelationalTestModelBuilderExtensions.cs
+++ b/test/EFCore.Relational.Tests/ModelBuilding/RelationalTestModelBuilderExtensions.cs
@@ -277,6 +277,82 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             return builder;
         }
 
+        public static ModelBuilderTest.TestEntityTypeBuilder<TEntity> ToView<TEntity>(
+            this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder,
+            string? schema)
+            where TEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<EntityTypeBuilder<TEntity>> genericBuilder:
+                    genericBuilder.Instance.ToView(schema);
+                    break;
+                case IInfrastructure<EntityTypeBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToView(schema);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestEntityTypeBuilder<TEntity> ToView<TEntity>(
+            this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder,
+            string? name,
+            string? schema)
+            where TEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<EntityTypeBuilder<TEntity>> genericBuilder:
+                    genericBuilder.Instance.ToView(name, schema);
+                    break;
+                case IInfrastructure<EntityTypeBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToView(name, schema);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestOwnedNavigationBuilder<TOwnerEntity, TRelatedEntity> ToView<TOwnerEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestOwnedNavigationBuilder<TOwnerEntity, TRelatedEntity> builder,
+            string? schema)
+            where TOwnerEntity : class
+            where TRelatedEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<OwnedNavigationBuilder<TOwnerEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.ToView(schema);
+                    break;
+                case IInfrastructure<OwnedNavigationBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToView(schema);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestOwnedNavigationBuilder<TOwnerEntity, TRelatedEntity> ToView<TOwnerEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestOwnedNavigationBuilder<TOwnerEntity, TRelatedEntity> builder,
+            string? name,
+            string? schema)
+            where TOwnerEntity : class
+            where TRelatedEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<OwnedNavigationBuilder<TOwnerEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.ToView(name, schema);
+                    break;
+                case IInfrastructure<OwnedNavigationBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToView(name, schema);
+                    break;
+            }
+
+            return builder;
+        }
+
         public static ModelBuilderTest.TestEntityTypeBuilder<TEntity> HasCheckConstraint<TEntity>(
             this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder,
             string name,

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
@@ -836,6 +836,84 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal("blah", owned.GetTableName());
                 Assert.Null(owned.GetSchema());
             }
+            
+            [ConditionalFact]
+            public virtual void Owned_type_collections_can_be_mapped_to_a_view()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<Customer>().OwnsMany(
+                    c => c.Orders,
+                    r =>
+                    {
+                        r.HasKey(o => o.OrderId);
+                        r.Ignore(o => o.OrderCombination);
+                        r.Ignore(o => o.Details);
+                        r.ToView("bar", "foo");
+                    });
+
+                var model = modelBuilder.FinalizeModel();
+
+                var owner = model.FindEntityType(typeof(Customer));
+                var ownership = owner.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
+                Assert.True(ownership.IsOwnership);
+                Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+                Assert.Empty(ownership.GetMappedConstraints());
+
+                Assert.Equal(nameof(Customer), owner.GetTableName());
+                Assert.Null(owner.GetSchema());
+
+                Assert.Null(owned.GetForeignKeys().Single().GetConstraintName());
+                Assert.Single(owned.GetIndexes());
+                Assert.Null(owned.FindPrimaryKey().GetName());
+                Assert.Equal(
+                    new[] { nameof(Order.OrderId), nameof(Order.AnotherCustomerId), nameof(Order.CustomerId) },
+                    owned.GetProperties().Select(p => p.GetColumnBaseName()));
+                Assert.Null(owned.GetTableName());
+                Assert.Null(owned.GetSchema());
+                Assert.Equal("bar", owned.GetViewName());
+                Assert.Equal("foo", owned.GetViewSchema());
+            }
+            
+            [ConditionalFact]
+            public virtual void Owner_can_be_mapped_to_a_view()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<Customer>().OwnsMany(
+                    c => c.Orders,
+                    r =>
+                    {
+                        r.HasKey(o => o.OrderId);
+                        r.Ignore(o => o.OrderCombination);
+                        r.Ignore(o => o.Details);
+                    })
+                    .ToView("bar", "foo");
+
+                var model = modelBuilder.FinalizeModel();
+
+                var owner = model.FindEntityType(typeof(Customer));
+                var ownership = owner.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
+                Assert.True(ownership.IsOwnership);
+                Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+                Assert.Empty(ownership.GetMappedConstraints());
+
+                Assert.Null(owner.GetTableName());
+                Assert.Null(owner.GetSchema());
+                Assert.Equal("bar", owner.GetViewName());
+                Assert.Equal("foo", owner.GetViewSchema());
+
+                Assert.Equal("FK_Order__CustomerId", owned.GetForeignKeys().Single().GetConstraintName());
+                Assert.Equal("IX_Order_CustomerId", owned.GetIndexes().Single().GetDatabaseName());
+                Assert.Equal("PK_Order", owned.FindPrimaryKey().GetName());
+                Assert.Equal(
+                    new[] { nameof(Order.OrderId), nameof(Order.AnotherCustomerId), nameof(Order.CustomerId) },
+                    owned.GetProperties().Select(p => p.GetColumnBaseName()));
+                Assert.Equal(nameof(Order), owned.GetTableName());
+                Assert.Null(owned.GetSchema());
+            }
 
             [ConditionalFact]
             public override void Can_configure_owned_type()


### PR DESCRIPTION
**Description**
When getting the FK name the code assumed that both entity types are mapped to tables, since it's the only way an FK constraint can be created in the database.

**Customer impact**
When creating a foreign key between an entity type mapped to a view and an entity type mapped to a table an exception is thrown. No known workaround other than not creating the FK.

**How found**
Customer reported on 6.0.

**Regression**
Yes, From 5.0.

**Testing**
Added tests for this scenario.

**Risk**
Low risk, avoids NRE.

Partial backport of https://github.com/dotnet/efcore/commit/786cb40576d47874549753e6d92fbcf3e65a4f64
Fixes #27854