### PR TITLE
Query: Add support for custom aggregate operators

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -66,6 +66,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
             { typeof(IModificationCommandBatchFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IRelationalSqlTranslatingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IMethodCallTranslatorProvider), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+            { typeof(IAggregateMethodCallTranslatorProvider), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IMemberTranslatorProvider), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(ISqlExpressionFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IRelationalQueryStringFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -171,6 +172,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
         TryAdd<IShapedQueryCompilingExpressionVisitorFactory, RelationalShapedQueryCompilingExpressionVisitorFactory>();
         TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, RelationalQueryableMethodTranslatingExpressionVisitorFactory>();
         TryAdd<IMethodCallTranslatorProvider, RelationalMethodCallTranslatorProvider>();
+        TryAdd<IAggregateMethodCallTranslatorProvider, RelationalAggregateMethodCallTranslatorProvider>();
         TryAdd<IMemberTranslatorProvider, RelationalMemberTranslatorProvider>();
         TryAdd<IQueryTranslationPostprocessorFactory, RelationalQueryTranslationPostprocessorFactory>();
         TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, RelationalSqlTranslatingExpressionVisitorFactory>();
@@ -202,6 +204,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
             .AddDependencyScoped<HistoryRepositoryDependencies>()
             .AddDependencyScoped<RelationalCompiledQueryCacheKeyGeneratorDependencies>()
             .AddDependencyScoped<RelationalMethodCallTranslatorProviderDependencies>()
+            .AddDependencyScoped<RelationalAggregateMethodCallTranslatorProviderDependencies>()
             .AddDependencyScoped<RelationalMemberTranslatorProviderDependencies>()
             .AddDependencyScoped<SqlExpressionFactoryDependencies>()
             .AddDependencyScoped<RelationalSqlTranslatingExpressionVisitorDependencies>()

--- a/src/EFCore.Relational/Query/IAggregateMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/IAggregateMethodCallTranslator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
@@ -7,26 +7,26 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
 ///     <para>
-///         A SQL translator for LINQ <see cref="MethodCallExpression" /> expression.
+///         A SQL translator for LINQ <see cref="MethodCallExpression" /> expression represending an aggregate function.
 ///     </para>
 ///     <para>
 ///         This interface is typically used by database providers (and other extensions). It is generally
 ///         not used in application code.
 ///     </para>
 /// </summary>
-public interface IMethodCallTranslator
+public interface IAggregateMethodCallTranslator
 {
     /// <summary>
     ///     Translates a LINQ <see cref="MethodCallExpression" /> to a SQL equivalent.
     /// </summary>
-    /// <param name="instance">A SQL representation of <see cref="MethodCallExpression.Object" />.</param>
     /// <param name="method">The method info from <see cref="MethodCallExpression.Method" />.</param>
-    /// <param name="arguments">SQL representations of <see cref="MethodCallExpression.Arguments" />.</param>
+    /// <param name="source">The source on which the aggregate method is applied.</param>
+    /// <param name="arguments">SQL representations of scalar <see cref="MethodCallExpression.Arguments" />.</param>
     /// <param name="logger">The query logger to use.</param>
     /// <returns>A SQL translation of the <see cref="MethodCallExpression" />.</returns>
     SqlExpression? Translate(
-        SqlExpression? instance,
         MethodInfo method,
+        EnumerableExpression source,
         IReadOnlyList<SqlExpression> arguments,
         IDiagnosticsLogger<DbLoggerCategory.Query> logger);
 }

--- a/src/EFCore.Relational/Query/IAggregateMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.Relational/Query/IAggregateMethodCallTranslatorPlugin.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     Represents plugin for <see cref="IAggregateMethodCallTranslator" />.
+/// </summary>
+/// <remarks>
+///     The service lifetime is <see cref="ServiceLifetime.Scoped" /> and multiple registrations
+///     are allowed. This means that each <see cref="DbContext" /> instance will use its own
+///     set of instances of this service.
+///     The implementations may depend on other services registered with any lifetime.
+///     The implementations do not need to be thread-safe.
+/// </remarks>
+public interface IAggregateMethodCallTranslatorPlugin
+{
+    /// <summary>
+    ///     Gets the method call translators.
+    /// </summary>
+    IEnumerable<IAggregateMethodCallTranslator> Translators { get; }
+}

--- a/src/EFCore.Relational/Query/IAggregateMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/IAggregateMethodCallTranslatorProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
-///     Provides translations for LINQ <see cref="MethodCallExpression" /> expressions which represents scalar methods.
+///     Provides translations for LINQ <see cref="MethodCallExpression" /> expressions which represents aggregate methods.
 /// </summary>
 /// <remarks>
 ///     The service lifetime is <see cref="ServiceLifetime.Scoped" /> and multiple registrations
@@ -15,21 +15,21 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     The implementations may depend on other services registered with any lifetime.
 ///     The implementations do not need to be thread-safe.
 /// </remarks>
-public interface IMethodCallTranslatorProvider
+public interface IAggregateMethodCallTranslatorProvider
 {
     /// <summary>
-    ///     Translates a LINQ <see cref="MethodCallExpression" /> to a SQL equivalent.
+    ///     Translates a LINQ aggregate <see cref="MethodCallExpression" /> to a SQL equivalent.
     /// </summary>
     /// <param name="model">A model to use for translation.</param>
-    /// <param name="instance">A SQL representation of <see cref="MethodCallExpression.Object" />.</param>
     /// <param name="method">The method info from <see cref="MethodCallExpression.Method" />.</param>
-    /// <param name="arguments">SQL representations of <see cref="MethodCallExpression.Arguments" />.</param>
+    /// <param name="source">The source on which the aggregate method is applied.</param>
+    /// <param name="arguments">SQL representations of scalar <see cref="MethodCallExpression.Arguments" />.</param>
     /// <param name="logger">The query logger to use.</param>
     /// <returns>A SQL translation of the <see cref="MethodCallExpression" />.</returns>
     SqlExpression? Translate(
         IModel model,
-        SqlExpression? instance,
         MethodInfo method,
+        EnumerableExpression source,
         IReadOnlyList<SqlExpression> arguments,
         IDiagnosticsLogger<DbLoggerCategory.Query> logger);
 }

--- a/src/EFCore.Relational/Query/Internal/QueryableAggregateMethodTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryableAggregateMethodTranslator.cs
@@ -1,0 +1,180 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class QueryableAggregateMethodTranslator : IAggregateMethodCallTranslator
+{
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public QueryableAggregateMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression? Translate(
+        MethodInfo method, EnumerableExpression source, IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType == typeof(Queryable))
+        {
+            var methodInfo = method.IsGenericMethod
+                ? method.GetGenericMethodDefinition()
+                : method;
+            switch (methodInfo.Name)
+            {
+                case nameof(Queryable.Average)
+                when (QueryableMethods.IsAverageWithoutSelector(methodInfo)
+                    || QueryableMethods.IsAverageWithSelector(methodInfo))
+                    && source.Selector is SqlExpression averageSqlExpression:
+                    var averageInputType = averageSqlExpression.Type;
+                    if (averageInputType == typeof(int)
+                        || averageInputType == typeof(long))
+                    {
+                        averageSqlExpression = _sqlExpressionFactory.ApplyDefaultTypeMapping(
+                            _sqlExpressionFactory.Convert(averageSqlExpression, typeof(double)));
+                    }
+
+                    averageSqlExpression = CombineTerms(source, averageSqlExpression);
+                    return averageInputType == typeof(float)
+                        ? _sqlExpressionFactory.Convert(
+                            _sqlExpressionFactory.Function(
+                                "AVG",
+                                new[] { averageSqlExpression },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { false },
+                                typeof(double)),
+                            averageSqlExpression.Type,
+                            averageSqlExpression.TypeMapping)
+                        : _sqlExpressionFactory.Function(
+                            "AVG",
+                            new[] { averageSqlExpression },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { false },
+                            averageSqlExpression.Type,
+                            averageSqlExpression.TypeMapping);
+
+                case nameof(Queryable.Count)
+                when methodInfo == QueryableMethods.CountWithoutPredicate
+                    || methodInfo == QueryableMethods.CountWithPredicate:
+                    var countSqlExpression = (source.Selector as SqlExpression) ?? _sqlExpressionFactory.Fragment("*");
+                    countSqlExpression = CombineTerms(source, countSqlExpression);
+                    return _sqlExpressionFactory.ApplyDefaultTypeMapping(
+                        _sqlExpressionFactory.Function(
+                            "COUNT",
+                            new[] { countSqlExpression },
+                            nullable: false,
+                            argumentsPropagateNullability: new[] { false },
+                            typeof(int)));
+
+                case nameof(Queryable.LongCount)
+                when methodInfo == QueryableMethods.LongCountWithoutPredicate
+                    || methodInfo == QueryableMethods.LongCountWithPredicate:
+                    var longCountSqlExpression = (source.Selector as SqlExpression) ?? _sqlExpressionFactory.Fragment("*");
+                    longCountSqlExpression = CombineTerms(source, longCountSqlExpression);
+
+                    return _sqlExpressionFactory.ApplyDefaultTypeMapping(
+                        _sqlExpressionFactory.Function(
+                            "COUNT",
+                            new[] { longCountSqlExpression },
+                            nullable: false,
+                            argumentsPropagateNullability: new[] { false },
+                            typeof(long)));
+
+                case nameof(Queryable.Max)
+                when (methodInfo == QueryableMethods.MaxWithoutSelector
+                    || methodInfo == QueryableMethods.MaxWithSelector)
+                    && source.Selector is SqlExpression maxSqlExpression:
+                    maxSqlExpression = CombineTerms(source, maxSqlExpression);
+                    return _sqlExpressionFactory.Function(
+                            "MAX",
+                            new[] { maxSqlExpression },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { false },
+                            maxSqlExpression.Type,
+                            maxSqlExpression.TypeMapping);
+
+                case nameof(Queryable.Min)
+                when (methodInfo == QueryableMethods.MinWithoutSelector
+                    || methodInfo == QueryableMethods.MinWithSelector)
+                    && source.Selector is SqlExpression minSqlExpression:
+                    minSqlExpression = CombineTerms(source, minSqlExpression);
+                    return _sqlExpressionFactory.Function(
+                            "MIN",
+                            new[] { minSqlExpression },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { false },
+                            minSqlExpression.Type,
+                            minSqlExpression.TypeMapping);
+
+                case nameof(Queryable.Sum)
+                when (QueryableMethods.IsSumWithoutSelector(methodInfo)
+                    || QueryableMethods.IsSumWithSelector(methodInfo))
+                    && source.Selector is SqlExpression sumSqlExpression:
+                    sumSqlExpression = CombineTerms(source, sumSqlExpression);
+                    var sumInputType = sumSqlExpression.Type;
+                    return sumInputType == typeof(float)
+                        ? _sqlExpressionFactory.Convert(
+                            _sqlExpressionFactory.Function(
+                                "SUM",
+                                new[] { sumSqlExpression },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { false },
+                                typeof(double)),
+                            sumInputType,
+                            sumSqlExpression.TypeMapping)
+                        : _sqlExpressionFactory.Function(
+                            "SUM",
+                            new[] { sumSqlExpression },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { false },
+                            sumInputType,
+                            sumSqlExpression.TypeMapping);
+            }
+        }
+
+        return null;
+    }
+
+    private SqlExpression CombineTerms(EnumerableExpression enumerableExpression, SqlExpression sqlExpression)
+    {
+        if (enumerableExpression.Predicate != null)
+        {
+            if (sqlExpression is SqlFragmentExpression)
+            {
+                sqlExpression = _sqlExpressionFactory.Constant(1);
+            }
+
+            sqlExpression = _sqlExpressionFactory.Case(
+                new List<CaseWhenClause> { new(enumerableExpression.Predicate, sqlExpression) },
+                elseResult: null);
+        }
+
+        if (enumerableExpression.IsDistinct)
+        {
+            sqlExpression = new DistinctExpression(sqlExpression);
+        }
+
+        return sqlExpression;
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalAggregateMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalAggregateMethodCallTranslatorProvider.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <inheritdoc />
+public class RelationalAggregateMethodCallTranslatorProvider : IAggregateMethodCallTranslatorProvider
+{
+    private readonly List<IAggregateMethodCallTranslator> _plugins = new();
+    private readonly List<IAggregateMethodCallTranslator> _translators = new();
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    /// <summary>
+    ///     Creates a new instance of the <see cref="RelationalAggregateMethodCallTranslatorProvider" /> class.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing dependencies for this class.</param>
+    public RelationalAggregateMethodCallTranslatorProvider(RelationalAggregateMethodCallTranslatorProviderDependencies dependencies)
+    {
+        Dependencies = dependencies;
+
+        _plugins.AddRange(dependencies.Plugins.SelectMany(p => p.Translators));
+
+        _sqlExpressionFactory = dependencies.SqlExpressionFactory;
+
+        _translators.AddRange(
+            new IAggregateMethodCallTranslator[]
+            {
+                new QueryableAggregateMethodTranslator(_sqlExpressionFactory)
+            }); ;
+    }
+
+    /// <summary>
+    ///     Dependencies for this service.
+    /// </summary>
+    protected virtual RelationalAggregateMethodCallTranslatorProviderDependencies Dependencies { get; }
+
+    /// <inheritdoc />
+    public virtual SqlExpression? Translate(
+        IModel model,
+        MethodInfo method,
+        EnumerableExpression source,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        // TODO: Add support for user defined aggregate functions
+        //var dbFunction = model.FindDbFunction(method);
+        //if (dbFunction != null)
+        //{
+        //    if (dbFunction.Translation != null)
+        //    {
+        //        return dbFunction.Translation.Invoke(
+        //            arguments.Select(e => _sqlExpressionFactory.ApplyDefaultTypeMapping(e)).ToList());
+        //    }
+
+        //    var argumentsPropagateNullability = dbFunction.Parameters.Select(p => p.PropagatesNullability);
+
+        //    return dbFunction.IsBuiltIn
+        //        ? _sqlExpressionFactory.Function(
+        //            dbFunction.Name,
+        //            arguments,
+        //            dbFunction.IsNullable,
+        //            argumentsPropagateNullability,
+        //            method.ReturnType.UnwrapNullableType(),
+        //            dbFunction.TypeMapping)
+        //        : _sqlExpressionFactory.Function(
+        //            dbFunction.Schema,
+        //            dbFunction.Name,
+        //            arguments,
+        //            dbFunction.IsNullable,
+        //            argumentsPropagateNullability,
+        //            method.ReturnType.UnwrapNullableType(),
+        //            dbFunction.TypeMapping);
+        //}
+
+        return _plugins.Concat(_translators)
+            .Select(t => t.Translate(method, source, arguments, logger))
+            .FirstOrDefault(t => t != null);
+    }
+
+    /// <summary>
+    ///     Adds additional translators which will take priority over existing registered translators.
+    /// </summary>
+    /// <param name="translators">Translators to add.</param>
+    protected virtual void AddTranslators(IEnumerable<IAggregateMethodCallTranslator> translators)
+        => _translators.InsertRange(0, translators);
+}

--- a/src/EFCore.Relational/Query/RelationalAggregateMethodCallTranslatorProviderDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalAggregateMethodCallTranslatorProviderDependencies.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
 ///     <para>
-///         Service dependencies parameter class for <see cref="RelationalQueryableMethodTranslatingExpressionVisitor" />
+///         Service dependencies parameter class for <see cref="RelationalAggregateMethodCallTranslatorProvider" />
 ///     </para>
 ///     <para>
 ///         This type is typically used by database providers (and other extensions). It is generally
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///         The implementation does not need to be thread-safe.
 ///     </para>
 /// </remarks>
-public sealed record RelationalQueryableMethodTranslatingExpressionVisitorDependencies
+public sealed record RelationalAggregateMethodCallTranslatorProviderDependencies
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -45,35 +45,28 @@ public sealed record RelationalQueryableMethodTranslatingExpressionVisitorDepend
     ///     the constructor at any point in this process.
     /// </remarks>
     [EntityFrameworkInternal]
-    public RelationalQueryableMethodTranslatingExpressionVisitorDependencies(
-        IRelationalSqlTranslatingExpressionVisitorFactory relationalSqlTranslatingExpressionVisitorFactory,
+    public RelationalAggregateMethodCallTranslatorProviderDependencies(
         ISqlExpressionFactory sqlExpressionFactory,
-        IModel model,
-        IAggregateMethodCallTranslatorProvider aggregateMethodCallTranslatorProvider)
+        IEnumerable<IAggregateMethodCallTranslatorPlugin> plugins,
+        IRelationalTypeMappingSource typeMappingSource)
     {
-        RelationalSqlTranslatingExpressionVisitorFactory = relationalSqlTranslatingExpressionVisitorFactory;
         SqlExpressionFactory = sqlExpressionFactory;
-        Model = model;
-        AggregateMethodCallTranslatorProvider = aggregateMethodCallTranslatorProvider;
+        Plugins = plugins;
+        RelationalTypeMappingSource = typeMappingSource;
     }
 
     /// <summary>
-    ///     The SQL-translating expression visitor factory.
-    /// </summary>
-    public IRelationalSqlTranslatingExpressionVisitorFactory RelationalSqlTranslatingExpressionVisitorFactory { get; init; }
-
-    /// <summary>
-    ///     The SQL expression factory.
+    ///     The expression factory..
     /// </summary>
     public ISqlExpressionFactory SqlExpressionFactory { get; init; }
 
     /// <summary>
-    ///     The model.
+    ///     Registered plugins.
     /// </summary>
-    public IModel Model { get; init; }
+    public IEnumerable<IAggregateMethodCallTranslatorPlugin> Plugins { get; init; }
 
     /// <summary>
-    ///     The aggregate method-call translation provider.
+    ///     Relational Type Mapping Source.
     /// </summary>
-    public IAggregateMethodCallTranslatorProvider AggregateMethodCallTranslatorProvider { get; }
+    public IRelationalTypeMappingSource RelationalTypeMappingSource { get; init; }
 }

--- a/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -3,22 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-/// <summary>
-///     <para>
-///         Creates keys that uniquely identifies a query. This is used to store and lookup
-///         compiled versions of a query in a cache.
-///     </para>
-///     <para>
-///         This type is typically used by database providers (and other extensions). It is generally
-///         not used in application code.
-///     </para>
-/// </summary>
-/// <remarks>
-///     The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
-///     <see cref="DbContext" /> instance will use its own instance of this service.
-///     The implementation may depend on other services registered with any lifetime.
-///     The implementation does not need to be thread-safe.
-/// </remarks>
+/// <inheritdoc />
 public class RelationalCompiledQueryCacheKeyGenerator : CompiledQueryCacheKeyGenerator
 {
     /// <summary>
@@ -39,12 +24,7 @@ public class RelationalCompiledQueryCacheKeyGenerator : CompiledQueryCacheKeyGen
     /// </summary>
     protected virtual RelationalCompiledQueryCacheKeyGeneratorDependencies RelationalDependencies { get; }
 
-    /// <summary>
-    ///     Generates the cache key for the given query.
-    /// </summary>
-    /// <param name="query">The query to get the cache key for.</param>
-    /// <param name="async">A value indicating whether the query will be executed asynchronously.</param>
-    /// <returns>The cache key.</returns>
+    /// <inheritdoc />
     public override object GenerateCacheKey(Expression query, bool async)
         => GenerateCacheKeyCore(query, async);
 
@@ -102,41 +82,19 @@ public class RelationalCompiledQueryCacheKeyGenerator : CompiledQueryCacheKeyGen
             _shouldBuffer = shouldBuffer;
         }
 
-        /// <summary>
-        ///     Determines if this key is equivalent to a given object (i.e. if they are keys for the same query).
-        /// </summary>
-        /// <param name="obj">
-        ///     The object to compare this key to.
-        /// </param>
-        /// <returns>
-        ///     <see langword="true" /> if the object is a <see cref="RelationalCompiledQueryCacheKey" /> and is for the same query,
-        ///     otherwise <see langword="false" />.
-        /// </returns>
+        /// <inheritdoc />
         public override bool Equals(object? obj)
             => obj is RelationalCompiledQueryCacheKey key
                 && Equals(key);
 
-        /// <summary>
-        ///     Indicates whether the current object is equal to another object of the same type.
-        /// </summary>
-        /// <param name="other">
-        ///     An object to compare with this object.
-        /// </param>
-        /// <returns>
-        ///     <see langword="true" /> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <see langword="false" />.
-        /// </returns>
+        /// <inheritdoc />
         public bool Equals(RelationalCompiledQueryCacheKey other)
             => _compiledQueryCacheKey.Equals(other._compiledQueryCacheKey)
                 && _useRelationalNulls == other._useRelationalNulls
                 && _querySplittingBehavior == other._querySplittingBehavior
                 && _shouldBuffer == other._shouldBuffer;
 
-        /// <summary>
-        ///     Gets the hash code for the key.
-        /// </summary>
-        /// <returns>
-        ///     The hash code for the key.
-        /// </returns>
+        /// <inheritdoc />
         public override int GetHashCode()
             => HashCode.Combine(
                 _compiledQueryCacheKey, _useRelationalNulls, _querySplittingBehavior, _shouldBuffer);

--- a/src/EFCore.Relational/Query/RelationalEvaluatableExpressionFilter.cs
+++ b/src/EFCore.Relational/Query/RelationalEvaluatableExpressionFilter.cs
@@ -3,14 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-/// <summary>
-///     Represents a filter for evaluatable expressions.
-/// </summary>
-/// <remarks>
-///     The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
-///     is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
-///     This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
-/// </remarks>
+/// <inheritdoc />
 public class RelationalEvaluatableExpressionFilter : EvaluatableExpressionFilter
 {
     /// <summary>
@@ -37,12 +30,7 @@ public class RelationalEvaluatableExpressionFilter : EvaluatableExpressionFilter
     /// </summary>
     protected virtual RelationalEvaluatableExpressionFilterDependencies RelationalDependencies { get; }
 
-    /// <summary>
-    ///     Checks whether the given expression can be evaluated.
-    /// </summary>
-    /// <param name="expression">The expression.</param>
-    /// <param name="model">The model.</param>
-    /// <returns><see langword="true" /> if the expression can be evaluated; <see langword="false" /> otherwise.</returns>
+    /// <inheritdoc />
     public override bool IsEvaluatableExpression(Expression expression, IModel model)
     {
         if (expression is MethodCallExpression methodCallExpression)

--- a/src/EFCore.Relational/Query/RelationalMemberTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMemberTranslatorProvider.cs
@@ -6,16 +6,7 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-/// <summary>
-///     Provides translations for LINQ <see cref="MemberExpression" /> expressions by dispatching to multiple specialized member
-///     translators.
-/// </summary>
-/// <remarks>
-///     The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
-///     <see cref="DbContext" /> instance will use its own instance of this service.
-///     The implementation may depend on other services registered with any lifetime.
-///     The implementation does not need to be thread-safe.
-/// </remarks>
+/// <inheritdoc />
 public class RelationalMemberTranslatorProvider : IMemberTranslatorProvider
 {
     private readonly List<IMemberTranslator> _plugins = new();

--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -6,16 +6,7 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-/// <summary>
-///     Provides translations for LINQ <see cref="MethodCallExpression" /> expressions by dispatching to multiple specialized
-///     method call translators.
-/// </summary>
-/// <remarks>
-///     The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
-///     <see cref="DbContext" /> instance will use its own instance of this service.
-///     The implementation may depend on other services registered with any lifetime.
-///     The implementation does not need to be thread-safe.
-/// </remarks>
+/// <inheritdoc />
 public class RelationalMethodCallTranslatorProvider : IMethodCallTranslatorProvider
 {
     private readonly List<IMethodCallTranslator> _plugins = new();

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -237,7 +237,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
         LambdaExpression? selector,
         Type resultType)
         => TranslateAggregateWithSelector(
-            source, selector, e => _sqlTranslator.TranslateAverage(e), throwWhenEmpty: true, resultType);
+            source, selector, e => TranslateAverage(e), throwWhenEmpty: true, resultType);
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateCast(ShapedQueryExpression source, Type resultType)
@@ -301,7 +301,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateCount(ShapedQueryExpression source, LambdaExpression? predicate)
-        => TranslateAggregateWithPredicate(source, predicate, e => _sqlTranslator.TranslateCount(e), typeof(int));
+        => TranslateAggregateWithPredicate(source, predicate, e => TranslateCount(e), typeof(int));
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateDefaultIfEmpty(ShapedQueryExpression source, Expression? defaultValue)
@@ -623,15 +623,15 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateLongCount(ShapedQueryExpression source, LambdaExpression? predicate)
-        => TranslateAggregateWithPredicate(source, predicate, e => _sqlTranslator.TranslateLongCount(e), typeof(long));
+        => TranslateAggregateWithPredicate(source, predicate, e => TranslateLongCount(e), typeof(long));
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateMax(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
-        => TranslateAggregateWithSelector(source, selector, e => _sqlTranslator.TranslateMax(e), throwWhenEmpty: true, resultType);
+        => TranslateAggregateWithSelector(source, selector, e => TranslateMax(e), throwWhenEmpty: true, resultType);
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateMin(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
-        => TranslateAggregateWithSelector(source, selector, e => _sqlTranslator.TranslateMin(e), throwWhenEmpty: true, resultType);
+        => TranslateAggregateWithSelector(source, selector, e => TranslateMin(e), throwWhenEmpty: true, resultType);
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateOfType(ShapedQueryExpression source, Type resultType)
@@ -888,7 +888,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateSum(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
-        => TranslateAggregateWithSelector(source, selector, e => _sqlTranslator.TranslateSum(e), throwWhenEmpty: false, resultType);
+        => TranslateAggregateWithSelector(source, selector, e => TranslateSum(e), throwWhenEmpty: false, resultType);
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateTake(ShapedQueryExpression source, Expression count)
@@ -1464,6 +1464,36 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                 return shaper1;
         }
     }
+
+    private SqlExpression? TranslateAverage(SqlExpression sqlExpression)
+        => RelationalDependencies.AggregateMethodCallTranslatorProvider.Translate(
+            RelationalDependencies.Model, QueryableMethods.GetAverageWithoutSelector(sqlExpression.Type),
+            new EnumerableExpression(sqlExpression), Array.Empty<SqlExpression>(), _queryCompilationContext.Logger);
+
+    private SqlExpression? TranslateCount(SqlExpression sqlExpression)
+        => RelationalDependencies.AggregateMethodCallTranslatorProvider.Translate(
+            RelationalDependencies.Model, QueryableMethods.CountWithoutPredicate,
+            new EnumerableExpression(sqlExpression), Array.Empty<SqlExpression>(), _queryCompilationContext.Logger);
+
+    private SqlExpression? TranslateLongCount(SqlExpression sqlExpression)
+        => RelationalDependencies.AggregateMethodCallTranslatorProvider.Translate(
+            RelationalDependencies.Model, QueryableMethods.LongCountWithoutPredicate,
+            new EnumerableExpression(sqlExpression), Array.Empty<SqlExpression>(), _queryCompilationContext.Logger);
+
+    private SqlExpression? TranslateMax(SqlExpression sqlExpression)
+        => RelationalDependencies.AggregateMethodCallTranslatorProvider.Translate(
+            RelationalDependencies.Model, QueryableMethods.MaxWithoutSelector,
+            new EnumerableExpression(sqlExpression), Array.Empty<SqlExpression>(), _queryCompilationContext.Logger);
+
+    private SqlExpression? TranslateMin(SqlExpression sqlExpression)
+        => RelationalDependencies.AggregateMethodCallTranslatorProvider.Translate(
+            RelationalDependencies.Model, QueryableMethods.MinWithoutSelector,
+            new EnumerableExpression(sqlExpression), Array.Empty<SqlExpression>(), _queryCompilationContext.Logger);
+
+    private SqlExpression? TranslateSum(SqlExpression sqlExpression)
+        => RelationalDependencies.AggregateMethodCallTranslatorProvider.Translate(
+            RelationalDependencies.Model, QueryableMethods.GetSumWithoutSelector(sqlExpression.Type),
+            new EnumerableExpression(sqlExpression), Array.Empty<SqlExpression>(), _queryCompilationContext.Logger);
 
     private ShapedQueryExpression? TranslateAggregateWithPredicate(
         ShapedQueryExpression source,

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitorDependencies.cs
@@ -50,13 +50,15 @@ public sealed record RelationalSqlTranslatingExpressionVisitorDependencies
         IModel model,
         IRelationalTypeMappingSource typeMappingSource,
         IMemberTranslatorProvider memberTranslatorProvider,
-        IMethodCallTranslatorProvider methodCallTranslatorProvider)
+        IMethodCallTranslatorProvider methodCallTranslatorProvider,
+        IAggregateMethodCallTranslatorProvider aggregateMethodCallTranslatorProvider)
     {
         SqlExpressionFactory = sqlExpressionFactory;
         Model = model;
         TypeMappingSource = typeMappingSource;
         MemberTranslatorProvider = memberTranslatorProvider;
         MethodCallTranslatorProvider = methodCallTranslatorProvider;
+        AggregateMethodCallTranslatorProvider = aggregateMethodCallTranslatorProvider;
     }
 
     /// <summary>
@@ -65,7 +67,7 @@ public sealed record RelationalSqlTranslatingExpressionVisitorDependencies
     public ISqlExpressionFactory SqlExpressionFactory { get; init; }
 
     /// <summary>
-    ///     The expression factory.
+    ///     The model.
     /// </summary>
     public IModel Model { get; init; }
 
@@ -80,7 +82,12 @@ public sealed record RelationalSqlTranslatingExpressionVisitorDependencies
     public IMemberTranslatorProvider MemberTranslatorProvider { get; init; }
 
     /// <summary>
-    ///     The method-call translation provider.
+    ///     The scalar method-call translation provider.
     /// </summary>
     public IMethodCallTranslatorProvider MethodCallTranslatorProvider { get; init; }
+
+    /// <summary>
+    ///     The aggregate method-call translation provider.
+    /// </summary>
+    public IAggregateMethodCallTranslatorProvider AggregateMethodCallTranslatorProvider { get; }
 }

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitorFactory.cs
@@ -3,15 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-/// <summary>
-///     A factory for creating <see cref="RelationalSqlTranslatingExpressionVisitor" /> instances.
-/// </summary>
-/// <remarks>
-///     The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
-///     <see cref="DbContext" /> instance will use its own instance of this service.
-///     The implementation may depend on other services registered with any lifetime.
-///     The implementation does not need to be thread-safe.
-/// </remarks>
+/// <inheritdoc />
 public class RelationalSqlTranslatingExpressionVisitorFactory : IRelationalSqlTranslatingExpressionVisitorFactory
 {
     /// <summary>
@@ -29,12 +21,7 @@ public class RelationalSqlTranslatingExpressionVisitorFactory : IRelationalSqlTr
     /// </summary>
     protected virtual RelationalSqlTranslatingExpressionVisitorDependencies Dependencies { get; }
 
-    /// <summary>
-    ///     Creates a new <see cref="RelationalSqlTranslatingExpressionVisitor" />.
-    /// </summary>
-    /// <param name="queryCompilationContext">The query compilation context to use.</param>
-    /// <param name="queryableMethodTranslatingExpressionVisitor">The visitor to use to translate subqueries.</param>
-    /// <returns>A relational sql translating expression visitor.</returns>
+    /// <inheritdoc />
     public virtual RelationalSqlTranslatingExpressionVisitor Create(
         QueryCompilationContext queryCompilationContext,
         QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -120,6 +120,7 @@ public static class SqlServerServiceCollectionExtensions
             .TryAdd<ICompiledQueryCacheKeyGenerator, SqlServerCompiledQueryCacheKeyGenerator>()
             .TryAdd<IQueryCompilationContextFactory, SqlServerQueryCompilationContextFactory>()
             .TryAdd<IMethodCallTranslatorProvider, SqlServerMethodCallTranslatorProvider>()
+            .TryAdd<IAggregateMethodCallTranslatorProvider, SqlServerAggregateMethodCallTranslatorProvider>()
             .TryAdd<IMemberTranslatorProvider, SqlServerMemberTranslatorProvider>()
             .TryAdd<IQuerySqlGeneratorFactory, SqlServerQuerySqlGeneratorFactory>()
             .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, SqlServerSqlTranslatingExpressionVisitorFactory>()

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerAggregateMethodCallTranslatorProvider.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerAggregateMethodCallTranslatorProvider.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqlServerAggregateMethodCallTranslatorProvider : RelationalAggregateMethodCallTranslatorProvider
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlServerAggregateMethodCallTranslatorProvider(RelationalAggregateMethodCallTranslatorProviderDependencies dependencies)
+        : base(dependencies)
+    {
+        var sqlExpressionFactory = dependencies.SqlExpressionFactory;
+        AddTranslators(
+            new IAggregateMethodCallTranslator[]
+            {
+                new SqlServerLongCountMethodTranslator(sqlExpressionFactory)
+            });
+    }
+}

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerLongCountMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerLongCountMethodTranslator.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqlServerLongCountMethodTranslator : IAggregateMethodCallTranslator
+{
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlServerLongCountMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression? Translate(
+        MethodInfo method, EnumerableExpression source, IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType == typeof(Queryable)
+            && method.IsGenericMethod
+            && method.GetGenericMethodDefinition() is MethodInfo genericMethod
+            && (genericMethod == QueryableMethods.LongCountWithoutPredicate
+                || genericMethod == QueryableMethods.LongCountWithPredicate))
+        {
+            var sqlExpression = (source.Selector as SqlExpression) ?? _sqlExpressionFactory.Fragment("*");
+            if (source.Predicate != null)
+            {
+                if (sqlExpression is SqlFragmentExpression)
+                {
+                    sqlExpression = _sqlExpressionFactory.Constant(1);
+                }
+
+                sqlExpression = _sqlExpressionFactory.Case(
+                    new List<CaseWhenClause> { new(source.Predicate, sqlExpression) },
+                    elseResult: null);
+            }
+
+            if (source.IsDistinct)
+            {
+                sqlExpression = new DistinctExpression(sqlExpression);
+            }
+
+            return _sqlExpressionFactory.ApplyDefaultTypeMapping(
+                _sqlExpressionFactory.Function(
+                    "COUNT_BIG",
+                    new[] { sqlExpression },
+                    nullable: false,
+                    argumentsPropagateNullability: new[] { false },
+                    typeof(long)));
+        }
+
+        return null;
+    }
+}

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -152,21 +152,6 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
         return base.VisitUnary(unaryExpression);
     }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public override SqlExpression? TranslateLongCount(SqlExpression sqlExpression)
-        => Dependencies.SqlExpressionFactory.ApplyDefaultTypeMapping(
-            Dependencies.SqlExpressionFactory.Function(
-                "COUNT_BIG",
-                new[] { sqlExpression },
-                nullable: false,
-                argumentsPropagateNullability: new[] { false },
-                typeof(long)));
-
     private static string? GetProviderType(SqlExpression expression)
         => expression.TypeMapping?.StoreType;
 }

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -112,6 +112,7 @@ public static class SqliteServiceCollectionExtensions
 
             // New Query Pipeline
             .TryAdd<IMethodCallTranslatorProvider, SqliteMethodCallTranslatorProvider>()
+            .TryAdd<IAggregateMethodCallTranslatorProvider, SqliteAggregateMethodCallTranslatorProvider>()
             .TryAdd<IMemberTranslatorProvider, SqliteMemberTranslatorProvider>()
             .TryAdd<IQuerySqlGeneratorFactory, SqliteQuerySqlGeneratorFactory>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, SqliteQueryableMethodTranslatingExpressionVisitorFactory>()

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteAggregateMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteAggregateMethodCallTranslatorProvider.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteAggregateMethodCallTranslatorProvider : RelationalAggregateMethodCallTranslatorProvider
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqliteAggregateMethodCallTranslatorProvider(RelationalAggregateMethodCallTranslatorProviderDependencies dependencies)
+        : base(dependencies)
+    {
+        var sqlExpressionFactory = dependencies.SqlExpressionFactory;
+
+        AddTranslators(
+            new IAggregateMethodCallTranslator[]
+            {
+                new SqliteQueryableAggregateMethodTranslator(sqlExpressionFactory)
+            });
+    }
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableAggregateMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableAggregateMethodTranslator.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteQueryableAggregateMethodTranslator : IAggregateMethodCallTranslator
+{
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqliteQueryableAggregateMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression? Translate(
+        MethodInfo method, EnumerableExpression source, IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType == typeof(Queryable))
+        {
+            var methodInfo = method.IsGenericMethod
+                ? method.GetGenericMethodDefinition()
+                : method;
+            switch (methodInfo.Name)
+            {
+                case nameof(Queryable.Average)
+                when (QueryableMethods.IsAverageWithoutSelector(methodInfo)
+                    || QueryableMethods.IsAverageWithSelector(methodInfo))
+                    && source.Selector is SqlExpression averageSqlExpression:
+                    var averageArgumentType = GetProviderType(averageSqlExpression);
+                    if (averageArgumentType == typeof(decimal))
+                    {
+                        throw new NotSupportedException(
+                            SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Average), averageArgumentType.ShortDisplayName()));
+                    }
+                    break;
+
+                case nameof(Queryable.Max)
+                when (methodInfo == QueryableMethods.MaxWithoutSelector
+                    || methodInfo == QueryableMethods.MaxWithSelector)
+                    && source.Selector is SqlExpression maxSqlExpression:
+                    var maxArgumentType = GetProviderType(maxSqlExpression);
+                    if (maxArgumentType == typeof(DateTimeOffset)
+                        || maxArgumentType == typeof(decimal)
+                        || maxArgumentType == typeof(TimeSpan)
+                        || maxArgumentType == typeof(ulong))
+                    {
+                        throw new NotSupportedException(
+                            SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), maxArgumentType.ShortDisplayName()));
+                    }
+                    break;
+
+                case nameof(Queryable.Min)
+                when (methodInfo == QueryableMethods.MinWithoutSelector
+                    || methodInfo == QueryableMethods.MinWithSelector)
+                    && source.Selector is SqlExpression minSqlExpression:
+                    var minArgumentType = GetProviderType(minSqlExpression);
+                    if (minArgumentType == typeof(DateTimeOffset)
+                        || minArgumentType == typeof(decimal)
+                        || minArgumentType == typeof(TimeSpan)
+                        || minArgumentType == typeof(ulong))
+                    {
+                        throw new NotSupportedException(
+                            SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), minArgumentType.ShortDisplayName()));
+                    }
+                    break;
+
+                case nameof(Queryable.Sum)
+                when (QueryableMethods.IsSumWithoutSelector(methodInfo)
+                    || QueryableMethods.IsSumWithSelector(methodInfo))
+                    && source.Selector is SqlExpression sumSqlExpression:
+                    var sumArgumentType = GetProviderType(sumSqlExpression);
+                    if (sumArgumentType == typeof(decimal))
+                    {
+                        throw new NotSupportedException(
+                            SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Sum), sumArgumentType.ShortDisplayName()));
+                    }
+                    break;
+            }
+        }
+
+        return null;
+    }
+
+    private static Type? GetProviderType(SqlExpression expression)
+        => expression.TypeMapping?.Converter?.ProviderClrType
+            ?? expression.TypeMapping?.ClrType
+            ?? expression.Type;
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 
@@ -207,88 +206,6 @@ public class SqliteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
             {
                 return QueryCompilationContext.NotTranslatedExpression;
             }
-        }
-
-        return visitedExpression;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public override SqlExpression? TranslateAverage(SqlExpression sqlExpression)
-    {
-        var visitedExpression = base.TranslateAverage(sqlExpression);
-        var argumentType = GetProviderType(visitedExpression);
-        if (argumentType == typeof(decimal))
-        {
-            throw new NotSupportedException(
-                SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Average), argumentType.ShortDisplayName()));
-        }
-
-        return visitedExpression;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public override SqlExpression? TranslateMax(SqlExpression sqlExpression)
-    {
-        var visitedExpression = base.TranslateMax(sqlExpression);
-        var argumentType = GetProviderType(visitedExpression);
-        if (argumentType == typeof(DateTimeOffset)
-            || argumentType == typeof(decimal)
-            || argumentType == typeof(TimeSpan)
-            || argumentType == typeof(ulong))
-        {
-            throw new NotSupportedException(
-                SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Max), argumentType.ShortDisplayName()));
-        }
-
-        return visitedExpression;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public override SqlExpression? TranslateMin(SqlExpression sqlExpression)
-    {
-        var visitedExpression = base.TranslateMin(sqlExpression);
-        var argumentType = GetProviderType(visitedExpression);
-        if (argumentType == typeof(DateTimeOffset)
-            || argumentType == typeof(decimal)
-            || argumentType == typeof(TimeSpan)
-            || argumentType == typeof(ulong))
-        {
-            throw new NotSupportedException(
-                SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Min), argumentType.ShortDisplayName()));
-        }
-
-        return visitedExpression;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public override SqlExpression? TranslateSum(SqlExpression sqlExpression)
-    {
-        var visitedExpression = base.TranslateSum(sqlExpression);
-        var argumentType = GetProviderType(visitedExpression);
-        if (argumentType == typeof(decimal))
-        {
-            throw new NotSupportedException(
-                SqliteStrings.AggregateOperationNotSupported(nameof(Queryable.Sum), argumentType.ShortDisplayName()));
         }
 
         return visitedExpression;

--- a/src/EFCore/Query/CompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore/Query/CompiledQueryCacheKeyGenerator.cs
@@ -3,28 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-/// <summary>
-///     <para>
-///         Creates keys that uniquely identifies a query. This is used to store and lookup
-///         compiled versions of a query in a cache.
-///     </para>
-///     <para>
-///         This type is typically used by database providers (and other extensions). It is generally
-///         not used in application code.
-///     </para>
-/// </summary>
-/// <remarks>
-///     <para>
-///         The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
-///         <see cref="DbContext" /> instance will use its own instance of this service.
-///         The implementation may depend on other services registered with any lifetime.
-///         The implementation does not need to be thread-safe.
-///     </para>
-///     <para>
-///         See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
-///         and <see href="https://aka.ms/efcore-docs-how-query-works">How EF Core queries work</see> for more information and examples.
-///     </para>
-/// </remarks>
+/// <inheritdoc />
 public class CompiledQueryCacheKeyGenerator : ICompiledQueryCacheKeyGenerator
 {
     /// <summary>
@@ -41,12 +20,7 @@ public class CompiledQueryCacheKeyGenerator : ICompiledQueryCacheKeyGenerator
     /// </summary>
     protected virtual CompiledQueryCacheKeyGeneratorDependencies Dependencies { get; }
 
-    /// <summary>
-    ///     Generates the cache key for the given query.
-    /// </summary>
-    /// <param name="query">The query to get the cache key for.</param>
-    /// <param name="async">A value indicating whether the query will be executed asynchronously.</param>
-    /// <returns>The cache key.</returns>
+    /// <inheritdoc />
     public virtual object GenerateCacheKey(Expression query, bool async)
         => GenerateCacheKeyCore(query, async);
 
@@ -99,40 +73,18 @@ public class CompiledQueryCacheKeyGenerator : ICompiledQueryCacheKeyGenerator
             _async = async;
         }
 
-        /// <summary>
-        ///     Determines if this key is equivalent to a given object (i.e. if they are keys for the same query).
-        /// </summary>
-        /// <param name="obj">
-        ///     The object to compare this key to.
-        /// </param>
-        /// <returns>
-        ///     <see langword="true" /> if the object is a <see cref="CompiledQueryCacheKey" /> and is for the same query, otherwise
-        ///     <see langword="false" />.
-        /// </returns>
+        /// <inheritdoc />
         public override bool Equals(object? obj)
             => obj is CompiledQueryCacheKey other && Equals(other);
 
-        /// <summary>
-        ///     Indicates whether the current object is equal to another object of the same type.
-        /// </summary>
-        /// <param name="other">
-        ///     An object to compare with this object.
-        /// </param>
-        /// <returns>
-        ///     <see langword="true" /> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <see langword="false" />.
-        /// </returns>
+        /// <inheritdoc />
         public bool Equals(CompiledQueryCacheKey other)
             => ReferenceEquals(_model, other._model)
                 && _queryTrackingBehavior == other._queryTrackingBehavior
                 && _async == other._async
                 && ExpressionEqualityComparer.Instance.Equals(_query, other._query);
 
-        /// <summary>
-        ///     Gets the hash code for the key.
-        /// </summary>
-        /// <returns>
-        ///     The hash code for the key.
-        /// </returns>
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             var hash = new HashCode();

--- a/src/EFCore/Query/EvaluatableExpressionFilter.cs
+++ b/src/EFCore/Query/EvaluatableExpressionFilter.cs
@@ -3,20 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-/// <summary>
-///     Represents a filter for evaluatable expressions.
-/// </summary>
-/// <remarks>
-///     <para>
-///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
-///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
-///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
-///     </para>
-///     <para>
-///         See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
-///         and <see href="https://aka.ms/efcore-docs-how-query-works">How EF Core queries work</see> for more information and examples.
-///     </para>
-/// </remarks>
+/// <inheritdoc />
 public class EvaluatableExpressionFilter : IEvaluatableExpressionFilter
 {
     // This methods are non-deterministic and result varies based on time of running the query.
@@ -69,12 +56,7 @@ public class EvaluatableExpressionFilter : IEvaluatableExpressionFilter
     /// </summary>
     protected virtual EvaluatableExpressionFilterDependencies Dependencies { get; }
 
-    /// <summary>
-    ///     Checks whether the given expression can be evaluated.
-    /// </summary>
-    /// <param name="expression">The expression.</param>
-    /// <param name="model">The model.</param>
-    /// <returns><see langword="true" /> if the expression can be evaluated; <see langword="false" /> otherwise.</returns>
+    /// <inheritdoc />
     public virtual bool IsEvaluatableExpression(Expression expression, IModel model)
     {
         switch (expression)

--- a/src/EFCore/Query/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/ExpressionEqualityComparer.cs
@@ -28,11 +28,7 @@ public sealed class ExpressionEqualityComparer : IEqualityComparer<Expression?>
     /// </summary>
     public static ExpressionEqualityComparer Instance { get; } = new();
 
-    /// <summary>
-    ///     Returns the hash code for given expression.
-    /// </summary>
-    /// <param name="obj">The <see cref="Expression" /> obj to compute hash code for.</param>
-    /// <returns>The hash code value for <paramref name="obj" />.</returns>
+    /// <inheritdoc />
     public int GetHashCode(Expression obj)
     {
         if (obj == null)
@@ -276,12 +272,7 @@ public sealed class ExpressionEqualityComparer : IEqualityComparer<Expression?>
         }
     }
 
-    /// <summary>
-    ///     Returns a value indicating whether the given expressions are equal.
-    /// </summary>
-    /// <param name="x">The left expression.</param>
-    /// <param name="y">The right expression.</param>
-    /// <returns><see langword="true" /> if the expressions are equal, <see langword="false" /> otherwise.</returns>
+    /// <inheritdoc />
     public bool Equals(Expression? x, Expression? y)
         => new ExpressionComparer().Compare(x, y);
 

--- a/src/EFCore/Query/ICompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore/Query/ICompiledQueryCacheKeyGenerator.cs
@@ -4,7 +4,14 @@
 namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
-///     A cache key generator for the compiled query cache.
+///     <para>
+///         Creates keys that uniquely identifies a query. This is used to store and lookup
+///         compiled versions of a query in a cache.
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
 /// </summary>
 /// <remarks>
 ///     <para>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -626,9 +626,9 @@ END) AS [Min], MAX(CASE
     WHEN 1 = [t].[Key] THEN [t].[OrderDate]
 END) AS [Max], COALESCE(SUM(CASE
     WHEN 1 = [t].[Key] THEN [t].[OrderID]
-END), 0) AS [Sum], AVG(CAST(CASE
-    WHEN 1 = [t].[Key] THEN [t].[OrderID]
-END AS float)) AS [Average]
+END), 0) AS [Sum], AVG(CASE
+    WHEN 1 = [t].[Key] THEN CAST([t].[OrderID] AS float)
+END) AS [Average]
 FROM (
     SELECT [o].[OrderID], [o].[OrderDate], 1 AS [Key]
     FROM [Orders] AS [o]
@@ -1782,9 +1782,9 @@ END");
         await base.GroupBy_Where_Average(async);
 
         AssertSql(
-            @"SELECT AVG(CAST(CASE
-    WHEN [o].[OrderID] < 10300 THEN [o].[OrderID]
-END AS float))
+            @"SELECT AVG(CASE
+    WHEN [o].[OrderID] < 10300 THEN CAST([o].[OrderID] AS float)
+END)
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
     }


### PR DESCRIPTION
Resolves #22957

- Introduce IAggregateMethodCallTranslator and family to translate aggregate methods
- Currently we assume that either method instance or first argument (for static method) will be the one which can be of type enumerable, rest of the arguments if any are scalar.
- Also refactor code in SqlTranslator.VisitMethodCall to avoid visiting grouping element source multiple times
