### PR TITLE
Always use explicit SQL Server schema in reverse engineered models

### DIFF
--- a/src/EFCore.SqlServer/Diagnostics/Internal/SqlServerLoggingDefinitions.cs
+++ b/src/EFCore.SqlServer/Diagnostics/Internal/SqlServerLoggingDefinitions.cs
@@ -49,14 +49,6 @@ public class SqlServerLoggingDefinitions : RelationalLoggingDefinitions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public EventDefinitionBase? LogFoundDefaultSchema;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public EventDefinitionBase? LogFoundTypeAlias;
 
     /// <summary>

--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -38,7 +38,7 @@ public static class SqlServerEventId
         ColumnFound = CoreEventId.ProviderDesignBaseId,
         ColumnNotNamedWarning,
         ColumnSkipped,
-        DefaultSchemaFound,
+        DefaultSchemaFound, // Obsolete, but must remain
         ForeignKeyColumnFound,
         ForeignKeyColumnMissingWarning,
         ForeignKeyColumnNotNamedWarning,

--- a/src/EFCore.SqlServer/Extensions/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/Internal/SqlServerLoggerExtensions.cs
@@ -246,26 +246,6 @@ public static class SqlServerLoggerExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static void DefaultSchemaFound(
-        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-        string schemaName)
-    {
-        var definition = SqlServerResources.LogFoundDefaultSchema(diagnostics);
-
-        if (diagnostics.ShouldLog(definition))
-        {
-            definition.Log(diagnostics, schemaName);
-        }
-
-        // No DiagnosticsSource events because these are purely design-time messages
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public static void TypeAliasFound(
         this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
         string typeAliasName,

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -571,31 +571,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     Found default schema '{defaultSchema}'.
-        /// </summary>
-        public static EventDefinition<string> LogFoundDefaultSchema(IDiagnosticsLogger logger)
-        {
-            var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundDefaultSchema;
-            if (definition == null)
-            {
-                definition = NonCapturingLazyInitializer.EnsureInitialized(
-                    ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundDefaultSchema,
-                    logger,
-                    static logger => new EventDefinition<string>(
-                        logger.Options,
-                        SqlServerEventId.DefaultSchemaFound,
-                        LogLevel.Debug,
-                        "SqlServerEventId.DefaultSchemaFound",
-                        level => LoggerMessage.Define<string>(
-                            level,
-                            SqlServerEventId.DefaultSchemaFound,
-                            _resourceManager.GetString("LogFoundDefaultSchema")!)));
-            }
-
-            return (EventDefinition<string>)definition;
-        }
-
-        /// <summary>
         ///     Found foreign key on table '{tableName}' with name '{foreignKeyName}', principal table '{principalTableName}', delete action {deleteAction}.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogFoundForeignKey(IDiagnosticsLogger logger)

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -208,10 +208,6 @@
     <value>Found column with table: {tableName}, column name: {columnName}, ordinal: {ordinal}, data type: {dataType}, maximum length: {maxLength}, precision: {precision}, scale: {scale}, nullable: {nullable}, identity: {identity}, default value: {defaultValue}, computed value: {computedValue}, computed value is stored: {stored}.</value>
     <comment>Debug SqlServerEventId.ColumnFound string string int string int int int bool bool string string bool?</comment>
   </data>
-  <data name="LogFoundDefaultSchema" xml:space="preserve">
-    <value>Found default schema '{defaultSchema}'.</value>
-    <comment>Debug SqlServerEventId.DefaultSchemaFound string</comment>
-  </data>
   <data name="LogFoundForeignKey" xml:space="preserve">
     <value>Found foreign key on table '{tableName}' with name '{foreignKeyName}', principal table '{principalTableName}', delete action {deleteAction}.</value>
     <comment>Debug SqlServerEventId.ForeignKeyFound string string string string</comment>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -116,7 +116,6 @@ public class SqlServerDatabaseModelFactory : DatabaseModelFactory
             _engineEdition = GetEngineEdition(connection);
 
             databaseModel.DatabaseName = connection.Database;
-            databaseModel.DefaultSchema = GetDefaultSchema(connection);
 
             var serverCollation = GetServerCollation(connection);
             var databaseCollation = GetDatabaseCollation(connection);
@@ -227,21 +226,6 @@ SELECT HAS_PERMS_BY_NAME(DB_NAME(), 'DATABASE', 'VIEW DEFINITION');";
         {
             _logger.MissingViewDefinitionRightsWarning();
         }
-    }
-
-    private string? GetDefaultSchema(DbConnection connection)
-    {
-        using var command = connection.CreateCommand();
-        command.CommandText = "SELECT SCHEMA_NAME()";
-
-        if (command.ExecuteScalar() is string schema)
-        {
-            _logger.DefaultSchemaFound(schema);
-
-            return schema;
-        }
-
-        return null;
     }
 
     private static Func<string, string>? GenerateSchemaFilter(IReadOnlyList<string> schemas)

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -232,7 +232,7 @@ DROP SEQUENCE [db2].[Sequence];");
     #region Model
 
     [ConditionalFact]
-    public void Set_default_schema()
+    public void Not_set_default_schema()
         => Test(
             "SELECT 1",
             Enumerable.Empty<string>(),
@@ -240,7 +240,8 @@ DROP SEQUENCE [db2].[Sequence];");
             dbModel =>
             {
                 var defaultSchema = Fixture.TestStore.ExecuteScalar<string>("SELECT SCHEMA_NAME()");
-                Assert.Equal(defaultSchema, dbModel.DefaultSchema);
+                Assert.NotEqual(defaultSchema, dbModel.DefaultSchema);
+                Assert.Null(dbModel.DefaultSchema);
             },
             null);
 


### PR DESCRIPTION
fixes #9318

relates to #27922
