### PR TITLE
Add entity splitting support to migration snapshot

### DIFF
--- a/rulesets/StyleCop.noxmldocs.ruleset
+++ b/rulesets/StyleCop.noxmldocs.ruleset
@@ -133,6 +133,7 @@
     <Rule Id="SA1520" Action="None" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1602" Action="None" />
     <Rule Id="SA1603" Action="Warning" />
     <Rule Id="SA1609" Action="None" />        <!-- Property documentation should have value -->
     <Rule Id="SA1611" Action="None" />

--- a/src/EFCore.Relational/Design/IAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/IAnnotationCodeGenerator.cs
@@ -89,6 +89,36 @@ public interface IAnnotationCodeGenerator
     }
 
     /// <summary>
+    ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+    ///     specified explicitly.
+    /// </summary>
+    /// <param name="checkConstraint">The check constraint to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to remove the conventional ones.</param>
+    void RemoveAnnotationsHandledByConventions(ICheckConstraint checkConstraint, IDictionary<string, IAnnotation> annotations)
+    {
+    }
+
+    /// <summary>
+    ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+    ///     specified explicitly.
+    /// </summary>
+    /// <param name="trigger">The trigger to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to remove the conventional ones.</param>
+    void RemoveAnnotationsHandledByConventions(ITrigger trigger, IDictionary<string, IAnnotation> annotations)
+    {
+    }
+
+    /// <summary>
+    ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+    ///     specified explicitly.
+    /// </summary>
+    /// <param name="overrides">The property overrides to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to remove the conventional ones.</param>
+    void RemoveAnnotationsHandledByConventions(IRelationalPropertyOverrides overrides, IDictionary<string, IAnnotation> annotations)
+    {
+    }
+
+    /// <summary>
     ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
     ///     and removes the annotations.
     /// </summary>
@@ -126,8 +156,20 @@ public interface IAnnotationCodeGenerator
                 RemoveAnnotationsHandledByConventions(skipNavigation, annotations);
                 return;
 
+            case ICheckConstraint checkConstraint:
+                RemoveAnnotationsHandledByConventions(checkConstraint, annotations);
+                return;
+
             case IIndex index:
                 RemoveAnnotationsHandledByConventions(index, annotations);
+                return;
+
+            case ITrigger trigger:
+                RemoveAnnotationsHandledByConventions(trigger, annotations);
+                return;
+
+            case IRelationalPropertyOverrides overrides:
+                RemoveAnnotationsHandledByConventions(overrides, annotations);
                 return;
 
             default:
@@ -227,10 +269,32 @@ public interface IAnnotationCodeGenerator
     ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
     ///     and removes the annotations.
     /// </summary>
+    /// <param name="checkConstraint">The check constraint to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to generate fluent API calls.</param>
+    IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        ICheckConstraint checkConstraint,
+        IDictionary<string, IAnnotation> annotations)
+        => Array.Empty<MethodCallCodeFragment>();
+
+    /// <summary>
+    ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+    ///     and removes the annotations.
+    /// </summary>
     /// <param name="trigger">The trigger to which the annotations are applied.</param>
     /// <param name="annotations">The set of annotations from which to generate fluent API calls.</param>
     IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
         ITrigger trigger,
+        IDictionary<string, IAnnotation> annotations)
+        => Array.Empty<MethodCallCodeFragment>();
+
+    /// <summary>
+    ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+    ///     and removes the annotations.
+    /// </summary>
+    /// <param name="overrides">The property overrides to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to generate fluent API calls.</param>
+    IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        IRelationalPropertyOverrides overrides,
         IDictionary<string, IAnnotation> annotations)
         => Array.Empty<MethodCallCodeFragment>();
 
@@ -251,7 +315,9 @@ public interface IAnnotationCodeGenerator
             INavigation navigation => GenerateFluentApiCalls(navigation, annotations),
             ISkipNavigation skipNavigation => GenerateFluentApiCalls(skipNavigation, annotations),
             IIndex index => GenerateFluentApiCalls(index, annotations),
+            ICheckConstraint checkConstraint => GenerateFluentApiCalls(checkConstraint, annotations),
             ITrigger trigger => GenerateFluentApiCalls(trigger, annotations),
+            IRelationalPropertyOverrides overrides => GenerateFluentApiCalls(overrides, annotations),
 
             _ => throw new ArgumentException(RelationalStrings.UnhandledAnnotatableType(annotatable.GetType()))
         };

--- a/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
@@ -239,7 +239,7 @@ public class SharedTableConvention : IModelFinalizingConvention
                     && !otherProperty.DeclaringEntityType.IsStrictlyDerivedFrom(property.DeclaringEntityType))
                 || property.DeclaringEntityType.FindRowInternalForeignKeys(storeObject).Any())
             {
-                var newColumnName = TryUniquify(property, columnName, properties, usePrefix, maxLength);
+                var newColumnName = TryUniquify(property, columnName, properties, storeObject, usePrefix, maxLength);
                 if (newColumnName != null)
                 {
                     properties[newColumnName] = property;
@@ -252,7 +252,7 @@ public class SharedTableConvention : IModelFinalizingConvention
                     && !otherProperty.DeclaringEntityType.IsStrictlyDerivedFrom(property.DeclaringEntityType))
                 || otherProperty.DeclaringEntityType.FindRowInternalForeignKeys(storeObject).Any())
             {
-                var newOtherColumnName = TryUniquify(otherProperty, columnName, properties, usePrefix, maxLength);
+                var newOtherColumnName = TryUniquify(otherProperty, columnName, properties, storeObject, usePrefix, maxLength);
                 if (newOtherColumnName != null)
                 {
                     properties[columnName] = property;
@@ -266,10 +266,12 @@ public class SharedTableConvention : IModelFinalizingConvention
         IConventionProperty property,
         string columnName,
         Dictionary<string, IConventionProperty> properties,
+        in StoreObjectIdentifier storeObject,
         bool usePrefix,
         int maxLength)
     {
-        if (property.Builder.CanSetColumnName(null))
+        if (property.Builder.CanSetColumnName(null)
+            && property.Builder.CanSetColumnName(null, storeObject))
         {
             if (usePrefix)
             {
@@ -281,7 +283,7 @@ public class SharedTableConvention : IModelFinalizingConvention
             }
 
             columnName = Uniquifier.Uniquify(columnName, properties, maxLength);
-            if (property.Builder.HasColumnName(columnName) == null)
+            if (property.Builder.HasColumnName(columnName, storeObject) == null)
             {
                 return null;
             }

--- a/src/EFCore.Relational/Metadata/Conventions/StoreGenerationConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/StoreGenerationConvention.cs
@@ -106,7 +106,7 @@ public class StoreGenerationConvention : IPropertyAnnotationChangedConvention, I
             foreach (var declaredProperty in entityType.GetDeclaredProperties())
             {
                 var declaringTable = declaredProperty.GetMappedStoreObjects(StoreObjectType.Table).FirstOrDefault();
-                if (declaringTable.Name == null)
+                if (declaringTable.Name == null!)
                 {
                     continue;
                 }

--- a/src/EFCore.Relational/Metadata/ITable.cs
+++ b/src/EFCore.Relational/Metadata/ITable.cs
@@ -109,7 +109,8 @@ public interface ITable : ITableBase
 
         builder.Append(Name);
         
-        if (EntityTypeMappings.First().EntityType is not RuntimeEntityType
+        if (EntityTypeMappings.Any()
+            && EntityTypeMappings.First().EntityType is not RuntimeEntityType
             && IsExcludedFromMigrations)
         {
             builder.Append(" ExcludedFromMigrations");

--- a/src/EFCore.Relational/Metadata/Internal/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalForeignKeyExtensions.cs
@@ -61,10 +61,10 @@ public static class RelationalForeignKeyExtensions
         if (principalTable is null
             || duplicatePrincipalTable is null
             || principalTable != duplicatePrincipalTable
-            || !(foreignKey.PrincipalKey.Properties.GetColumnNames(principalTable.Value)
-                is IReadOnlyList<string> principalColumns)
-            || !(duplicateForeignKey.PrincipalKey.Properties.GetColumnNames(principalTable.Value)
-                is IReadOnlyList<string> duplicatePrincipalColumns))
+            || foreignKey.PrincipalKey.Properties.GetColumnNames(principalTable.Value)
+                is not { } principalColumns
+            || duplicateForeignKey.PrincipalKey.Properties.GetColumnNames(principalTable.Value)
+                is not { } duplicatePrincipalColumns)
         {
             if (shouldThrow)
             {

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -936,7 +936,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, functionName);
 
         /// <summary>
-        ///     Table name must be specified to configure a mapping fragment.
+        ///     Table name must be specified to configure a table-specific property mapping.
         /// </summary>
         public static string MappingFragmentMissingName
             => GetString("MappingFragmentMissingName");

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -735,7 +735,7 @@
     <value>The entity type '{entityType}' is mapped to the DbFunction named '{functionName}', but no DbFunction with that name was found in the model. Ensure that the entity type mapping is configured using the model name of a function in the model.</value>
   </data>
   <data name="MappingFragmentMissingName" xml:space="preserve">
-    <value>Table name must be specified to configure a mapping fragment.</value>
+    <value>Table name must be specified to configure a table-specific property mapping.</value>
   </data>
   <data name="MethodOnNonTphRootNotSupported" xml:space="preserve">
     <value>Using '{methodName}' on DbSet of '{entityType}' is not supported since '{entityType}' is part of hierarchy and does not contain a discriminator property.</value>

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
@@ -61,7 +61,7 @@ public class SqlServerValueGenerationStrategyConvention : IModelInitializedConve
             {
                 SqlServerValueGenerationStrategy? strategy = null;
                 var declaringTable = property.GetMappedStoreObjects(StoreObjectType.Table).FirstOrDefault();
-                if (declaringTable.Name != null)
+                if (declaringTable.Name != null!)
                 {
                     strategy = property.GetValueGenerationStrategy(declaringTable, Dependencies.TypeMappingSource);
                     if (strategy == SqlServerValueGenerationStrategy.None
@@ -73,7 +73,7 @@ public class SqlServerValueGenerationStrategyConvention : IModelInitializedConve
                 else
                 {
                     var declaringView = property.GetMappedStoreObjects(StoreObjectType.View).FirstOrDefault();
-                    if (declaringView.Name != null)
+                    if (declaringView.Name != null!)
                     {
                         strategy = property.GetValueGenerationStrategy(declaringView, Dependencies.TypeMappingSource);
                         if (strategy == SqlServerValueGenerationStrategy.None

--- a/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
@@ -60,7 +60,7 @@ public class EntityReferenceMap
         }
         else
         {
-            var mapKey = entry.Entity ?? entry;
+            var mapKey = entry.Entity;
 
             if (oldState.HasValue)
             {

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1300,7 +1300,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
                     if (valueType == CurrentValueType.StoreGenerated)
                     {
                         var defaultValue = asProperty!.ClrType.GetDefaultValue();
-                        if (!AreEqual(currentValue, defaultValue, asProperty!))
+                        if (!AreEqual(currentValue, defaultValue, asProperty))
                         {
                             WritePropertyValue(asProperty, defaultValue, isMaterialization);
                         }
@@ -1311,13 +1311,13 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
                     else
                     {
                         var defaultValue = asProperty!.ClrType.GetDefaultValue();
-                        if (!AreEqual(currentValue, defaultValue, asProperty!))
+                        if (!AreEqual(currentValue, defaultValue, asProperty))
                         {
                             WritePropertyValue(asProperty, defaultValue, isMaterialization);
                         }
 
                         if (_storeGeneratedValues.TryGetValue(storeGeneratedIndex, out var generatedValue)
-                            && !AreEqual(generatedValue, defaultValue, asProperty!))
+                            && !AreEqual(generatedValue, defaultValue, asProperty))
                         {
                             _storeGeneratedValues.SetValue(asProperty, defaultValue, storeGeneratedIndex);
                         }

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -310,7 +310,7 @@ public class StateManager : IStateManager
         var entityType = entry.EntityType;
         if (entityType.HasSharedClrType)
         {
-            var mapKey = entry.Entity ?? entry;
+            var mapKey = entry.Entity;
             foreach (var otherType in _model.FindEntityTypes(entityType.ClrType)
                          .Where(et => et != entityType && TryGetEntry(mapKey, et) != null))
             {
@@ -546,7 +546,7 @@ public class StateManager : IStateManager
         }
 
 #if DEBUG
-        var existingEntry = TryGetEntry(entry.Entity ?? entry, entityType);
+        var existingEntry = TryGetEntry(entry.Entity, entityType);
 
         Check.DebugAssert(existingEntry == null || existingEntry == entry, "Duplicate InternalEntityEntry");
 #endif

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -900,6 +900,10 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
         {
             relatedEntityType = model.FindEntityType(relatedTypeName, navigationName, DependentEntityType);
         }
+        else if (DependentEntityType.Name == relatedTypeName)
+        {
+            return DependentEntityType;
+        }
 
         if (relatedEntityType == null
             && ((IReadOnlyModel)model).GetProductVersion()?.StartsWith("2.", StringComparison.Ordinal) == true)

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 

--- a/src/Shared/DictionaryExtensions.cs
+++ b/src/Shared/DictionaryExtensions.cs
@@ -35,17 +35,17 @@ internal static class DictionaryExtensions
     public static bool TryGetAndRemove<TKey, TValue, TReturn>(
         this IDictionary<TKey, TValue> source,
         TKey key,
-        [NotNullWhen(true)] out TReturn annotationValue)
+        [NotNullWhen(true)] out TReturn value)
     {
-        if (source.TryGetValue(key, out var value)
-            && value != null)
+        if (source.TryGetValue(key, out var item)
+            && item != null)
         {
             source.Remove(key);
-            annotationValue = (TReturn)(object)value;
+            value = (TReturn)(object)item;
             return true;
         }
 
-        annotationValue = default!;
+        value = default!;
         return false;
     }
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -907,11 +907,9 @@ namespace MyNamespace
     [Flags]
     public enum Enum1
     {
-#pragma warning disable SA1602 // Enumeration items should be documented
         Default = 0,
         One = 1,
         Two = 2
-#pragma warning restore SA1602 // Enumeration items should be documented
     }
 
     private ModelSnapshot CompileModelSnapshot(string modelSnapshotCode, string modelSnapshotTypeName)

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -1880,11 +1880,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         public enum Mapping
         {
-#pragma warning disable SA1602 // Enumeration items should be documented
             TPH,
             TPT,
             TPC
-#pragma warning restore SA1602 // Enumeration items should be documented
         }
 
         private enum MyEnum : ulong

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Internal;

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -980,9 +980,7 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
 
     public enum Grade
     {
-#pragma warning disable SA1602 // Enumeration items should be documented
         A, B, C, D, F
-#pragma warning restore SA1602 // Enumeration items should be documented
     }
 
     public class Enrollment

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
@@ -173,10 +173,10 @@ WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_Princ
             entityType2.GetKeys().Single().GetName());
         Assert.Equal(
             "ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCo~",
-            entityType2.GetProperties().ElementAt(1).GetColumnName());
+            entityType2.GetProperties().ElementAt(1).GetColumnName(StoreObjectIdentifier.Table(entityType2.GetTableName())));
         Assert.Equal(
             "ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingC~1",
-            entityType2.GetProperties().ElementAt(2).GetColumnName());
+            entityType2.GetProperties().ElementAt(2).GetColumnName(StoreObjectIdentifier.Table(entityType2.GetTableName())));
         Assert.Equal(
             "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWor~1",
             entityType2.GetIndexes().Single().GetDatabaseName());

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderTestBase.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderTestBase.cs
@@ -190,7 +190,8 @@ public class SqlServerModelBuilderTestBase : RelationalModelBuilderTest
             Assert.Equal("ParentId", property1.GetColumnName());
             var property2 = model.FindEntityType(typeof(DisjointChildSubclass2))!.FindProperty("ParentId")!;
             Assert.True(property2.IsForeignKey());
-            Assert.Equal("DisjointChildSubclass2_ParentId", property2.GetColumnName());
+            Assert.Equal("ParentId", property2.GetColumnName());
+            Assert.Equal("DisjointChildSubclass2_ParentId", property2.GetColumnName(StoreObjectIdentifier.Table(nameof(Child))));
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 // ReSharper disable MemberHidesStaticFromOuterClass
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable InconsistentNaming
 // ReSharper disable AccessToDisposedClosure
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 public class FixupTest
 {

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -528,12 +528,10 @@ public abstract partial class ModelBuilderTest
         [Flags]
         public enum HasDataOverload
         {
-#pragma warning disable SA1602 // Enumeration items should be documented
             Array = 0,
             Enumerable = 1,
             Generic = 2,
             Params = 4
-#pragma warning restore SA1602 // Enumeration items should be documented
         }
 
         [ConditionalTheory]


### PR DESCRIPTION
Add check constraint and trigger annotation support to migration snapshot
Improve owned type FK discovery

Part of #620

