### PR TITLE
Query: Remove the requirement that instance or first argument would b…

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -943,8 +943,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     {
                         var argument = arguments[i];
                         var visitedArgument = Visit(argument);
-                        if (i == 0
-                            && visitedArgument is EnumerableExpression)
+                        if (visitedArgument is EnumerableExpression)
                         {
                             if (enumerableExpression != null)
                             {

--- a/src/EFCore/Query/ICompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore/Query/ICompiledQueryCacheKeyGenerator.cs
@@ -5,12 +5,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 /// <summary>
 ///     <para>
-///         Creates keys that uniquely identifies a query. This is used to store and lookup
-///         compiled versions of a query in a cache.
+///         Creates keys that uniquely identifies a query. This is used to store and lookup compiled versions of a query in a cache.
 ///     </para>
 ///     <para>
-///         This type is typically used by database providers (and other extensions). It is generally
-///         not used in application code.
+///         This type is typically used by database providers (and other extensions). It is generally not used in application code.
 ///     </para>
 /// </summary>
 /// <remarks>


### PR DESCRIPTION
…e enumerable in aggregate function

Feedback on #28092
