### PR TITLE
Respect EvaluatableExpressionFilter in RelationalSqlTranslatingEV

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitorDependencies.cs
@@ -50,13 +50,15 @@ public sealed record RelationalSqlTranslatingExpressionVisitorDependencies
         IModel model,
         IRelationalTypeMappingSource typeMappingSource,
         IMemberTranslatorProvider memberTranslatorProvider,
-        IMethodCallTranslatorProvider methodCallTranslatorProvider)
+        IMethodCallTranslatorProvider methodCallTranslatorProvider,
+        IEvaluatableExpressionFilter evaluatableExpressionFilter)
     {
         SqlExpressionFactory = sqlExpressionFactory;
         Model = model;
         TypeMappingSource = typeMappingSource;
         MemberTranslatorProvider = memberTranslatorProvider;
         MethodCallTranslatorProvider = methodCallTranslatorProvider;
+        EvaluatableExpressionFilter = evaluatableExpressionFilter;
     }
 
     /// <summary>
@@ -83,4 +85,9 @@ public sealed record RelationalSqlTranslatingExpressionVisitorDependencies
     ///     The method-call translation provider.
     /// </summary>
     public IMethodCallTranslatorProvider MethodCallTranslatorProvider { get; init; }
+
+    /// <summary>
+    ///     Evaluatable expression filter.
+    /// </summary>
+    public IEvaluatableExpressionFilter EvaluatableExpressionFilter { get; init; }
 }


### PR DESCRIPTION
RelationalSqlTranslatingEV evaluates NewExpression and MemberInitExpression when it can, but does not check EvaluatableExpressionFilter when doing so.

Concrete scenario: https://github.com/npgsql/efcore.pg/pull/2350 adds row value comparison support for PostgreSQL, to allow queries such as:

```c#
_ = await ctx.Customers
    .Where(c => EF.Functions.GreaterThan(
        new ValueTuple<string, string>(c.City, c.CustomerID),
        new ValueTuple<string, string>("Buenos Aires", "OCEAN")))
    .CountAsync();
```

The 2nd tuple above gets evaluated to a constant expression, although Npgsql's EvaluatableExpressionFilter disallows it.
