### PR TITLE
Remove Convert node when up-casting to an interface

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -852,9 +852,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         var operand = Visit(unaryExpression.Operand);
 
         if (operand is EntityReferenceExpression entityReferenceExpression
-            && (unaryExpression.NodeType == ExpressionType.Convert
-                || unaryExpression.NodeType == ExpressionType.ConvertChecked
-                || unaryExpression.NodeType == ExpressionType.TypeAs))
+            && unaryExpression.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked or ExpressionType.TypeAs)
         {
             return entityReferenceExpression.Convert(unaryExpression.Type);
         }
@@ -877,8 +875,8 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             case ExpressionType.ConvertChecked:
             case ExpressionType.TypeAs:
                 // Object convert needs to be converted to explicit cast when mismatching types
-                if (operand.Type.IsInterface
-                    && unaryExpression.Type.GetInterfaces().Any(e => e == operand.Type)
+                if (operand.Type.IsInterface && unaryExpression.Type.IsAssignableTo(operand.Type)
+                    || unaryExpression.Type.IsInterface && operand.Type.IsAssignableTo(unaryExpression.Type)
                     || unaryExpression.Type.UnwrapNullableType() == operand.Type.UnwrapNullableType()
                     || unaryExpression.Type.UnwrapNullableType() == typeof(Enum))
                 {


### PR DESCRIPTION
In RelationalSqlTranslatingEV we have the [following code](https://github.com/dotnet/efcore/blob/main/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs#L894):

```c#
if (operand.Type.IsInterface
    && unaryExpression.Type.GetInterfaces().Any(e => e == operand.Type)
    || unaryExpression.Type.UnwrapNullableType() == operand.Type.UnwrapNullableType()
    || unaryExpression.Type.UnwrapNullableType() == typeof(Enum))
{
    return sqlOperand!;
}
```

The first part removes Convert nodes when there's a downcast from an Interface to a type which implements that interface.

This PR proposes to add the opposite, i.e. remove Convert nodes when there's an upcast to an implemented interface - what do you think @smitpatel?

Concrete scenario: https://github.com/npgsql/efcore.pg/pull/2350 adds row value comparison support for PostgreSQL, and introduces DbFunctionsExtensions such as:

```c#
public static bool GreaterThan(this DbFunctions _, ITuple a, ITuple b)
    => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(GreaterThan)));
```

The concrete arguments passed in by users are e.g. `ValueTuple<string, int>`, and so the tree contains an upcast Convert node.

Note: after removing the downcast, all SQL Server tests still pass - we may be missing a bit of test coverage.