### PR TITLE
Improve SQL Server IndexOf translation and change tests to use Where

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -807,9 +807,19 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (LOWER(c[""CustomerID""]) = ""a
         await base.Indexof_with_emptystring(async);
 
         AssertSql(
-            @"SELECT INDEX_OF(c[""ContactName""], """") AS c
+            @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (INDEX_OF(c[""ContactName""], """") = 0))");
+    }
+
+    public override async Task Indexof_with_one_arg(bool async)
+    {
+        await base.Indexof_with_one_arg(async);
+
+        AssertSql(
+            @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (INDEX_OF(c[""ContactName""], ""a"") = 1))");
     }
 
     public override async Task Indexof_with_starting_position(bool async)
@@ -817,9 +827,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
         await base.Indexof_with_starting_position(async);
 
         AssertSql(
-            @"SELECT INDEX_OF(c[""ContactName""], ""a"", 3) AS c
+            @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (INDEX_OF(c[""ContactName""], ""a"", 2) = 4))");
     }
 
     public override async Task Replace_with_emptystring(bool async)
@@ -827,9 +837,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
         await base.Replace_with_emptystring(async);
 
         AssertSql(
-            @"SELECT REPLACE(c[""ContactName""], ""ari"", """") AS c
+            @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (REPLACE(c[""ContactName""], ""ia"", """") = ""Mar Anders""))");
     }
 
     public override async Task Replace_using_property_arguments(bool async)
@@ -837,9 +847,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
         await base.Replace_using_property_arguments(async);
 
         AssertSql(
-            @"SELECT REPLACE(c[""ContactName""], c[""ContactName""], c[""CustomerID""]) AS c
+            @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (REPLACE(c[""ContactName""], c[""ContactName""], c[""CustomerID""]) = c[""CustomerID""]))");
     }
 
     public override async Task Substring_with_one_arg_with_zero_startindex(bool async)
@@ -1290,16 +1300,6 @@ WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5))");
             @"SELECT c[""UnitPrice""]
 FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5))");
-    }
-
-    public override async Task Indexof_with_one_arg(bool async)
-    {
-        await base.Indexof_with_one_arg(async);
-
-        AssertSql(
-            @"SELECT INDEX_OF(c[""ContactName""], ""a"") AS c
-FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
     }
 
     private void AssertSql(params string[] expected)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -812,9 +812,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (INDEX_OF(c[""ContactName""], """") = 0))");
     }
 
-    public override async Task Indexof_with_one_arg(bool async)
+    public override async Task Indexof_with_one_constant_arg(bool async)
     {
-        await base.Indexof_with_one_arg(async);
+        await base.Indexof_with_one_constant_arg(async);
 
         AssertSql(
             @"SELECT c
@@ -822,14 +822,38 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (INDEX_OF(c[""ContactName""], ""a"") = 1))");
     }
 
-    public override async Task Indexof_with_starting_position(bool async)
+    public override async Task Indexof_with_one_parameter_arg(bool async)
     {
-        await base.Indexof_with_starting_position(async);
+        await base.Indexof_with_one_parameter_arg(async);
+
+        AssertSql(
+            @"@__pattern_0='a'
+
+SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (INDEX_OF(c[""ContactName""], @__pattern_0) = 1))");
+    }
+
+    public override async Task Indexof_with_constant_starting_position(bool async)
+    {
+        await base.Indexof_with_constant_starting_position(async);
 
         AssertSql(
             @"SELECT c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (INDEX_OF(c[""ContactName""], ""a"", 2) = 4))");
+    }
+
+    public override async Task Indexof_with_parameter_starting_position(bool async)
+    {
+        await base.Indexof_with_parameter_starting_position(async);
+
+        AssertSql(
+            @"@__start_0='2'
+
+SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (INDEX_OF(c[""ContactName""], ""a"", @__start_0) = 4))");
     }
 
     public override async Task Replace_with_emptystring(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -1406,38 +1406,42 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Indexof_with_emptystring(bool async)
-        => AssertQueryScalar(
+        => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.IndexOf(string.Empty)));
+            ss => ss.Set<Customer>().Where(c => c.ContactName.IndexOf(string.Empty) == 0),
+            entryCount: 91);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Indexof_with_one_arg(bool async)
-        => AssertQueryScalar(
+        => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.IndexOf("a")));
+            ss => ss.Set<Customer>().Where(c => c.ContactName.IndexOf("a") == 1),
+            entryCount: 32);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Indexof_with_starting_position(bool async)
-        => AssertQueryScalar(
+        => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.IndexOf("a", 3)));
+            ss => ss.Set<Customer>().Where(c => c.ContactName.IndexOf("a", 2) == 4),
+            entryCount: 15);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Replace_with_emptystring(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => c.ContactName.Replace("ari", string.Empty)));
+            ss => ss.Set<Customer>().Where(c => c.ContactName.Replace("ia", string.Empty) == "Mar Anders"),
+            entryCount: 1);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Replace_using_property_arguments(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI")
-                .Select(c => c.ContactName.Replace(c.ContactName, c.CustomerID)));
+            ss => ss.Set<Customer>().Where(c => c.ContactName.Replace(c.ContactName, c.CustomerID) == c.CustomerID),
+            entryCount: 91);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -1413,7 +1413,7 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Indexof_with_one_arg(bool async)
+    public virtual Task Indexof_with_one_constant_arg(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.ContactName.IndexOf("a") == 1),
@@ -1421,11 +1421,35 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Indexof_with_starting_position(bool async)
+    public virtual Task Indexof_with_one_parameter_arg(bool async)
+    {
+        var pattern = "a";
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ContactName.IndexOf(pattern) == 1),
+            entryCount: 32);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Indexof_with_constant_starting_position(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.ContactName.IndexOf("a", 2) == 4),
             entryCount: 15);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Indexof_with_parameter_starting_position(bool async)
+    {
+        var start = 2;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ContactName.IndexOf("a", start) == 4),
+            entryCount: 15);
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -83,10 +83,7 @@ WHERE [m].[TimeSpanAsTime] = @__timeSpan_0");
 
             Assert.Equal(-1, Assert.Single(results));
             AssertSql(
-                @"SELECT CASE
-    WHEN 'a' = '' THEN 0
-    ELSE CAST(CHARINDEX('a', [m].[StringAsVarcharMax]) AS int) - 1
-END
+                @"SELECT CAST(CHARINDEX('a', [m].[StringAsVarcharMax]) AS int) - 1
 FROM [MappedNullableDataTypes] AS [m]
 WHERE [m].[Int] = 81");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1571,9 +1571,8 @@ WHERE [o].[CustomerID] = N'ALFKI' AND ((CONVERT(nvarchar(max), [o].[OrderDate]) 
         await base.Indexof_with_emptystring(async);
 
         AssertSql(
-            @"SELECT 0
-FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI'");
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
     }
 
     public override async Task Indexof_with_one_arg(bool async)
@@ -1581,12 +1580,12 @@ WHERE [c].[CustomerID] = N'ALFKI'");
         await base.Indexof_with_one_arg(async);
 
         AssertSql(
-            @"SELECT CASE
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE CASE
     WHEN N'a' = N'' THEN 0
     ELSE CAST(CHARINDEX(N'a', [c].[ContactName]) AS int) - 1
-END
-FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI'");
+END = 1");
     }
 
     public override async Task Indexof_with_starting_position(bool async)
@@ -1594,12 +1593,12 @@ WHERE [c].[CustomerID] = N'ALFKI'");
         await base.Indexof_with_starting_position(async);
 
         AssertSql(
-            @"SELECT CASE
-    WHEN N'a' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'a', [c].[ContactName], 3 + 1) AS int) - 1
-END
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI'");
+WHERE CASE
+    WHEN N'a' = N'' THEN 0
+    ELSE CAST(CHARINDEX(N'a', [c].[ContactName], 2 + 1) AS int) - 1
+END = 4");
     }
 
     public override async Task Replace_with_emptystring(bool async)
@@ -1607,9 +1606,9 @@ WHERE [c].[CustomerID] = N'ALFKI'");
         await base.Replace_with_emptystring(async);
 
         AssertSql(
-            @"SELECT REPLACE([c].[ContactName], N'ari', N'')
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI'");
+WHERE REPLACE([c].[ContactName], N'ia', N'') = N'Mar Anders'");
     }
 
     public override async Task Replace_using_property_arguments(bool async)
@@ -1617,9 +1616,9 @@ WHERE [c].[CustomerID] = N'ALFKI'");
         await base.Replace_using_property_arguments(async);
 
         AssertSql(
-            @"SELECT REPLACE([c].[ContactName], [c].[ContactName], [c].[CustomerID])
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI'");
+WHERE REPLACE([c].[ContactName], [c].[ContactName], [c].[CustomerID]) = [c].[CustomerID]");
     }
 
     public override async Task Substring_with_one_arg_with_zero_startindex(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1575,30 +1575,51 @@ WHERE [o].[CustomerID] = N'ALFKI' AND ((CONVERT(nvarchar(max), [o].[OrderDate]) 
 FROM [Customers] AS [c]");
     }
 
-    public override async Task Indexof_with_one_arg(bool async)
+    public override async Task Indexof_with_one_constant_arg(bool async)
     {
-        await base.Indexof_with_one_arg(async);
+        await base.Indexof_with_one_constant_arg(async);
 
         AssertSql(
             @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
+WHERE (CAST(CHARINDEX(N'a', [c].[ContactName]) AS int) - 1) = 1");
+    }
+
+    public override async Task Indexof_with_one_parameter_arg(bool async)
+    {
+        await base.Indexof_with_one_parameter_arg(async);
+
+        AssertSql(
+            @"@__pattern_0='a' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
 WHERE CASE
-    WHEN N'a' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'a', [c].[ContactName]) AS int) - 1
+    WHEN @__pattern_0 = N'' THEN 0
+    ELSE CAST(CHARINDEX(@__pattern_0, [c].[ContactName]) AS int) - 1
 END = 1");
     }
 
-    public override async Task Indexof_with_starting_position(bool async)
+    public override async Task Indexof_with_constant_starting_position(bool async)
     {
-        await base.Indexof_with_starting_position(async);
+        await base.Indexof_with_constant_starting_position(async);
 
         AssertSql(
             @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CASE
-    WHEN N'a' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'a', [c].[ContactName], 2 + 1) AS int) - 1
-END = 4");
+WHERE (CAST(CHARINDEX(N'a', [c].[ContactName], 3) AS int) - 1) = 4");
+    }
+
+    public override async Task Indexof_with_parameter_starting_position(bool async)
+    {
+        await base.Indexof_with_parameter_starting_position(async);
+
+        AssertSql(
+            @"@__start_0='2'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (CAST(CHARINDEX(N'a', [c].[ContactName], @__start_0 + 1) AS int) - 1) = 4");
     }
 
     public override async Task Replace_with_emptystring(bool async)
@@ -1700,10 +1721,7 @@ WHERE [c].[CustomerID] = N'ALFKI'");
         await base.Substring_with_two_args_with_Index_of(async);
 
         AssertSql(
-            @"SELECT SUBSTRING([c].[ContactName], CASE
-    WHEN N'a' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'a', [c].[ContactName]) AS int) - 1
-END + 1, 3)
+            @"SELECT SUBSTRING([c].[ContactName], (CAST(CHARINDEX(N'a', [c].[ContactName]) AS int) - 1) + 1, 3)
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'");
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -674,13 +674,7 @@ WHERE CAST(LEN([c].[City]) AS int) = 6");
         AssertSql(
             @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CASE
-    WHEN N'Sea' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'Sea', [c].[City]) AS int) - 1
-END <> -1 OR CASE
-    WHEN N'Sea' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'Sea', [c].[City]) AS int) - 1
-END IS NULL");
+WHERE (CAST(CHARINDEX(N'Sea', [c].[City]) AS int) - 1) <> -1 OR [c].[City] IS NULL");
     }
 
     public override async Task Where_string_replace(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1248,36 +1248,15 @@ FROM [Entities1] AS [e]");
         AssertSql(
             @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END = [e].[NullableIntA] OR (CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL AND [e].[NullableIntA] IS NULL)",
+WHERE (CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1) = [e].[NullableIntA] OR ([e].[NullableStringA] IS NULL AND [e].[NullableIntA] IS NULL)",
             //
             @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END = [e].[NullableIntA] OR (CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END IS NULL AND [e].[NullableIntA] IS NULL)",
+WHERE (CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1) = [e].[NullableIntA] OR ([e].[NullableStringA] IS NULL AND [e].[NullableIntA] IS NULL)",
             //
             @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END <> [e].[NullableIntB] OR CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL OR [e].[NullableIntB] IS NULL) AND (CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)");
+WHERE ((CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1) <> [e].[NullableIntB] OR [e].[NullableStringA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)");
     }
 
     public override async Task Where_IndexOf_empty(bool async)
@@ -1293,10 +1272,7 @@ END IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)");
         await base.Select_IndexOf(async);
 
         AssertSql(
-            @"SELECT CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END
+            @"SELECT CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
 FROM [Entities1] AS [e]
 ORDER BY [e].[Id]");
     }
@@ -1308,63 +1284,15 @@ ORDER BY [e].[Id]");
         AssertSql(
             @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END = CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END OR (CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL AND CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END IS NULL)",
+WHERE (CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1) = (CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)",
             //
             @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END <> CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END OR CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL OR CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END IS NULL) AND (CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NOT NULL OR CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1
-END IS NOT NULL)",
+WHERE ((CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1) <> (CAST(CHARINDEX(N'ar', [e].[NullableStringB]) AS int) - 1) OR [e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)",
             //
             @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END <> CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END OR CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NULL OR CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END IS NULL) AND (CASE
-    WHEN N'oo' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1
-END IS NOT NULL OR CASE
-    WHEN N'ar' = N'' THEN 0
-    ELSE CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1
-END IS NOT NULL)");
+WHERE ((CAST(CHARINDEX(N'oo', [e].[NullableStringA]) AS int) - 1) <> (CAST(CHARINDEX(N'ar', [e].[NullableStringA]) AS int) - 1) OR [e].[NullableStringA] IS NULL) AND [e].[NullableStringA] IS NOT NULL");
     }
 
     public override async Task Null_semantics_applied_when_comparing_two_functions_with_multiple_nullable_arguments(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -332,9 +332,9 @@ FROM ""Customers"" AS ""c""
 WHERE (instr(""c"".""ContactName"", '') - 1) = 0");
     }
 
-    public override async Task Indexof_with_one_arg(bool async)
+    public override async Task Indexof_with_one_constant_arg(bool async)
     {
-        await base.Indexof_with_one_arg(async);
+        await base.Indexof_with_one_constant_arg(async);
 
         AssertSql(
             @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -342,8 +342,23 @@ FROM ""Customers"" AS ""c""
 WHERE (instr(""c"".""ContactName"", 'a') - 1) = 1");
     }
 
-    public override Task Indexof_with_starting_position(bool async)
-        => AssertTranslationFailed(() => base.Indexof_with_starting_position(async));
+    public override async Task Indexof_with_one_parameter_arg(bool async)
+    {
+        await base.Indexof_with_one_parameter_arg(async);
+
+        AssertSql(
+            @"@__pattern_0='a' (Size = 1)
+
+SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE (instr(""c"".""ContactName"", @__pattern_0) - 1) = 1");
+    }
+
+    public override Task Indexof_with_constant_starting_position(bool async)
+        => AssertTranslationFailed(() => base.Indexof_with_constant_starting_position(async));
+
+    public override Task Indexof_with_parameter_starting_position(bool async)
+        => AssertTranslationFailed(() => base.Indexof_with_parameter_starting_position(async));
 
     public override async Task Replace_with_emptystring(bool async)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -327,19 +327,42 @@ WHERE ""c"".""Region"" IS NULL OR trim(""c"".""Region"") = ''");
         await base.Indexof_with_emptystring(async);
 
         AssertSql(
-            @"SELECT instr(""c"".""ContactName"", '') - 1
+            @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""CustomerID"" = 'ALFKI'");
+WHERE (instr(""c"".""ContactName"", '') - 1) = 0");
     }
+
+    public override async Task Indexof_with_one_arg(bool async)
+    {
+        await base.Indexof_with_one_arg(async);
+
+        AssertSql(
+            @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE (instr(""c"".""ContactName"", 'a') - 1) = 1");
+    }
+
+    public override Task Indexof_with_starting_position(bool async)
+        => AssertTranslationFailed(() => base.Indexof_with_starting_position(async));
 
     public override async Task Replace_with_emptystring(bool async)
     {
         await base.Replace_with_emptystring(async);
 
         AssertSql(
-            @"SELECT replace(""c"".""ContactName"", 'ari', '')
+            @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ""c"".""CustomerID"" = 'ALFKI'");
+WHERE replace(""c"".""ContactName"", 'ia', '') = 'Mar Anders'");
+    }
+
+    public override async Task Replace_using_property_arguments(bool async)
+    {
+        await base.Replace_using_property_arguments(async);
+
+        AssertSql(
+            @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE replace(""c"".""ContactName"", ""c"".""ContactName"", ""c"".""CustomerID"") = ""c"".""CustomerID""");
     }
 
     public override async Task Substring_with_one_arg_with_zero_startindex(bool async)


### PR DESCRIPTION
After the discussion in #1625, it turns out the Npgsql provider didn't implement IndexOf with starting position (see #25396), but this didn't surface because the relevant test was calling the function in the top-most projection, and not in a Where clause (so it was client-evaled).

Changed the IndexOf/Replace tests to use Where - we should avoid testing translations in top-most projections except where we specifically need to test materialization etc.

Also tweaked SQL Server IndexOf translation to be better with constants.