### PR TITLE
Add entity splitting tests for migrations and update pipeline

### DIFF
--- a/src/EFCore.Relational/Metadata/Internal/ColumnMappingBaseComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMappingBaseComparer.cs
@@ -52,19 +52,19 @@ public sealed class ColumnMappingBaseComparer : IEqualityComparer<IColumnMapping
             return result;
         }
 
+        result = TableMappingBaseComparer.Instance.Compare(x.TableMapping, y.TableMapping);
+        if (result != 0)
+        {
+            return result;
+        }
+
         result = StringComparer.Ordinal.Compare(x.Property.Name, y.Property.Name);
         if (result != 0)
         {
             return result;
         }
 
-        result = StringComparer.Ordinal.Compare(x.Column.Name, y.Column.Name);
-        if (result != 0)
-        {
-            return result;
-        }
-
-        return TableMappingBaseComparer.Instance.Compare(x.TableMapping, y.TableMapping);
+        return StringComparer.Ordinal.Compare(x.Column.Name, y.Column.Name);
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Globalization;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationConvention.cs
@@ -102,6 +102,8 @@ public class SqlServerValueGenerationConvention : RelationalValueGenerationConve
             return null;
         }
 
+        // If the first mapping can be value generated then we'll consider all mappings to be value generated
+        // as this is a client-side configuration and can't be specified per-table.
         return GetValueGenerated(property, declaringTable, Dependencies.TypeMappingSource);
     }
 

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -219,8 +219,7 @@ public class SqlServerAnnotationProvider : RelationalAnnotationProvider
 
         var table = StoreObjectIdentifier.Table(column.Table.Name, column.Table.Schema);
         var identityProperty = column.PropertyMappings.Where(
-                m => (m.TableMapping.IsSharedTablePrincipal ?? true)
-                    && m.TableMapping.EntityType == m.Property.DeclaringEntityType)
+                m => m.TableMapping.EntityType == m.Property.DeclaringEntityType)
             .Select(m => m.Property)
             .FirstOrDefault(
                 p => p.GetValueGenerationStrategy(table)

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -574,8 +574,6 @@ public class ModelSnapshotSqlServerTest
                     b.Property<int>(""Id"")
                         .HasColumnType(""int"");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
-
                     b.HasKey(""Id"");
 
                     b.ToView(""EntityWithOneProperty"", (string)null);
@@ -595,8 +593,6 @@ public class ModelSnapshotSqlServerTest
                 {
                     b.Property<int>(""Id"")
                         .HasColumnType(""int"");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -947,8 +943,6 @@ public class ModelSnapshotSqlServerTest
                     b.Property<int>(""Id"")
                         .HasColumnType(""int"");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
-
                     b.Property<int>(""Shadow"")
                         .HasColumnType(""int"");
 
@@ -1040,7 +1034,6 @@ public class ModelSnapshotSqlServerTest
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
                 {
                     b.Property<int>(""Id"")
-                        .ValueGeneratedOnAdd()
                         .HasColumnType(""int"");
 
                     b.HasKey(""Id"");
@@ -1122,7 +1115,6 @@ public class ModelSnapshotSqlServerTest
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
                 {
                     b.Property<int>(""Id"")
-                        .ValueGeneratedOnAdd()
                         .HasColumnType(""int"");
 
                     b.HasKey(""Id"");
@@ -3328,8 +3320,6 @@ namespace RootNamespace
 
                             b1.Property<int>(""Id"")
                                 .HasColumnType(""int"");
-
-                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>(""Id""), 1L, 1);
 
                             b1.Property<int>(""TestEnum"")
                                 .HasColumnType(""int"");

--- a/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore;
+
+public abstract class EntitySplittingTestBase : NonSharedModelTestBase
+{
+    protected EntitySplittingTestBase(ITestOutputHelper testOutputHelper)
+    {
+        //TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    [ConditionalFact(Skip = "Entity splitting query Issue #620")]
+    public virtual async Task Can_roundtrip()
+    {
+        await InitializeAsync(OnModelCreating, sensitiveLogEnabled: false);
+
+        await using (var context = CreateContext())
+        {
+            var meterReading = new MeterReading { ReadingStatus = MeterReadingStatus.NotAccesible, CurrentRead = "100" };
+
+            context.Add(meterReading);
+
+            TestSqlLoggerFactory.Clear();
+
+            await context.SaveChangesAsync();
+
+            Assert.Empty(TestSqlLoggerFactory.Log.Where(l => l.Level == LogLevel.Warning));
+        }
+        
+        await using (var context = CreateContext())
+        {
+            var reading = await context.MeterReadings.SingleAsync();
+
+            Assert.Equal(MeterReadingStatus.NotAccesible, reading.ReadingStatus);
+            Assert.Equal("100", reading.CurrentRead);
+        }
+    }
+
+    protected override string StoreName { get; } = "EntitySplittingTest";
+
+    protected TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    protected ContextFactory<EntitySplittingContext> ContextFactory { get; private set; }
+
+    protected void AssertSql(params string[] expected)
+        => TestSqlLoggerFactory.AssertBaseline(expected);
+    
+    protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<MeterReading>(
+            ob =>
+            {
+                ob.ToTable("MeterReadings");
+                ob.SplitToTable(
+                    "MeterReadingDetails", t =>
+                    {
+                        t.Property(o => o.PreviousRead);
+                        t.Property(o => o.CurrentRead);
+                    });
+            });
+    }
+
+    protected async Task InitializeAsync(Action<ModelBuilder> onModelCreating, bool sensitiveLogEnabled = true)
+        => ContextFactory = await InitializeAsync<EntitySplittingContext>(
+            onModelCreating,
+            shouldLogCategory: _ => true,
+            onConfiguring: options =>
+            {
+                options.ConfigureWarnings(w => w.Log(RelationalEventId.OptionalDependentWithAllNullPropertiesWarning))
+                    .ConfigureWarnings(w => w.Log(RelationalEventId.OptionalDependentWithoutIdentifyingPropertyWarning))
+                    .EnableSensitiveDataLogging(sensitiveLogEnabled);
+            }
+        );
+
+    protected virtual EntitySplittingContext CreateContext()
+        => ContextFactory.CreateContext();
+
+    public override void Dispose()
+    {
+        base.Dispose();
+
+        ContextFactory = null;
+    }
+
+    protected class EntitySplittingContext : PoolableDbContext
+    {
+        public EntitySplittingContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<MeterReading> MeterReadings { get; set; }
+    }
+
+    protected class MeterReading
+    {
+        public int Id { get; set; }
+        public MeterReadingStatus? ReadingStatus { get; set; }
+        public string CurrentRead { get; set; }
+        public string PreviousRead { get; set; }
+    }
+
+    protected enum MeterReadingStatus
+    {
+        Running = 0,
+        NotAccesible = 2
+    }
+}

--- a/test/EFCore.Specification.Tests/NonSharedModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/NonSharedModelTestBase.cs
@@ -16,14 +16,14 @@ public abstract class NonSharedModelTestBase : IDisposable, IAsyncLifetime
     protected IServiceProvider ServiceProvider
         => _serviceProvider
             ?? throw new InvalidOperationException(
-                $"You must call `await {nameof(InitializeAsync)}(\"DatabaseName\");` at the beggining of the test.");
+                $"You must call `await {nameof(InitializeAsync)}(\"DatabaseName\");` at the beginning of the test.");
 
     private TestStore _testStore;
 
     protected TestStore TestStore
         => _testStore
             ?? throw new InvalidOperationException(
-                $"You must call `await {nameof(InitializeAsync)}(\"DatabaseName\");` at the beggining of the test.");
+                $"You must call `await {nameof(InitializeAsync)}(\"DatabaseName\");` at the beginning of the test.");
 
     private ListLoggerFactory _listLoggerFactory;
 

--- a/test/EFCore.SqlServer.FunctionalTests/EntitySplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EntitySplittingSqlServerTest.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class EntitySplittingSqlServerTest : EntitySplittingTestBase
+{
+    public EntitySplittingSqlServerTest(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    protected override ITestStoreFactory TestStoreFactory
+        => SqlServerTestStoreFactory.Instance;
+    
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/EntitySplittingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/EntitySplittingSqliteTest.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class EntitySplittingSqliteTest : EntitySplittingTestBase
+{
+    public EntitySplittingSqliteTest(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+    
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+    }
+}


### PR DESCRIPTION
Don't use identity by default for columns with FKs even when the property is mapped to other columns that should use identity
Update value generation on properties when an entity type is no longer mapped to a table or is mapped again

Part of #620