### PR TITLE
Revert "Bump Microsoft.Data.SqlClient from 5.0.0-preview2.22096.2 to 5.0.0-preview3.22168.1"

### DIFF
--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.0-preview3.22168.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.0-preview2.22096.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts dotnet/efcore#28278

Fixes #28293.