### PR TITLE
Suppress uninitialized DbSet warnings when a ctor is present

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,6 +26,6 @@
     <MicrosoftExtensionsLoggingVersion>7.0.0-preview.4.22217.5</MicrosoftExtensionsLoggingVersion>
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
-    <MicrosoftCodeAnalysisVersion>4.0.1</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>4.2.0-2.final</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #26879

