### PR TITLE
[6.0.x] Add [DynamicDependency] on DateOnly/TimeOnly for trimming

### DIFF
--- a/src/EFCore.Relational/Query/IMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/IMethodCallTranslator.cs
@@ -33,6 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         // This is a 6.0.x hack to make trimming work, since the linker doesn't see our GetRequiredRuntimeMethod invocations below
         // (see #26288)
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Math))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DateOnly))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TimeOnly))]
         SqlExpression? Translate(
             SqlExpression? instance,
             MethodInfo method,


### PR DESCRIPTION
### Description

Due to EF Core using wrappers to look up methods via reflection (GetRequiredRuntimeMethod), the linker cannot see the dependency on those methods, and trimmed applications fail.

### Customer impact

It isn't possible to use EF Core's SQLite provider in a trimmed application.

### How found

Customer report on 6.0

### Regression

Yes, from 5.0. Although EF Core 5.0 was never officially trimming-compatible, at least basic scenarios were possible.

### Testing

Coverage will be added in 7.0, where trimming will be a focus. The fix was verified manually.

Note that EF Core 6.0 still won't be fully trimming-compatible, but this unlocks at least the basic SQLite scenarios which customers were asking for.

### Risk

Very low - the fix only adds an attribute which is meaningful only to the linker.

### Details

This uses the [DynamicDependency] attribute to make sure System.DateOnly and TimeOnly aren't trimmed when using EF Core.

Fixes #27311
Similar to #27098
