### PR TITLE
Add interception for DbDataReader.Close

### DIFF
--- a/src/EFCore.Relational/Diagnostics/DataReaderClosingEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/DataReaderClosingEventData.cs
@@ -1,18 +1,18 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics;
 
 /// <summary>
-///     <see cref="DiagnosticSource" /> event payload for <see cref="RelationalEventId.DataReaderDisposing" />.
+///     <see cref="DiagnosticSource" /> event payload for <see cref="RelationalEventId.DataReaderClosing" />.
 /// </summary>
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
 /// </remarks>
-public class DataReaderDisposingEventData : DataReaderEventData
+public class DataReaderClosingEventData : DataReaderEventData
 {
     /// <summary>
-    ///     Constructs a <see cref="DiagnosticSource" /> event payload for <see cref="RelationalEventId.DataReaderDisposing" />.
+    ///     Constructs a <see cref="DiagnosticSource" /> event payload for <see cref="RelationalEventId.DataReaderClosing" />.
     /// </summary>
     /// <param name="eventDefinition">The event definition.</param>
     /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
@@ -21,14 +21,11 @@ public class DataReaderDisposingEventData : DataReaderEventData
     /// <param name="context">The <see cref="DbContext" /> currently being used, to null if not known.</param>
     /// <param name="commandId">A correlation ID that identifies the <see cref="DbCommand" /> instance being used.</param>
     /// <param name="connectionId">A correlation ID that identifies the <see cref="DbConnection" /> instance being used.</param>
+    /// <param name="async">Indicates whether or not the command was executed asynchronously.</param>
     /// <param name="recordsAffected">Gets the number of rows changed, inserted, or deleted by execution of the SQL statement.</param>
     /// <param name="readCount">Gets the number of read operations performed by this reader.</param>
     /// <param name="startTime">The time when the data reader was created.</param>
-    /// <param name="duration">
-    ///     The duration from the time the data reader is created until it is disposed. This corresponds to the time reading
-    ///     for reading results of a query.
-    /// </param>
-    public DataReaderDisposingEventData(
+    public DataReaderClosingEventData(
         EventDefinitionBase eventDefinition,
         Func<EventDefinitionBase, EventData, string> messageGenerator,
         DbCommand command,
@@ -36,19 +33,18 @@ public class DataReaderDisposingEventData : DataReaderEventData
         DbContext? context,
         Guid commandId,
         Guid connectionId,
+        bool async,
         int recordsAffected,
         int readCount,
-        DateTimeOffset startTime,
-        TimeSpan duration)
+        DateTimeOffset startTime)
         : base(
             eventDefinition, messageGenerator, command, dataReader, context, commandId, connectionId, recordsAffected, readCount, startTime)
     {
-        Duration = duration;
+        IsAsync = async;
     }
 
     /// <summary>
-    ///     The duration from the time the data reader is created until it is disposed. This corresponds to the time reading
-    ///     for reading results of a query.
+    ///     Indicates whether or not the operation is being executed asynchronously.
     /// </summary>
-    public virtual TimeSpan Duration { get; }
+    public virtual bool IsAsync { get; }
 }

--- a/src/EFCore.Relational/Diagnostics/DataReaderEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/DataReaderEventData.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+///     <see cref="DiagnosticSource" /> event payload for <see cref="RelationalEventId.DataReaderClosing" />.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
+/// </remarks>
+public class DataReaderEventData : DbContextEventData
+{
+    /// <summary>
+    ///     Constructs a <see cref="DiagnosticSource" /> event payload for <see cref="RelationalEventId.DataReaderClosing" />.
+    /// </summary>
+    /// <param name="eventDefinition">The event definition.</param>
+    /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
+    /// <param name="command">The <see cref="DbCommand" /> that created the reader.</param>
+    /// <param name="dataReader">The <see cref="DbDataReader" /> that is being disposed.</param>
+    /// <param name="context">The <see cref="DbContext" /> currently being used, to null if not known.</param>
+    /// <param name="commandId">A correlation ID that identifies the <see cref="DbCommand" /> instance being used.</param>
+    /// <param name="connectionId">A correlation ID that identifies the <see cref="DbConnection" /> instance being used.</param>
+    /// <param name="recordsAffected">Gets the number of rows changed, inserted, or deleted by execution of the SQL statement.</param>
+    /// <param name="readCount">Gets the number of read operations performed by this reader.</param>
+    /// <param name="startTime">The start time of this event.</param>
+    public DataReaderEventData(
+        EventDefinitionBase eventDefinition,
+        Func<EventDefinitionBase, EventData, string> messageGenerator,
+        DbCommand command,
+        DbDataReader dataReader,
+        DbContext? context,
+        Guid commandId,
+        Guid connectionId,
+        int recordsAffected,
+        int readCount,
+        DateTimeOffset startTime)
+        : base(eventDefinition, messageGenerator, context)
+    {
+        Command = command;
+        DataReader = dataReader;
+        CommandId = commandId;
+        ConnectionId = connectionId;
+        RecordsAffected = recordsAffected;
+        ReadCount = readCount;
+        StartTime = startTime;
+    }
+
+    /// <summary>
+    ///     The <see cref="DbCommand" /> that created the reader.
+    /// </summary>
+    public virtual DbCommand Command { get; }
+
+    /// <summary>
+    ///     The <see cref="DbDataReader" /> that is being disposed.
+    /// </summary>
+    public virtual DbDataReader DataReader { get; }
+
+    /// <summary>
+    ///     A correlation ID that identifies the <see cref="DbCommand" /> instance being used.
+    /// </summary>
+    public virtual Guid CommandId { get; }
+
+    /// <summary>
+    ///     A correlation ID that identifies the <see cref="DbConnection" /> instance being used.
+    /// </summary>
+    public virtual Guid ConnectionId { get; }
+
+    /// <summary>
+    ///     Gets the number of rows changed, inserted, or deleted by execution of the SQL statement.
+    /// </summary>
+    public virtual int RecordsAffected { get; }
+
+    /// <summary>
+    ///     Gets the number of read operations performed by this reader.
+    /// </summary>
+    public virtual int ReadCount { get; }
+
+    /// <summary>
+    ///     The start time of this event.
+    /// </summary>
+    public virtual DateTimeOffset StartTime { get; }
+}

--- a/src/EFCore.Relational/Diagnostics/IDbCommandInterceptor.cs
+++ b/src/EFCore.Relational/Diagnostics/IDbCommandInterceptor.cs
@@ -413,6 +413,48 @@ public interface IDbCommandInterceptor : IInterceptor
         => Task.CompletedTask;
 
     /// <summary>
+    ///     Called just before EF intends to call <see cref="DbDataReader.Close()" />.
+    /// </summary>
+    /// <param name="command">The command.</param>
+    /// <param name="eventData">Contextual information about the command.</param>
+    /// <param name="result">
+    ///     Represents the current result if one exists.
+    ///     This value will have <see cref="InterceptionResult.IsSuppressed" /> set to <see langword="true" /> if some previous
+    ///     interceptor suppressed execution by calling <see cref="InterceptionResult.Suppress" />.
+    ///     This value is typically used as the return value for the implementation of this method.
+    /// </param>
+    /// <returns>
+    ///     If <see cref="InterceptionResult.IsSuppressed" /> is <see langword="false" />, then EF will continue as normal.
+    ///     If <see cref="InterceptionResult.IsSuppressed" /> is <see langword="true" />, then EF will suppress the operation
+    ///     it was about to perform.
+    ///     An implementation of this method for any interceptor that is not attempting to suppress
+    ///     the operation is to return the <paramref name="result" /> value passed in.
+    /// </returns>
+    InterceptionResult DataReaderClosing(DbCommand command, DataReaderClosingEventData eventData, InterceptionResult result)
+        => result;
+
+    /// <summary>
+    ///     Called just before EF intends to call <see cref="DbDataReader.CloseAsync()" /> in an async context.
+    /// </summary>
+    /// <param name="command">The command.</param>
+    /// <param name="eventData">Contextual information about the command.</param>
+    /// <param name="result">
+    ///     Represents the current result if one exists.
+    ///     This value will have <see cref="InterceptionResult.IsSuppressed" /> set to <see langword="true" /> if some previous
+    ///     interceptor suppressed execution by calling <see cref="InterceptionResult.Suppress" />.
+    ///     This value is typically used as the return value for the implementation of this method.
+    /// </param>
+    /// <returns>
+    ///     If <see cref="InterceptionResult.IsSuppressed" /> is <see langword="false" />, then EF will continue as normal.
+    ///     If <see cref="InterceptionResult.IsSuppressed" /> is <see langword="true" />, then EF will suppress the operation
+    ///     it was about to perform.
+    ///     An implementation of this method for any interceptor that is not attempting to suppress
+    ///     the operation is to return the <paramref name="result" /> value passed in.
+    /// </returns>
+    ValueTask<InterceptionResult> DataReaderClosingAsync(DbCommand command, DataReaderClosingEventData eventData, InterceptionResult result)
+        => new(result);
+
+    /// <summary>
     ///     Called when execution of a <see cref="DbDataReader" /> is about to be disposed.
     /// </summary>
     /// <param name="command">The command.</param>

--- a/src/EFCore.Relational/Diagnostics/IRelationalCommandDiagnosticsLogger.cs
+++ b/src/EFCore.Relational/Diagnostics/IRelationalCommandDiagnosticsLogger.cs
@@ -497,6 +497,46 @@ public interface IRelationalCommandDiagnosticsLogger : IDiagnosticsLogger<DbLogg
         TimeSpan duration);
 
     /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.DataReaderClosing" /> event.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="command">The database command object.</param>
+    /// <param name="dataReader">The data reader.</param>
+    /// <param name="commandId">The correlation ID associated with the given <see cref="DbCommand" />.</param>
+    /// <param name="recordsAffected">The number of records in the database that were affected.</param>
+    /// <param name="readCount">The number of records that were read.</param>
+    /// <param name="startTime">The time that the operation was started.</param>
+    /// <returns>The result of execution, which may have been modified by an interceptor.</returns>
+    InterceptionResult DataReaderClosing(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbDataReader dataReader,
+        Guid commandId,
+        int recordsAffected,
+        int readCount,
+        DateTimeOffset startTime);
+    
+    /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.DataReaderClosing" /> event.
+    /// </summary>
+    /// <param name="connection">The connection.</param>
+    /// <param name="command">The database command object.</param>
+    /// <param name="dataReader">The data reader.</param>
+    /// <param name="commandId">The correlation ID associated with the given <see cref="DbCommand" />.</param>
+    /// <param name="recordsAffected">The number of records in the database that were affected.</param>
+    /// <param name="readCount">The number of records that were read.</param>
+    /// <param name="startTime">The time that the operation was started.</param>
+    /// <returns>The result of execution, which may have been modified by an interceptor.</returns>
+    ValueTask<InterceptionResult> DataReaderClosingAsync(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbDataReader dataReader,
+        Guid commandId,
+        int recordsAffected,
+        int readCount,
+        DateTimeOffset startTime);
+
+    /// <summary>
     ///     Whether <see cref="RelationalEventId.CommandCreating" /> or <see cref="RelationalEventId.CommandCreated" /> need
     ///     to be logged.
     /// </summary>
@@ -509,10 +549,12 @@ public interface IRelationalCommandDiagnosticsLogger : IDiagnosticsLogger<DbLogg
     bool ShouldLogCommandExecute(DateTimeOffset now);
 
     /// <summary>
+    ///     Whether <see cref="RelationalEventId.DataReaderClosing" /> needs to be logged.
+    /// </summary>
+    bool ShouldLogDataReaderClose(DateTimeOffset now);
+
+    /// <summary>
     ///     Whether <see cref="RelationalEventId.DataReaderDisposing" /> needs to be logged.
     /// </summary>
     bool ShouldLogDataReaderDispose(DateTimeOffset now);
-
-    private bool ShouldLogParameterValues(DbCommand command)
-        => command.Parameters.Count > 0 && ShouldLogSensitiveData();
 }

--- a/src/EFCore.Relational/Diagnostics/Internal/DbCommandInterceptorAggregator.cs
+++ b/src/EFCore.Relational/Diagnostics/Internal/DbCommandInterceptorAggregator.cs
@@ -273,6 +273,30 @@ public class DbCommandInterceptorAggregator : InterceptorAggregator<IDbCommandIn
             }
         }
 
+        public InterceptionResult DataReaderClosing(DbCommand command, DataReaderClosingEventData eventData, InterceptionResult result)
+        {
+            for (var i = 0; i < _interceptors.Length; i++)
+            {
+                result = _interceptors[i].DataReaderClosing(command, eventData, result);
+            }
+
+            return result;
+        }
+
+        public async ValueTask<InterceptionResult> DataReaderClosingAsync(
+            DbCommand command,
+            DataReaderClosingEventData eventData,
+            InterceptionResult result)
+        {
+            for (var i = 0; i < _interceptors.Length; i++)
+            {
+                result = await _interceptors[i].DataReaderClosingAsync(command, eventData, result)
+                    .ConfigureAwait(false);
+            }
+
+            return result;
+        }
+
         public InterceptionResult DataReaderDisposing(
             DbCommand command,
             DataReaderDisposingEventData eventData,

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -65,6 +65,7 @@ public static class RelationalEventId
 
         // DataReader events
         DataReaderDisposing = CoreEventId.RelationalBaseId + 300,
+        DataReaderClosing,
 
         // Migrations events
         MigrateUsingConnection = CoreEventId.RelationalBaseId + 400,
@@ -576,6 +577,19 @@ public static class RelationalEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId DataReaderDisposing = MakeCommandId(Id.DataReaderDisposing);
+
+    /// <summary>
+    ///     A database data reader is about to be closed.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="DataReaderClosingEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId DataReaderClosing = MakeCommandId(Id.DataReaderClosing);
 
     private static readonly string _migrationsPrefix = DbLoggerCategory.Migrations.Name + ".";
 

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -113,6 +113,15 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    public EventDefinitionBase? LogClosingDataReader;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     public EventDefinitionBase? LogClosedConnection;
 
     /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1802,6 +1802,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     Closing data reader to '{database}' on server '{server}'.
+        /// </summary>
+        public static EventDefinition<string, string> LogClosingDataReader(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogClosingDataReader;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogClosingDataReader,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        RelationalEventId.DataReaderClosing,
+                        LogLevel.Debug,
+                        "RelationalEventId.DataReaderClosing",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            RelationalEventId.DataReaderClosing,
+                            _resourceManager.GetString("LogClosingDataReader")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
         ///     The order of column '{table}.{column}' was ignored. Column orders are only used when the table is first created.
         /// </summary>
         public static EventDefinition<string, string> LogColumnOrderIgnoredWarning(IDiagnosticsLogger logger)
@@ -2202,9 +2227,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     A data reader was disposed.
+        ///     A data reader for '{database}' on server '{server}' is being disposed after spending {elapsed}ms reading results.
         /// </summary>
-        public static EventDefinition LogDisposingDataReader(IDiagnosticsLogger logger)
+        public static EventDefinition<string, string, int> LogDisposingDataReader(IDiagnosticsLogger logger)
         {
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogDisposingDataReader;
             if (definition == null)
@@ -2212,18 +2237,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                 definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogDisposingDataReader,
                     logger,
-                    static logger => new EventDefinition(
+                    static logger => new EventDefinition<string, string, int>(
                         logger.Options,
                         RelationalEventId.DataReaderDisposing,
                         LogLevel.Debug,
                         "RelationalEventId.DataReaderDisposing",
-                        level => LoggerMessage.Define(
+                        level => LoggerMessage.Define<string, string, int>(
                             level,
                             RelationalEventId.DataReaderDisposing,
                             _resourceManager.GetString("LogDisposingDataReader")!)));
             }
 
-            return (EventDefinition)definition;
+            return (EventDefinition<string, string, int>)definition;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -508,6 +508,10 @@
     <value>Closing connection to database '{database}' on server '{server}'.</value>
     <comment>Debug RelationalEventId.ConnectionClosing string string</comment>
   </data>
+  <data name="LogClosingDataReader" xml:space="preserve">
+    <value>Closing data reader to '{database}' on server '{server}'.</value>
+    <comment>Debug RelationalEventId.DataReaderClosing string string</comment>
+  </data>
   <data name="LogColumnOrderIgnoredWarning" xml:space="preserve">
     <value>The order of column '{table}.{column}' was ignored. Column orders are only used when the table is first created.</value>
     <comment>Warning RelationalEventId.ColumnOrderIgnoredWarning string string</comment>
@@ -573,8 +577,8 @@
     <comment>Debug RelationalEventId.CreatingTransactionSavepoint</comment>
   </data>
   <data name="LogDisposingDataReader" xml:space="preserve">
-    <value>A data reader was disposed.</value>
-    <comment>Debug RelationalEventId.DataReaderDisposing</comment>
+    <value>A data reader for '{database}' on server '{server}' is being disposed after spending {elapsed}ms reading results.</value>
+    <comment>Debug RelationalEventId.DataReaderDisposing string string int</comment>
   </data>
   <data name="LogDisposingTransaction" xml:space="preserve">
     <value>Disposing transaction.</value>

--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -103,7 +103,28 @@ public class RelationalDataReader : IDisposable, IAsyncDisposable
             var interceptionResult = default(InterceptionResult);
             try
             {
-                _reader.Close(); // can throw
+                var closeInterceptionResult = default(InterceptionResult);
+                try
+                {
+                    if (_logger?.ShouldLogDataReaderClose(DateTimeOffset.UtcNow) == true)
+                    {
+                        closeInterceptionResult = _logger.DataReaderClosing(
+                            _relationalConnection,
+                            _command,
+                            _reader,
+                            _commandId,
+                            _reader.RecordsAffected,
+                            _readCount,
+                            _startTime); // can throw
+                    }
+                }
+                finally
+                {
+                    if (!closeInterceptionResult.IsSuppressed)
+                    {
+                        _reader.Close(); // can throw
+                    }
+                }
 
                 if (_logger?.ShouldLogDataReaderDispose(DateTimeOffset.UtcNow) == true)
                 {
@@ -143,7 +164,28 @@ public class RelationalDataReader : IDisposable, IAsyncDisposable
             var interceptionResult = default(InterceptionResult);
             try
             {
-                await _reader.CloseAsync().ConfigureAwait(false); // can throw
+                var closeInterceptionResult = default(InterceptionResult);
+                try
+                {
+                    if (_logger?.ShouldLogDataReaderClose(DateTimeOffset.UtcNow) == true)
+                    {
+                        closeInterceptionResult = await _logger.DataReaderClosingAsync(
+                            _relationalConnection,
+                            _command,
+                            _reader,
+                            _commandId,
+                            _reader.RecordsAffected,
+                            _readCount,
+                            _startTime).ConfigureAwait(false); // can throw
+                    }
+                }
+                finally
+                {
+                    if (!closeInterceptionResult.IsSuppressed)
+                    {
+                        await _reader.CloseAsync().ConfigureAwait(false); // can throw
+                    }
+                }
 
                 if (_logger?.ShouldLogDataReaderDispose(DateTimeOffset.UtcNow) == true)
                 {

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -303,7 +303,7 @@ public class RelationalEventIdTest : EventIdTestBase
         public override CommandType CommandType { get; set; }
         public override bool DesignTimeVisible { get; set; }
         public override UpdateRowSource UpdatedRowSource { get; set; }
-        protected override DbConnection DbConnection { get; set; }
+        protected override DbConnection DbConnection { get; set; } = new FakeDbConnection();
 
         protected override DbParameterCollection DbParameterCollection
             => new FakeDbParameterCollection();

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -391,9 +391,14 @@ public class RelationalCommandTest
             diagnosticEvents.Clear();
         }
 
-        var diagnostic = diagnosticEvents.Single();
-        Assert.Equal(RelationalEventId.DataReaderDisposing.Name, diagnostic.Item1);
-        var dataReaderDisposingEventData = (DataReaderDisposingEventData)diagnostic.Item2;
+        Assert.Equal(2, diagnosticEvents.Count);
+
+        Assert.Equal(RelationalEventId.DataReaderClosing.Name, diagnosticEvents[0].Item1);
+        var dataReaderClosingEventData = (DataReaderClosingEventData)diagnosticEvents[0].Item2;
+        Assert.Equal(3, dataReaderClosingEventData.ReadCount);
+
+        Assert.Equal(RelationalEventId.DataReaderDisposing.Name, diagnosticEvents[1].Item1);
+        var dataReaderDisposingEventData = (DataReaderDisposingEventData)diagnosticEvents[1].Item2;
         Assert.Equal(3, dataReaderDisposingEventData.ReadCount);
 
         diagnosticEvents.Clear();
@@ -417,9 +422,14 @@ public class RelationalCommandTest
             diagnosticEvents.Clear();
         }
 
-        diagnostic = diagnosticEvents.Single();
-        Assert.Equal(RelationalEventId.DataReaderDisposing.Name, diagnostic.Item1);
-        dataReaderDisposingEventData = (DataReaderDisposingEventData)diagnostic.Item2;
+        Assert.Equal(2, diagnosticEvents.Count);
+
+        Assert.Equal(RelationalEventId.DataReaderClosing.Name, diagnosticEvents[0].Item1);
+        dataReaderClosingEventData = (DataReaderClosingEventData)diagnosticEvents[0].Item2;
+        Assert.Equal(3, dataReaderClosingEventData.ReadCount);
+
+        Assert.Equal(RelationalEventId.DataReaderDisposing.Name, diagnosticEvents[1].Item1);
+        dataReaderDisposingEventData = (DataReaderDisposingEventData)diagnosticEvents[1].Item2;
         Assert.Equal(3, dataReaderDisposingEventData.ReadCount);
     }
 

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeRelationalCommandDiagnosticsLogger.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeRelationalCommandDiagnosticsLogger.cs
@@ -273,10 +273,33 @@ public class FakeRelationalCommandDiagnosticsLogger
         TimeSpan duration)
         => default;
 
+    public InterceptionResult DataReaderClosing(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbDataReader dataReader,
+        Guid commandId,
+        int recordsAffected,
+        int readCount,
+        DateTimeOffset startTime)
+        => default;
+
+    public ValueTask<InterceptionResult> DataReaderClosingAsync(
+        IRelationalConnection connection,
+        DbCommand command,
+        DbDataReader dataReader,
+        Guid commandId,
+        int recordsAffected,
+        int readCount,
+        DateTimeOffset startTime)
+        => default;
+
     public bool ShouldLogCommandCreate(DateTimeOffset now)
         => true;
 
     public bool ShouldLogCommandExecute(DateTimeOffset now)
+        => true;
+
+    public bool ShouldLogDataReaderClose(DateTimeOffset now)
         => true;
 
     public bool ShouldLogDataReaderDispose(DateTimeOffset now)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Data;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 // ReSharper disable InconsistentNaming
@@ -337,7 +338,7 @@ public class BadDataSqliteTest : IClassFixture<BadDataSqliteTest.BadDataSqliteFi
         public SemaphoreSlim Semaphore { get; }
 
         public string ConnectionString { get; set; }
-        public DbConnection DbConnection { get; set; }
+        public DbConnection DbConnection { get; set; } = new SqliteConnection();
 
         public DbContext Context
             => null;


### PR DESCRIPTION
Part of #626
Fixes #23535

Also added tests to:
 - Show that this can be used to get statistics from a query, as requested in #23535.
 - Show that Close and/or Dispose can be suppressed, as requested in #24295.

