### PR TITLE
MSSQL Spatial: Add EF.Functions.CurveToLine

### DIFF
--- a/src/EFCore.SqlServer.NTS/Extensions/SqlServerNetTopologySuiteDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer.NTS/Extensions/SqlServerNetTopologySuiteDbFunctionsExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using NetTopologySuite.Geometries;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Contains extension methods on <see cref="DbFunctions" /> for the Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite library.
+/// </summary>
+public static class SqlServerNetTopologySuiteDbFunctionsExtensions
+{
+    /// <summary>
+    /// Maps to the SQL Server <c>STCurveToLine</c> function which returns a polygonal approximation of an instance that contains circular arc segments.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="geometry">The instance containing circular arc segments.</param>
+    /// <returns>The polygonal approximation.</returns>
+    public static Geometry CurveToLine(this DbFunctions _, Geometry geometry)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(CurveToLine)));
+}

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPointMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPointMemberTranslator.cs
@@ -6,7 +6,13 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 
-internal class SqlServerPointMemberTranslator : IMemberTranslator
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqlServerPointMemberTranslator : IMemberTranslator
 {
     private static readonly IDictionary<MemberInfo, string> MemberToPropertyName = new Dictionary<MemberInfo, string>
     {
@@ -28,12 +34,24 @@ internal class SqlServerPointMemberTranslator : IMemberTranslator
 
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public SqlServerPointMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
     {
         _sqlExpressionFactory = sqlExpressionFactory;
     }
 
-    public SqlExpression? Translate(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression? Translate(
         SqlExpression? instance,
         MemberInfo member,
         Type returnType,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -172,6 +172,26 @@ SELECT [l].[Id], [l].[LineString].STCrosses(@__lineString_0) AS [Crosses]
 FROM [LineStringEntity] AS [l]");
     }
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task CurveToLine(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, CurveToLine = EF.Functions.CurveToLine(e.Polygon) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, CurveToLine = (Geometry)e.Polygon }),
+            elementSorter: x => x.Id,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Id, a.Id);
+                Assert.Equal(e.CurveToLine, a.CurveToLine, GeometryComparer.Instance);
+            });
+
+        AssertSql(
+            @"SELECT [p].[Id], [p].[Polygon].STCurveToLine() AS [CurveToLine]
+FROM [PolygonEntity] AS [p]");
+    }
+
     public override async Task Difference(bool async)
     {
         await base.Difference(async);


### PR DESCRIPTION
Provides a workaround for returning CircularString, CompoundCurve, and CurvePolygon instances to the client