### PR TITLE
[release/6.0] Force NullabilityInfoContextSupport=true in user projects

### DIFF
--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -32,6 +32,13 @@ Microsoft.EntityFrameworkCore.DbSet
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="buildTransitive\**\*">
+      <Pack>True</Pack>
+      <PackagePath>buildTransitive</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="Properties\CoreStrings.Designer.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>CoreStrings.Designer.cs</LastGenOutput>

--- a/src/EFCore/buildTransitive/net6.0/Microsoft.EntityFrameworkCore.props
+++ b/src/EFCore/buildTransitive/net6.0/Microsoft.EntityFrameworkCore.props
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!--
+         MAUI (and other size-conscient profiles) trim the nullability attributes, causing the EF Core NRT support to break.
+         This prevents the attributes from being trimmed.
+    -->
+    <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
### Description

MAUI's aggressive trimming of NRT-related attributes (https://github.com/dotnet/runtime/issues/55860) doesn't allow users to use NRTs in EF Core models.

### Customer impact

EF Core currently cannot be used with NRTs in MAUI. In 6.0, these attributes are silendly discarded (and an incorrect model is built); in EF Core, an exception is thrown (since NullabilityInfoContext is used).

### How found

Reported by @eerhardt in #27474

### Regression

No, MAUI hasn't yet been released.

### Testing

Manual.

### Risk

Very low - this simply adds a .props file to the EF Core nuget package.

### Details

As suggested by @eerhardt, this adds a .props file to the EF Core main nuget package, which overrides the <NullabilityInfoContextSupport> msbuild property to conserve the nullability attributes.

Fixes #27474