### PR TITLE
Refactor UpdateSqlGenerator to separate select logic

### DIFF
--- a/src/EFCore.Relational/Update/SelectingUpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/SelectingUpdateSqlGenerator.cs
@@ -1,0 +1,308 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Microsoft.EntityFrameworkCore.Update;
+
+/// <summary>
+///     <para>
+///         A base class for the <see cref="IUpdateSqlGenerator" /> service that is typically inherited from by database providers.
+///         The implementation uses a separate SELECT query after the update SQL to retrieve any database-generated values or for
+///         concurrency checking.
+///     </para>
+///     <para>
+///         This type is typically used by database providers; it is generally not used in application code.
+///     </para>
+/// </summary>
+/// <remarks>
+///     <para>
+///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance is used by many
+///         <see cref="DbContext" /> instances. The implementation must be thread-safe. This service cannot depend on services registered
+///         as <see cref="ServiceLifetime.Scoped" />.
+///     </para>
+///     <para>
+///         See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see> for more
+///         information and examples.
+///     </para>
+/// </remarks>
+public abstract class SelectingUpdateSqlGenerator : UpdateSqlGenerator
+{
+    /// <summary>
+    ///     Initializes a new instance of the this class.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing dependencies for this service.</param>
+    protected SelectingUpdateSqlGenerator(UpdateSqlGeneratorDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    /// <inheritdoc />
+    public override ResultSetMapping AppendInsertOperation(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
+        => AppendInsertAndSelectOperations(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    /// <summary>
+    ///     Appends SQL for inserting a row to the commands being built, via an INSERT followed by an optional SELECT to retrieve any
+    ///     database-generated values.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="command">The command that represents the delete operation.</param>
+    /// <param name="commandPosition">The ordinal of this command in the batch.</param>
+    /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
+    protected virtual ResultSetMapping AppendInsertAndSelectOperations(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
+    {
+        var name = command.TableName;
+        var schema = command.Schema;
+        var operations = command.ColumnModifications;
+
+        var writeOperations = operations.Where(o => o.IsWrite).ToList();
+        var readOperations = operations.Where(o => o.IsRead).ToList();
+
+        AppendInsertCommand(commandStringBuilder, name, schema, writeOperations, readOperations: Array.Empty<IColumnModification>());
+
+        if (readOperations.Count > 0)
+        {
+            var keyOperations = operations.Where(o => o.IsKey).ToList();
+
+            requiresTransaction = true;
+
+            return AppendSelectAffectedCommand(commandStringBuilder, name, schema, readOperations, keyOperations, commandPosition);
+        }
+
+        requiresTransaction = false;
+
+        return AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
+    }
+
+    /// <inheritdoc />
+    public override ResultSetMapping AppendUpdateOperation(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
+        => AppendUpdateAndSelectOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    /// <summary>
+    ///     Appends SQL for updating a row to the commands being built, via an UPDATE followed by a SELECT to retrieve any
+    ///     database-generated values or for concurrency checking.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="command">The command that represents the delete operation.</param>
+    /// <param name="commandPosition">The ordinal of this command in the batch.</param>
+    /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
+    protected virtual ResultSetMapping AppendUpdateAndSelectOperation(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
+    {
+        var name = command.TableName;
+        var schema = command.Schema;
+        var operations = command.ColumnModifications;
+
+        var writeOperations = operations.Where(o => o.IsWrite).ToList();
+        var conditionOperations = operations.Where(o => o.IsCondition).ToList();
+        var readOperations = operations.Where(o => o.IsRead).ToList();
+
+        AppendUpdateCommand(commandStringBuilder, name, schema, writeOperations, Array.Empty<IColumnModification>(), conditionOperations);
+
+        if (readOperations.Count > 0)
+        {
+            var keyOperations = operations.Where(o => o.IsKey).ToList();
+
+            requiresTransaction = true;
+
+            return AppendSelectAffectedCommand(commandStringBuilder, name, schema, readOperations, keyOperations, commandPosition);
+        }
+
+        requiresTransaction = false;
+
+        return AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
+    }
+
+    /// <inheritdoc />
+    public override ResultSetMapping AppendDeleteOperation(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
+        => AppendDeleteAndSelectOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    /// <summary>
+    ///     Appends SQL for updating a row to the commands being built, via a DELETE followed by a SELECT for concurrency checking.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="command">The command that represents the delete operation.</param>
+    /// <param name="commandPosition">The ordinal of this command in the batch.</param>
+    /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
+    protected virtual ResultSetMapping AppendDeleteAndSelectOperation(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
+    {
+        var name = command.TableName;
+        var schema = command.Schema;
+        var operations = command.ColumnModifications;
+
+        var conditionOperations = operations.Where(o => o.IsCondition).ToList();
+
+        requiresTransaction = false;
+
+        AppendDeleteCommand(commandStringBuilder, name, schema, Array.Empty<IColumnModification>(), conditionOperations);
+
+        return AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
+    }
+
+    /// <summary>
+    ///     Appends a SQL command for selecting affected data.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="name">The name of the table.</param>
+    /// <param name="schema">The table schema, or <see langword="null" /> to use the default schema.</param>
+    /// <param name="readOperations">The operations representing the data to be read.</param>
+    /// <param name="conditionOperations">The operations used to generate the <c>WHERE</c> clause for the select.</param>
+    /// <param name="commandPosition">The ordinal of the command for which rows affected it being returned.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for this command.</returns>
+    protected virtual ResultSetMapping AppendSelectAffectedCommand(
+        StringBuilder commandStringBuilder,
+        string name,
+        string? schema,
+        IReadOnlyList<IColumnModification> readOperations,
+        IReadOnlyList<IColumnModification> conditionOperations,
+        int commandPosition)
+    {
+        AppendSelectCommandHeader(commandStringBuilder, readOperations);
+        AppendFromClause(commandStringBuilder, name, schema);
+        AppendWhereAffectedClause(commandStringBuilder, conditionOperations);
+        commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator)
+            .AppendLine();
+
+        return ResultSetMapping.LastInResultSet;
+    }
+
+    /// <summary>
+    ///     Appends a SQL fragment for starting a <c>SELECT</c>.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="operations">The operations representing the data to be read.</param>
+    protected virtual void AppendSelectCommandHeader(
+        StringBuilder commandStringBuilder,
+        IReadOnlyList<IColumnModification> operations)
+        => commandStringBuilder
+            .Append("SELECT ")
+            .AppendJoin(
+                operations,
+                SqlGenerationHelper,
+                (sb, o, helper) => helper.DelimitIdentifier(sb, o.ColumnName));
+
+    /// <summary>
+    ///     Appends a SQL fragment for starting a <c>FROM</c> clause.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="name">The name of the table.</param>
+    /// <param name="schema">The table schema, or <see langword="null" /> to use the default schema.</param>
+    protected virtual void AppendFromClause(
+        StringBuilder commandStringBuilder,
+        string name,
+        string? schema)
+    {
+        commandStringBuilder
+            .AppendLine()
+            .Append("FROM ");
+        SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, name, schema);
+    }
+
+    /// <summary>
+    ///     Appends a <c>WHERE</c> clause involving rows affected.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="operations">The operations from which to build the conditions.</param>
+    protected virtual void AppendWhereAffectedClause(
+        StringBuilder commandStringBuilder,
+        IReadOnlyList<IColumnModification> operations)
+    {
+        commandStringBuilder
+            .AppendLine()
+            .Append("WHERE ");
+
+        AppendRowsAffectedWhereCondition(commandStringBuilder, 1);
+
+        if (operations.Count > 0)
+        {
+            commandStringBuilder
+                .Append(" AND ")
+                .AppendJoin(
+                    operations, (sb, v) =>
+                    {
+                        if (v.IsKey)
+                        {
+                            if (!v.IsRead)
+                            {
+                                AppendWhereCondition(sb, v, v.UseOriginalValueParameter);
+                                return true;
+                            }
+                        }
+
+                        if (IsIdentityOperation(v))
+                        {
+                            AppendIdentityWhereCondition(sb, v);
+                            return true;
+                        }
+
+                        return false;
+                    }, " AND ");
+        }
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether the given modification represents an auto-incrementing column.
+    /// </summary>
+    /// <param name="modification">The column modification.</param>
+    /// <returns><see langword="true" /> if the given modification represents an auto-incrementing column.</returns>
+    protected virtual bool IsIdentityOperation(IColumnModification modification)
+        => modification.IsKey && modification.IsRead;
+
+    /// <summary>
+    ///     Appends a <c>WHERE</c> condition checking rows affected.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="expectedRowsAffected">The expected number of rows affected.</param>
+    protected abstract void AppendRowsAffectedWhereCondition(
+        StringBuilder commandStringBuilder,
+        int expectedRowsAffected);
+
+    /// <summary>
+    ///     Appends a <c>WHERE</c> condition for the identity (i.e. key value) of the given column.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="columnModification">The column for which the condition is being generated.</param>
+    protected abstract void AppendIdentityWhereCondition(
+        StringBuilder commandStringBuilder,
+        IColumnModification columnModification);
+
+    /// <summary>
+    ///     Appends a SQL command for selecting the number of rows affected.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="name">The name of the table.</param>
+    /// <param name="schema">The table schema, or <see langword="null" /> to use the default schema.</param>
+    /// <param name="commandPosition">The ordinal of the command for which rows affected it being returned.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for this command.</returns>
+    protected abstract ResultSetMapping AppendSelectAffectedCountCommand(
+        StringBuilder commandStringBuilder,
+        string name,
+        string? schema,
+        int commandPosition);
+}

--- a/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
@@ -7,8 +7,8 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 /// <summary>
 ///     <para>
-///         A base class for the <see cref="IUpdateSqlGenerator" /> service that is typically inherited from
-///         by database providers.
+///         A base class for the <see cref="IUpdateSqlGenerator" /> service that is typically inherited from by database providers.
+///         The implementation uses a SQL RETURNING clause to retrieve any database-generated values or for concurrency checking.
 ///     </para>
 ///     <para>
 ///         This type is typically used by database providers; it is generally not used in application code.
@@ -16,13 +16,13 @@ namespace Microsoft.EntityFrameworkCore.Update;
 /// </summary>
 /// <remarks>
 ///     <para>
-///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
-///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
-///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance is used by many
+///         <see cref="DbContext" /> instances. The implementation must be thread-safe. This service cannot depend on services registered
+///         as <see cref="ServiceLifetime.Scoped" />.
 ///     </para>
 ///     <para>
-///         See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
-///         for more information and examples.
+///         See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see> for more
+///         information and examples.
 ///     </para>
 /// </remarks>
 public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
@@ -60,6 +60,22 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
         IReadOnlyModificationCommand command,
         int commandPosition,
         out bool requiresTransaction)
+        => AppendInsertReturningOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    /// <summary>
+    ///     Appends SQL for inserting a row to the commands being built, via an INSERT containing an optional RETURNING clause to retrieve
+    ///     any database-generated values.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="command">The command that represents the delete operation.</param>
+    /// <param name="commandPosition">The ordinal of this command in the batch.</param>
+    /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
+    public virtual ResultSetMapping AppendInsertReturningOperation(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
     {
         var name = command.TableName;
         var schema = command.Schema;
@@ -84,6 +100,22 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
     /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
     /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
     public virtual ResultSetMapping AppendUpdateOperation(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
+        => AppendUpdateReturningOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    /// <summary>
+    ///     Appends SQL for updating a row to the commands being built, via an UPDATE containing an RETURNING clause to retrieve any
+    ///     database-generated values or for concurrency checking.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="command">The command that represents the delete operation.</param>
+    /// <param name="commandPosition">The ordinal of this command in the batch.</param>
+    /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
+    protected virtual ResultSetMapping AppendUpdateReturningOperation(
         StringBuilder commandStringBuilder,
         IReadOnlyModificationCommand command,
         int commandPosition,
@@ -115,6 +147,21 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
     /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
     /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
     public virtual ResultSetMapping AppendDeleteOperation(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction)
+        => AppendDeleteReturningOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
+
+    /// <summary>
+    ///     Appends SQL for deleting a row to the commands being built, via a DELETE containing a RETURNING clause for concurrency checking.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="command">The command that represents the delete operation.</param>
+    /// <param name="commandPosition">The ordinal of this command in the batch.</param>
+    /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
+    protected virtual ResultSetMapping AppendDeleteReturningOperation(
         StringBuilder commandStringBuilder,
         IReadOnlyModificationCommand command,
         int commandPosition,
@@ -203,33 +250,6 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
     }
 
     /// <summary>
-    ///     Appends a SQL command for selecting affected data.
-    /// </summary>
-    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
-    /// <param name="name">The name of the table.</param>
-    /// <param name="schema">The table schema, or <see langword="null" /> to use the default schema.</param>
-    /// <param name="readOperations">The operations representing the data to be read.</param>
-    /// <param name="conditionOperations">The operations used to generate the <c>WHERE</c> clause for the select.</param>
-    /// <param name="commandPosition">The ordinal of the command for which rows affected it being returned.</param>
-    /// <returns>The <see cref="ResultSetMapping" /> for this command.</returns>
-    protected virtual ResultSetMapping AppendSelectAffectedCommand(
-        StringBuilder commandStringBuilder,
-        string name,
-        string? schema,
-        IReadOnlyList<IColumnModification> readOperations,
-        IReadOnlyList<IColumnModification> conditionOperations,
-        int commandPosition)
-    {
-        AppendSelectCommandHeader(commandStringBuilder, readOperations);
-        AppendFromClause(commandStringBuilder, name, schema);
-        AppendWhereAffectedClause(commandStringBuilder, conditionOperations);
-        commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator)
-            .AppendLine();
-
-        return ResultSetMapping.LastInResultSet;
-    }
-
-    /// <summary>
     ///     Appends a SQL fragment for starting an <c>INSERT</c>.
     /// </summary>
     /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
@@ -305,38 +325,6 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
                         g.SqlGenerationHelper.GenerateParameterNamePlaceholder(sb, o.ParameterName);
                     }
                 });
-    }
-
-    /// <summary>
-    ///     Appends a SQL fragment for starting a <c>SELECT</c>.
-    /// </summary>
-    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
-    /// <param name="operations">The operations representing the data to be read.</param>
-    protected virtual void AppendSelectCommandHeader(
-        StringBuilder commandStringBuilder,
-        IReadOnlyList<IColumnModification> operations)
-        => commandStringBuilder
-            .Append("SELECT ")
-            .AppendJoin(
-                operations,
-                SqlGenerationHelper,
-                (sb, o, helper) => helper.DelimitIdentifier(sb, o.ColumnName));
-
-    /// <summary>
-    ///     Appends a SQL fragment for starting a <c>FROM</c> clause.
-    /// </summary>
-    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
-    /// <param name="name">The name of the table.</param>
-    /// <param name="schema">The table schema, or <see langword="null" /> to use the default schema.</param>
-    protected virtual void AppendFromClause(
-        StringBuilder commandStringBuilder,
-        string name,
-        string? schema)
-    {
-        commandStringBuilder
-            .AppendLine()
-            .Append("FROM ");
-        SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, name, schema);
     }
 
     /// <summary>
@@ -447,65 +435,6 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
     }
 
     /// <summary>
-    ///     Appends a <c>WHERE</c> clause involving rows affected.
-    /// </summary>
-    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
-    /// <param name="operations">The operations from which to build the conditions.</param>
-    protected virtual void AppendWhereAffectedClause(
-        StringBuilder commandStringBuilder,
-        IReadOnlyList<IColumnModification> operations)
-    {
-        commandStringBuilder
-            .AppendLine()
-            .Append("WHERE ");
-
-        AppendRowsAffectedWhereCondition(commandStringBuilder, 1);
-
-        if (operations.Count > 0)
-        {
-            commandStringBuilder
-                .Append(" AND ")
-                .AppendJoin(
-                    operations, (sb, v) =>
-                    {
-                        if (v.IsKey)
-                        {
-                            if (!v.IsRead)
-                            {
-                                AppendWhereCondition(sb, v, v.UseOriginalValueParameter);
-                                return true;
-                            }
-                        }
-
-                        if (IsIdentityOperation(v))
-                        {
-                            AppendIdentityWhereCondition(sb, v);
-                            return true;
-                        }
-
-                        return false;
-                    }, " AND ");
-        }
-    }
-
-    /// <summary>
-    ///     Returns a value indicating whether the given modification represents an auto-incrementing column.
-    /// </summary>
-    /// <param name="modification">The column modification.</param>
-    /// <returns><see langword="true" /> if the given modification represents an auto-incrementing column.</returns>
-    protected virtual bool IsIdentityOperation(IColumnModification modification)
-        => modification.IsKey && modification.IsRead;
-
-    /// <summary>
-    ///     Appends a <c>WHERE</c> condition checking rows affected.
-    /// </summary>
-    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
-    /// <param name="expectedRowsAffected">The expected number of rows affected.</param>
-    protected abstract void AppendRowsAffectedWhereCondition(
-        StringBuilder commandStringBuilder,
-        int expectedRowsAffected);
-
-    /// <summary>
     ///     Appends a <c>WHERE</c> condition for the given column.
     /// </summary>
     /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
@@ -544,15 +473,6 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
             }
         }
     }
-
-    /// <summary>
-    ///     Appends a <c>WHERE</c> condition for the identity (i.e. key value) of the given column.
-    /// </summary>
-    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
-    /// <param name="columnModification">The column for which the condition is being generated.</param>
-    protected abstract void AppendIdentityWhereCondition(
-        StringBuilder commandStringBuilder,
-        IColumnModification columnModification);
 
     /// <summary>
     ///     Appends SQL text that defines the start of a batch.
@@ -596,7 +516,15 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
         SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, name, schema);
     }
 
-    private static void AppendSqlLiteral(
+    /// <summary>
+    ///     Appends the literal value for <paramref name="modification" /> to the command being built by
+    ///     <paramref name="commandStringBuilder" />.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL fragment should be appended.</param>
+    /// <param name="modification">The column modification whose literal should get appended.</param>
+    /// <param name="tableName">The table name of the column, used when an exception is thrown.</param>
+    /// <param name="schema">The schema of the column, used when an exception is thrown.</param>
+    protected static void AppendSqlLiteral(
         StringBuilder commandStringBuilder,
         IColumnModification modification,
         string? tableName,

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
@@ -31,28 +31,6 @@ public class SqliteUpdateSqlGenerator : UpdateSqlGenerator
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, IColumnModification columnModification)
-    {
-        SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, "rowid");
-        commandStringBuilder.Append(" = ")
-            .Append("last_insert_rowid()");
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    protected override void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
-        => commandStringBuilder.Append("changes() = ").Append(expectedRowsAffected);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public override string GenerateNextSequenceValueOperation(string name, string? schema)
         => throw new NotSupportedException(SqliteStrings.SequencesNotSupported);
 }

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeSqlGenerator.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeSqlGenerator.cs
@@ -50,14 +50,4 @@ public class FakeSqlGenerator : UpdateSqlGenerator
         AppendBatchHeaderCalls++;
         base.AppendBatchHeader(commandStringBuilder);
     }
-
-    protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, IColumnModification columnModification)
-        => commandStringBuilder
-            .Append(SqlGenerationHelper.DelimitIdentifier(columnModification.ColumnName))
-            .Append(" = ")
-            .Append("provider_specific_identity()");
-
-    protected override void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
-        => commandStringBuilder
-            .Append("provider_specific_rowcount() = ").Append(expectedRowsAffected);
 }


### PR DESCRIPTION
This introduces a new SelectingUpdateSqlGenerator abstract class, which uses SELECT after the INSERT/UPDATE/DELETE to retrieve database-generated values or to perform concurrency checks. This moves all SELECT logic out of UpdateSqlGenerator, for providers which don't require it. SqlServerUpdateSqlGenerator inherits from SelectingUpdateSqlGenerator and uses the SELECT logic in various cases where triggers are defined (and OUTPUT cannot be used).

The design isn't amazing: SelectingUpdateSqlGenerator extends UpdateSqlGenerator, so that SqlServerUpdateSqlGenerator can call methods from both (it's a combination of both modes, depending on whether there are triggers or not). But it seems reasonable (am open for other ideas).

Note that most of SelectingUpdateSqlGenerator is covered for SQL Server tests which involve triggers.

Closes #10431
