### PR TITLE
[release/6.0] Query: Don't add DbParameter if already added

### DIFF
--- a/src/EFCore.Relational/Storage/Internal/RawRelationalParameter.cs
+++ b/src/EFCore.Relational/Storage/Internal/RawRelationalParameter.cs
@@ -58,11 +58,19 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 value is DbParameter,
                 $"{nameof(value)} isn't a DbParameter in {nameof(RawRelationalParameter)}.{nameof(AddDbParameter)}");
 
-            if (value is DbParameter dbParameter
-                && dbParameter.Direction == ParameterDirection.Input
-                && value is ICloneable cloneable)
+            if (value is DbParameter dbParameter)
             {
-                value = cloneable.Clone();
+                if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27427", out var enabled) && enabled)
+                    && command.Parameters.Contains(dbParameter.ParameterName))
+                {
+                    return;
+                }
+
+                if (dbParameter.Direction == ParameterDirection.Input
+                    && value is ICloneable cloneable)
+                {
+                    value = cloneable.Clone();
+                }
             }
 
             command.Parameters.Add(value);

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -1502,6 +1502,25 @@ AND (([UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             Assert.Equal(26, actual.Length);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Multiple_occurrences_of_FromSql_with_db_parameter_adds_parameter_only_once(bool async)
+        {
+            using var context = CreateContext();
+            var city = "Seattle";
+            var fromSqlQuery = context.Customers.FromSqlRaw(
+                NormalizeDelimitersInRawString(@"SELECT * FROM [Customers] WHERE [City] = {0}"),
+                                CreateDbParameter("city", city));
+
+            var query = fromSqlQuery.Intersect(fromSqlQuery);
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Single(actual);
+        }
+
         protected string NormalizeDelimitersInRawString(string sql)
             => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -752,6 +752,24 @@ WHERE EXISTS (
     WHERE [m].[CustomerID] = [o].[CustomerID])");
         }
 
+        public override async Task Multiple_occurrences_of_FromSql_with_db_parameter_adds_parameter_only_once(bool async)
+        {
+            await base.Multiple_occurrences_of_FromSql_with_db_parameter_adds_parameter_only_once(async);
+
+            AssertSql(
+                @"city='Seattle' (Nullable = false) (Size = 7)
+
+SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
+FROM (
+    SELECT * FROM ""Customers"" WHERE ""City"" = @city
+) AS [m]
+INTERSECT
+SELECT [m0].[CustomerID], [m0].[Address], [m0].[City], [m0].[CompanyName], [m0].[ContactName], [m0].[ContactTitle], [m0].[Country], [m0].[Fax], [m0].[Phone], [m0].[PostalCode], [m0].[Region]
+FROM (
+    SELECT * FROM ""Customers"" WHERE ""City"" = @city
+) AS [m0]");
+        }
+
         protected override DbParameter CreateDbParameter(string name, object value)
             => new SqlParameter { ParameterName = name, Value = value };
 


### PR DESCRIPTION
Resolves #27427

If a FromSql with DbParameter is reused in multiple parts of query then we need to add the DbParameter only once

**Description**

If same FromSql with DbParameter is reused in multiple parts of a query then we try to add DbParameter twice which throws an error.

**Customer impact**

Customers reusing FromSql will see an error. In case of GroupBy aggregate even if customer didn't write query in reusable way, it can still cause an error because we internally create copy.

**How found**

Customer reported on 6.0.2

**Regression**

Partially. In the scenario, where customer is reusing the query it threw error always. In case of groupby aggregate it is regression caused by us when we stopped lifting the aggregate element in all cases.

**Testing**

Added tests for affected scenario.

**Risk**

Low. Also added quirk to revert back to older behavior.