### PR TITLE
Query: Provide a way to translate aggregate methods on top level

### DIFF
--- a/src/EFCore.Relational/Query/Internal/QueryableAggregateMethodTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryableAggregateMethodTranslator.cs
@@ -79,27 +79,24 @@ public class QueryableAggregateMethodTranslator : IAggregateMethodCallTranslator
                     || methodInfo == QueryableMethods.CountWithPredicate:
                     var countSqlExpression = (source.Selector as SqlExpression) ?? _sqlExpressionFactory.Fragment("*");
                     countSqlExpression = CombineTerms(source, countSqlExpression);
-                    return _sqlExpressionFactory.ApplyDefaultTypeMapping(
-                        _sqlExpressionFactory.Function(
-                            "COUNT",
-                            new[] { countSqlExpression },
-                            nullable: false,
-                            argumentsPropagateNullability: new[] { false },
-                            typeof(int)));
+                    return _sqlExpressionFactory.Function(
+                        "COUNT",
+                        new[] { countSqlExpression },
+                        nullable: false,
+                        argumentsPropagateNullability: new[] { false },
+                        typeof(int));
 
                 case nameof(Queryable.LongCount)
                 when methodInfo == QueryableMethods.LongCountWithoutPredicate
                     || methodInfo == QueryableMethods.LongCountWithPredicate:
                     var longCountSqlExpression = (source.Selector as SqlExpression) ?? _sqlExpressionFactory.Fragment("*");
                     longCountSqlExpression = CombineTerms(source, longCountSqlExpression);
-
-                    return _sqlExpressionFactory.ApplyDefaultTypeMapping(
-                        _sqlExpressionFactory.Function(
-                            "COUNT",
-                            new[] { longCountSqlExpression },
-                            nullable: false,
-                            argumentsPropagateNullability: new[] { false },
-                            typeof(long)));
+                    return _sqlExpressionFactory.Function(
+                        "COUNT",
+                        new[] { longCountSqlExpression },
+                        nullable: false,
+                        argumentsPropagateNullability: new[] { false },
+                        typeof(long));
 
                 case nameof(Queryable.Max)
                 when (methodInfo == QueryableMethods.MaxWithoutSelector
@@ -107,12 +104,12 @@ public class QueryableAggregateMethodTranslator : IAggregateMethodCallTranslator
                     && source.Selector is SqlExpression maxSqlExpression:
                     maxSqlExpression = CombineTerms(source, maxSqlExpression);
                     return _sqlExpressionFactory.Function(
-                            "MAX",
-                            new[] { maxSqlExpression },
-                            nullable: true,
-                            argumentsPropagateNullability: new[] { false },
-                            maxSqlExpression.Type,
-                            maxSqlExpression.TypeMapping);
+                        "MAX",
+                        new[] { maxSqlExpression },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { false },
+                        maxSqlExpression.Type,
+                        maxSqlExpression.TypeMapping);
 
                 case nameof(Queryable.Min)
                 when (methodInfo == QueryableMethods.MinWithoutSelector
@@ -120,12 +117,12 @@ public class QueryableAggregateMethodTranslator : IAggregateMethodCallTranslator
                     && source.Selector is SqlExpression minSqlExpression:
                     minSqlExpression = CombineTerms(source, minSqlExpression);
                     return _sqlExpressionFactory.Function(
-                            "MIN",
-                            new[] { minSqlExpression },
-                            nullable: true,
-                            argumentsPropagateNullability: new[] { false },
-                            minSqlExpression.Type,
-                            minSqlExpression.TypeMapping);
+                        "MIN",
+                        new[] { minSqlExpression },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { false },
+                        minSqlExpression.Type,
+                        minSqlExpression.TypeMapping);
 
                 case nameof(Queryable.Sum)
                 when (QueryableMethods.IsSumWithoutSelector(methodInfo)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitorDependencies.cs
@@ -47,14 +47,10 @@ public sealed record RelationalQueryableMethodTranslatingExpressionVisitorDepend
     [EntityFrameworkInternal]
     public RelationalQueryableMethodTranslatingExpressionVisitorDependencies(
         IRelationalSqlTranslatingExpressionVisitorFactory relationalSqlTranslatingExpressionVisitorFactory,
-        ISqlExpressionFactory sqlExpressionFactory,
-        IModel model,
-        IAggregateMethodCallTranslatorProvider aggregateMethodCallTranslatorProvider)
+        ISqlExpressionFactory sqlExpressionFactory)
     {
         RelationalSqlTranslatingExpressionVisitorFactory = relationalSqlTranslatingExpressionVisitorFactory;
         SqlExpressionFactory = sqlExpressionFactory;
-        Model = model;
-        AggregateMethodCallTranslatorProvider = aggregateMethodCallTranslatorProvider;
     }
 
     /// <summary>
@@ -66,14 +62,4 @@ public sealed record RelationalQueryableMethodTranslatingExpressionVisitorDepend
     ///     The SQL expression factory.
     /// </summary>
     public ISqlExpressionFactory SqlExpressionFactory { get; init; }
-
-    /// <summary>
-    ///     The model.
-    /// </summary>
-    public IModel Model { get; init; }
-
-    /// <summary>
-    ///     The aggregate method-call translation provider.
-    /// </summary>
-    public IAggregateMethodCallTranslatorProvider AggregateMethodCallTranslatorProvider { get; }
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -3150,7 +3150,8 @@ public sealed partial class SelectExpression : TableExpressionBase
     {
         if (IsDistinct
             || Limit != null
-            || Offset != null)
+            || Offset != null
+            || _groupBy.Count > 0)
         {
             PushdownIntoSubquery();
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2051,7 +2051,7 @@ FROM [LevelOne] AS [l]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT TOP(10) [l0].[Id], [l0].[Date], [l0].[Name], [l0].[OneToMany_Optional_Self_Inverse1Id], [l0].[OneToMany_Required_Self_Inverse1Id], [l0].[OneToOne_Optional_Self1Id], [l1].[Id] AS [Id0], [l1].[Date] AS [Date0], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name] AS [Name0], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
+        SELECT TOP(10) [l0].[Id], [l1].[Id] AS [Id0]
         FROM [LevelOne] AS [l0]
         LEFT JOIN [LevelTwo] AS [l1] ON [l0].[Id] = [l1].[Level1_Optional_Id]
         WHERE (

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -6997,7 +6997,7 @@ FROM [Level1] AS [l]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT TOP(10) [l0].[Id], [l0].[Date], [l0].[Name], [t0].[Id] AS [Id0], [t0].[Date] AS [Date0], [t0].[Name] AS [Name0], [t0].[Id0] AS [Id00], [t0].[OneToOne_Required_PK_Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Level2_Name], [t0].[OneToMany_Optional_Inverse2Id], [t0].[OneToMany_Required_Inverse2Id], [t0].[OneToOne_Optional_PK_Inverse2Id]
+        SELECT TOP(10) [l0].[Id], [t0].[Id] AS [Id0], [t0].[Id0] AS [Id00]
         FROM [Level1] AS [l0]
         LEFT JOIN (
             SELECT [l1].[Id], [l1].[Date], [l1].[Name], [t].[Id] AS [Id0], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -2124,7 +2124,7 @@ ORDER BY [c].[CustomerID]");
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@__p_0) [o].[OrderID]
     FROM [Orders] AS [o]
 ) AS [t]");
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1281,7 +1281,7 @@ ORDER BY [c].[CustomerID]");
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@__p_0) [o].[OrderID]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [t]");
@@ -3644,8 +3644,8 @@ ORDER BY [t].[CustomerID]");
 FROM (
     SELECT DISTINCT [c].[CustomerID]
     FROM [Customers] AS [c]
-) AS [t]
-WHERE [t].[CustomerID] LIKE N'A%'");
+    WHERE [c].[CustomerID] LIKE N'A%'
+) AS [t]");
     }
 
     public override async Task Anonymous_complex_distinct_where(bool async)
@@ -3680,8 +3680,8 @@ ORDER BY [t].[A]");
 FROM (
     SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [A]
     FROM [Customers] AS [c]
-) AS [t]
-WHERE [t].[A] IS NOT NULL AND ([t].[A] LIKE N'A%')");
+    WHERE [c].[CustomerID] + COALESCE([c].[City], N'') LIKE N'A%'
+) AS [t]");
     }
 
     public override async Task Anonymous_complex_orderby(bool async)
@@ -3748,8 +3748,8 @@ ORDER BY [t].[Property]");
 FROM (
     SELECT DISTINCT [c].[CustomerID] AS [Property]
     FROM [Customers] AS [c]
-) AS [t]
-WHERE [t].[Property] LIKE N'A%'");
+    WHERE [c].[CustomerID] LIKE N'A%'
+) AS [t]");
     }
 
     public override async Task DTO_complex_distinct_where(bool async)
@@ -3784,8 +3784,8 @@ ORDER BY [t].[Property]");
 FROM (
     SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [Property]
     FROM [Customers] AS [c]
-) AS [t]
-WHERE [t].[Property] IS NOT NULL AND ([t].[Property] LIKE N'A%')");
+    WHERE [c].[CustomerID] + COALESCE([c].[City], N'') LIKE N'A%'
+) AS [t]");
     }
 
     public override async Task DTO_complex_orderby(bool async)
@@ -3900,7 +3900,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@__p_0) [c].[CustomerID]
     FROM [Customers] AS [c]
 ) AS [t]");
     }
@@ -3914,7 +3914,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Country]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
 ) AS [t]");
@@ -3929,7 +3929,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@__p_0) [c].[CustomerID]
     FROM [Customers] AS [c]
 ) AS [t]");
     }
@@ -3943,7 +3943,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Country]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
 ) AS [t]");
@@ -4019,7 +4019,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS
@@ -4035,7 +4035,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].[CustomerID], [c].[Country]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
     OFFSET @__p_0 ROWS
@@ -4051,7 +4051,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS
@@ -4067,7 +4067,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].[CustomerID], [c].[Country]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
     OFFSET @__p_0 ROWS
@@ -4439,10 +4439,10 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID] AS [CustomerID0], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+    SELECT TOP(@__p_0) [o].[OrderID], [t].[CustomerID]
     FROM [Orders] AS [o]
     INNER JOIN (
-        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] = N'ALFKI'
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -207,7 +207,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    SELECT ""c"".""CustomerID"", ""c"".""Country""
     FROM ""Customers"" AS ""c""
     ORDER BY ""c"".""Country""
     LIMIT -1 OFFSET @__p_0
@@ -223,7 +223,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    SELECT ""c"".""CustomerID"", ""c"".""Country""
     FROM ""Customers"" AS ""c""
     ORDER BY ""c"".""Country""
     LIMIT @__p_0
@@ -239,7 +239,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    SELECT ""c"".""CustomerID""
     FROM ""Customers"" AS ""c""
     LIMIT -1 OFFSET @__p_0
 ) AS ""t""");
@@ -254,7 +254,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+    SELECT ""c"".""CustomerID""
     FROM ""Customers"" AS ""c""
     LIMIT @__p_0
 ) AS ""t""");


### PR DESCRIPTION
To translate an aggregate operation on top level, provider would get a SelectExpression which would have facets applied and the method call with additional arguments. They should wrap the selector into EnumerableExpression (also add other facets from SelectExpression if needed), wrap into AsQueryable (if queryable method else optional) and the aggregate method over it and use SqlTranslator to translate it.
Also exposed TranslateExpression & TranslateLambdaExpression in QueryableMethodTranslator for relational

Resolves #28097
