### PR TITLE
Query: Infer type mapping from IDbFunction while translating

### DIFF
--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -81,14 +81,16 @@ public class RelationalMethodCallTranslatorProvider : IMethodCallTranslatorProvi
                     arguments,
                     dbFunction.IsNullable,
                     argumentsPropagateNullability,
-                    method.ReturnType.UnwrapNullableType())
+                    method.ReturnType.UnwrapNullableType(),
+                    dbFunction.TypeMapping)
                 : _sqlExpressionFactory.Function(
                     dbFunction.Schema,
                     dbFunction.Name,
                     arguments,
                     dbFunction.IsNullable,
                     argumentsPropagateNullability,
-                    method.ReturnType.UnwrapNullableType());
+                    method.ReturnType.UnwrapNullableType(),
+                    dbFunction.TypeMapping);
         }
 
         return _plugins.Concat(_translators)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -391,4 +391,22 @@ INNER JOIN (
 ) AS [t0] ON [p].[Id] = [t0].[ParentId]
 WHERE [t0].[SomeOtherNullableDateTime] IS NOT NULL");
     }
+
+    public override async Task StoreType_for_UDF_used(bool async)
+    {
+        await base.StoreType_for_UDF_used(async);
+
+        AssertSql(
+            @"@__date_0='2012-12-12T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [m].[Id], [m].[SomeDate]
+FROM [MyEntities] AS [m]
+WHERE [m].[SomeDate] = @__date_0",
+                //
+                @"@__date_0='2012-12-12T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [m].[Id], [m].[SomeDate]
+FROM [MyEntities] AS [m]
+WHERE [dbo].[ModifyDate]([m].[SomeDate]) = @__date_0");
+    }
 }


### PR DESCRIPTION
- We use TypeMapping if configured on the DbFunction, or
- We try to get it if store type is specified
- If neither of above work then we do the default type mapping based on return type

Resolves https://github.com/dotnet/efcore/issues/27954
Resolves https://github.com/dotnet/efcore/issues/27524