### PR TITLE
Query: Don't add grouping key to projection when Distinct is applied

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2993,7 +2993,8 @@ public sealed partial class SelectExpression : TableExpressionBase
             }
         }
 
-        if (subquery._groupBy.Count > 0)
+        if (subquery._groupBy.Count > 0
+            && !subquery.IsDistinct)
         {
             foreach (var key in subquery._groupBy)
             {

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -1856,6 +1856,21 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture> : QueryTestBase<TF
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Join_GroupBy_Aggregate_distinct_single_join(bool async)
+        => AssertQuery(
+            async,
+            ss =>
+                from c in ss.Set<Customer>()
+                join a in ss.Set<Order>().GroupBy(o => new { o.CustomerID, o.OrderDate.Value.Year } )
+                        .Where(g => g.Count() > 5)
+                        .Select(g => new { CustomerID = g.Key.CustomerID, LastOrderID = g.Max(o => o.OrderID) })
+                        .Distinct()
+                    on c.CustomerID equals a.CustomerID
+                select new { c, a.LastOrderID },
+            entryCount: 31);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Join_GroupBy_Aggregate_with_left_join(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1589,6 +1589,24 @@ INNER JOIN (
 INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]");
     }
 
+    public override async Task Join_GroupBy_Aggregate_distinct_single_join(bool async)
+    {
+        await base.Join_GroupBy_Aggregate_distinct_single_join(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[LastOrderID]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT DISTINCT [t].[CustomerID], MAX([t].[OrderID]) AS [LastOrderID]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], DATEPART(year, [o].[OrderDate]) AS [Year]
+        FROM [Orders] AS [o]
+    ) AS [t]
+    GROUP BY [t].[CustomerID], [t].[Year]
+    HAVING COUNT(*) > 5
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]");
+    }
+
     public override async Task Join_GroupBy_Aggregate_with_left_join(bool async)
     {
         await base.Join_GroupBy_Aggregate_with_left_join(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -409,4 +409,24 @@ SELECT [m].[Id], [m].[SomeDate]
 FROM [MyEntities] AS [m]
 WHERE [dbo].[ModifyDate]([m].[SomeDate]) = @__date_0");
     }
+
+    public override async Task Pushdown_does_not_add_grouping_key_to_projection_when_distinct_is_applied(bool async)
+    {
+        await base.Pushdown_does_not_add_grouping_key_to_projection_when_distinct_is_applied(async);
+
+        AssertSql(
+            @"@__p_0='123456'
+
+SELECT TOP(@__p_0) [t].[JSON]
+FROM [TableData] AS [t]
+INNER JOIN (
+    SELECT DISTINCT [i].[Parcel]
+    FROM [IndexData] AS [i]
+    WHERE [i].[Parcel] = N'some condition'
+    GROUP BY [i].[Parcel], [i].[RowId]
+    HAVING COUNT(*) = 1
+) AS [t0] ON [t].[ParcelNumber] = [t0].[Parcel]
+WHERE [t].[TableId] = 123
+ORDER BY [t].[ParcelNumber]");
+    }
 }


### PR DESCRIPTION
Resolves #28039
