### PR TITLE
Capitalize database name

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CandidateNamingService.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CandidateNamingService.cs
@@ -38,6 +38,15 @@ public class CandidateNamingService : ICandidateNamingService
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public virtual string GenerateCandidateIdentifier(DatabaseModel originalModel)
+        => GenerateCandidateIdentifier(originalModel.DatabaseName ?? "Main");
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual string GetDependentEndCandidateNavigationPropertyName(IReadOnlyForeignKey foreignKey)
     {
         var candidateName = FindCandidateNavigationName(foreignKey.Properties);

--- a/src/EFCore.Design/Scaffolding/Internal/ICandidateNamingService.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ICandidateNamingService.cs
@@ -35,6 +35,14 @@ public interface ICandidateNamingService
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    string GenerateCandidateIdentifier(DatabaseModel databaseName);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     string GetDependentEndCandidateNavigationPropertyName(IReadOnlyForeignKey foreignKey);
 
     /// <summary>

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -166,7 +166,11 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
 
         if (!string.IsNullOrEmpty(databaseModel.DatabaseName))
         {
-            modelBuilder.Model.SetDatabaseName(databaseModel.DatabaseName);
+            if (_options.UseDatabaseNames)
+            {
+                modelBuilder.Model.SetDatabaseName(
+                    _candidateNamingService.GenerateCandidateIdentifier(databaseModel));
+            }
         }
 
         if (!string.IsNullOrEmpty(databaseModel.Collation))

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -51,6 +51,14 @@ public class RelationalScaffoldingModelFactoryTest
     }
 
     [ConditionalFact]
+    public void Capitalize_DatabaseName()
+    {
+        var database = new DatabaseModel { DatabaseName = "northwind" };
+        var model = _factory.Create(database, new ModelReverseEngineerOptions { UseDatabaseNames = true });
+        Assert.Equal("Northwind", model.GetDatabaseName());
+    }
+
+    [ConditionalFact]
     public void Creates_entity_types()
     {
         var info = new DatabaseModel


### PR DESCRIPTION
- When scaffolding from a database the database name is modified in order to respect .NET conventions

#Fixes 27886