### PR TITLE
Throw if an entity type in table-sharing uses TPC

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -187,6 +187,12 @@ public static class RelationalEntityTypeBuilderExtensions
     {
         Check.NotNull(buildAction, nameof(buildAction));
 
+        var entityTypeConventionBuilder = entityTypeBuilder.GetInfrastructure();
+        if (entityTypeConventionBuilder.Metadata[RelationalAnnotationNames.TableName] == null)
+        {
+            entityTypeConventionBuilder.ToTable(entityTypeBuilder.Metadata.GetDefaultTableName());
+        }
+        
         buildAction(new TableBuilder<TEntity>(null, null, entityTypeBuilder));
 
         return entityTypeBuilder;

--- a/src/EFCore.Relational/Metadata/ITable.cs
+++ b/src/EFCore.Relational/Metadata/ITable.cs
@@ -108,8 +108,9 @@ public interface ITable : ITableBase
         }
 
         builder.Append(Name);
-
-        if (IsExcludedFromMigrations)
+        
+        if (EntityTypeMappings.First().EntityType is not RuntimeEntityType
+            && IsExcludedFromMigrations)
         {
             builder.Append(" ExcludedFromMigrations");
         }

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -538,7 +538,7 @@ public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConvention
                     var relationalTypeMappingSource =
                         (IRelationalTypeMappingSource)((IModel)dbFunction.Model).GetModelDependencies().TypeMappingSource;
                     return !string.IsNullOrEmpty(dbFunction._storeType)
-                        ? relationalTypeMappingSource.FindMapping(dbFunction._storeType)!
+                        ? relationalTypeMappingSource.FindMapping(dbFunction.ReturnType, dbFunction._storeType)!
                         : relationalTypeMappingSource.FindMapping(dbFunction.ReturnType, (IModel)dbFunction.Model)!;
                 })
             : _typeMapping;

--- a/src/EFCore.Relational/Metadata/RuntimeDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/RuntimeDbFunction.cs
@@ -98,7 +98,7 @@ public class RuntimeDbFunction : AnnotatableBase, IRuntimeDbFunction
                     var relationalTypeMappingSource =
                         (IRelationalTypeMappingSource)((IModel)dbFunction.Model).GetModelDependencies().TypeMappingSource;
                     return !string.IsNullOrEmpty(dbFunction._storeType)
-                        ? relationalTypeMappingSource.FindMapping(dbFunction._storeType)!
+                        ? relationalTypeMappingSource.FindMapping(dbFunction._returnType, dbFunction._storeType)!
                         : relationalTypeMappingSource.FindMapping(dbFunction._returnType, dbFunction.Model)!;
                 })
             : _typeMapping;

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1192,6 +1192,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 expected, actual);
 
         /// <summary>
+        ///     The entity type '{dependentType}' is mapped to '{storeObject}'. However the principal entity type '{principalEntityType}' is also mapped to '{storeObject}' and it's using the TPC mapping strategy. Only leaf entity types in a TPC hierarchy can use table-sharing.
+        /// </summary>
+        public static string TpcTableSharing(object? dependentType, object? storeObject, object? principalEntityType)
+            => string.Format(
+                GetString("TpcTableSharing", nameof(dependentType), nameof(storeObject), nameof(principalEntityType)),
+                dependentType, storeObject, principalEntityType);
+
+        /// <summary>
+        ///     The entity type '{dependentType}' is mapped to '{storeObject}'. However one of its derived types '{derivedType}' is mapped to '{otherStoreObject}'. Hierarchies using table-sharing cannot be mapped using the TPC mapping strategy.
+        /// </summary>
+        public static string TpcTableSharingDependent(object? dependentType, object? storeObject, object? derivedType, object? otherStoreObject)
+            => string.Format(
+                GetString("TpcTableSharingDependent", nameof(dependentType), nameof(storeObject), nameof(derivedType), nameof(otherStoreObject)),
+                dependentType, storeObject, derivedType, otherStoreObject);
+
+        /// <summary>
         ///     '{entityType}' is mapped to the table '{table}' while '{otherEntityType}' is mapped to the table '{otherTable}'. Map all the entity types in the hierarchy to the same table, or remove the discriminator and map them all to different tables. See https://go.microsoft.com/fwlink/?linkid=2130430 for more information.
         /// </summary>
         public static string TphTableMismatch(object? entityType, object? table, object? otherEntityType, object? otherTable)
@@ -1916,7 +1932,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Created DbConnection ({elapsed}ms).
+        ///     Created DbConnection. ({elapsed}ms).
         /// </summary>
         public static EventDefinition<int> LogConnectionCreated(IDiagnosticsLogger logger)
         {

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -838,6 +838,12 @@
   <data name="TooFewReaderFields" xml:space="preserve">
     <value>The underlying reader doesn't have as many fields as expected. Expected: {expected}, actual: {actual}.</value>
   </data>
+  <data name="TpcTableSharing" xml:space="preserve">
+    <value>The entity type '{dependentType}' is mapped to '{storeObject}'. However the principal entity type '{principalEntityType}' is also mapped to '{storeObject}' and it's using the TPC mapping strategy. Only leaf entity types in a TPC hierarchy can use table-sharing.</value>
+  </data>
+  <data name="TpcTableSharingDependent" xml:space="preserve">
+    <value>The entity type '{dependentType}' is mapped to '{storeObject}'. However one of its derived types '{derivedType}' is mapped to '{otherStoreObject}'. Hierarchies using table-sharing cannot be mapped using the TPC mapping strategy.</value>
+  </data>
   <data name="TphTableMismatch" xml:space="preserve">
     <value>'{entityType}' is mapped to the table '{table}' while '{otherEntityType}' is mapped to the table '{otherTable}'. Map all the entity types in the hierarchy to the same table, or remove the discriminator and map them all to different tables. See https://go.microsoft.com/fwlink/?linkid=2130430 for more information.</value>
   </data>

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCGearsOfWarQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCGearsOfWarQueryRelationalFixture.cs
@@ -31,9 +31,6 @@ public abstract class TPCGearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtu
         modelBuilder.Entity<Faction>().UseTpcMappingStrategy();
         modelBuilder.Entity<LocustLeader>().UseTpcMappingStrategy();
 
-        // Work-around for issue#27947
-        modelBuilder.Entity<Faction>().ToTable((string)null);
-
         modelBuilder.Entity<Gear>().ToTable("Gears");
         modelBuilder.Entity<Officer>().ToTable("Officers");
 

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCInheritanceQueryFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCInheritanceQueryFixture.cs
@@ -25,10 +25,6 @@ public abstract class TPCInheritanceQueryFixture : InheritanceQueryFixtureBase
         modelBuilder.Entity<Animal>().UseTpcMappingStrategy();
         modelBuilder.Entity<Drink>().UseTpcMappingStrategy();
 
-        // Work-around for issue#27947
-        modelBuilder.Entity<Animal>().ToTable((string)null);
-        modelBuilder.Entity<Plant>().ToTable((string)null);
-
         modelBuilder.Entity<Flower>().ToTable("Flowers");
         modelBuilder.Entity<Rose>().ToTable("Roses");
         modelBuilder.Entity<Daisy>().ToTable("Daisies");

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCRelationshipsQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCRelationshipsQueryRelationalFixture.cs
@@ -11,14 +11,16 @@ public abstract class TPCRelationshipsQueryRelationalFixture : InheritanceRelati
 
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
         => base.AddOptions(builder).ConfigureWarnings(
-            w =>
-                w.Log(RelationalEventId.ForeignKeyTpcPrincipalWarning));
+            w => w.Log(RelationalEventId.ForeignKeyTpcPrincipalWarning));
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
         base.OnModelCreating(modelBuilder, context);
 
-        modelBuilder.Entity<BaseInheritanceRelationshipEntity>().UseTpcMappingStrategy();
+        modelBuilder.Entity<BaseInheritanceRelationshipEntity>().UseTpcMappingStrategy()
+            // Table-sharing is not supported in TPC mapping
+            .OwnsMany(e => e.OwnedCollectionOnBase, e => e.ToTable("OwnedCollections"))
+            .OwnsOne(e => e.OwnedReferenceOnBase, e => e.ToTable("OwnedReferences"));
         modelBuilder.Entity<BaseReferenceOnBase>().UseTpcMappingStrategy();
         modelBuilder.Entity<BaseCollectionOnBase>().UseTpcMappingStrategy();
         modelBuilder.Entity<BaseReferenceOnDerived>().UseTpcMappingStrategy();

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -919,7 +919,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
                         if (mapToTables)
                         {
-                            cb.ToTable("AbstractBase");
+                            cb.ToTable(t => { });
                         }
                     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCRelationshipsQuerySqlServerTest.cs
@@ -12,565 +12,3093 @@ public class TPCRelationshipsQuerySqlServerTest
         : base(fixture)
     {
         fixture.TestSqlLoggerFactory.Clear();
+        //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ConditionalFact(Skip = "Issue#27945")]
+    [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
-    [ConditionalFact(Skip = "Issue#27945")]
     public override void Changes_in_derived_related_entities_are_detected()
     {
         base.Changes_in_derived_related_entities_are_detected();
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [t1].[BaseInheritanceRelationshipEntityId], [t1].[Id1], [t1].[Id00], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t1].[Id0], [t1].[Name0], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name], [t2].[Id], [t2].[BaseParentId], [t2].[Name], [t2].[DerivedProperty], [t2].[Discriminator]
+FROM (
+    SELECT TOP(2) [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [o].[Id] AS [Id0], [o].[Name] AS [Name0], [t0].[Id] AS [Id1], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [t0].[Id0] AS [Id00]
+    FROM (
+        SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+        FROM [BaseEntities] AS [b]
+        UNION ALL
+        SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+        FROM [DerivedEntities] AS [d]
+    ) AS [t]
+    LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+    LEFT JOIN (
+        SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+        FROM [DerivedEntities] AS [d0]
+        INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+        WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+    ) AS [t0] ON [t].[Id] = CASE
+        WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+    END
+    WHERE [t].[Name] = N'Derived1(4)'
+) AS [t1]
+LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t1].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d3]
+) AS [t2] ON [t1].[Id] = [t2].[BaseParentId]
+ORDER BY [t1].[Id], [t1].[BaseInheritanceRelationshipEntityId], [t1].[Id1], [t1].[Id00], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_without_inheritance(bool async)
     {
         await base.Include_collection_without_inheritance(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [c].[Id], [c].[Name], [c].[ParentId]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [CollectionsOnBase] AS [c] ON [t].[Id] = [c].[ParentId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_without_inheritance_reverse(bool async)
     {
         await base.Include_collection_without_inheritance_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM [CollectionsOnBase] AS [c]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [c].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_without_inheritance_with_filter(bool async)
     {
         await base.Include_collection_without_inheritance_with_filter(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [c].[Id], [c].[Name], [c].[ParentId]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [CollectionsOnBase] AS [c] ON [t].[Id] = [c].[ParentId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_without_inheritance_with_filter_reverse(bool async)
     {
         await base.Include_collection_without_inheritance_with_filter_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM [CollectionsOnBase] AS [c]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [c].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [c].[Name] <> N'Bar' OR [c].[Name] IS NULL
+ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance(bool async)
     {
         await base.Include_collection_with_inheritance(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [t1].[Id], [t1].[BaseParentId], [t1].[Name], [t1].[DerivedProperty], [t1].[Discriminator]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d3]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_on_derived1(bool async)
     {
         await base.Include_collection_with_inheritance_on_derived1(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d1].[Id], [d1].[BaseParentId], [d1].[Name], [d1].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d1]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_on_derived2(bool async)
     {
         await base.Include_collection_with_inheritance_on_derived2(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[Id], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], [b].[ParentId], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseCollectionOnDerived' AS [Discriminator]
+    FROM [BaseCollectionsOnDerived] AS [b]
+    UNION ALL
+    SELECT [d1].[Id], [d1].[Name], [d1].[ParentId], [d1].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
+    FROM [DerivedCollectionsOnDerived] AS [d1]
+) AS [t] ON [d].[Id] = [t].[ParentId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_on_derived3(bool async)
     {
         await base.Include_collection_with_inheritance_on_derived3(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [d1].[Id], [d1].[Name], [d1].[ParentId], [d1].[DerivedInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedCollectionsOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_on_derived_reverse(bool async)
     {
         await base.Include_collection_with_inheritance_on_derived_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], [b].[ParentId], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseCollectionOnDerived' AS [Discriminator]
+    FROM [BaseCollectionsOnDerived] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[ParentId], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
+    FROM [DerivedCollectionsOnDerived] AS [d]
+) AS [t]
+LEFT JOIN [DerivedEntities] AS [d0] ON [t].[ParentId] = [d0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_reverse(bool async)
     {
         await base.Include_collection_with_inheritance_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_with_filter(bool async)
     {
         await base.Include_collection_with_inheritance_with_filter(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [t1].[Id], [t1].[BaseParentId], [t1].[Name], [t1].[DerivedProperty], [t1].[Discriminator]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d3]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_with_filter_reverse(bool async)
     {
         await base.Include_collection_with_inheritance_with_filter_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_without_inheritance(bool async)
     {
         await base.Include_reference_without_inheritance(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [r].[Name], [r].[ParentId]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [ReferencesOnBase] AS [r] ON [t].[Id] = [r].[ParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_without_inheritance_on_derived1(bool async)
     {
         await base.Include_reference_without_inheritance_on_derived1(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [r].[Name], [r].[ParentId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [ReferencesOnBase] AS [r] ON [d].[Id] = [r].[ParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_without_inheritance_on_derived2(bool async)
     {
         await base.Include_reference_without_inheritance_on_derived2(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [r].[Name], [r].[ParentId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [ReferencesOnDerived] AS [r] ON [d].[Id] = [r].[ParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_without_inheritance_on_derived_reverse(bool async)
     {
         await base.Include_reference_without_inheritance_on_derived_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [r].[Id], [r].[Name], [r].[ParentId], [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name]
+FROM [ReferencesOnDerived] AS [r]
+LEFT JOIN [DerivedEntities] AS [d] ON [r].[ParentId] = [d].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [r].[Id], [d].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_without_inheritance_reverse(bool async)
     {
         await base.Include_reference_without_inheritance_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [r].[Id], [r].[Name], [r].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM [ReferencesOnBase] AS [r]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [r].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [r].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_without_inheritance_with_filter(bool async)
     {
         await base.Include_reference_without_inheritance_with_filter(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [r].[Name], [r].[ParentId]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [ReferencesOnBase] AS [r] ON [t].[Id] = [r].[ParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [r].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_without_inheritance_with_filter_reverse(bool async)
     {
         await base.Include_reference_without_inheritance_with_filter_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [r].[Id], [r].[Name], [r].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM [ReferencesOnBase] AS [r]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [r].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [r].[Name] <> N'Bar' OR [r].[Name] IS NULL
+ORDER BY [r].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance(bool async)
     {
         await base.Include_reference_with_inheritance(async);
-
-        AssertSql();
+        
+    AssertSql(
+        @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_on_derived1(bool async)
     {
         await base.Include_reference_with_inheritance_on_derived1(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_on_derived2(bool async)
     {
         await base.Include_reference_with_inheritance_on_derived2(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseReferenceOnDerived' AS [Discriminator]
+    FROM [BaseReferencesOnDerived] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedInheritanceRelationshipEntityId], N'DerivedReferenceOnDerived' AS [Discriminator]
+    FROM [DerivedReferencesOnDerived] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_on_derived4(bool async)
     {
         await base.Include_reference_with_inheritance_on_derived4(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [DerivedReferencesOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_on_derived_reverse(bool async)
     {
         await base.Include_reference_with_inheritance_on_derived_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseReferenceOnDerived' AS [Discriminator]
+    FROM [BaseReferencesOnDerived] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedReferenceOnDerived' AS [Discriminator]
+    FROM [DerivedReferencesOnDerived] AS [d]
+) AS [t]
+LEFT JOIN [DerivedEntities] AS [d0] ON [t].[BaseParentId] = [d0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_on_derived_with_filter1(bool async)
     {
         await base.Include_reference_with_inheritance_on_derived_with_filter1(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+WHERE [d].[Name] <> N'Bar' OR [d].[Name] IS NULL
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_on_derived_with_filter2(bool async)
     {
         await base.Include_reference_with_inheritance_on_derived_with_filter2(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseReferenceOnDerived' AS [Discriminator]
+    FROM [BaseReferencesOnDerived] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedInheritanceRelationshipEntityId], N'DerivedReferenceOnDerived' AS [Discriminator]
+    FROM [DerivedReferencesOnDerived] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+WHERE [d].[Name] <> N'Bar' OR [d].[Name] IS NULL
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_on_derived_with_filter4(bool async)
     {
         await base.Include_reference_with_inheritance_on_derived_with_filter4(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [DerivedReferencesOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+WHERE [d].[Name] <> N'Bar' OR [d].[Name] IS NULL
+ORDER BY [d].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_on_derived_with_filter_reverse(bool async)
     {
         await base.Include_reference_with_inheritance_on_derived_with_filter_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseReferenceOnDerived' AS [Discriminator]
+    FROM [BaseReferencesOnDerived] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedReferenceOnDerived' AS [Discriminator]
+    FROM [DerivedReferencesOnDerived] AS [d]
+) AS [t]
+LEFT JOIN [DerivedEntities] AS [d0] ON [t].[BaseParentId] = [d0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_reverse(bool async)
     {
         await base.Include_reference_with_inheritance_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_with_filter(bool async)
     {
         await base.Include_reference_with_inheritance_with_filter(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_reference_with_inheritance_with_filter_reverse(bool async)
     {
         await base.Include_reference_with_inheritance_with_filter_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_self_reference_with_inheritance(bool async)
     {
         await base.Include_self_reference_with_inheritance(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [d0].[Name], [d0].[BaseId], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [o2].[Name], [o0].[Id], [o0].[Name], [d4].[DerivedInheritanceRelationshipEntityId], [d4].[Id], [d4].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [DerivedEntities] AS [d0] ON [t].[Id] = [d0].[BaseId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedReferences] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o1] ON [t].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o2] ON [d0].[Id] = [o2].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d4] ON [d0].[Id] = [d4].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [d4].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_self_reference_with_inheritance_reverse(bool async)
     {
         await base.Include_self_reference_with_inheritance_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [o1].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[Name], [t].[BaseId], [t].[Discriminator], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [o2].[Name], [o0].[Id], [o0].[Name], [d4].[DerivedInheritanceRelationshipEntityId], [d4].[Id], [d4].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t] ON [d].[BaseId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedReferences] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o1] ON [d].[Id] = [o1].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [d].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o2] ON [t].[Id] = [o2].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d4] ON [t].[Id] = [d4].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o1].[BaseInheritanceRelationshipEntityId], [o1].[Id], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [o2].[BaseInheritanceRelationshipEntityId], [o2].[Id], [d4].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_collection_reference_on_non_entity_base(bool async)
     {
         await base.Nested_include_collection_reference_on_non_entity_base(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [r].[Id], [r].[Name], [t].[Id], [t].[Name], [t].[ReferenceId], [t].[ReferencedEntityId], [t].[Id0], [t].[Name0]
+FROM [ReferencedEntities] AS [r]
+LEFT JOIN (
+    SELECT [p].[Id], [p].[Name], [p].[ReferenceId], [p].[ReferencedEntityId], [r0].[Id] AS [Id0], [r0].[Name] AS [Name0]
+    FROM [PrincipalEntities] AS [p]
+    LEFT JOIN [ReferencedEntities] AS [r0] ON [p].[ReferenceId] = [r0].[Id]
+) AS [t] ON [r].[Id] = [t].[ReferencedEntityId]
+ORDER BY [r].[Id], [t].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_collection_collection(bool async)
     {
         await base.Nested_include_with_inheritance_collection_collection(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [t1].[Id], [t1].[BaseParentId], [t1].[Name], [t1].[DerivedProperty], [t1].[Discriminator], [t1].[Id0], [t1].[Name0], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [t2].[Id], [t2].[BaseParentId], [t2].[Name], [t2].[DerivedProperty], [t2].[Discriminator], [t3].[Id] AS [Id0], [t3].[Name] AS [Name0], [t3].[ParentCollectionId], [t3].[ParentReferenceId], [t3].[Discriminator] AS [Discriminator0]
+    FROM (
+        SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+        FROM [BaseCollectionsOnBase] AS [b0]
+        UNION ALL
+        SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+        FROM [DerivedCollectionsOnBase] AS [d3]
+    ) AS [t2]
+    LEFT JOIN (
+        SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+        FROM [NestedCollections] AS [n]
+        UNION ALL
+        SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+        FROM [NestedCollectionsDerived] AS [n0]
+    ) AS [t3] ON [t2].[Id] = [t3].[ParentCollectionId]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [t1].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_collection_collection_reverse(bool async)
     {
         await base.Nested_include_with_inheritance_collection_collection_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t2].[OwnedReferenceOnDerived_Id], [t2].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_collection_reference(bool async)
     {
         await base.Nested_include_with_inheritance_collection_reference(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [t1].[Id], [t1].[BaseParentId], [t1].[Name], [t1].[DerivedProperty], [t1].[Discriminator], [t1].[Id0], [t1].[Name0], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [t2].[Id], [t2].[BaseParentId], [t2].[Name], [t2].[DerivedProperty], [t2].[Discriminator], [t3].[Id] AS [Id0], [t3].[Name] AS [Name0], [t3].[ParentCollectionId], [t3].[ParentReferenceId], [t3].[Discriminator] AS [Discriminator0]
+    FROM (
+        SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+        FROM [BaseCollectionsOnBase] AS [b0]
+        UNION ALL
+        SELECT [d3].[Id], [d3].[BaseParentId], [d3].[Name], [d3].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+        FROM [DerivedCollectionsOnBase] AS [d3]
+    ) AS [t2]
+    LEFT JOIN (
+        SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+        FROM [NestedReferences] AS [n]
+        UNION ALL
+        SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+        FROM [NestedReferencesDerived] AS [n0]
+    ) AS [t3] ON [t2].[Id] = [t3].[ParentCollectionId]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [t1].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_collection_reference_reverse(bool async)
     {
         await base.Nested_include_with_inheritance_collection_reference_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t2].[OwnedReferenceOnDerived_Id], [t2].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+    FROM [NestedReferences] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+    FROM [NestedReferencesDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_collection(bool async)
     {
         await base.Nested_include_with_inheritance_reference_collection(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t2].[Id], [t2].[Name], [t2].[ParentCollectionId], [t2].[ParentReferenceId], [t2].[Discriminator]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t2] ON [t0].[Id] = [t2].[ParentReferenceId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_collection_on_base(bool async)
     {
         await base.Nested_include_with_inheritance_reference_collection_on_base(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[ParentCollectionId], [t0].[ParentReferenceId], [t0].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_collection_reverse(bool async)
     {
         await base.Nested_include_with_inheritance_reference_collection_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t2].[OwnedReferenceOnDerived_Id], [t2].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d]
+) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_reference(bool async)
     {
         await base.Nested_include_with_inheritance_reference_reference(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t2].[OwnedReferenceOnDerived_Id], [t2].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Name], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+LEFT JOIN (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+    FROM [NestedReferences] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+    FROM [NestedReferencesDerived] AS [n0]
+) AS [t1] ON [t0].[Id] = [t1].[ParentReferenceId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_reference_on_base(bool async)
     {
         await base.Nested_include_with_inheritance_reference_reference_on_base(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator], [t0].[Name], [t0].[ParentCollectionId], [t0].[ParentReferenceId], [t0].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+    FROM [NestedReferences] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+    FROM [NestedReferencesDerived] AS [n0]
+) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_reference_reverse(bool async)
     {
         await base.Nested_include_with_inheritance_reference_reference_reverse(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t2].[OwnedReferenceOnDerived_Id], [t2].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+    FROM [NestedReferences] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+    FROM [NestedReferencesDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d]
+) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d3].[DerivedInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Collection_projection_on_base_type(bool async)
     {
         await base.Collection_projection_on_base_type(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+ORDER BY [t].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_on_derived_type_with_queryable_Cast(bool async)
     {
         await base.Include_on_derived_type_with_queryable_Cast(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [o].[Id], [o].[Name], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name], [d3].[Id], [d3].[Name], [d3].[ParentId], [d3].[DerivedInheritanceRelationshipEntityId]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+LEFT JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+LEFT JOIN [DerivedCollectionsOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Id] >= 4
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_split(bool async)
     {
         await base.Include_collection_with_inheritance_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [t1].[Id], [t1].[BaseParentId], [t1].[Name], [t1].[DerivedProperty], [t1].[Discriminator], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d2]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_reverse_split(bool async)
     {
         await base.Include_collection_with_inheritance_reverse_split(async);
-
-        AssertSql();
+        
+        AssertSql(
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o].[Id], [o].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]",
+            //
+            @"SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_with_filter_split(bool async)
     {
         await base.Include_collection_with_inheritance_with_filter_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [t1].[Id], [t1].[BaseParentId], [t1].[Name], [t1].[DerivedProperty], [t1].[Discriminator], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d2]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_with_filter_reverse_split(bool async)
     {
         await base.Include_collection_with_inheritance_with_filter_reverse_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [t0].[Id], [t0].[Name], [t0].[BaseId], [t0].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o].[Id], [o].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]",
+            //
+            @"SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t0].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t0].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_without_inheritance_split(bool async)
     {
         await base.Include_collection_without_inheritance_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [CollectionsOnBase] AS [c] ON [t].[Id] = [c].[ParentId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_without_inheritance_reverse_split(bool async)
     {
         await base.Include_collection_without_inheritance_reverse_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM [CollectionsOnBase] AS [c]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [c].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM [CollectionsOnBase] AS [c]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [c].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM [CollectionsOnBase] AS [c]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [c].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_without_inheritance_with_filter_split(bool async)
     {
         await base.Include_collection_without_inheritance_with_filter_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [CollectionsOnBase] AS [c] ON [t].[Id] = [c].[ParentId]
+WHERE [t].[Name] <> N'Bar' OR [t].[Name] IS NULL
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_without_inheritance_with_filter_reverse_split(bool async)
     {
         await base.Include_collection_without_inheritance_with_filter_reverse_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [c].[Id], [c].[Name], [c].[ParentId], [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM [CollectionsOnBase] AS [c]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [c].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+WHERE [c].[Name] <> N'Bar' OR [c].[Name] IS NULL
+ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM [CollectionsOnBase] AS [c]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [c].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+WHERE [c].[Name] <> N'Bar' OR [c].[Name] IS NULL
+ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM [CollectionsOnBase] AS [c]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t] ON [c].[ParentId] = [t].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [c].[Name] <> N'Bar' OR [c].[Name] IS NULL
+ORDER BY [c].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_on_derived1_split(bool async)
     {
         await base.Include_collection_with_inheritance_on_derived1_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [t].[Id], [t].[BaseParentId], [t].[Name], [t].[DerivedProperty], [t].[Discriminator], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_on_derived2_split(bool async)
     {
         await base.Include_collection_with_inheritance_on_derived2_split(async);
-
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN (
+    SELECT [b].[Id], [b].[Name], [b].[ParentId], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseCollectionOnDerived' AS [Discriminator]
+    FROM [BaseCollectionsOnDerived] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[ParentId], [d0].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
+    FROM [DerivedCollectionsOnDerived] AS [d0]
+) AS [t] ON [d].[Id] = [t].[ParentId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_on_derived3_split(bool async)
     {
         await base.Include_collection_with_inheritance_on_derived3_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [d0].[Name], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [d0].[Id], [d0].[Name], [d0].[ParentId], [d0].[DerivedInheritanceRelationshipEntityId], [d].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [DerivedCollectionsOnDerived] AS [d0] ON [d].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [o].[BaseInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_collection_with_inheritance_on_derived_reverse_split(bool async)
     {
         await base.Include_collection_with_inheritance_on_derived_reverse_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentId], [t].[DerivedInheritanceRelationshipEntityId], [t].[Discriminator], [d0].[Id], [d0].[Name], [d0].[BaseId], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], [b].[ParentId], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseCollectionOnDerived' AS [Discriminator]
+    FROM [BaseCollectionsOnDerived] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[ParentId], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
+    FROM [DerivedCollectionsOnDerived] AS [d]
+) AS [t]
+LEFT JOIN [DerivedEntities] AS [d0] ON [t].[ParentId] = [d0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM (
+    SELECT [b].[Id], [b].[Name], [b].[ParentId], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseCollectionOnDerived' AS [Discriminator]
+    FROM [BaseCollectionsOnDerived] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[ParentId], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
+    FROM [DerivedCollectionsOnDerived] AS [d]
+) AS [t]
+LEFT JOIN [DerivedEntities] AS [d0] ON [t].[ParentId] = [d0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [OwnedCollections] AS [o0] ON [d0].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM (
+    SELECT [b].[Id], [b].[Name], [b].[ParentId], NULL AS [DerivedInheritanceRelationshipEntityId], N'BaseCollectionOnDerived' AS [Discriminator]
+    FROM [BaseCollectionsOnDerived] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[ParentId], [d].[DerivedInheritanceRelationshipEntityId], N'DerivedCollectionOnDerived' AS [Discriminator]
+    FROM [DerivedCollectionsOnDerived] AS [d]
+) AS [t]
+LEFT JOIN [DerivedEntities] AS [d0] ON [t].[ParentId] = [d0].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [d0].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [d0].[Id], [o].[BaseInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_collection_split(bool async)
     {
         await base.Nested_include_with_inheritance_reference_collection_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0], [o].[Id], [o].[Name], [t1].[OwnedReferenceOnDerived_Id], [t1].[OwnedReferenceOnDerived_Name], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]",
+            //
+            @"SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]",
+            //
+            @"SELECT [t2].[Id], [t2].[Name], [t2].[ParentCollectionId], [t2].[ParentReferenceId], [t2].[Discriminator], [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t1] ON [t].[Id] = CASE
+    WHEN [t1].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t1].[Id]
+END
+INNER JOIN (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t2] ON [t0].[Id] = [t2].[ParentReferenceId]
+ORDER BY [t].[Id], [t0].[Id], [o].[BaseInheritanceRelationshipEntityId], [t1].[Id], [t1].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_collection_on_base_split(bool async)
     {
         await base.Nested_include_with_inheritance_reference_collection_on_base_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [d].[Id], [d].[Name], [d].[BaseId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [o].[Id], [o].[Name], [d].[OwnedReferenceOnDerived_Id], [d].[OwnedReferenceOnDerived_Name], [t].[BaseParentId], [t].[Name], [t].[Discriminator]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [OwnedCollections] AS [o0] ON [d].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [d1].[Name], [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [d].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId]",
+            //
+            @"SELECT [t0].[Id], [t0].[Name], [t0].[ParentCollectionId], [t0].[ParentReferenceId], [t0].[Discriminator], [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId]
+FROM [DerivedEntities] AS [d]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d0]
+) AS [t] ON [d].[Id] = [t].[BaseParentId]
+LEFT JOIN [OwnedReferences] AS [o] ON [d].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+INNER JOIN (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
+ORDER BY [d].[Id], [t].[Id], [o].[BaseInheritanceRelationshipEntityId]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_reference_collection_reverse_split(bool async)
     {
         await base.Nested_include_with_inheritance_reference_collection_reverse_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o].[Id], [o].[Name], [t2].[OwnedReferenceOnDerived_Id], [t2].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d]
+) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d]
+) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]",
+            //
+            @"SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], N'BaseReferenceOnBase' AS [Discriminator]
+    FROM [BaseReferencesOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], N'DerivedReferenceOnBase' AS [Discriminator]
+    FROM [DerivedReferencesOnBase] AS [d]
+) AS [t0] ON [t].[ParentReferenceId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_collection_reference_split(bool async)
     {
         await base.Nested_include_with_inheritance_collection_reference_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [t1].[Id], [t1].[BaseParentId], [t1].[Name], [t1].[DerivedProperty], [t1].[Discriminator], [t1].[Id0], [t1].[Name0], [t1].[ParentCollectionId], [t1].[ParentReferenceId], [t1].[Discriminator0] AS [Discriminator], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN (
+    SELECT [t2].[Id], [t2].[BaseParentId], [t2].[Name], [t2].[DerivedProperty], [t2].[Discriminator], [t3].[Id] AS [Id0], [t3].[Name] AS [Name0], [t3].[ParentCollectionId], [t3].[ParentReferenceId], [t3].[Discriminator] AS [Discriminator0]
+    FROM (
+        SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+        FROM [BaseCollectionsOnBase] AS [b0]
+        UNION ALL
+        SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+        FROM [DerivedCollectionsOnBase] AS [d2]
+    ) AS [t2]
+    LEFT JOIN (
+        SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+        FROM [NestedReferences] AS [n]
+        UNION ALL
+        SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+        FROM [NestedReferencesDerived] AS [n0]
+    ) AS [t3] ON [t2].[Id] = [t3].[ParentCollectionId]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_collection_reference_reverse_split(bool async)
     {
         await base.Nested_include_with_inheritance_collection_reference_reverse_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o].[Id], [o].[Name], [t2].[OwnedReferenceOnDerived_Id], [t2].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+    FROM [NestedReferences] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+    FROM [NestedReferencesDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+    FROM [NestedReferences] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+    FROM [NestedReferencesDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]",
+            //
+            @"SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedReferenceBase' AS [Discriminator]
+    FROM [NestedReferences] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedReferenceDerived' AS [Discriminator]
+    FROM [NestedReferencesDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_collection_collection_split(bool async)
     {
         await base.Nested_include_with_inheritance_collection_collection_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [t1].[Id], [t1].[BaseParentId], [t1].[Name], [t1].[DerivedProperty], [t1].[Discriminator], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d2]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [t1].[Id]",
+            //
+            @"SELECT [t2].[Id], [t2].[Name], [t2].[ParentCollectionId], [t2].[ParentReferenceId], [t2].[Discriminator], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [t1].[Id]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d2].[Id], [d2].[BaseParentId], [d2].[Name], [d2].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d2]
+) AS [t1] ON [t].[Id] = [t1].[BaseParentId]
+INNER JOIN (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t2] ON [t1].[Id] = [t2].[ParentCollectionId]
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [t1].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_with_inheritance_collection_collection_reverse_split(bool async)
     {
         await base.Nested_include_with_inheritance_collection_collection_reverse_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[ParentCollectionId], [t].[ParentReferenceId], [t].[Discriminator], [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t1].[Id], [t1].[Name], [t1].[BaseId], [t1].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0], [o].[Id], [o].[Name], [t2].[OwnedReferenceOnDerived_Id], [t2].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d1].[OwnedReferenceOnDerived_Name], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t1].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]",
+            //
+            @"SELECT [d3].[DerivedInheritanceRelationshipEntityId], [d3].[Id], [d3].[Name], [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]
+FROM (
+    SELECT [n].[Id], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId], N'NestedCollectionBase' AS [Discriminator]
+    FROM [NestedCollections] AS [n]
+    UNION ALL
+    SELECT [n0].[Id], [n0].[Name], [n0].[ParentCollectionId], [n0].[ParentReferenceId], N'NestedCollectionDerived' AS [Discriminator]
+    FROM [NestedCollectionsDerived] AS [n0]
+) AS [t]
+LEFT JOIN (
+    SELECT [b].[Id], [b].[BaseParentId], [b].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[BaseParentId], [d].[Name], [d].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d]
+) AS [t0] ON [t].[ParentCollectionId] = [t0].[Id]
+LEFT JOIN (
+    SELECT [b0].[Id], [b0].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[Name], [d0].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d0]
+) AS [t1] ON [t0].[BaseParentId] = [t1].[Id]
+LEFT JOIN [OwnedReferences] AS [o] ON [t1].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d1].[Id], [d1].[OwnedReferenceOnDerived_Id], [d2].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d1]
+    INNER JOIN [DerivedEntities] AS [d2] ON [d1].[Id] = [d2].[Id]
+    WHERE [d1].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t2] ON [t1].[Id] = CASE
+    WHEN [t2].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t2].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d3] ON [t1].[Id] = [d3].[DerivedInheritanceRelationshipEntityId]
+ORDER BY [t].[Id], [t0].[Id], [t1].[Id], [o].[BaseInheritanceRelationshipEntityId], [t2].[Id], [t2].[Id0]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Nested_include_collection_reference_on_non_entity_base_split(bool async)
     {
         await base.Nested_include_collection_reference_on_non_entity_base_split(async);
-
-        AssertSql();
+        
+        AssertSql(
+            @"SELECT [r].[Id], [r].[Name]
+FROM [ReferencedEntities] AS [r]
+ORDER BY [r].[Id]",
+            //
+            @"SELECT [t].[Id], [t].[Name], [t].[ReferenceId], [t].[ReferencedEntityId], [t].[Id0], [t].[Name0], [r].[Id]
+FROM [ReferencedEntities] AS [r]
+INNER JOIN (
+    SELECT [p].[Id], [p].[Name], [p].[ReferenceId], [p].[ReferencedEntityId], [r0].[Id] AS [Id0], [r0].[Name] AS [Name0]
+    FROM [PrincipalEntities] AS [p]
+    LEFT JOIN [ReferencedEntities] AS [r0] ON [p].[ReferenceId] = [r0].[Id]
+) AS [t] ON [r].[Id] = [t].[ReferencedEntityId]
+ORDER BY [r].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Collection_projection_on_base_type_split(bool async)
     {
         await base.Collection_projection_on_base_type_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+ORDER BY [t].[Id]",
+            //
+            @"SELECT [t0].[Id], [t0].[BaseParentId], [t0].[Name], [t0].[DerivedProperty], [t0].[Discriminator], [t].[Id]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+INNER JOIN (
+    SELECT [b0].[Id], [b0].[BaseParentId], [b0].[Name], NULL AS [DerivedProperty], N'BaseCollectionOnBase' AS [Discriminator]
+    FROM [BaseCollectionsOnBase] AS [b0]
+    UNION ALL
+    SELECT [d0].[Id], [d0].[BaseParentId], [d0].[Name], [d0].[DerivedProperty], N'DerivedCollectionOnBase' AS [Discriminator]
+    FROM [DerivedCollectionsOnBase] AS [d0]
+) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
+ORDER BY [t].[Id]");
     }
 
-    [ConditionalTheory(Skip = "Issue#27945")]
+    [ConditionalTheory]
     public override async Task Include_on_derived_type_with_queryable_Cast_split(bool async)
     {
         await base.Include_on_derived_type_with_queryable_Cast_split(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [t].[Id], [t].[Name], [t].[BaseId], [t].[Discriminator], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0], [o].[Id], [o].[Name], [t0].[OwnedReferenceOnDerived_Id], [t0].[OwnedReferenceOnDerived_Name]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d0].[OwnedReferenceOnDerived_Name], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+WHERE [t].[Id] >= 4
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [o0].[BaseInheritanceRelationshipEntityId], [o0].[Id], [o0].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [OwnedCollections] AS [o0] ON [t].[Id] = [o0].[BaseInheritanceRelationshipEntityId]
+WHERE [t].[Id] >= 4
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id], [d2].[Name], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Id] >= 4
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]",
+            //
+            @"SELECT [d2].[Id], [d2].[Name], [d2].[ParentId], [d2].[DerivedInheritanceRelationshipEntityId], [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT [b].[Id], [b].[Name], NULL AS [BaseId], N'BaseInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [BaseEntities] AS [b]
+    UNION ALL
+    SELECT [d].[Id], [d].[Name], [d].[BaseId], N'DerivedInheritanceRelationshipEntity' AS [Discriminator]
+    FROM [DerivedEntities] AS [d]
+) AS [t]
+LEFT JOIN [OwnedReferences] AS [o] ON [t].[Id] = [o].[BaseInheritanceRelationshipEntityId]
+LEFT JOIN (
+    SELECT [d0].[Id], [d0].[OwnedReferenceOnDerived_Id], [d1].[Id] AS [Id0]
+    FROM [DerivedEntities] AS [d0]
+    INNER JOIN [DerivedEntities] AS [d1] ON [d0].[Id] = [d1].[Id]
+    WHERE [d0].[OwnedReferenceOnDerived_Id] IS NOT NULL
+) AS [t0] ON [t].[Id] = CASE
+    WHEN [t0].[OwnedReferenceOnDerived_Id] IS NOT NULL THEN [t0].[Id]
+END
+INNER JOIN [DerivedCollectionsOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
+WHERE [t].[Id] >= 4
+ORDER BY [t].[Id], [o].[BaseInheritanceRelationshipEntityId], [t0].[Id], [t0].[Id0]");
     }
 
-    [ConditionalFact(Skip = "Issue#27945")]
     public override void Entity_can_make_separate_relationships_with_base_type_and_derived_type_both()
     {
         base.Entity_can_make_separate_relationships_with_base_type_and_derived_type_both();


### PR DESCRIPTION
Don't configure table name for abstract types in TPC that have a corresponding DbSet property
Make `ToTable(b => {})` map the entity type to the default table

Fixes #3170
Fixes #27608
Fixes #27945
Fixes #27947