### PR TITLE
Add a way to configure identity columns and triggers for split enities

### DIFF
--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -159,6 +159,12 @@ public class AnnotationCodeGenerator : IAnnotationCodeGenerator
 
     /// <inheritdoc />
     public virtual void RemoveAnnotationsHandledByConventions(
+        IEntityTypeMappingFragment fragment,
+        IDictionary<string, IAnnotation> annotations)
+        => RemoveConventionalAnnotationsHelper(fragment, annotations, IsHandledByConvention);
+
+    /// <inheritdoc />
+    public virtual void RemoveAnnotationsHandledByConventions(
         IProperty property,
         IDictionary<string, IAnnotation> annotations)
     {
@@ -184,6 +190,25 @@ public class AnnotationCodeGenerator : IAnnotationCodeGenerator
     /// <inheritdoc />
     public virtual void RemoveAnnotationsHandledByConventions(IIndex index, IDictionary<string, IAnnotation> annotations)
         => RemoveConventionalAnnotationsHelper(index, annotations, IsHandledByConvention);
+
+    /// <inheritdoc />
+    public virtual void RemoveAnnotationsHandledByConventions(
+        ICheckConstraint checkConstraint, IDictionary<string, IAnnotation> annotations)
+        => RemoveConventionalAnnotationsHelper(checkConstraint, annotations, IsHandledByConvention);
+
+    /// <inheritdoc />
+    public virtual void RemoveAnnotationsHandledByConventions(ITrigger trigger, IDictionary<string, IAnnotation> annotations)
+        => RemoveConventionalAnnotationsHelper(trigger, annotations, IsHandledByConvention);
+
+    /// <inheritdoc />
+    public virtual void RemoveAnnotationsHandledByConventions(
+        IRelationalPropertyOverrides overrides, IDictionary<string, IAnnotation> annotations)
+        => RemoveConventionalAnnotationsHelper(overrides, annotations, IsHandledByConvention);
+
+    /// <inheritdoc />
+    public virtual void RemoveAnnotationsHandledByConventions(
+        ISequence sequence, IDictionary<string, IAnnotation> annotations)
+        => RemoveConventionalAnnotationsHelper(sequence, annotations, IsHandledByConvention);
 
     /// <inheritdoc />
     public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
@@ -240,6 +265,18 @@ public class AnnotationCodeGenerator : IAnnotationCodeGenerator
         }
 
         methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(entityType, annotations, GenerateFluentApi));
+
+        return methodCallCodeFragments;
+    }
+
+    /// <inheritdoc />
+    public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        IEntityTypeMappingFragment fragment,
+        IDictionary<string, IAnnotation> annotations)
+    {
+        var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+        methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(fragment, annotations, GenerateFluentApi));
 
         return methodCallCodeFragments;
     }
@@ -372,6 +409,54 @@ public class AnnotationCodeGenerator : IAnnotationCodeGenerator
     }
 
     /// <inheritdoc />
+    public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        ICheckConstraint checkConstraint,
+        IDictionary<string, IAnnotation> annotations)
+    {
+        var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+        methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(checkConstraint, annotations, GenerateFluentApi));
+
+        return methodCallCodeFragments;
+    }
+
+    /// <inheritdoc />
+    public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        ITrigger trigger,
+        IDictionary<string, IAnnotation> annotations)
+    {
+        var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+        methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(trigger, annotations, GenerateFluentApi));
+
+        return methodCallCodeFragments;
+    }
+
+    /// <inheritdoc />
+    public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        IRelationalPropertyOverrides overrides,
+        IDictionary<string, IAnnotation> annotations)
+    {
+        var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+        methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(overrides, annotations, GenerateFluentApi));
+
+        return methodCallCodeFragments;
+    }
+
+    /// <inheritdoc />
+    public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        ISequence sequence,
+        IDictionary<string, IAnnotation> annotations)
+    {
+        var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+        methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(sequence, annotations, GenerateFluentApi));
+
+        return methodCallCodeFragments;
+    }
+
+    /// <inheritdoc />
     public virtual IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
         IEntityType entityType,
         IDictionary<string, IAnnotation> annotations)
@@ -436,6 +521,19 @@ public class AnnotationCodeGenerator : IAnnotationCodeGenerator
 
     /// <summary>
     ///     Checks if the given <paramref name="annotation" /> is handled by convention when
+    ///     applied to the given <paramref name="fragment" />.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="false" />.
+    /// </remarks>
+    /// <param name="fragment">The <see cref="IEntityTypeMappingFragment" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="false" />.</returns>
+    protected virtual bool IsHandledByConvention(IEntityTypeMappingFragment fragment, IAnnotation annotation)
+        => false;
+
+    /// <summary>
+    ///     Checks if the given <paramref name="annotation" /> is handled by convention when
     ///     applied to the given <paramref name="key" />.
     /// </summary>
     /// <remarks>
@@ -487,6 +585,58 @@ public class AnnotationCodeGenerator : IAnnotationCodeGenerator
         => false;
 
     /// <summary>
+    ///     Checks if the given <paramref name="annotation" /> is handled by convention when
+    ///     applied to the given <paramref name="checkConstraint" />.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="false" />.
+    /// </remarks>
+    /// <param name="checkConstraint">The <see cref="ICheckConstraint" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="false" />.</returns>
+    protected virtual bool IsHandledByConvention(ICheckConstraint checkConstraint, IAnnotation annotation)
+        => false;
+
+    /// <summary>
+    ///     Checks if the given <paramref name="annotation" /> is handled by convention when
+    ///     applied to the given <paramref name="trigger" />.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="false" />.
+    /// </remarks>
+    /// <param name="trigger">The <see cref="ITrigger" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="false" />.</returns>
+    protected virtual bool IsHandledByConvention(ITrigger trigger, IAnnotation annotation)
+        => false;
+
+    /// <summary>
+    ///     Checks if the given <paramref name="annotation" /> is handled by convention when
+    ///     applied to the given <paramref name="overrides" />.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="false" />.
+    /// </remarks>
+    /// <param name="overrides">The <see cref="IRelationalPropertyOverrides" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="false" />.</returns>
+    protected virtual bool IsHandledByConvention(IRelationalPropertyOverrides overrides, IAnnotation annotation)
+        => false;
+
+    /// <summary>
+    ///     Checks if the given <paramref name="annotation" /> is handled by convention when
+    ///     applied to the given <paramref name="sequence" />.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="false" />.
+    /// </remarks>
+    /// <param name="sequence">The <see cref="ISequence" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="false" />.</returns>
+    protected virtual bool IsHandledByConvention(ISequence sequence, IAnnotation annotation)
+        => false;
+
+    /// <summary>
     ///     Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
     ///     if no fluent API call exists for it.
     /// </summary>
@@ -510,6 +660,19 @@ public class AnnotationCodeGenerator : IAnnotationCodeGenerator
     /// <param name="annotation">The <see cref="IAnnotation" />.</param>
     /// <returns><see langword="null" />.</returns>
     protected virtual MethodCallCodeFragment? GenerateFluentApi(IEntityType entityType, IAnnotation annotation)
+        => null;
+
+    /// <summary>
+    ///     Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+    ///     if no fluent API call exists for it.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="null" />.
+    /// </remarks>
+    /// <param name="fragment">The <see cref="IEntityTypeMappingFragment" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="null" />.</returns>
+    protected virtual MethodCallCodeFragment? GenerateFluentApi(IEntityTypeMappingFragment fragment, IAnnotation annotation)
         => null;
 
     /// <summary>
@@ -588,6 +751,58 @@ public class AnnotationCodeGenerator : IAnnotationCodeGenerator
     /// <param name="annotation">The <see cref="IAnnotation" />.</param>
     /// <returns><see langword="null" />.</returns>
     protected virtual MethodCallCodeFragment? GenerateFluentApi(IIndex index, IAnnotation annotation)
+        => null;
+
+    /// <summary>
+    ///     Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+    ///     if no fluent API call exists for it.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="null" />.
+    /// </remarks>
+    /// <param name="checkConstraint">The <see cref="ICheckConstraint" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="null" />.</returns>
+    protected virtual MethodCallCodeFragment? GenerateFluentApi(ICheckConstraint checkConstraint, IAnnotation annotation)
+        => null;
+
+    /// <summary>
+    ///     Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+    ///     if no fluent API call exists for it.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="null" />.
+    /// </remarks>
+    /// <param name="trigger">The <see cref="ITrigger" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="null" />.</returns>
+    protected virtual MethodCallCodeFragment? GenerateFluentApi(ITrigger trigger, IAnnotation annotation)
+        => null;
+
+    /// <summary>
+    ///     Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+    ///     if no fluent API call exists for it.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="null" />.
+    /// </remarks>
+    /// <param name="overrides">The <see cref="IRelationalPropertyOverrides" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="null" />.</returns>
+    protected virtual MethodCallCodeFragment? GenerateFluentApi(IRelationalPropertyOverrides overrides, IAnnotation annotation)
+        => null;
+
+    /// <summary>
+    ///     Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+    ///     if no fluent API call exists for it.
+    /// </summary>
+    /// <remarks>
+    ///     The default implementation always returns <see langword="null" />.
+    /// </remarks>
+    /// <param name="sequence">The <see cref="ISequence" />.</param>
+    /// <param name="annotation">The <see cref="IAnnotation" />.</param>
+    /// <returns><see langword="null" />.</returns>
+    protected virtual MethodCallCodeFragment? GenerateFluentApi(ISequence sequence, IAnnotation annotation)
         => null;
 
     /// <summary>

--- a/src/EFCore.Relational/Design/IAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/IAnnotationCodeGenerator.cs
@@ -52,6 +52,16 @@ public interface IAnnotationCodeGenerator
     ///     Removes annotation whose configuration is already applied by convention, and do not need to be
     ///     specified explicitly.
     /// </summary>
+    /// <param name="fragment">The entity mapping fragment to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to remove the conventional ones.</param>
+    void RemoveAnnotationsHandledByConventions(IEntityTypeMappingFragment fragment, IDictionary<string, IAnnotation> annotations)
+    {
+    }
+
+    /// <summary>
+    ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+    ///     specified explicitly.
+    /// </summary>
     /// <param name="property">The property to which the annotations are applied.</param>
     /// <param name="annotations">The set of annotations from which to remove the conventional ones.</param>
     void RemoveAnnotationsHandledByConventions(IProperty property, IDictionary<string, IAnnotation> annotations)
@@ -119,6 +129,16 @@ public interface IAnnotationCodeGenerator
     }
 
     /// <summary>
+    ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+    ///     specified explicitly.
+    /// </summary>
+    /// <param name="sequence">The sequence to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to remove the conventional ones.</param>
+    void RemoveAnnotationsHandledByConventions(ISequence sequence, IDictionary<string, IAnnotation> annotations)
+    {
+    }
+
+    /// <summary>
     ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
     ///     and removes the annotations.
     /// </summary>
@@ -136,6 +156,10 @@ public interface IAnnotationCodeGenerator
                 RemoveAnnotationsHandledByConventions(entityType, annotations);
                 return;
 
+            case IEntityTypeMappingFragment fragment:
+                RemoveAnnotationsHandledByConventions(fragment, annotations);
+                return;
+            
             case IProperty property:
                 RemoveAnnotationsHandledByConventions(property, annotations);
                 return;
@@ -172,6 +196,10 @@ public interface IAnnotationCodeGenerator
                 RemoveAnnotationsHandledByConventions(overrides, annotations);
                 return;
 
+            case ISequence sequence:
+                RemoveAnnotationsHandledByConventions(sequence, annotations);
+                return;
+
             default:
                 throw new ArgumentException(RelationalStrings.UnhandledAnnotatableType(annotatable.GetType()));
         }
@@ -196,6 +224,17 @@ public interface IAnnotationCodeGenerator
     /// <param name="annotations">The set of annotations from which to generate fluent API calls.</param>
     IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
         IEntityType entityType,
+        IDictionary<string, IAnnotation> annotations)
+        => Array.Empty<MethodCallCodeFragment>();
+
+    /// <summary>
+    ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+    ///     and removes the annotations.
+    /// </summary>
+    /// <param name="fragment">The entity mapping fragment to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to generate fluent API calls.</param>
+    IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        IEntityTypeMappingFragment fragment,
         IDictionary<string, IAnnotation> annotations)
         => Array.Empty<MethodCallCodeFragment>();
 
@@ -302,6 +341,17 @@ public interface IAnnotationCodeGenerator
     ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
     ///     and removes the annotations.
     /// </summary>
+    /// <param name="sequence">The sequence to which the annotations are applied.</param>
+    /// <param name="annotations">The set of annotations from which to generate fluent API calls.</param>
+    IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        ISequence sequence,
+        IDictionary<string, IAnnotation> annotations)
+        => Array.Empty<MethodCallCodeFragment>();
+
+    /// <summary>
+    ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+    ///     and removes the annotations.
+    /// </summary>
     /// <param name="annotatable">The annotatable to which the annotations are applied.</param>
     /// <param name="annotations">The set of annotations from which to generate fluent API calls.</param>
     IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(IAnnotatable annotatable, IDictionary<string, IAnnotation> annotations)
@@ -309,7 +359,9 @@ public interface IAnnotationCodeGenerator
         {
             IModel model => GenerateFluentApiCalls(model, annotations),
             IEntityType entityType => GenerateFluentApiCalls(entityType, annotations),
+            IEntityTypeMappingFragment fragment => GenerateFluentApiCalls(fragment, annotations),
             IProperty property => GenerateFluentApiCalls(property, annotations),
+            IRelationalPropertyOverrides overrides => GenerateFluentApiCalls(overrides, annotations),
             IKey key => GenerateFluentApiCalls(key, annotations),
             IForeignKey foreignKey => GenerateFluentApiCalls(foreignKey, annotations),
             INavigation navigation => GenerateFluentApiCalls(navigation, annotations),
@@ -317,7 +369,7 @@ public interface IAnnotationCodeGenerator
             IIndex index => GenerateFluentApiCalls(index, annotations),
             ICheckConstraint checkConstraint => GenerateFluentApiCalls(checkConstraint, annotations),
             ITrigger trigger => GenerateFluentApiCalls(trigger, annotations),
-            IRelationalPropertyOverrides overrides => GenerateFluentApiCalls(overrides, annotations),
+            ISequence sequence => GenerateFluentApiCalls(sequence, annotations),
 
             _ => throw new ArgumentException(RelationalStrings.UnhandledAnnotatableType(annotatable.GetType()))
         };

--- a/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
@@ -385,7 +385,7 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
 
         CreateAnnotations(
             fragment,
-            GenerateOverrides,
+            Generate,
             parameters with { TargetName = overrideVariable });
 
         mainBuilder.Append(fragmentsVariable).Append(".Add(");
@@ -395,6 +395,14 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
             .Append(", ")
             .Append(overrideVariable).AppendLine(");");
     }
+
+    /// <summary>
+    ///     Generates code to create the given annotations.
+    /// </summary>
+    /// <param name="fragment">The fragment to which the annotations are applied.</param>
+    /// <param name="parameters">Additional parameters used during code generation.</param>
+    public virtual void Generate(IEntityTypeMappingFragment fragment, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+        => GenerateSimpleAnnotations(parameters);
 
     private void Create(ITrigger trigger, string triggersVariable, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
     {
@@ -500,7 +508,7 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
 
         CreateAnnotations(
             overrides,
-            GenerateOverrides,
+            Generate,
             parameters with { TargetName = overrideVariable });
 
         mainBuilder.Append(overridesVariable).Append(".Add(");
@@ -516,7 +524,7 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
     /// </summary>
     /// <param name="overrides">The property overrides to which the annotations are applied.</param>
     /// <param name="parameters">Additional parameters used during code generation.</param>
-    public virtual void GenerateOverrides(IAnnotatable overrides, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    public virtual void Generate(IRelationalPropertyOverrides overrides, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
         => GenerateSimpleAnnotations(parameters);
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -1075,7 +1075,7 @@ public static class RelationalEntityTypeExtensions
     public static IMutableEntityTypeMappingFragment? RemoveMappingFragment(
         this IMutableEntityType entityType,
         in StoreObjectIdentifier storeObject)
-        => EntityTypeMappingFragment.Remove(entityType, storeObject, ConfigurationSource.Explicit);
+        => EntityTypeMappingFragment.Remove(entityType, storeObject);
 
     /// <summary>
     ///     <para>
@@ -1088,17 +1088,14 @@ public static class RelationalEntityTypeExtensions
     /// </summary>
     /// <param name="entityType">The entity type.</param>
     /// <param name="storeObject">The identifier of a table-like store object.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>
     ///     The removed <see cref="IConventionEntityTypeMappingFragment" /> or <see langword="null" />
     ///     if no overrides for the given store object were found or the existing overrides were configured from a higher source.
     /// </returns>
     public static IConventionEntityTypeMappingFragment? RemoveMappingFragment(
         this IConventionEntityType entityType,
-        in StoreObjectIdentifier storeObject,
-        bool fromDataAnnotation = false)
-        => EntityTypeMappingFragment.Remove((IMutableEntityType)entityType, storeObject,
-            fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+        in StoreObjectIdentifier storeObject)
+        => EntityTypeMappingFragment.Remove((IMutableEntityType)entityType, storeObject);
 
     /// <summary>
     ///     Gets the foreign keys for the given entity type that point to other entity types

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -51,7 +51,7 @@ public static class RelationalPropertyExtensions
     /// <returns>The name of the column to which the property is mapped.</returns>
     public static string? GetColumnName(this IReadOnlyProperty property, in StoreObjectIdentifier storeObject)
     {
-        var overrides = RelationalPropertyOverrides.Find(property, storeObject);
+        var overrides = property.FindOverrides(storeObject);
         if (overrides?.ColumnNameOverridden == true)
         {
             return overrides.ColumnName;
@@ -294,8 +294,7 @@ public static class RelationalPropertyExtensions
     public static ConfigurationSource? GetColumnNameConfigurationSource(
         this IConventionProperty property,
         in StoreObjectIdentifier storeObject)
-        => ((IConventionRelationalPropertyOverrides?)RelationalPropertyOverrides.Find(property, storeObject))
-            ?.GetColumnNameConfigurationSource();
+        => property.FindOverrides(storeObject)?.GetColumnNameConfigurationSource();
 
     /// <summary>
     ///     Returns the order of the column this property is mapped to.
@@ -1451,8 +1450,38 @@ public static class RelationalPropertyExtensions
     /// </summary>
     /// <param name="property">The property.</param>
     /// <returns>The property facet overrides.</returns>
+    public static IEnumerable<IMutableRelationalPropertyOverrides> GetOverrides(this IMutableProperty property)
+        => ((IEnumerable<IMutableRelationalPropertyOverrides>?)RelationalPropertyOverrides.Get(property))
+        ?? Enumerable.Empty<IMutableRelationalPropertyOverrides>();
+
+    /// <summary>
+    ///     <para>
+    ///         Returns all the property facet overrides.
+    ///     </para>
+    ///     <para>
+    ///         This method is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <returns>The property facet overrides.</returns>
+    public static IEnumerable<IConventionRelationalPropertyOverrides> GetOverrides(this IConventionProperty property)
+        => ((IEnumerable<IConventionRelationalPropertyOverrides>?)RelationalPropertyOverrides.Get(property))
+        ?? Enumerable.Empty<IConventionRelationalPropertyOverrides>();
+
+    /// <summary>
+    ///     <para>
+    ///         Returns all the property facet overrides.
+    ///     </para>
+    ///     <para>
+    ///         This method is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <returns>The property facet overrides.</returns>
     public static IEnumerable<IRelationalPropertyOverrides> GetOverrides(this IProperty property)
-        => RelationalPropertyOverrides.Get(property)?.Cast<IRelationalPropertyOverrides>()
+        => ((IEnumerable<IRelationalPropertyOverrides>?)RelationalPropertyOverrides.Get(property))
         ?? Enumerable.Empty<IRelationalPropertyOverrides>();
 
     /// <summary>
@@ -1471,6 +1500,40 @@ public static class RelationalPropertyExtensions
         this IReadOnlyProperty property,
         in StoreObjectIdentifier storeObject)
         => RelationalPropertyOverrides.Find(property, storeObject);
+
+    /// <summary>
+    ///     <para>
+    ///         Returns the property facet overrides for a particular table-like store object.
+    ///     </para>
+    ///     <para>
+    ///         This method is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="storeObject">The identifier of the table-like store object containing the column.</param>
+    /// <returns>An object that stores property facet overrides.</returns>
+    public static IMutableRelationalPropertyOverrides? FindOverrides(
+        this IMutableProperty property,
+        in StoreObjectIdentifier storeObject)
+        => (IMutableRelationalPropertyOverrides?)RelationalPropertyOverrides.Find(property, storeObject);
+
+    /// <summary>
+    ///     <para>
+    ///         Returns the property facet overrides for a particular table-like store object.
+    ///     </para>
+    ///     <para>
+    ///         This method is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="storeObject">The identifier of the table-like store object containing the column.</param>
+    /// <returns>An object that stores property facet overrides.</returns>
+    public static IConventionRelationalPropertyOverrides? FindOverrides(
+        this IConventionProperty property,
+        in StoreObjectIdentifier storeObject)
+        => (IConventionRelationalPropertyOverrides?)RelationalPropertyOverrides.Find(property, storeObject);
 
     /// <summary>
     ///     <para>
@@ -1544,7 +1607,7 @@ public static class RelationalPropertyExtensions
     public static IMutableRelationalPropertyOverrides? RemoveOverrides(
         this IMutableProperty property,
         in StoreObjectIdentifier storeObject)
-        => RelationalPropertyOverrides.Remove(property, storeObject, ConfigurationSource.Explicit);
+        => RelationalPropertyOverrides.Remove(property, storeObject);
 
     /// <summary>
     ///     <para>
@@ -1557,17 +1620,14 @@ public static class RelationalPropertyExtensions
     /// </summary>
     /// <param name="property">The property.</param>
     /// <param name="storeObject">The identifier of a table-like store object.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>
     ///     The removed <see cref="IConventionRelationalPropertyOverrides" /> or <see langword="null" />
     ///     if no overrides for the given store object were found or the existing overrides were configured from a higher source.
     /// </returns>
     public static IConventionRelationalPropertyOverrides? RemoveOverrides(
         this IConventionProperty property,
-        in StoreObjectIdentifier storeObject,
-        bool fromDataAnnotation = false)
-        => RelationalPropertyOverrides.Remove((IMutableProperty)property, storeObject,
-            fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+        in StoreObjectIdentifier storeObject)
+        => RelationalPropertyOverrides.Remove((IMutableProperty)property, storeObject);
 
     /// <summary>
     ///     <para>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -1864,8 +1864,10 @@ public class RelationalModelValidator : ModelValidator
                         RelationalStrings.TriggerOnUnmappedEntityType(trigger.ModelName, entityType.DisplayName()));
                 }
 
-                if ((trigger.TableName != tableName)
-                    || (trigger.TableSchema is not null && trigger.TableSchema != tableSchema))
+                if ((trigger.TableName != tableName
+                    || trigger.TableSchema != tableSchema)
+                    && entityType.GetMappingFragments(StoreObjectType.Table)
+                        .All(f => trigger.TableName != f.StoreObject.Name || trigger.TableSchema != f.StoreObject.Schema))
                 {
                     throw new InvalidOperationException(
                         RelationalStrings.TriggerWithMismatchedTable(

--- a/src/EFCore.Relational/Metadata/Builders/ColumnBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/ColumnBuilder.cs
@@ -62,6 +62,23 @@ public class ColumnBuilder : IInfrastructure<PropertyBuilder>
         return this;
     }
 
+    /// <summary>
+    ///     Adds or updates an annotation on the property for a specific table.
+    ///     If an annotation with the key specified in <paramref name="annotation" />
+    ///     already exists, its value will be updated.
+    /// </summary>
+    /// <param name="annotation">The key of the annotation to be added or updated.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public virtual ColumnBuilder HasAnnotation(string annotation, object? value)
+    {
+        Check.NotEmpty(annotation, nameof(annotation));
+
+        InternalOverrides.Builder.HasAnnotation(annotation, value, ConfigurationSource.Explicit);
+
+        return this;
+    }
+
     PropertyBuilder IInfrastructure<PropertyBuilder>.Instance => PropertyBuilder;
 
     #region Hidden System.Object members

--- a/src/EFCore.Relational/Metadata/Builders/ColumnBuilder`.cs
+++ b/src/EFCore.Relational/Metadata/Builders/ColumnBuilder`.cs
@@ -34,6 +34,17 @@ public class ColumnBuilder<TProperty> : ColumnBuilder, IInfrastructure<PropertyB
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public new virtual ColumnBuilder<TProperty> HasColumnName(string? name)
         => (ColumnBuilder<TProperty>)base.HasColumnName(name);
+    
+    /// <summary>
+    ///     Adds or updates an annotation on the property for a specific table.
+    ///     If an annotation with the key specified in <paramref name="annotation" />
+    ///     already exists, its value will be updated.
+    /// </summary>
+    /// <param name="annotation">The key of the annotation to be added or updated.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public new virtual ColumnBuilder<TProperty> HasAnnotation(string annotation, object? value)
+        => (ColumnBuilder<TProperty>)base.HasAnnotation(annotation, value);
 
     PropertyBuilder<TProperty> IInfrastructure<PropertyBuilder<TProperty>>.Instance => PropertyBuilder;
 }

--- a/src/EFCore.Relational/Metadata/Builders/IConventionEntityTypeMappingFragmentBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionEntityTypeMappingFragmentBuilder.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+///     Provides a simple API for configuring a <see cref="IConventionEntityTypeMappingFragment" />.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.
+/// </remarks>
+public interface IConventionEntityTypeMappingFragmentBuilder : IConventionAnnotatableBuilder
+{
+    /// <summary>
+    ///     The fragment being configured.
+    /// </summary>
+    new IConventionEntityTypeMappingFragment Metadata { get; }
+}

--- a/src/EFCore.Relational/Metadata/Builders/IConventionRelationalPropertyOverridesBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionRelationalPropertyOverridesBuilder.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+///     Provides a simple API for configuring a <see cref="IConventionRelationalPropertyOverrides" />.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.
+/// </remarks>
+public interface IConventionRelationalPropertyOverridesBuilder : IConventionAnnotatableBuilder
+{
+    /// <summary>
+    ///     The overrides being configured.
+    /// </summary>
+    new IConventionRelationalPropertyOverrides Metadata { get; }
+}

--- a/src/EFCore.Relational/Metadata/Builders/OwnedNavigationSplitTableBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/OwnedNavigationSplitTableBuilder.cs
@@ -24,7 +24,7 @@ public class OwnedNavigationSplitTableBuilder : IInfrastructure<OwnedNavigationB
         Check.DebugAssert(storeObject.StoreObjectType == StoreObjectType.Table,
             "StoreObjectType should be Table, not " + storeObject.StoreObjectType);
 
-        MappingFragment = EntityTypeMappingFragment.GetOrCreate(
+        InternalMappingFragment = EntityTypeMappingFragment.GetOrCreate(
             ownedNavigationBuilder.OwnedEntityType, storeObject, ConfigurationSource.Explicit);
         OwnedNavigationBuilder = ownedNavigationBuilder;
     }
@@ -40,9 +40,18 @@ public class OwnedNavigationSplitTableBuilder : IInfrastructure<OwnedNavigationB
     public virtual string? Schema => MappingFragment.StoreObject.Schema;
 
     /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    protected virtual EntityTypeMappingFragment InternalMappingFragment { get; }
+
+    /// <summary>
     ///     The mapping fragment being configured.
     /// </summary>
-    public virtual IMutableEntityTypeMappingFragment MappingFragment { get; }
+    public virtual IMutableEntityTypeMappingFragment MappingFragment => InternalMappingFragment;
 
     private OwnedNavigationBuilder OwnedNavigationBuilder { get; }
 
@@ -95,6 +104,22 @@ public class OwnedNavigationSplitTableBuilder : IInfrastructure<OwnedNavigationB
     /// <returns>An object that can be used to configure the property.</returns>
     public virtual ColumnBuilder<TProperty> Property<TProperty>(string propertyName)
         => new(MappingFragment.StoreObject, OwnedNavigationBuilder.Property<TProperty>(propertyName));
+
+    /// <summary>
+    ///     Adds or updates an annotation on the table. If an annotation with the key specified in <paramref name="annotation" />
+    ///     already exists, its value will be updated.
+    /// </summary>
+    /// <param name="annotation">The key of the annotation to be added or updated.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public virtual OwnedNavigationSplitTableBuilder HasAnnotation(string annotation, object? value)
+    {
+        Check.NotEmpty(annotation, nameof(annotation));
+
+        InternalMappingFragment.Builder.HasAnnotation(annotation, value, ConfigurationSource.Explicit);
+
+        return this;
+    }
 
     OwnedNavigationBuilder IInfrastructure<OwnedNavigationBuilder>.Instance => OwnedNavigationBuilder;
 

--- a/src/EFCore.Relational/Metadata/Builders/OwnedNavigationSplitTableBuilder``.cs
+++ b/src/EFCore.Relational/Metadata/Builders/OwnedNavigationSplitTableBuilder``.cs
@@ -55,6 +55,17 @@ public class OwnedNavigationSplitTableBuilder<TOwnerEntity, TDependentEntity> :
     public virtual ColumnBuilder<TProperty> Property<TProperty>(Expression<Func<TDependentEntity, TProperty>> propertyExpression)
         => new(MappingFragment.StoreObject, OwnedNavigationBuilder.Property(propertyExpression));
 
+    /// <summary>
+    ///     Adds or updates an annotation on the table. If an annotation with the key specified in <paramref name="annotation" />
+    ///     already exists, its value will be updated.
+    /// </summary>
+    /// <param name="annotation">The key of the annotation to be added or updated.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public new virtual OwnedNavigationSplitTableBuilder<TOwnerEntity, TDependentEntity> HasAnnotation(
+        string annotation, object? value)
+        => (OwnedNavigationSplitTableBuilder<TOwnerEntity, TDependentEntity>)base.HasAnnotation(annotation, value);
+
     OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> IInfrastructure<OwnedNavigationBuilder<TOwnerEntity, TDependentEntity>>.Instance
         => OwnedNavigationBuilder;
 }

--- a/src/EFCore.Relational/Metadata/Builders/SequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/SequenceBuilder.cs
@@ -114,6 +114,22 @@ public class SequenceBuilder : IInfrastructure<IConventionSequenceBuilder>
         return this;
     }
 
+    /// <summary>
+    ///     Adds or updates an annotation on the sequence. If an annotation with the key specified in <paramref name="annotation" />
+    ///     already exists, its value will be updated.
+    /// </summary>
+    /// <param name="annotation">The key of the annotation to be added or updated.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public virtual SequenceBuilder HasAnnotation(string annotation, object? value)
+    {
+        Check.NotEmpty(annotation, nameof(annotation));
+
+        Builder.HasAnnotation(annotation, value, ConfigurationSource.Explicit);
+
+        return this;
+    }
+
     #region Hidden System.Object members
 
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Builders/SplitTableBuilder`.cs
+++ b/src/EFCore.Relational/Metadata/Builders/SplitTableBuilder`.cs
@@ -47,5 +47,15 @@ public class SplitTableBuilder<TEntity> : SplitTableBuilder, IInfrastructure<Ent
     public virtual ColumnBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
         => new(MappingFragment.StoreObject, EntityTypeBuilder.Property(propertyExpression));
 
+    /// <summary>
+    ///     Adds or updates an annotation on the table. If an annotation with the key specified in <paramref name="annotation" />
+    ///     already exists, its value will be updated.
+    /// </summary>
+    /// <param name="annotation">The key of the annotation to be added or updated.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public new virtual SplitTableBuilder<TEntity> HasAnnotation(string annotation, object? value)
+        => (SplitTableBuilder<TEntity>)base.HasAnnotation(annotation, value);
+
     EntityTypeBuilder<TEntity> IInfrastructure<EntityTypeBuilder<TEntity>>.Instance => EntityTypeBuilder;
 }

--- a/src/EFCore.Relational/Metadata/Conventions/CheckConstraintConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/CheckConstraintConvention.cs
@@ -144,7 +144,7 @@ public class CheckConstraintConvention : IEntityTypeBaseTypeChangedConvention, I
                 foreach (var checkConstraintToBeDetached in checkConstraintsToBeDetached)
                 {
                     var baseCheckConstraint = baseCheckConstraints[checkConstraintToBeDetached.ModelName];
-                    CheckConstraint.Attach(checkConstraintToBeDetached, baseCheckConstraint);
+                    CheckConstraint.MergeInto(checkConstraintToBeDetached, baseCheckConstraint);
 
                     checkConstraintToBeDetached.EntityType.RemoveCheckConstraint(checkConstraintToBeDetached.ModelName);
                 }

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -64,13 +64,15 @@ public abstract class RelationalConventionSetBuilder : ProviderConventionSetBuil
         conventionSet.PropertyAddedConventions.Add(relationalColumnAttributeConvention);
         conventionSet.PropertyAddedConventions.Add(relationalCommentAttributeConvention);
 
+        var tableNameFromDbSetConvention = new TableNameFromDbSetConvention(Dependencies, RelationalDependencies);
+        var entitySplittingConvention = new EntitySplittingConvention(Dependencies, RelationalDependencies);
         var checkConstraintConvention = new CheckConstraintConvention(Dependencies, RelationalDependencies);
         var triggerConvention = new TriggerConvention(Dependencies, RelationalDependencies);
-        var tableNameFromDbSetConvention = new TableNameFromDbSetConvention(Dependencies, RelationalDependencies);
         conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention(Dependencies, RelationalDependencies));
         conventionSet.EntityTypeAddedConventions.Add(
             new RelationalTableCommentAttributeConvention(Dependencies, RelationalDependencies));
         conventionSet.EntityTypeAddedConventions.Add(tableNameFromDbSetConvention);
+        conventionSet.EntityTypeAddedConventions.Add(entitySplittingConvention);
         conventionSet.EntityTypeAddedConventions.Add(checkConstraintConvention);
         conventionSet.EntityTypeAddedConventions.Add(triggerConvention);
 
@@ -93,6 +95,8 @@ public abstract class RelationalConventionSetBuilder : ProviderConventionSetBuil
 
         ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGenerationConvention);
 
+        conventionSet.PropertyAddedConventions.Add(new PropertyOverridesConvention(Dependencies, RelationalDependencies));
+
         conventionSet.PropertyFieldChangedConventions.Add(relationalColumnAttributeConvention);
         conventionSet.PropertyFieldChangedConventions.Add(relationalCommentAttributeConvention);
 
@@ -112,7 +116,7 @@ public abstract class RelationalConventionSetBuilder : ProviderConventionSetBuil
         conventionSet.ModelFinalizingConventions.Add(dbFunctionAttributeConvention);
         conventionSet.ModelFinalizingConventions.Add(tableNameFromDbSetConvention);
         conventionSet.ModelFinalizingConventions.Add(storeGenerationConvention);
-        conventionSet.ModelFinalizingConventions.Add(new EntitySplittingConvention(Dependencies, RelationalDependencies));
+        conventionSet.ModelFinalizingConventions.Add(entitySplittingConvention);
         conventionSet.ModelFinalizingConventions.Add(new EntityTypeHierarchyMappingConvention(Dependencies, RelationalDependencies));
         conventionSet.ModelFinalizingConventions.Add(new SequenceUniquificationConvention(Dependencies, RelationalDependencies));
         conventionSet.ModelFinalizingConventions.Add(new SharedTableConvention(Dependencies, RelationalDependencies));

--- a/src/EFCore.Relational/Metadata/Conventions/PropertyOverridesConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/PropertyOverridesConvention.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+///     A convention that ensures that the declaring property is current for the property overrides.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> and
+///     <see href="https://aka.ms/efcore-docs-inheritance">Entity type hierarchy mapping</see> for more information and examples.
+/// </remarks>
+public class PropertyOverridesConvention : IPropertyAddedConvention
+{
+    /// <summary>
+    ///     Creates a new instance of <see cref="PropertyOverridesConvention" />.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing dependencies for this convention.</param>
+    /// <param name="relationalDependencies"> Parameter object containing relational dependencies for this convention.</param>
+    public PropertyOverridesConvention(
+        ProviderConventionSetBuilderDependencies dependencies,
+        RelationalConventionSetBuilderDependencies relationalDependencies)
+    {
+        Dependencies = dependencies;
+        RelationalDependencies = relationalDependencies;
+    }
+
+    /// <summary>
+    ///     Dependencies for this service.
+    /// </summary>
+    protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
+
+    /// <summary>
+    ///     Relational provider-specific dependencies for this service.
+    /// </summary>
+    protected virtual RelationalConventionSetBuilderDependencies RelationalDependencies { get; }
+
+    /// <inheritdoc />
+    public virtual void ProcessPropertyAdded(
+        IConventionPropertyBuilder propertyBuilder,
+        IConventionContext<IConventionPropertyBuilder> context)
+    {
+        var property = propertyBuilder.Metadata;
+        if (!property.DeclaringEntityType.HasSharedClrType)
+        {
+            return;
+        }
+
+        List<IConventionRelationalPropertyOverrides>? overridesToReattach = null;
+        foreach (var overrides in property.GetOverrides())
+        {
+            if (overrides.Property == property)
+            {
+                continue;
+            }
+
+            overridesToReattach ??= new();
+
+            overridesToReattach.Add(overrides);
+        }
+
+        if (overridesToReattach == null)
+        {
+            return;
+        }
+
+        foreach (var overrides in overridesToReattach)
+        {
+            var removedOverrides = property.RemoveOverrides(overrides.StoreObject);
+            if (removedOverrides != null)
+            {
+                RelationalPropertyOverrides.Attach(property, removedOverrides);
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/Conventions/TriggerConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TriggerConvention.cs
@@ -49,14 +49,14 @@ public class TriggerConvention : IEntityTypeBaseTypeChangedConvention, IEntityTy
         }
 
         List<IConventionTrigger>? triggersToReattach = null;
-        foreach (var trigger in entityType.GetTriggers())
+        foreach (var trigger in entityType.GetDeclaredTriggers())
         {
             if (trigger.EntityType == entityType)
             {
                 continue;
             }
 
-            triggersToReattach ??= new List<IConventionTrigger>();
+            triggersToReattach ??= new();
 
             triggersToReattach.Add(trigger);
         }
@@ -71,7 +71,7 @@ public class TriggerConvention : IEntityTypeBaseTypeChangedConvention, IEntityTy
             var removedTrigger = entityType.RemoveTrigger(trigger.ModelName);
             if (removedTrigger != null)
             {
-                Trigger.MergeInto(entityType, removedTrigger);
+                Trigger.Attach(entityType, removedTrigger);
             }
         }
     }

--- a/src/EFCore.Relational/Metadata/ICheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/ICheckConstraint.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text;
-
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -17,41 +15,4 @@ public interface ICheckConstraint : IReadOnlyCheckConstraint, IAnnotatable
     ///     Gets the entity type on which this check constraint is defined.
     /// </summary>
     new IEntityType EntityType { get; }
-
-    /// <summary>
-    ///     <para>
-    ///         Creates a human-readable representation of the given metadata.
-    ///     </para>
-    ///     <para>
-    ///         Warning: Do not rely on the format of the returned string.
-    ///         It is designed for debugging only and may change arbitrarily between releases.
-    ///     </para>
-    /// </summary>
-    /// <param name="options">Options for generating the string.</param>
-    /// <param name="indent">The number of indent spaces to use before each new line.</param>
-    /// <returns>A human-readable representation.</returns>
-    string ToDebugString(MetadataDebugStringOptions options = MetadataDebugStringOptions.ShortDefault, int indent = 0)
-    {
-        var builder = new StringBuilder();
-        var indentString = new string(' ', indent);
-
-        builder
-            .Append(indentString)
-            .Append("Check: ");
-
-        builder.Append(ModelName)
-            .Append(" \"")
-            .Append(Sql)
-            .Append('"');
-
-        if ((options & MetadataDebugStringOptions.SingleLine) == 0)
-        {
-            if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
-            {
-                builder.Append(AnnotationsToDebugString(indent: indent + 2));
-            }
-        }
-
-        return builder.ToString();
-    }
 }

--- a/src/EFCore.Relational/Metadata/IConventionEntityTypeMappingFragment.cs
+++ b/src/EFCore.Relational/Metadata/IConventionEntityTypeMappingFragment.cs
@@ -17,6 +17,12 @@ public interface IConventionEntityTypeMappingFragment : IReadOnlyEntityTypeMappi
     new IConventionEntityType EntityType { get; }
 
     /// <summary>
+    ///     Gets the builder that can be used to configure this fragment.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">If the fragment has been removed from the model.</exception>
+    new IConventionEntityTypeMappingFragmentBuilder Builder { get; }
+
+    /// <summary>
     ///     Returns the configuration source for this fragment.
     /// </summary>
     /// <returns>The configuration source.</returns>

--- a/src/EFCore.Relational/Metadata/IConventionRelationalPropertyOverrides.cs
+++ b/src/EFCore.Relational/Metadata/IConventionRelationalPropertyOverrides.cs
@@ -17,6 +17,12 @@ public interface IConventionRelationalPropertyOverrides : IReadOnlyRelationalPro
     new IConventionProperty Property { get; }
 
     /// <summary>
+    ///     Gets the builder that can be used to configure this function.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">If the function has been removed from the model.</exception>
+    new IConventionRelationalPropertyOverridesBuilder Builder { get; }
+
+    /// <summary>
     ///     Returns the configuration source for these overrides.
     /// </summary>
     /// <returns>The configuration source.</returns>

--- a/src/EFCore.Relational/Metadata/IReadOnlyCheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlyCheckConstraint.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -57,4 +59,47 @@ public interface IReadOnlyCheckConstraint : IReadOnlyAnnotatable
     ///     Gets the constraint sql used in a check constraint in the database.
     /// </summary>
     string Sql { get; }
+
+    /// <summary>
+    ///     <para>
+    ///         Creates a human-readable representation of the given metadata.
+    ///     </para>
+    ///     <para>
+    ///         Warning: Do not rely on the format of the returned string.
+    ///         It is designed for debugging only and may change arbitrarily between releases.
+    ///     </para>
+    /// </summary>
+    /// <param name="options">Options for generating the string.</param>
+    /// <param name="indent">The number of indent spaces to use before each new line.</param>
+    /// <returns>A human-readable representation.</returns>
+    string ToDebugString(MetadataDebugStringOptions options = MetadataDebugStringOptions.ShortDefault, int indent = 0)
+    {
+        var builder = new StringBuilder();
+        var indentString = new string(' ', indent);
+
+        builder
+            .Append(indentString)
+            .Append("Check: ");
+
+        builder.Append(ModelName);
+        if (Name != ModelName)
+        {
+            builder.Append('*');
+        }
+
+        builder
+            .Append(" \"")
+            .Append(Sql)
+            .Append('"');
+
+        if ((options & MetadataDebugStringOptions.SingleLine) == 0)
+        {
+            if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+            {
+                builder.Append(AnnotationsToDebugString(indent: indent + 2));
+            }
+        }
+
+        return builder.ToString();
+    }
 }

--- a/src/EFCore.Relational/Metadata/IReadOnlyDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlyDbFunction.cs
@@ -119,6 +119,11 @@ public interface IReadOnlyDbFunction : IReadOnlyAnnotatable
 
         builder.Append(Name);
 
+        if (Name != ModelName)
+        {
+            builder.Append('*');
+        }
+
         if ((options & MetadataDebugStringOptions.SingleLine) == 0)
         {
             var parameters = Parameters.ToList();

--- a/src/EFCore.Relational/Metadata/IReadOnlyEntityTypeMappingFragment.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlyEntityTypeMappingFragment.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -26,4 +28,42 @@ public interface IReadOnlyEntityTypeMappingFragment : IReadOnlyAnnotatable
     /// </summary>
     /// <returns>A value indicating whether the associated table is ignored by Migrations.</returns>
     bool? IsTableExcludedFromMigrations { get; }
+
+    /// <summary>
+    ///     <para>
+    ///         Creates a human-readable representation of the given metadata.
+    ///     </para>
+    ///     <para>
+    ///         Warning: Do not rely on the format of the returned string.
+    ///         It is designed for debugging only and may change arbitrarily between releases.
+    ///     </para>
+    /// </summary>
+    /// <param name="options">Options for generating the string.</param>
+    /// <param name="indent">The number of indent spaces to use before each new line.</param>
+    /// <returns>A human-readable representation.</returns>
+    string ToDebugString(MetadataDebugStringOptions options = MetadataDebugStringOptions.ShortDefault, int indent = 0)
+    {
+        var builder = new StringBuilder();
+        var indentString = new string(' ', indent);
+
+        builder
+            .Append(indentString)
+            .Append("Fragment: ")
+            .Append(StoreObject.DisplayName());
+
+        if (IsTableExcludedFromMigrations == true)
+        {
+            builder.Append("ExcludedFromMigrations");
+        }
+
+        if ((options & MetadataDebugStringOptions.SingleLine) == 0)
+        {
+            if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+            {
+                builder.Append(AnnotationsToDebugString(indent: indent + 2));
+            }
+        }
+
+        return builder.ToString();
+    }
 }

--- a/src/EFCore.Relational/Metadata/IReadOnlyRelationalPropertyOverrides.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlyRelationalPropertyOverrides.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -30,4 +32,43 @@ public interface IReadOnlyRelationalPropertyOverrides : IReadOnlyAnnotatable
     ///     Gets a value indicating whether the column name is overriden.
     /// </summary>
     bool ColumnNameOverridden { get; }
+
+    /// <summary>
+    ///     <para>
+    ///         Creates a human-readable representation of the given metadata.
+    ///     </para>
+    ///     <para>
+    ///         Warning: Do not rely on the format of the returned string.
+    ///         It is designed for debugging only and may change arbitrarily between releases.
+    ///     </para>
+    /// </summary>
+    /// <param name="options">Options for generating the string.</param>
+    /// <param name="indent">The number of indent spaces to use before each new line.</param>
+    /// <returns>A human-readable representation.</returns>
+    string ToDebugString(MetadataDebugStringOptions options = MetadataDebugStringOptions.ShortDefault, int indent = 0)
+    {
+        var builder = new StringBuilder();
+        var indentString = new string(' ', indent);
+
+        builder
+            .Append(indentString)
+            .Append("Override: ")
+            .Append(StoreObject.DisplayName());
+
+        if (ColumnNameOverridden)
+        {
+            builder.Append(" ColumnName: ")
+                .Append(ColumnName);
+        }
+
+        if ((options & MetadataDebugStringOptions.SingleLine) == 0)
+        {
+            if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+            {
+                builder.Append(AnnotationsToDebugString(indent: indent + 2));
+            }
+        }
+
+        return builder.ToString();
+    }
 }

--- a/src/EFCore.Relational/Metadata/IReadOnlyTrigger.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlyTrigger.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -67,4 +69,53 @@ public interface IReadOnlyTrigger : IReadOnlyAnnotatable
     ///     Gets the entity type on which this trigger is defined.
     /// </summary>
     IReadOnlyEntityType EntityType { get; }
+
+    /// <summary>
+    ///     <para>
+    ///         Creates a human-readable representation of the given metadata.
+    ///     </para>
+    ///     <para>
+    ///         Warning: Do not rely on the format of the returned string.
+    ///         It is designed for debugging only and may change arbitrarily between releases.
+    ///     </para>
+    /// </summary>
+    /// <param name="options">Options for generating the string.</param>
+    /// <param name="indent">The number of indent spaces to use before each new line.</param>
+    /// <returns>A human-readable representation.</returns>
+    string ToDebugString(MetadataDebugStringOptions options = MetadataDebugStringOptions.ShortDefault, int indent = 0)
+    {
+        var builder = new StringBuilder();
+        var indentString = new string(' ', indent);
+
+        builder
+            .Append(indentString)
+            .Append("Trigger: ")
+            .Append(ModelName);
+
+        if (Name != ModelName)
+        {
+            builder.Append('*');
+        }
+
+        builder.Append(" ");
+
+        if (TableSchema != null)
+        {
+            builder
+                .Append('.')
+                .Append(TableSchema);
+        }
+
+        builder.Append(TableName);
+
+        if ((options & MetadataDebugStringOptions.SingleLine) == 0)
+        {
+            if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+            {
+                builder.Append(AnnotationsToDebugString(indent: indent + 2));
+            }
+        }
+
+        return builder.ToString();
+    }
 }

--- a/src/EFCore.Relational/Metadata/ITableMapping.cs
+++ b/src/EFCore.Relational/Metadata/ITableMapping.cs
@@ -48,13 +48,36 @@ public interface ITableMapping : ITableMappingBase
             builder.Append("TableMapping: ");
         }
 
-        builder.Append(EntityType.Name).Append(" - ");
+        builder
+            .Append(EntityType.Name)
+            .Append(" - ")
+            .Append(Table.Name);
 
-        builder.Append(Table.Name);
-
-        if (IncludesDerivedTypes)
+        builder.Append(" ");
+        if (!IncludesDerivedTypes)
         {
-            builder.Append(" IncludesDerivedTypes");
+            builder.Append("!");
+        }
+        builder.Append("IncludesDerivedTypes");
+
+        if (IsSharedTablePrincipal != null)
+        {
+            builder.Append(" ");
+            if (!IsSharedTablePrincipal.Value)
+            {
+                builder.Append("!");
+            }
+            builder.Append("IsSharedTablePrincipal");
+        }
+
+        if (IsSplitEntityTypePrincipal != null)
+        {
+            builder.Append(" ");
+            if (!IsSplitEntityTypePrincipal.Value)
+            {
+                builder.Append("!");
+            }
+            builder.Append("IsSplitEntityTypePrincipal");
         }
 
         if (!singleLine && (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)

--- a/src/EFCore.Relational/Metadata/ITrigger.cs
+++ b/src/EFCore.Relational/Metadata/ITrigger.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text;
-
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -24,35 +22,7 @@ public interface ITrigger : IReadOnlyTrigger, IAnnotatable
     new IEntityType EntityType { get; }
 
     /// <summary>
-    ///     <para>
-    ///         Creates a human-readable representation of the given metadata.
-    ///     </para>
-    ///     <para>
-    ///         Warning: Do not rely on the format of the returned string.
-    ///         It is designed for debugging only and may change arbitrarily between releases.
-    ///     </para>
+    ///     Gets the database name of the trigger.
     /// </summary>
-    /// <param name="options">Options for generating the string.</param>
-    /// <param name="indent">The number of indent spaces to use before each new line.</param>
-    /// <returns>A human-readable representation.</returns>
-    string ToDebugString(MetadataDebugStringOptions options = MetadataDebugStringOptions.ShortDefault, int indent = 0)
-    {
-        var builder = new StringBuilder();
-        var indentString = new string(' ', indent);
-
-        builder
-            .Append(indentString)
-            .Append("Trigger: ")
-            .Append(ModelName);
-
-        if ((options & MetadataDebugStringOptions.SingleLine) == 0)
-        {
-            if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
-            {
-                builder.Append(AnnotationsToDebugString(indent: indent + 2));
-            }
-        }
-
-        return builder.ToString();
-    }
+    new string Name { get; }
 }

--- a/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
@@ -169,7 +169,7 @@ public class CheckConstraint : ConventionAnnotatable, IMutableCheckConstraint, I
             detachedCheckConstraint.Sql,
             detachedCheckConstraint.GetConfigurationSource());
 
-        Attach(detachedCheckConstraint, newCheckConstraint);
+        MergeInto(detachedCheckConstraint, newCheckConstraint);
     }
 
     /// <summary>
@@ -178,7 +178,7 @@ public class CheckConstraint : ConventionAnnotatable, IMutableCheckConstraint, I
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static void Attach(IConventionCheckConstraint detachedCheckConstraint, IConventionCheckConstraint existingCheckConstraint)
+    public static void MergeInto(IConventionCheckConstraint detachedCheckConstraint, IConventionCheckConstraint existingCheckConstraint)
     {
         var nameConfigurationSource = detachedCheckConstraint.GetNameConfigurationSource();
         if (nameConfigurationSource != null)
@@ -415,6 +415,18 @@ public class CheckConstraint : ConventionAnnotatable, IMutableCheckConstraint, I
     /// </summary>
     public override string ToString()
         => ((ICheckConstraint)this).ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual DebugView DebugView
+        => new(
+            () => ((ICheckConstraint)this).ToDebugString(),
+            () => ((ICheckConstraint)this).ToDebugString(MetadataDebugStringOptions.LongDefault));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -651,6 +651,18 @@ public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConvention
     public override string ToString()
         => ((IDbFunction)this).ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual DebugView DebugView
+        => new(
+            () => ((IDbFunction)this).ToDebugString(),
+            () => ((IDbFunction)this).ToDebugString(MetadataDebugStringOptions.LongDefault));
+
     /// <inheritdoc />
     IConventionDbFunctionBuilder IConventionDbFunction.Builder
     {

--- a/src/EFCore.Relational/Metadata/Internal/EntityTypeMappingFragment.cs
+++ b/src/EFCore.Relational/Metadata/Internal/EntityTypeMappingFragment.cs
@@ -16,10 +16,11 @@ public class EntityTypeMappingFragment :
     IConventionEntityTypeMappingFragment
 {
     private bool? _isTableExcludedFromMigrations;
+    private InternalEntityTypeMappingFragmentBuilder? _builder;
 
     private ConfigurationSource _configurationSource;
     private ConfigurationSource? _isTableExcludedFromMigrationsConfigurationSource;
-    
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -34,7 +35,38 @@ public class EntityTypeMappingFragment :
         EntityType = entityType;
         StoreObject = storeObject;
         _configurationSource = configurationSource;
+        _builder = new InternalEntityTypeMappingFragmentBuilder(this, ((IConventionModel)entityType.Model).Builder);
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual InternalEntityTypeMappingFragmentBuilder Builder
+    {
+        [DebuggerStepThrough]
+        get => _builder ?? throw new InvalidOperationException(CoreStrings.ObjectRemovedFromModel);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool IsInModel
+        => _builder is not null;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual void SetRemovedFromModel()
+        => _builder = null;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -79,6 +111,44 @@ public class EntityTypeMappingFragment :
     public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
         => _configurationSource = configurationSource.Max(_configurationSource);
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static void Attach(IConventionEntityType entityType, IConventionEntityTypeMappingFragment detachedFragment)
+    {
+        var newFragment = GetOrCreate(
+            (IMutableEntityType)entityType,
+            detachedFragment.StoreObject,
+            detachedFragment.GetConfigurationSource());
+
+        MergeInto(detachedFragment, newFragment);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static EntityTypeMappingFragment MergeInto(
+        IConventionEntityTypeMappingFragment detachedFragment, IConventionEntityTypeMappingFragment existingFragment)
+    {
+        var isTableExcludedFromMigrationsConfigurationSource = detachedFragment.GetIsTableExcludedFromMigrationsConfigurationSource();
+        if (isTableExcludedFromMigrationsConfigurationSource != null)
+        {
+            existingFragment = ((InternalEntityTypeMappingFragmentBuilder)existingFragment.Builder).ExcludeTableFromMigrations(
+                detachedFragment.IsTableExcludedFromMigrations, isTableExcludedFromMigrationsConfigurationSource.Value)
+                !.Metadata;
+        }
+
+        return ((InternalEntityTypeMappingFragmentBuilder)existingFragment.Builder)
+            .MergeAnnotationsFrom((EntityTypeMappingFragment)detachedFragment)
+                .Metadata;
+    }
+
     /// <inheritdoc />
     public virtual bool? IsTableExcludedFromMigrations
     {
@@ -98,7 +168,7 @@ public class EntityTypeMappingFragment :
         {
             return null;
         }
-        
+
         _isTableExcludedFromMigrations = excluded;
         _isTableExcludedFromMigrationsConfigurationSource =
             excluded == null
@@ -160,7 +230,7 @@ public class EntityTypeMappingFragment :
         var fragment = fragments.Find(storeObject);
         if (fragment == null)
         {
-            fragment = new (entityType, storeObject, configurationSource);
+            fragment = new(entityType, storeObject, configurationSource);
             fragments.Add(storeObject, fragment);
         }
         else
@@ -170,7 +240,7 @@ public class EntityTypeMappingFragment :
 
         return fragment;
     }
-    
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -179,8 +249,7 @@ public class EntityTypeMappingFragment :
     /// </summary>
     public static EntityTypeMappingFragment? Remove(
         IMutableEntityType entityType,
-        in StoreObjectIdentifier storeObject,
-        ConfigurationSource configurationSource)
+        in StoreObjectIdentifier storeObject)
     {
         var fragments = (StoreObjectDictionary<EntityTypeMappingFragment>?)
             entityType[RelationalAnnotationNames.MappingFragments];
@@ -195,15 +264,32 @@ public class EntityTypeMappingFragment :
             return null;
         }
 
-        if (configurationSource.Overrides(fragment.GetConfigurationSource()))
-        {
-            fragments.Remove(storeObject);
+        fragments.Remove(storeObject);
+        fragment.SetRemovedFromModel();
 
-            return fragment;
-        }
-
-        return null;
+        return fragment;
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override string ToString()
+        => ((IEntityTypeMappingFragment)this).ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual DebugView DebugView
+        => new(
+            () => ((IEntityTypeMappingFragment)this).ToDebugString(),
+            () => ((IEntityTypeMappingFragment)this).ToDebugString(MetadataDebugStringOptions.LongDefault));
 
     /// <inheritdoc />
     IEntityType IEntityTypeMappingFragment.EntityType
@@ -211,7 +297,7 @@ public class EntityTypeMappingFragment :
         [DebuggerStepThrough]
         get => (IEntityType)EntityType;
     }
-    
+
     /// <inheritdoc />
     IMutableEntityType IMutableEntityTypeMappingFragment.EntityType
     {
@@ -229,5 +315,15 @@ public class EntityTypeMappingFragment :
     bool? IConventionEntityTypeMappingFragment.SetIsTableExcludedFromMigrations(bool? excluded, bool fromDataAnnotation)
         => SetIsTableExcludedFromMigrations(excluded, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
-    bool? IReadOnlyEntityTypeMappingFragment.IsTableExcludedFromMigrations => IsTableExcludedFromMigrations;
+    bool? IReadOnlyEntityTypeMappingFragment.IsTableExcludedFromMigrations
+    {
+        [DebuggerStepThrough]
+        get => IsTableExcludedFromMigrations;
+    }
+
+    IConventionEntityTypeMappingFragmentBuilder IConventionEntityTypeMappingFragment.Builder
+    {
+        [DebuggerStepThrough]
+        get => Builder;
+    }
 }

--- a/src/EFCore.Relational/Metadata/Internal/InternalCheckConstraintBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalCheckConstraintBuilder.cs
@@ -123,7 +123,7 @@ public class InternalCheckConstraintBuilder :
             {
                 foreach (var detachedCheckConstraint in detachedCheckConstraints)
                 {
-                    CheckConstraint.Attach(detachedCheckConstraint, constraint);
+                    CheckConstraint.MergeInto(detachedCheckConstraint, constraint);
                 }
             }
         }

--- a/src/EFCore.Relational/Metadata/Internal/InternalEntityTypeMappingFragmentBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalEntityTypeMappingFragmentBuilder.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class InternalEntityTypeMappingFragmentBuilder :
+    AnnotatableBuilder<EntityTypeMappingFragment, IConventionModelBuilder>,
+    IConventionEntityTypeMappingFragmentBuilder
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public InternalEntityTypeMappingFragmentBuilder(
+        EntityTypeMappingFragment fragment, IConventionModelBuilder modelBuilder)
+        : base(fragment, modelBuilder)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual InternalEntityTypeMappingFragmentBuilder? ExcludeTableFromMigrations(
+        bool? excludedFromMigrations,
+        ConfigurationSource configurationSource)
+    {
+        if (!CanExcludeTableFromMigrations(excludedFromMigrations, configurationSource))
+        {
+            return null;
+        }
+
+        Metadata.SetIsTableExcludedFromMigrations(excludedFromMigrations, configurationSource);
+        return this;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool CanExcludeTableFromMigrations(
+        bool? excludedFromMigrations,
+        ConfigurationSource configurationSource)
+        => configurationSource.Overrides(Metadata.GetIsTableExcludedFromMigrationsConfigurationSource())
+            || Metadata.IsTableExcludedFromMigrations == excludedFromMigrations;
+
+    /// <inheritdoc />
+    IConventionEntityTypeMappingFragment IConventionEntityTypeMappingFragmentBuilder.Metadata
+    {
+        [DebuggerStepThrough]
+        get => Metadata;
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/InternalRelationalPropertyOverridesBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalRelationalPropertyOverridesBuilder.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class InternalRelationalPropertyOverridesBuilder :
+    AnnotatableBuilder<RelationalPropertyOverrides, IConventionModelBuilder>,
+    IConventionRelationalPropertyOverridesBuilder
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public InternalRelationalPropertyOverridesBuilder(
+        RelationalPropertyOverrides overrides, IConventionModelBuilder modelBuilder)
+        : base(overrides, modelBuilder)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual InternalRelationalPropertyOverridesBuilder? HasColumnName(
+        string? name,
+        ConfigurationSource configurationSource)
+    {
+        if (!CanSetColumnName(name, configurationSource))
+        {
+            return null;
+        }
+
+        Metadata.SetColumnName(name, configurationSource);
+        
+        return this;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool CanSetColumnName(
+        string? name,
+        ConfigurationSource configurationSource)
+        => configurationSource.Overrides(Metadata.GetColumnNameConfigurationSource())
+            || Metadata.ColumnName == name;
+
+    /// <inheritdoc />
+    IConventionRelationalPropertyOverrides IConventionRelationalPropertyOverridesBuilder.Metadata
+    {
+        [DebuggerStepThrough]
+        get => Metadata;
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/InternalTriggerBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalTriggerBuilder.cs
@@ -66,7 +66,8 @@ public class InternalTriggerBuilder : AnnotatableBuilder<Trigger, IConventionMod
         var trigger = entityType.FindTrigger(name);
         if (trigger != null)
         {
-            if (trigger.TableName == tableName && trigger.TableSchema == tableSchema)
+            if ((tableName == null && tableSchema == null)
+                || (trigger.TableName == tableName && trigger.TableSchema == tableSchema))
             {
                 ((Trigger)trigger).UpdateConfigurationSource(configurationSource);
                 return trigger;
@@ -83,14 +84,14 @@ public class InternalTriggerBuilder : AnnotatableBuilder<Trigger, IConventionMod
         {
             foreach (var derivedType in entityType.GetDerivedTypes())
             {
-                var derivedTrigger =
-                    (IConventionTrigger?)Trigger.FindDeclaredTrigger(derivedType, name);
+                var derivedTrigger = (IConventionTrigger?)Trigger.FindDeclaredTrigger(derivedType, name);
                 if (derivedTrigger == null)
                 {
                     continue;
                 }
 
-                if ((derivedTrigger.TableName != tableName || derivedTrigger.TableSchema != tableSchema)
+                if ((tableName != null || tableSchema != null)
+                    && (derivedTrigger.TableName != tableName || derivedTrigger.TableSchema != tableSchema)
                     && !configurationSource.Overrides(derivedTrigger.GetConfigurationSource()))
                 {
                     return null;
@@ -139,6 +140,12 @@ public class InternalTriggerBuilder : AnnotatableBuilder<Trigger, IConventionMod
         string? tableSchema,
         ConfigurationSource configurationSource)
     {
+        if (tableName == null
+            && tableSchema == null)
+        {
+            return true;
+        }
+
         if (entityType.FindTrigger(name) is IConventionTrigger trigger)
         {
             return (trigger.TableName == tableName

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -970,7 +970,8 @@ public class RelationalModel : Annotatable, IRelationalModel
                 }
             }
 
-            foreach (var trigger in entityType.GetTriggers())
+            // Triggers cannot be inherited
+            foreach (var trigger in entityType.GetDeclaredTriggers())
             {
                 var name = trigger.GetName(storeObject);
                 if (name == null)
@@ -979,7 +980,7 @@ public class RelationalModel : Annotatable, IRelationalModel
                 }
 
                 Check.DebugAssert(trigger.TableName == table.Name, "Mismatch in trigger table name");
-                Check.DebugAssert(trigger.TableSchema is null || trigger.TableSchema == table.Schema, "Mismatch in trigger table schema");
+                Check.DebugAssert(trigger.TableSchema == table.Schema, "Mismatch in trigger table schema");
 
                 if (!table.Triggers.ContainsKey(name))
                 {

--- a/src/EFCore.Relational/Metadata/RuntimeEntityTypeMappingFragment.cs
+++ b/src/EFCore.Relational/Metadata/RuntimeEntityTypeMappingFragment.cs
@@ -44,6 +44,22 @@ public class RuntimeEntityTypeMappingFragment : AnnotatableBase, IEntityTypeMapp
     public virtual bool? IsTableExcludedFromMigrations => (bool?)this[RelationalAnnotationNames.IsTableExcludedFromMigrations];
 
     /// <inheritdoc />
+    public override string ToString()
+        => ((IEntityTypeMappingFragment)this).ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual DebugView DebugView
+        => new(
+            () => ((IEntityTypeMappingFragment)this).ToDebugString(),
+            () => ((IEntityTypeMappingFragment)this).ToDebugString(MetadataDebugStringOptions.LongDefault));
+
+    /// <inheritdoc />
     IEntityType IEntityTypeMappingFragment.EntityType
     {
         [DebuggerStepThrough]

--- a/src/EFCore.Relational/Metadata/RuntimeRelationalPropertyOverrides.cs
+++ b/src/EFCore.Relational/Metadata/RuntimeRelationalPropertyOverrides.cs
@@ -41,6 +41,22 @@ public class RuntimeRelationalPropertyOverrides : AnnotatableBase, IRelationalPr
     public virtual StoreObjectIdentifier StoreObject { get; }
 
     /// <inheritdoc />
+    public override string ToString()
+        => ((IRelationalPropertyOverrides)this).ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual DebugView DebugView
+        => new(
+            () => ((IRelationalPropertyOverrides)this).ToDebugString(),
+            () => ((IRelationalPropertyOverrides)this).ToDebugString(MetadataDebugStringOptions.LongDefault));
+
+    /// <inheritdoc />
     IProperty IRelationalPropertyOverrides.Property
     {
         [DebuggerStepThrough]

--- a/src/EFCore.Relational/Metadata/RuntimeTrigger.cs
+++ b/src/EFCore.Relational/Metadata/RuntimeTrigger.cs
@@ -20,7 +20,7 @@ public class RuntimeTrigger : AnnotatableBase, ITrigger
     public RuntimeTrigger(
         RuntimeEntityType entityType,
         string modelName,
-        string? name,
+        string name,
         string tableName,
         string? tableSchema)
     {
@@ -37,11 +37,15 @@ public class RuntimeTrigger : AnnotatableBase, ITrigger
     /// <summary>
     ///     Gets the database name of the trigger.
     /// </summary>
-    public virtual string? Name { get; }
+    public virtual string Name { get; }
 
     /// <inheritdoc />
     public virtual string? GetName(in StoreObjectIdentifier storeObject)
-        => Name;
+        => storeObject.StoreObjectType == StoreObjectType.Table
+                && TableName == storeObject.Name
+                && TableSchema == storeObject.Schema
+            ? Name
+            : null;
 
     /// <inheritdoc />
     public virtual string TableName { get; }
@@ -51,6 +55,22 @@ public class RuntimeTrigger : AnnotatableBase, ITrigger
 
     /// <inheritdoc />
     public virtual IEntityType EntityType { get; }
+
+    /// <inheritdoc />
+    public override string ToString()
+        => ((ITrigger)this).ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual DebugView DebugView
+        => new(
+            () => ((ITrigger)this).ToDebugString(),
+            () => ((ITrigger)this).ToDebugString(MetadataDebugStringOptions.LongDefault));
 
     /// <inheritdoc />
     IReadOnlyEntityType IReadOnlyTrigger.EntityType

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -176,6 +176,13 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
         return fragments;
     }
 
+    /// <inheritdoc />
+    public override IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+        IRelationalPropertyOverrides overrides, IDictionary<String, IAnnotation> annotations)
+    {
+        return base.GenerateFluentApiCalls(overrides, annotations);
+    }
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
@@ -106,4 +106,17 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
 
         base.Generate(entityType, parameters);
     }
+
+    /// <inheritdoc />
+    public override void Generate(IRelationalPropertyOverrides overrides, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+    {
+        if (!parameters.IsRuntime)
+        {
+            var annotations = parameters.Annotations;
+            annotations.Remove(SqlServerAnnotationNames.IdentityIncrement);
+            annotations.Remove(SqlServerAnnotationNames.IdentitySeed);
+        }
+        
+        base.Generate(overrides, parameters);
+    }
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
@@ -184,6 +184,32 @@ public static class SqlServerPropertyBuilderExtensions
         => propertyBuilder.UseIdentityColumn((long)seed, increment);
 
     /// <summary>
+    ///     Configures the key column to use the SQL Server IDENTITY feature to generate values for new entities,
+    ///     when targeting SQL Server. This method sets the property to be <see cref="ValueGenerated.OnAdd" />.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="columnBuilder">The builder for the column being configured.</param>
+    /// <param name="seed">The value that is used for the very first row loaded into the table.</param>
+    /// <param name="increment">The incremental value that is added to the identity value of the previous row that was loaded.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static ColumnBuilder UseIdentityColumn(
+        this ColumnBuilder columnBuilder,
+        long seed = 1,
+        int increment = 1)
+    {
+        var overrides = columnBuilder.Overrides;
+        overrides.SetValueGenerationStrategy(SqlServerValueGenerationStrategy.IdentityColumn);
+        overrides.SetIdentitySeed(seed);
+        overrides.SetIdentityIncrement(increment);
+
+        return columnBuilder;
+    }
+
+    /// <summary>
     ///     Configures the key property to use the SQL Server IDENTITY feature to generate values for new entities,
     ///     when targeting SQL Server. This method sets the property to be <see cref="ValueGenerated.OnAdd" />.
     /// </summary>
@@ -224,6 +250,26 @@ public static class SqlServerPropertyBuilderExtensions
         => (PropertyBuilder<TProperty>)UseIdentityColumn((PropertyBuilder)propertyBuilder, (long)seed, increment);
 
     /// <summary>
+    ///     Configures the key column to use the SQL Server IDENTITY feature to generate values for new entities,
+    ///     when targeting SQL Server. This method sets the property to be <see cref="ValueGenerated.OnAdd" />.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+    /// <param name="columnBuilder">The builder for the column being configured.</param>
+    /// <param name="seed">The value that is used for the very first row loaded into the table.</param>
+    /// <param name="increment">The incremental value that is added to the identity value of the previous row that was loaded.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static ColumnBuilder<TProperty> UseIdentityColumn<TProperty>(
+        this ColumnBuilder<TProperty> columnBuilder,
+        long seed = 1,
+        int increment = 1)
+        => (ColumnBuilder<TProperty>)UseIdentityColumn((ColumnBuilder)columnBuilder, seed, increment);
+
+    /// <summary>
     ///     Configures the seed for SQL Server IDENTITY.
     /// </summary>
     /// <remarks>
@@ -253,6 +299,37 @@ public static class SqlServerPropertyBuilderExtensions
     }
 
     /// <summary>
+    ///     Configures the seed for SQL Server IDENTITY for a particular table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="seed">The value that is used for the very first row loaded into the table.</param>
+    /// <param name="storeObject">The table identifier.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionPropertyBuilder? HasIdentityColumnSeed(
+        this IConventionPropertyBuilder propertyBuilder,
+        long? seed,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+    {
+        if (propertyBuilder.CanSetIdentityColumnSeed(seed, storeObject, fromDataAnnotation))
+        {
+            propertyBuilder.Metadata.SetIdentitySeed(seed, storeObject, fromDataAnnotation);
+            return propertyBuilder;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     ///     Returns a value indicating whether the given value can be set as the seed for SQL Server IDENTITY.
     /// </summary>
     /// <remarks>
@@ -269,6 +346,32 @@ public static class SqlServerPropertyBuilderExtensions
         long? seed,
         bool fromDataAnnotation = false)
         => propertyBuilder.CanSetAnnotation(SqlServerAnnotationNames.IdentitySeed, seed, fromDataAnnotation);
+
+    /// <summary>
+    ///     Returns a value indicating whether the given value can be set as the seed for SQL Server IDENTITY
+    ///     for a particular table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="seed">The value that is used for the very first row loaded into the table.</param>
+    /// <param name="storeObject">The table identifier.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the given value can be set as the seed for SQL Server IDENTITY.</returns>
+    public static bool CanSetIdentityColumnSeed(
+        this IConventionPropertyBuilder propertyBuilder,
+        long? seed,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+        => propertyBuilder.Metadata.FindOverrides(storeObject)?.Builder
+            .CanSetAnnotation(
+                SqlServerAnnotationNames.IdentitySeed,
+                seed,
+                fromDataAnnotation)
+            ?? true;
 
     /// <summary>
     ///     Configures the increment for SQL Server IDENTITY.
@@ -300,6 +403,37 @@ public static class SqlServerPropertyBuilderExtensions
     }
 
     /// <summary>
+    ///     Configures the increment for SQL Server IDENTITY for a particular table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="increment">The incremental value that is added to the identity value of the previous row that was loaded.</param> 
+    /// <param name="storeObject">The table identifier.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionPropertyBuilder? HasIdentityColumnIncrement(
+        this IConventionPropertyBuilder propertyBuilder,
+        int? increment,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+    {
+        if (propertyBuilder.CanSetIdentityColumnIncrement(increment, storeObject, fromDataAnnotation))
+        {
+            propertyBuilder.Metadata.SetIdentityIncrement(increment, storeObject, fromDataAnnotation);
+            return propertyBuilder;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     ///     Returns a value indicating whether the given value can be set as the increment for SQL Server IDENTITY.
     /// </summary>
     /// <remarks>
@@ -316,6 +450,32 @@ public static class SqlServerPropertyBuilderExtensions
         int? increment,
         bool fromDataAnnotation = false)
         => propertyBuilder.CanSetAnnotation(SqlServerAnnotationNames.IdentityIncrement, increment, fromDataAnnotation);
+
+    /// <summary>
+    ///     Returns a value indicating whether the given value can be set as the increment for SQL Server IDENTITY
+    ///     for a particular table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="increment">The incremental value that is added to the identity value of the previous row that was loaded.</param>
+    /// <param name="storeObject">The table identifier.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the given value can be set as the default increment for SQL Server IDENTITY.</returns>
+    public static bool CanSetIdentityColumnIncrement(
+        this IConventionPropertyBuilder propertyBuilder,
+        int? increment,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+        => propertyBuilder.Metadata.FindOverrides(storeObject)?.Builder
+            .CanSetAnnotation(
+                SqlServerAnnotationNames.IdentityIncrement,
+                increment,
+                fromDataAnnotation)
+            ?? true;
 
     /// <summary>
     ///     Configures the value generation strategy for the key property, when targeting SQL Server.
@@ -359,6 +519,43 @@ public static class SqlServerPropertyBuilderExtensions
     }
 
     /// <summary>
+    ///     Configures the value generation strategy for the key property, when targeting SQL Server for a particular table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="valueGenerationStrategy">The value generation strategy.</param>
+    /// <param name="storeObject">The table identifier.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionPropertyBuilder? HasValueGenerationStrategy(
+        this IConventionPropertyBuilder propertyBuilder,
+        SqlServerValueGenerationStrategy? valueGenerationStrategy,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+    {
+        if (propertyBuilder.CanSetValueGenerationStrategy(valueGenerationStrategy, storeObject, fromDataAnnotation))
+        {
+            propertyBuilder.Metadata.SetValueGenerationStrategy(valueGenerationStrategy, storeObject, fromDataAnnotation);
+            if (valueGenerationStrategy != SqlServerValueGenerationStrategy.IdentityColumn)
+            {
+                propertyBuilder.HasIdentityColumnSeed(null, storeObject, fromDataAnnotation);
+                propertyBuilder.HasIdentityColumnIncrement(null, storeObject, fromDataAnnotation);
+            }
+
+            return propertyBuilder;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     ///     Returns a value indicating whether the given value can be set as the value generation strategy.
     /// </summary>
     /// <remarks>
@@ -378,6 +575,33 @@ public static class SqlServerPropertyBuilderExtensions
                 || SqlServerPropertyExtensions.IsCompatibleWithValueGeneration(propertyBuilder.Metadata))
             && propertyBuilder.CanSetAnnotation(
                 SqlServerAnnotationNames.ValueGenerationStrategy, valueGenerationStrategy, fromDataAnnotation);
+
+    /// <summary>
+    ///     Returns a value indicating whether the given value can be set as the value generation strategy for a particular table.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see>, and
+    ///     <see href="https://aka.ms/efcore-docs-sqlserver">Accessing SQL Server and SQL Azure databases with EF Core</see>
+    ///     for more information and examples.
+    /// </remarks>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="valueGenerationStrategy">The value generation strategy.</param>
+    /// <param name="storeObject">The table identifier.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the given value can be set as the default value generation strategy.</returns>
+    public static bool CanSetValueGenerationStrategy(
+        this IConventionPropertyBuilder propertyBuilder,
+        SqlServerValueGenerationStrategy? valueGenerationStrategy,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+        => (valueGenerationStrategy == null
+                || SqlServerPropertyExtensions.IsCompatibleWithValueGeneration(propertyBuilder.Metadata))
+            && (propertyBuilder.Metadata.FindOverrides(storeObject)?.Builder
+                .CanSetAnnotation(
+                    SqlServerAnnotationNames.ValueGenerationStrategy,
+                    valueGenerationStrategy,
+                    fromDataAnnotation)
+                ?? true);
 
     /// <summary>
     ///     Configures whether the property's column is created as sparse when targeting SQL Server.

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -231,6 +231,12 @@ public static class SqlServerPropertyExtensions
             throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData);
         }
 
+        var @override = property.FindOverrides(storeObject)?.FindAnnotation(SqlServerAnnotationNames.IdentitySeed);
+        if (@override != null)
+        {
+            return (long?)@override.Value;
+        }
+
         var annotation = property.FindAnnotation(SqlServerAnnotationNames.IdentitySeed);
         if (annotation is not null)
         {
@@ -245,6 +251,16 @@ public static class SqlServerPropertyExtensions
             ? property.DeclaringEntityType.Model.GetIdentitySeed()
             : sharedProperty.GetIdentitySeed(storeObject);
     }
+
+    /// <summary>
+    ///     Returns the identity seed.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <returns>The identity seed.</returns>
+    public static long? GetIdentitySeed(this IReadOnlyRelationalPropertyOverrides overrides)
+        => overrides is RuntimeRelationalPropertyOverrides
+            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+            : (long?)overrides.FindAnnotation(SqlServerAnnotationNames.IdentitySeed)?.Value;
 
     /// <summary>
     ///     Sets the identity seed.
@@ -277,12 +293,82 @@ public static class SqlServerPropertyExtensions
     }
 
     /// <summary>
+    ///     Sets the identity seed for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="seed">The value to set.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    public static void SetIdentitySeed(
+        this IMutableProperty property,
+        long? seed,
+        in StoreObjectIdentifier storeObject)
+        => property.GetOrCreateOverrides(storeObject)
+            .SetIdentitySeed(seed);
+
+    /// <summary>
+    ///     Sets the identity seed for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="seed">The value to set.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static long? SetIdentitySeed(
+        this IConventionProperty property,
+        long? seed,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+        => property.GetOrCreateOverrides(storeObject, fromDataAnnotation)
+            .SetIdentitySeed(seed, fromDataAnnotation);
+
+    /// <summary>
+    ///     Sets the identity seed for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <param name="seed">The value to set.</param>
+    public static void SetIdentitySeed(this IMutableRelationalPropertyOverrides overrides, long? seed)
+        => overrides.SetOrRemoveAnnotation(SqlServerAnnotationNames.IdentitySeed, seed);
+
+    /// <summary>
+    ///     Sets the identity seed for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <param name="seed">The value to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static long? SetIdentitySeed(
+        this IConventionRelationalPropertyOverrides overrides,
+        long? seed,
+        bool fromDataAnnotation = false)
+        => (long?)overrides.SetOrRemoveAnnotation(SqlServerAnnotationNames.IdentitySeed, seed, fromDataAnnotation)?.Value;
+
+    /// <summary>
     ///     Returns the <see cref="ConfigurationSource" /> for the identity seed.
     /// </summary>
     /// <param name="property">The property.</param>
     /// <returns>The <see cref="ConfigurationSource" /> for the identity seed.</returns>
     public static ConfigurationSource? GetIdentitySeedConfigurationSource(this IConventionProperty property)
         => property.FindAnnotation(SqlServerAnnotationNames.IdentitySeed)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for the identity seed for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the identity seed.</returns>
+    public static ConfigurationSource? GetIdentitySeedConfigurationSource(
+        this IConventionProperty property,
+        in StoreObjectIdentifier storeObject)
+        => property.FindOverrides(storeObject)?.GetIdentitySeedConfigurationSource();
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for the identity seed for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the identity seed.</returns>
+    public static ConfigurationSource? GetIdentitySeedConfigurationSource(
+        this IConventionRelationalPropertyOverrides overrides)
+        => overrides.FindAnnotation(SqlServerAnnotationNames.IdentitySeed)?.GetConfigurationSource();
 
     /// <summary>
     ///     Returns the identity increment.
@@ -308,6 +394,12 @@ public static class SqlServerPropertyExtensions
             throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData);
         }
 
+        var @override = property.FindOverrides(storeObject)?.FindAnnotation(SqlServerAnnotationNames.IdentityIncrement);
+        if (@override != null)
+        {
+            return (int?)@override.Value;
+        }
+
         var annotation = property.FindAnnotation(SqlServerAnnotationNames.IdentityIncrement);
         if (annotation != null)
         {
@@ -319,6 +411,16 @@ public static class SqlServerPropertyExtensions
             ? property.DeclaringEntityType.Model.GetIdentityIncrement()
             : sharedProperty.GetIdentityIncrement(storeObject);
     }
+
+    /// <summary>
+    ///     Returns the identity increment.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <returns>The identity increment.</returns>
+    public static int? GetIdentityIncrement(this IReadOnlyRelationalPropertyOverrides overrides)
+        => overrides is RuntimeRelationalPropertyOverrides
+            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+            : (int?)overrides.FindAnnotation(SqlServerAnnotationNames.IdentityIncrement)?.Value;
 
     /// <summary>
     ///     Sets the identity increment.
@@ -341,14 +443,61 @@ public static class SqlServerPropertyExtensions
         this IConventionProperty property,
         int? increment,
         bool fromDataAnnotation = false)
-    {
-        property.SetOrRemoveAnnotation(
+        => (int?)property.SetOrRemoveAnnotation(
             SqlServerAnnotationNames.IdentityIncrement,
             increment,
-            fromDataAnnotation);
+            fromDataAnnotation)?.Value;
 
-        return increment;
-    }
+    /// <summary>
+    ///     Sets the identity increment for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="increment">The value to set.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    public static void SetIdentityIncrement(
+        this IMutableProperty property,
+        int? increment,
+        in StoreObjectIdentifier storeObject)
+        => property.GetOrCreateOverrides(storeObject)
+            .SetIdentityIncrement(increment);
+
+    /// <summary>
+    ///     Sets the identity increment for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="increment">The value to set.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static int? SetIdentityIncrement(
+        this IConventionProperty property,
+        int? increment,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+        => property.GetOrCreateOverrides(storeObject, fromDataAnnotation)
+            .SetIdentityIncrement(increment, fromDataAnnotation);
+
+    /// <summary>
+    ///     Sets the identity increment for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <param name="increment">The value to set.</param>
+    public static void SetIdentityIncrement(this IMutableRelationalPropertyOverrides overrides, int? increment)
+        => overrides.SetOrRemoveAnnotation(SqlServerAnnotationNames.IdentityIncrement, increment);
+
+    /// <summary>
+    ///     Sets the identity increment for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <param name="increment">The value to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static int? SetIdentityIncrement(
+        this IConventionRelationalPropertyOverrides overrides,
+        int? increment,
+        bool fromDataAnnotation = false)
+        => (int?)overrides.SetOrRemoveAnnotation(SqlServerAnnotationNames.IdentityIncrement, increment, fromDataAnnotation)
+            ?.Value;
 
     /// <summary>
     ///     Returns the <see cref="ConfigurationSource" /> for the identity increment.
@@ -357,6 +506,26 @@ public static class SqlServerPropertyExtensions
     /// <returns>The <see cref="ConfigurationSource" /> for the identity increment.</returns>
     public static ConfigurationSource? GetIdentityIncrementConfigurationSource(this IConventionProperty property)
         => property.FindAnnotation(SqlServerAnnotationNames.IdentityIncrement)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for the identity increment for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the identity increment.</returns>
+    public static ConfigurationSource? GetIdentityIncrementConfigurationSource(
+        this IConventionProperty property,
+        in StoreObjectIdentifier storeObject)
+        => property.FindOverrides(storeObject)?.GetIdentityIncrementConfigurationSource();
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for the identity increment for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the identity increment.</returns>
+    public static ConfigurationSource? GetIdentityIncrementConfigurationSource(
+        this IConventionRelationalPropertyOverrides overrides)
+        => overrides.FindAnnotation(SqlServerAnnotationNames.IdentityIncrement)?.GetConfigurationSource();
 
     /// <summary>
     ///     Returns the <see cref="SqlServerValueGenerationStrategy" /> to use for the property.
@@ -405,6 +574,12 @@ public static class SqlServerPropertyExtensions
         in StoreObjectIdentifier storeObject,
         ITypeMappingSource? typeMappingSource)
     {
+        var @override = property.FindOverrides(storeObject)?.FindAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy);
+        if (@override != null)
+        {
+            return (SqlServerValueGenerationStrategy?)@override.Value ?? SqlServerValueGenerationStrategy.None;
+        }
+        
         var annotation = property.FindAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy);
         if (annotation?.Value != null
             && StoreObjectIdentifier.Create(property.DeclaringEntityType, storeObject.StoreObjectType) == storeObject)
@@ -454,6 +629,19 @@ public static class SqlServerPropertyExtensions
 
         return defaultStategy;
     }
+
+    /// <summary>
+    ///     Returns the <see cref="SqlServerValueGenerationStrategy" /> to use for the property.
+    /// </summary>
+    /// <remarks>
+    ///     If no strategy is set for the property, then the strategy to use will be taken from the <see cref="IModel" />.
+    /// </remarks>
+    /// <param name="overrides">The property overrides.</param>
+    /// <returns>The strategy, or <see cref="SqlServerValueGenerationStrategy.None" /> if none was set.</returns>
+    public static SqlServerValueGenerationStrategy? GetValueGenerationStrategy(
+        this IReadOnlyRelationalPropertyOverrides overrides)
+        => (SqlServerValueGenerationStrategy?)overrides.FindAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy)
+            ?.Value;
 
     private static SqlServerValueGenerationStrategy GetDefaultValueGenerationStrategy(IReadOnlyProperty property)
     {
@@ -517,9 +705,71 @@ public static class SqlServerPropertyExtensions
     {
         CheckValueGenerationStrategy(property, value);
 
-        property.SetOrRemoveAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy, value, fromDataAnnotation);
+        return (SqlServerValueGenerationStrategy?)property.SetOrRemoveAnnotation(
+            SqlServerAnnotationNames.ValueGenerationStrategy, value, fromDataAnnotation)
+            ?.Value;
+    }
 
-        return value;
+    /// <summary>
+    ///     Sets the <see cref="SqlServerValueGenerationStrategy" /> to use for the property for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="value">The strategy to use.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    public static void SetValueGenerationStrategy(
+        this IMutableProperty property,
+        SqlServerValueGenerationStrategy? value,
+        in StoreObjectIdentifier storeObject)
+        => property.GetOrCreateOverrides(storeObject)
+            .SetValueGenerationStrategy(value);
+
+    /// <summary>
+    ///     Sets the <see cref="SqlServerValueGenerationStrategy" /> to use for the property for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="value">The strategy to use.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static SqlServerValueGenerationStrategy? SetValueGenerationStrategy(
+        this IConventionProperty property,
+        SqlServerValueGenerationStrategy? value,
+        in StoreObjectIdentifier storeObject,
+        bool fromDataAnnotation = false)
+        => property.GetOrCreateOverrides(storeObject, fromDataAnnotation)
+            .SetValueGenerationStrategy(value, fromDataAnnotation);
+
+    /// <summary>
+    ///     Sets the <see cref="SqlServerValueGenerationStrategy" /> to use for the property for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <param name="value">The strategy to use.</param>
+    public static void SetValueGenerationStrategy(
+        this IMutableRelationalPropertyOverrides overrides,
+        SqlServerValueGenerationStrategy? value)
+    {
+        CheckValueGenerationStrategy(overrides.Property, value);
+
+        overrides.SetOrRemoveAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy, value);
+    }
+
+    /// <summary>
+    ///     Sets the <see cref="SqlServerValueGenerationStrategy" /> to use for the property for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <param name="value">The strategy to use.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static SqlServerValueGenerationStrategy? SetValueGenerationStrategy(
+        this IConventionRelationalPropertyOverrides overrides,
+        SqlServerValueGenerationStrategy? value,
+        bool fromDataAnnotation = false)
+    {
+        CheckValueGenerationStrategy(overrides.Property, value);
+
+        return (SqlServerValueGenerationStrategy?)overrides.SetOrRemoveAnnotation(
+                SqlServerAnnotationNames.ValueGenerationStrategy, value, fromDataAnnotation)
+            ?.Value;
     }
 
     private static void CheckValueGenerationStrategy(IReadOnlyProperty property, SqlServerValueGenerationStrategy? value)
@@ -556,6 +806,26 @@ public static class SqlServerPropertyExtensions
         => property.FindAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy)?.GetConfigurationSource();
 
     /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for the <see cref="SqlServerValueGenerationStrategy" /> for a particular table.
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <param name="storeObject">The identifier of the table containing the column.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the <see cref="SqlServerValueGenerationStrategy" />.</returns>
+    public static ConfigurationSource? GetValueGenerationStrategyConfigurationSource(
+        this IConventionProperty property,
+        in StoreObjectIdentifier storeObject)
+        => property.FindOverrides(storeObject)?.GetValueGenerationStrategyConfigurationSource();
+
+    /// <summary>
+    ///     Returns the <see cref="ConfigurationSource" /> for the <see cref="SqlServerValueGenerationStrategy" /> for a particular table.
+    /// </summary>
+    /// <param name="overrides">The property overrides.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the <see cref="SqlServerValueGenerationStrategy" />.</returns>
+    public static ConfigurationSource? GetValueGenerationStrategyConfigurationSource(
+        this IConventionRelationalPropertyOverrides overrides)
+        => overrides.FindAnnotation(SqlServerAnnotationNames.ValueGenerationStrategy)?.GetConfigurationSource();
+
+    /// <summary>
     ///     Returns a value indicating whether the property is compatible with any <see cref="SqlServerValueGenerationStrategy" />.
     /// </summary>
     /// <param name="property">The property.</param>
@@ -566,10 +836,9 @@ public static class SqlServerPropertyExtensions
             ?? property.FindTypeMapping()?.Converter;
 
         var type = (valueConverter?.ProviderClrType ?? property.ClrType).UnwrapNullableType();
-
-        return (type.IsInteger()
+        return type.IsInteger()
             || type.IsEnum
-            || type == typeof(decimal));
+            || type == typeof(decimal);
     }
 
     private static bool IsCompatibleWithValueGeneration(

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerRuntimeModelConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerRuntimeModelConvention.cs
@@ -29,13 +29,7 @@ public class SqlServerRuntimeModelConvention : RelationalRuntimeModelConvention
     {
     }
 
-    /// <summary>
-    ///     Updates the model annotations that will be set on the read-only object.
-    /// </summary>
-    /// <param name="annotations">The annotations to be processed.</param>
-    /// <param name="model">The source model.</param>
-    /// <param name="runtimeModel">The target model that will contain the annotations.</param>
-    /// <param name="runtime">Indicates whether the given annotations are runtime annotations.</param>
+    /// <inheritdoc />
     protected override void ProcessModelAnnotations(
         Dictionary<string, object?> annotations,
         IModel model,
@@ -54,13 +48,7 @@ public class SqlServerRuntimeModelConvention : RelationalRuntimeModelConvention
         }
     }
 
-    /// <summary>
-    ///     Updates the property annotations that will be set on the read-only object.
-    /// </summary>
-    /// <param name="annotations">The annotations to be processed.</param>
-    /// <param name="property">The source property.</param>
-    /// <param name="runtimeProperty">The target property that will contain the annotations.</param>
-    /// <param name="runtime">Indicates whether the given annotations are runtime annotations.</param>
+    /// <inheritdoc />
     protected override void ProcessPropertyAnnotations(
         Dictionary<string, object?> annotations,
         IProperty property,
@@ -82,13 +70,23 @@ public class SqlServerRuntimeModelConvention : RelationalRuntimeModelConvention
         }
     }
 
-    /// <summary>
-    ///     Updates the index annotations that will be set on the read-only object.
-    /// </summary>
-    /// <param name="annotations">The annotations to be processed.</param>
-    /// <param name="index">The source index.</param>
-    /// <param name="runtimeIndex">The target index that will contain the annotations.</param>
-    /// <param name="runtime">Indicates whether the given annotations are runtime annotations.</param>
+    /// <inheritdoc />
+    protected override void ProcessPropertyOverridesAnnotations(
+        Dictionary<string, object?> annotations,
+        IRelationalPropertyOverrides propertyOverrides,
+        RuntimeRelationalPropertyOverrides runtimePropertyOverrides,
+        bool runtime)
+    {
+        base.ProcessPropertyOverridesAnnotations(annotations, propertyOverrides, runtimePropertyOverrides, runtime);
+        
+        if (!runtime)
+        {
+            annotations.Remove(SqlServerAnnotationNames.IdentityIncrement);
+            annotations.Remove(SqlServerAnnotationNames.IdentitySeed);
+        }
+    }
+
+    /// <inheritdoc />
     protected override void ProcessIndexAnnotations(
         Dictionary<string, object?> annotations,
         IIndex index,
@@ -106,13 +104,7 @@ public class SqlServerRuntimeModelConvention : RelationalRuntimeModelConvention
         }
     }
 
-    /// <summary>
-    ///     Updates the key annotations that will be set on the read-only object.
-    /// </summary>
-    /// <param name="annotations">The annotations to be processed.</param>
-    /// <param name="key">The source key.</param>
-    /// <param name="runtimeKey">The target key that will contain the annotations.</param>
-    /// <param name="runtime">Indicates whether the given annotations are runtime annotations.</param>
+    /// <inheritdoc />
     protected override void ProcessKeyAnnotations(
         IDictionary<string, object?> annotations,
         IKey key,
@@ -127,13 +119,7 @@ public class SqlServerRuntimeModelConvention : RelationalRuntimeModelConvention
         }
     }
 
-    /// <summary>
-    ///     Updates the entity type annotations that will be set on the read-only object.
-    /// </summary>
-    /// <param name="annotations">The annotations to be processed.</param>
-    /// <param name="entityType">The source entity type.</param>
-    /// <param name="runtimeEntityType">The target entity type that will contain the annotations.</param>
-    /// <param name="runtime">Indicates whether the given annotations are runtime annotations.</param>
+    /// <inheritdoc />
     protected override void ProcessEntityTypeAnnotations(
         IDictionary<string, object?> annotations,
         IEntityType entityType,

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -846,5 +846,5 @@ public class SqlServerUpdateSqlGenerator : SelectingUpdateSqlGenerator, ISqlServ
         // Data seeding doesn't provide any entries, so we we don't know if the table has triggers; assume it does to generate SQL
         // that works everywhere.
         => command.Entries.Count == 0
-            || command.Entries[0].EntityType.Model.GetRelationalModel().FindTable(command.TableName, command.Schema)!.Triggers.Any();
+            || command.Table!.Triggers.Any();
 }

--- a/src/EFCore/Infrastructure/ConventionAnnotatable.cs
+++ b/src/EFCore/Infrastructure/ConventionAnnotatable.cs
@@ -56,6 +56,7 @@ public abstract class ConventionAnnotatable : Annotatable, IConventionAnnotatabl
     /// <param name="name">The key of the annotation to be added.</param>
     /// <param name="value">The value to be stored in the annotation.</param>
     /// <param name="configurationSource">The configuration source of the annotation to be set.</param>
+    /// <returns>The new annotation.</returns>
     public virtual ConventionAnnotation? SetAnnotation(
         string name,
         object? value,
@@ -77,11 +78,14 @@ public abstract class ConventionAnnotatable : Annotatable, IConventionAnnotatabl
     }
 
     /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     Sets the annotation with given key and value on this object using given configuration source.
+    ///     Removes the existing annotation if an annotation with the specified name already exists and
+    ///     <paramref name="value"/> is <see langword="null"/>.
     /// </summary>
+    /// <param name="name">The key of the annotation to be added.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <param name="configurationSource">The configuration source of the annotation to be set.</param>
+    /// <returns>The new annotation.</returns>
     public virtual ConventionAnnotation? SetOrRemoveAnnotation(
         string name,
         object? value,

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1252,10 +1252,12 @@ namespace TestNamespace
             {
                 entity.Property(e => e.Id).UseIdentityColumn();
 
-                entity.ToTable(tb => {
-                    tb.HasTrigger(""Trigger1"");
-                    tb.HasTrigger(""Trigger2"");
-                });
+                entity.ToTable(tb =>
+                    {
+                        tb.HasTrigger(""Trigger1"");
+
+                        tb.HasTrigger(""Trigger2"");
+                    });
             });
 
             OnModelCreatingPartial(modelBuilder);


### PR DESCRIPTION
Add support for annotations to mapping fragments, property overrides and sequences
Update back-reference on mapping fragments and overrides when reattaching

Fixes #28195
Fixes #28237