### PR TITLE
Fix tool when using under .NET 6 for real this time.

### DIFF
--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Microsoft.EntityFrameworkCore.Tools</PackageId>
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -19,8 +19,8 @@
     <file src="../../artifacts/bin/ef/$configuration$/net461/ef.pdb" target="tools/net461/any/" />
     <file src="../../artifacts/bin/ef/x86/$configuration$/net461/ef.exe" target="tools/net461/win-x86/" />
     <file src="../../artifacts/bin/ef/x86/$configuration$/net461/ef.pdb" target="tools/net461/win-x86/" />
-    <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.dll" target="tools/netcoreapp2.0/any/" />
-    <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.pdb" target="tools/netcoreapp2.0/any/" />
-    <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.runtimeconfig.json" target="tools/netcoreapp2.0/any/" />
+    <file src="../../artifacts/bin/ef/$configuration$/net6.0/ef.dll" target="tools/net6.0/any/" />
+    <file src="../../artifacts/bin/ef/$configuration$/net6.0/ef.pdb" target="tools/net6.0/any/" />
+    <file src="../../artifacts/bin/ef/$configuration$/net6.0/ef.runtimeconfig.json" target="tools/net6.0/any/" />
   </files>
 </package>

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -1249,7 +1249,7 @@ function EF($project, $startupProject, $params, $applicationArgs, [switch] $skip
         $projectAssetsFile = GetCpsProperty $startupProject 'ProjectAssetsFile'
         $runtimeConfig = Join-Path $targetDir ($startupTargetName + '.runtimeconfig.json')
         $runtimeFrameworkVersion = GetCpsProperty $startupProject 'RuntimeFrameworkVersion'
-        $efPath = Join-Path $PSScriptRoot 'netcoreapp2.0\any\ef.dll'
+        $efPath = Join-Path $PSScriptRoot 'net6.0\any\ef.dll'
 
         $dotnetParams = 'exec', '--depsfile', $depsFile
 

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -157,7 +157,7 @@ internal class RootCommand : CommandBase
                 args.Add(startupProject.RuntimeFrameworkVersion);
             }
 
-            args.Add(Path.Combine(toolsPath, "netcoreapp2.0", "any", "ef.dll"));
+            args.Add(Path.Combine(toolsPath, "net6.0", "any", "ef.dll"));
         }
         else if (targetFramework.Identifier == ".NETStandard")
         {

--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -85,9 +85,9 @@ dotnet ef database update
 
       <NuspecProperty Include="SettingsFile=$(_ToolsSettingsFilePath)" />
       <NuspecProperty Include="Output=$(PublishDir)**\*" />
-      <NuspecProperty Include="OutputBinary=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.dll" />
-      <NuspecProperty Include="OutputRuntimeConfig=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.runtimeconfig.json" />
-      <NuspecProperty Include="OutputSymbol=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.pdb" />
+      <NuspecProperty Include="OutputBinary=..\..\artifacts\bin\ef\$(Configuration)\net6.0\ef.dll" />
+      <NuspecProperty Include="OutputRuntimeConfig=..\..\artifacts\bin\ef\$(Configuration)\net6.0\ef.runtimeconfig.json" />
+      <NuspecProperty Include="OutputSymbol=..\..\artifacts\bin\ef\$(Configuration)\net6.0\ef.pdb" />
       <NuspecProperty Include="OutputExe=..\..\artifacts\bin\ef\$(Configuration)\net461\ef.exe" />
       <NuspecProperty Include="OutputExeSymbol=..\..\artifacts\bin\ef\$(Configuration)\net461\ef.pdb" />
       <NuspecProperty Include="OutputX86Exe=..\..\artifacts\bin\ef\x86\$(Configuration)\net461\ef.exe" />

--- a/src/dotnet-ef/dotnet-ef.nuspec
+++ b/src/dotnet-ef/dotnet-ef.nuspec
@@ -11,9 +11,9 @@
     $CommonFileElements$
     <file src="$SettingsFile$" target="tools\$targetFramework$\any" />
     <file src="$Output$" target="tools\$targetFramework$\any" />
-    <file src="$OutputBinary$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
-    <file src="$OutputRuntimeConfig$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
-    <file src="$OutputSymbol$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
+    <file src="$OutputBinary$" target="tools\$targetFramework$\any\tools\net6.0\any" />
+    <file src="$OutputRuntimeConfig$" target="tools\$targetFramework$\any\tools\net6.0\any" />
+    <file src="$OutputSymbol$" target="tools\$targetFramework$\any\tools\net6.0\any" />
     <file src="$OutputExe$" target="tools\$targetFramework$\any\tools\net461\any" />
     <file src="$OutputExeSymbol$" target="tools\$targetFramework$\any\tools\net461\any" />
     <file src="$OutputX86Exe$" target="tools\$targetFramework$\any\tools\net461\win-x86" />

--- a/src/ef/AppDomainOperationExecutor.cs
+++ b/src/ef/AppDomainOperationExecutor.cs
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
         }
     }
 }
-#elif NETCOREAPP2_0
+#elif NET6_0
 #else
 #error target frameworks need to be updated.
 #endif

--- a/src/ef/Commands/MigrationsBundleCommand.cs
+++ b/src/ef/Commands/MigrationsBundleCommand.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             string context;
             using (var executor = CreateExecutor(args))
             {
-                context = (string)executor.GetContextInfo(Context!.Value())["Type"];
+                context = (string)executor.GetContextInfo(Context!.Value())["Type"]!;
             }
 
             Reporter.WriteInformation(Resources.BuildBundleStarted);
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                 var searchPath = WorkingDir!.Value();
                 do
                 {
-                    foreach (var file in Directory.EnumerateFiles(searchPath))
+                    foreach (var file in Directory.EnumerateFiles(searchPath!))
                     {
                         var fileName = Path.GetFileName(file);
                         if (fileName.Equals("NuGet.Config", StringComparison.OrdinalIgnoreCase))
@@ -132,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
 
                 var runtime = _runtime!.HasValue()
                     ? _runtime!.Value()!
-                    : (string)AppContext.GetData("RUNTIME_IDENTIFIER");
+                    : (string)AppContext.GetData("RUNTIME_IDENTIFIER")!;
                 publishArgs.Add("--runtime");
                 publishArgs.Add(runtime);
 

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                         }
                     }
                 }
-#elif !NETCOREAPP2_0
+#elif !NET6_0
 #error target frameworks need to be updated.
 #endif
                 return new ReflectionOperationExecutor(

--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
     <Description>Entity Framework Core Command-line Tools</Description>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
After trying the current preview tool as I must use the preview EFCore builds with .NET 6 due to reasons I cannot control. I still had the tool be broken even with the roll forward. As such I have discovered the reason for this is because of the fact that for some reason even roll forward did not properly tell it how to run as if the tool were compiled for .NET 6. As such the tool had to be patched to change .NET Core 2.0 to .NET 6 in order to get it to work.

Fixes https://github.com/dotnet/efcore/issues/27660#issuecomment-1127107433.

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features) No need, this just fixes the tool to run with only the .NET 6 SDK and runtime installed. For some reason my previous PR that only changed RollForward was not enough.
- [x] Code follows the same patterns and style as existing code in this repo

