### PR TITLE
Cosmos: Add translator for Regex.IsMatch method

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosMathTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMathTranslator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class MathTranslator : IMethodCallTranslator
+public class CosmosMathTranslator : IMethodCallTranslator
 {
     private static readonly Dictionary<MethodInfo, string> SupportedMethodTranslations = new()
     {
@@ -77,7 +77,7 @@ public class MathTranslator : IMethodCallTranslator
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public MathTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    public CosmosMathTranslator(ISqlExpressionFactory sqlExpressionFactory)
     {
         _sqlExpressionFactory = sqlExpressionFactory;
     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
@@ -29,12 +29,12 @@ public class CosmosMethodCallTranslatorProvider : IMethodCallTranslatorProvider
         _translators.AddRange(
             new IMethodCallTranslator[]
             {
-                new EqualsTranslator(sqlExpressionFactory),
+                new CosmosEqualsTranslator(sqlExpressionFactory),
                 new CosmosStringMethodTranslator(sqlExpressionFactory),
-                new ContainsTranslator(sqlExpressionFactory),
-                new RandomTranslator(sqlExpressionFactory),
-                new MathTranslator(sqlExpressionFactory),
-                new RegexMethodTranslator(sqlExpressionFactory)
+                new CosmosContainsTranslator(sqlExpressionFactory),
+                new CosmosRandomTranslator(sqlExpressionFactory),
+                new CosmosMathTranslator(sqlExpressionFactory),
+                new CosmosRegexTranslator(sqlExpressionFactory)
                 //new LikeTranslator(sqlExpressionFactory),
                 //new EnumHasFlagTranslator(sqlExpressionFactory),
                 //new GetValueOrDefaultTranslator(sqlExpressionFactory),

--- a/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
@@ -33,7 +33,8 @@ public class CosmosMethodCallTranslatorProvider : IMethodCallTranslatorProvider
                 new CosmosStringMethodTranslator(sqlExpressionFactory),
                 new ContainsTranslator(sqlExpressionFactory),
                 new RandomTranslator(sqlExpressionFactory),
-                new MathTranslator(sqlExpressionFactory)
+                new MathTranslator(sqlExpressionFactory),
+                new RegexMethodTranslator(sqlExpressionFactory)
                 //new LikeTranslator(sqlExpressionFactory),
                 //new EnumHasFlagTranslator(sqlExpressionFactory),
                 //new GetValueOrDefaultTranslator(sqlExpressionFactory),

--- a/src/EFCore.Cosmos/Query/Internal/CosmosRandomTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosRandomTranslator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class RandomTranslator : IMethodCallTranslator
+public class CosmosRandomTranslator : IMethodCallTranslator
 {
     private static readonly MethodInfo MethodInfo = typeof(DbFunctionsExtensions).GetRuntimeMethod(
         nameof(DbFunctionsExtensions.Random), new[] { typeof(DbFunctions) });
@@ -24,7 +24,7 @@ public class RandomTranslator : IMethodCallTranslator
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public RandomTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    public CosmosRandomTranslator(ISqlExpressionFactory sqlExpressionFactory)
     {
         _sqlExpressionFactory = sqlExpressionFactory;
     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosRegexTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosRegexTranslator.cs
@@ -91,7 +91,7 @@ public class CosmosRegexTranslator : IMethodCallTranslator
                      {
                         _sqlExpressionFactory.ApplyTypeMapping(input, typeMapping),
                         _sqlExpressionFactory.ApplyTypeMapping(pattern, typeMapping),
-                        _sqlExpressionFactory.Constant(modifier, typeMapping)
+                        _sqlExpressionFactory.Constant(modifier)
                      },
                      typeof(bool))
                 : null;

--- a/src/EFCore.Cosmos/Query/Internal/RegexMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/RegexMethodTranslator.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class RegexMethodTranslator : IMethodCallTranslator
+{
+    private static readonly HashSet<MethodInfo> MethodInfoDataLengthMapping
+        = new()
+        {
+            typeof(Regex).GetRuntimeMethod(nameof(Regex.IsMatch), new[] { typeof(string), typeof(string) })!,
+            typeof(Regex).GetRuntimeMethod(nameof(Regex.IsMatch), new[] { typeof(ReadOnlySpan<char>), typeof(string) })!
+        };
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public RegexMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (MethodInfoDataLengthMapping.Contains(method))
+        {
+            var typeMapping = arguments.Count == 2
+                ? ExpressionExtensions.InferTypeMapping(arguments[0], arguments[1])
+                : ExpressionExtensions.InferTypeMapping(arguments[0], arguments[1], arguments[2]);
+
+            var newArguments = arguments.Select(e => _sqlExpressionFactory.ApplyTypeMapping(e, typeMapping));
+
+            return _sqlExpressionFactory.Function(
+                "RegexMatch",
+                newArguments,
+                method.ReturnType,
+                typeMapping);
+        }
+
+        return null;
+    }
+}
+

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1204,18 +1204,22 @@ WHERE ((c[""Discriminator""] = ""Order"") AND false)");
 
     public override async Task Regex_IsMatch_MethodCall(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Regex_IsMatch_MethodCall(async));
+        await base.Regex_IsMatch_MethodCall(async);
 
-        AssertSql();
+        AssertSql(
+           @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(c[""CustomerID""], ""^T""))");
     }
 
     public override async Task Regex_IsMatch_MethodCall_constant_input(bool async)
     {
-        // Cosmos client evaluation. Issue #17246.
-        await AssertTranslationFailed(() => base.Regex_IsMatch_MethodCall_constant_input(async));
+        await base.Regex_IsMatch_MethodCall_constant_input(async);
 
-        AssertSql();
+        AssertSql(
+           @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(""ALFKI"", c[""CustomerID""]))");
     }
 
     [ConditionalTheory]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1210,7 +1210,7 @@ WHERE ((c[""Discriminator""] = ""Order"") AND false)");
         AssertSql(
            @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(c[""CustomerID""], ""^T"", """"))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(c[""CustomerID""], ""^T""))");
     }
 
     public override async Task Regex_IsMatch_MethodCall_constant_input(bool async)
@@ -1220,7 +1220,7 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(c[""CustomerID""], "
         AssertSql(
            @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(""ALFKI"", c[""CustomerID""], """"))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(""ALFKI"", c[""CustomerID""]))");
     }
 
     [ConditionalTheory]
@@ -1298,10 +1298,30 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(c[""CustomerID""], ""^T"", ""x""))");
     }
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Regex_IsMatch_MethodCall_With_Options_IgnoreCase_And_IgnorePatternWhitespace(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace)),
+            entryCount: 6);
+
+        AssertSql(
+          @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND RegexMatch(c[""CustomerID""], ""^T"", ""ix""))");
+    }
+
     [Fact]
-    public void Regex_IsMatchOptionsUnsupported()
+    public virtual void Regex_IsMatch_MethodCall_With_Unsupported_Option()
        => Assert.Throws<InvalidOperationException>(() =>
            Fixture.CreateContext().Customers.Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.RightToLeft)).ToList());
+
+    [Fact]
+    public virtual void Regex_IsMatch_MethodCall_With_Any_Unsupported_Option()
+       => Assert.Throws<InvalidOperationException>(() =>
+           Fixture.CreateContext().Customers.Where(o => Regex.IsMatch(o.CustomerID, "^T", RegexOptions.IgnoreCase | RegexOptions.RightToLeft)).ToList());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]


### PR DESCRIPTION
Add translator for Regex.IsMatch method to [REGEXMATCH](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/sql-query-regexmatch)

Fixes #28078

Please review
Thank you in advance
