### PR TITLE
Adjust DetectChanges events so they can be used to get a notification when all changes for an entity have been detected

### DIFF
--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -381,25 +381,63 @@ public class ChangeTracker : IResettableService
     }
 
     /// <summary>
-    ///     An event fired when detecting changes to the entity graph or a single entity is about to happen, either through an
+    ///     An event fired when detecting changes to a single entity is about to happen, either through an
     ///     explicit call to <see cref="DetectChanges" /> or <see cref="EntityEntry.DetectChanges" />, or automatically, such as part of
     ///     executing <see cref="DbContext.SaveChanges()" /> or <see cref="DbContext.SaveChangesAsync(System.Threading.CancellationToken)" />.
     /// </summary>
-    public event EventHandler<DetectChangesEventArgs> DetectingChanges
+    /// <remarks>
+    ///     <see cref="AutoDetectChangesEnabled" /> is set to <see langword="false" /> for the duration of the event to prevent an infinite
+    ///     loop of recursive automatic calls.
+    /// </remarks>
+    public event EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges
     {
-        add => ChangeDetector.DetectingChanges += value;
-        remove => ChangeDetector.DetectingChanges -= value;
+        add => ChangeDetector.DetectingEntityChanges += value;
+        remove => ChangeDetector.DetectingEntityChanges -= value;
     }
 
     /// <summary>
-    ///     An event fired when any changes have been detected to the entity graph or a single entity, either through an
+    ///     An event fired when any changes have been detected to a single entity, either through an
     ///     explicit call to <see cref="DetectChanges" /> or <see cref="EntityEntry.DetectChanges" />, or automatically, such as part of
     ///     executing <see cref="DbContext.SaveChanges()" /> or <see cref="DbContext.SaveChangesAsync(System.Threading.CancellationToken)" />.
     /// </summary>
-    public event EventHandler<DetectedChangesEventArgs> DetectedChanges
+    /// <remarks>
+    ///     <see cref="AutoDetectChangesEnabled" /> is set to <see langword="false" /> for the duration of the event to prevent an infinite
+    ///     loop of recursive automatic calls.
+    /// </remarks>
+    public event EventHandler<DetectedEntityChangesEventArgs> DetectedEntityChanges
     {
-        add => ChangeDetector.DetectedChanges += value;
-        remove => ChangeDetector.DetectedChanges -= value;
+        add => ChangeDetector.DetectedEntityChanges += value;
+        remove => ChangeDetector.DetectedEntityChanges -= value;
+    }
+
+    /// <summary>
+    ///     An event fired when detecting changes to the entity graph about to happen, either through an
+    ///     explicit call to <see cref="DetectChanges" />, or automatically, such as part of
+    ///     executing <see cref="DbContext.SaveChanges()" /> or <see cref="DbContext.SaveChangesAsync(System.Threading.CancellationToken)" />.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="AutoDetectChangesEnabled" /> is set to <see langword="false" /> for the duration of the event to prevent an infinite
+    ///     loop of recursive automatic calls.
+    /// </remarks>
+    public event EventHandler<DetectChangesEventArgs> DetectingAllChanges
+    {
+        add => ChangeDetector.DetectingAllChanges += value;
+        remove => ChangeDetector.DetectingAllChanges -= value;
+    }
+
+    /// <summary>
+    ///     An event fired when any changes have been detected to the entity graph, either through an
+    ///     explicit call to <see cref="DetectChanges" />, or automatically, such as part of
+    ///     executing <see cref="DbContext.SaveChanges()" /> or <see cref="DbContext.SaveChangesAsync(System.Threading.CancellationToken)" />.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="AutoDetectChangesEnabled" /> is set to <see langword="false" /> for the duration of the event to prevent an infinite
+    ///     loop of recursive automatic calls.
+    /// </remarks>
+    public event EventHandler<DetectedChangesEventArgs> DetectedAllChanges
+    {
+        add => ChangeDetector.DetectedAllChanges += value;
+        remove => ChangeDetector.DetectedAllChanges -= value;
     }
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/DetectChangesEventArgs.cs
+++ b/src/EFCore/ChangeTracking/DetectChangesEventArgs.cs
@@ -1,39 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-
 namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 
 /// <summary>
-///     Event arguments for the <see cref="ChangeTracker.DetectingChanges" /> event.
+///     Event arguments for the <see cref="ChangeTracker.DetectingAllChanges" /> event.
 /// </summary>
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-state-changes">State changes of entities in EF Core</see> for more information and examples.
 /// </remarks>
 public class DetectChangesEventArgs : EventArgs
 {
-    private readonly InternalEntityEntry? _internalEntityEntry;
-    private EntityEntry? _entry;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public DetectChangesEventArgs(InternalEntityEntry? internalEntityEntry)
-    {
-        _internalEntityEntry = internalEntityEntry;
-    }
-
-    /// <summary>
-    ///     If detecting changes for a single entity, then this is the <see cref="EntityEntry" /> for that entity.
-    ///     If detecting changes for an entire graph, then <see langword="null" />.
-    /// </summary>
-    public virtual EntityEntry? Entry
-        => _internalEntityEntry == null
-            ? null
-            : (_entry ??= new EntityEntry(_internalEntityEntry));
 }

--- a/src/EFCore/ChangeTracking/DetectEntityChangesEventArgs.cs
+++ b/src/EFCore/ChangeTracking/DetectEntityChangesEventArgs.cs
@@ -1,16 +1,21 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 
 /// <summary>
-///     Event arguments for the <see cref="ChangeTracker.DetectedAllChanges" /> event.
+///     Event arguments for the <see cref="ChangeTracker.DetectingEntityChanges" /> event.
 /// </summary>
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-state-changes">State changes of entities in EF Core</see> for more information and examples.
 /// </remarks>
-public class DetectedChangesEventArgs : EventArgs
+public class DetectEntityChangesEventArgs : DetectChangesEventArgs
 {
+    private readonly InternalEntityEntry _internalEntityEntry;
+    private EntityEntry? _entry;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -18,13 +23,14 @@ public class DetectedChangesEventArgs : EventArgs
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public DetectedChangesEventArgs(bool changesFound)
+    public DetectEntityChangesEventArgs(InternalEntityEntry internalEntityEntry)
     {
-        ChangesFound = changesFound;
+        _internalEntityEntry = internalEntityEntry;
     }
 
     /// <summary>
-    ///     Returns <see langword="true" /> if changes were found, <see langword="false" /> otherwise.
+    ///     The <see cref="EntityEntry" /> for the entity.
     /// </summary>
-    public virtual bool ChangesFound { get; }
+    public virtual EntityEntry Entry
+        => _entry ??= new EntityEntry(_internalEntityEntry);
 }

--- a/src/EFCore/ChangeTracking/DetectedEntityChangesEventArgs.cs
+++ b/src/EFCore/ChangeTracking/DetectedEntityChangesEventArgs.cs
@@ -1,16 +1,21 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 
 /// <summary>
-///     Event arguments for the <see cref="ChangeTracker.DetectedAllChanges" /> event.
+///     Event arguments for the <see cref="ChangeTracker.DetectedEntityChanges" /> event.
 /// </summary>
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-state-changes">State changes of entities in EF Core</see> for more information and examples.
 /// </remarks>
-public class DetectedChangesEventArgs : EventArgs
+public class DetectedEntityChangesEventArgs : DetectedChangesEventArgs
 {
+    private readonly InternalEntityEntry _internalEntityEntry;
+    private EntityEntry? _entry;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -18,13 +23,17 @@ public class DetectedChangesEventArgs : EventArgs
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public DetectedChangesEventArgs(bool changesFound)
+    public DetectedEntityChangesEventArgs(
+        InternalEntityEntry internalEntityEntry,
+        bool changesFound)
+        : base(changesFound)
     {
-        ChangesFound = changesFound;
+        _internalEntityEntry = internalEntityEntry;
     }
 
     /// <summary>
-    ///     Returns <see langword="true" /> if changes were found, <see langword="false" /> otherwise.
+    ///     The <see cref="EntityEntry" /> for the entity.
     /// </summary>
-    public virtual bool ChangesFound { get; }
+    public virtual EntityEntry Entry
+        => _entry ??= new EntityEntry(_internalEntityEntry);
 }

--- a/src/EFCore/ChangeTracking/Internal/IChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/IChangeDetector.cs
@@ -55,8 +55,10 @@ public interface IChangeDetector
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    (EventHandler<DetectChangesEventArgs>? DetectingChanges,
-        EventHandler<DetectedChangesEventArgs>? DetectedChanges) CaptureEvents();
+    (EventHandler<DetectChangesEventArgs>? DetectingAllChanges,
+        EventHandler<DetectedChangesEventArgs>? DetectedAllChanges,
+        EventHandler<DetectEntityChangesEventArgs>? DetectingEntityChanges,
+        EventHandler<DetectedEntityChangesEventArgs>? DetectedEntityChanges) CaptureEvents();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -65,8 +67,10 @@ public interface IChangeDetector
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     void SetEvents(
-        EventHandler<DetectChangesEventArgs>? detectingChanges,
-        EventHandler<DetectedChangesEventArgs>? detectedChanges);
+        EventHandler<DetectChangesEventArgs>? detectingAllChanges,
+        EventHandler<DetectedChangesEventArgs>? detectedAllChanges,
+        EventHandler<DetectEntityChangesEventArgs>? detectingEntityChanges,
+        EventHandler<DetectedEntityChangesEventArgs>? detectedEntityChanges);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -74,7 +78,7 @@ public interface IChangeDetector
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    event EventHandler<DetectChangesEventArgs>? DetectingChanges;
+    public event EventHandler<DetectEntityChangesEventArgs>? DetectingEntityChanges;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -82,7 +86,7 @@ public interface IChangeDetector
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void OnDetectingChanges(InternalEntityEntry internalEntityEntry);
+    void OnDetectingEntityChanges(InternalEntityEntry internalEntityEntry);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -90,7 +94,7 @@ public interface IChangeDetector
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void OnDetectingChanges(IStateManager stateManager);
+    public event EventHandler<DetectChangesEventArgs>? DetectingAllChanges;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -98,7 +102,7 @@ public interface IChangeDetector
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    event EventHandler<DetectedChangesEventArgs>? DetectedChanges;
+    void OnDetectingAllChanges(IStateManager stateManager);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -106,7 +110,7 @@ public interface IChangeDetector
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void OnDetectedChanges(InternalEntityEntry internalEntityEntry, bool changesFound);
+    event EventHandler<DetectedEntityChangesEventArgs>? DetectedEntityChanges;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -114,7 +118,23 @@ public interface IChangeDetector
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void OnDetectedChanges(IStateManager stateManager, bool changesFound);
+    void OnDetectedEntityChanges(InternalEntityEntry internalEntityEntry, bool changesFound);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    event EventHandler<DetectedChangesEventArgs>? DetectedAllChanges;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    void OnDetectedAllChanges(IStateManager stateManager, bool changesFound);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -887,8 +887,10 @@ public class DbContext :
             || _configurationSnapshot.HasChangeDetectorConfiguration)
         {
             DbContextDependencies.ChangeDetector.SetEvents(
-                _configurationSnapshot.DetectingChanges,
-                _configurationSnapshot.DetectedChanges);
+                _configurationSnapshot.DetectingAllChanges,
+                _configurationSnapshot.DetectedAllChanges,
+                _configurationSnapshot.DetectingEntityChanges,
+                _configurationSnapshot.DetectedEntityChanges);
         }
 
         SavingChanges = _configurationSnapshot.SavingChanges;
@@ -927,8 +929,10 @@ public class DbContext :
             stateManagerEvents?.Tracked,
             stateManagerEvents?.StateChanging,
             stateManagerEvents?.StateChanged,
-            changeDetectorEvents?.DetectingChanges,
-            changeDetectorEvents?.DetectedChanges);
+            changeDetectorEvents?.DetectingAllChanges,
+            changeDetectorEvents?.DetectedAllChanges,
+            changeDetectorEvents?.DetectingEntityChanges,
+            changeDetectorEvents?.DetectedEntityChanges);
     }
 
     /// <summary>

--- a/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
+++ b/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
@@ -36,8 +36,10 @@ public sealed class DbContextPoolConfigurationSnapshot
         EventHandler<EntityTrackedEventArgs>? tracked,
         EventHandler<EntityStateChangingEventArgs>? stateChanging,
         EventHandler<EntityStateChangedEventArgs>? stateChanged,
-        EventHandler<DetectChangesEventArgs>? detectingChanges,
-        EventHandler<DetectedChangesEventArgs>? detectedChanges)
+        EventHandler<DetectChangesEventArgs>? detectingAllChanges,
+        EventHandler<DetectedChangesEventArgs>? detectedAllChanges,
+        EventHandler<DetectEntityChangesEventArgs>? detectingEntityChanges,
+        EventHandler<DetectedEntityChangesEventArgs>? detectedEntityChanges)
     {
         HasDatabaseConfiguration = hasDatabaseConfiguration;
         HasStateManagerConfiguration = hasStateManagerConfiguration;
@@ -57,8 +59,10 @@ public sealed class DbContextPoolConfigurationSnapshot
         Tracked = tracked;
         StateChanging = stateChanging;
         StateChanged = stateChanged;
-        DetectingChanges = detectingChanges;
-        DetectedChanges = detectedChanges;
+        DetectingAllChanges = detectingAllChanges;
+        DetectedAllChanges = detectedAllChanges;
+        DetectingEntityChanges = detectingEntityChanges;
+        DetectedEntityChanges = detectedEntityChanges;
     }
 
     /// <summary>
@@ -211,7 +215,7 @@ public sealed class DbContextPoolConfigurationSnapshot
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public EventHandler<DetectChangesEventArgs>? DetectingChanges { get; }
+    public EventHandler<DetectChangesEventArgs>? DetectingAllChanges { get; }
     
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -219,5 +223,21 @@ public sealed class DbContextPoolConfigurationSnapshot
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public EventHandler<DetectedChangesEventArgs>? DetectedChanges { get; }
+    public EventHandler<DetectedChangesEventArgs>? DetectedAllChanges { get; }
+    
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public EventHandler<DetectEntityChangesEventArgs>? DetectingEntityChanges { get; }
+    
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public EventHandler<DetectedEntityChangesEventArgs>? DetectedEntityChanges { get; }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -118,8 +118,10 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
             ChangeTracker.Tracked += (sender, args) => { };
             ChangeTracker.StateChanging += (sender, args) => { };
             ChangeTracker.StateChanged += (sender, args) => { };
-            ChangeTracker.DetectingChanges += (sender, args) => { };
-            ChangeTracker.DetectedChanges += (sender, args) => { };
+            ChangeTracker.DetectingAllChanges += (sender, args) => { };
+            ChangeTracker.DetectedAllChanges += (sender, args) => { };
+            ChangeTracker.DetectingEntityChanges += (sender, args) => { };
+            ChangeTracker.DetectedEntityChanges += (sender, args) => { };
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -731,8 +733,10 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         context1.ChangeTracker.Tracked += ChangeTracker_OnTracked;
         context1.ChangeTracker.StateChanging += ChangeTracker_OnStateChanging;
         context1.ChangeTracker.StateChanged += ChangeTracker_OnStateChanged;
-        context1.ChangeTracker.DetectingChanges += ChangeTracker_OnDetectingChanges;
-        context1.ChangeTracker.DetectedChanges += ChangeTracker_OnDetectedChanges;
+        context1.ChangeTracker.DetectingAllChanges += ChangeTracker_OnDetectingAllChanges;
+        context1.ChangeTracker.DetectedAllChanges += ChangeTracker_OnDetectedAllChanges;
+        context1.ChangeTracker.DetectingEntityChanges += ChangeTracker_OnDetectingEntityChanges;
+        context1.ChangeTracker.DetectedEntityChanges += ChangeTracker_OnDetectedEntityChanges;
         context1.SavingChanges += Context_OnSavingChanges;
         context1.SavedChanges += Context_OnSavedChanges;
         context1.SaveChangesFailed += Context_OnSaveChangesFailed;
@@ -768,8 +772,10 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
 
         context2.SaveChanges();
 
-        Assert.False(_changeTracker_OnDetectingChanges);
-        Assert.False(_changeTracker_OnDetectedChanges);
+        Assert.False(_changeTracker_OnDetectingAllChanges);
+        Assert.False(_changeTracker_OnDetectedAllChanges);
+        Assert.False(_changeTracker_OnDetectingEntityChanges);
+        Assert.False(_changeTracker_OnDetectedEntityChanges);
         Assert.False(_context_OnSavedChanges);
         Assert.False(_context_OnSavingChanges);
         Assert.False(_context_OnSaveChangesFailed);
@@ -824,8 +830,10 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         context1.ChangeTracker.Tracked += ChangeTracker_OnTracked;
         context1.ChangeTracker.StateChanging += ChangeTracker_OnStateChanging;
         context1.ChangeTracker.StateChanged += ChangeTracker_OnStateChanged;
-        context1.ChangeTracker.DetectingChanges += ChangeTracker_OnDetectingChanges;
-        context1.ChangeTracker.DetectedChanges += ChangeTracker_OnDetectedChanges;
+        context1.ChangeTracker.DetectingAllChanges += ChangeTracker_OnDetectingAllChanges;
+        context1.ChangeTracker.DetectedAllChanges += ChangeTracker_OnDetectedAllChanges;
+        context1.ChangeTracker.DetectingEntityChanges += ChangeTracker_OnDetectingEntityChanges;
+        context1.ChangeTracker.DetectedEntityChanges += ChangeTracker_OnDetectedEntityChanges;
         context1.SavingChanges += Context_OnSavingChanges;
         context1.SavedChanges += Context_OnSavedChanges;
         context1.SaveChangesFailed += Context_OnSaveChangesFailed;
@@ -847,8 +855,10 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
 
         context2.SaveChanges();
 
-        Assert.False(_changeTracker_OnDetectingChanges);
-        Assert.False(_changeTracker_OnDetectedChanges);
+        Assert.False(_changeTracker_OnDetectingAllChanges);
+        Assert.False(_changeTracker_OnDetectedAllChanges);
+        Assert.False(_changeTracker_OnDetectingEntityChanges);
+        Assert.False(_changeTracker_OnDetectedEntityChanges);
         Assert.False(_context_OnSavedChanges);
         Assert.False(_context_OnSavingChanges);
         Assert.False(_context_OnSaveChangesFailed);
@@ -872,8 +882,10 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         context.ChangeTracker.Tracked += ChangeTracker_OnTracked;
         context.ChangeTracker.StateChanging += ChangeTracker_OnStateChanging;
         context.ChangeTracker.StateChanged += ChangeTracker_OnStateChanged;
-        context.ChangeTracker.DetectingChanges += ChangeTracker_OnDetectingChanges;
-        context.ChangeTracker.DetectedChanges += ChangeTracker_OnDetectedChanges;
+        context.ChangeTracker.DetectingAllChanges += ChangeTracker_OnDetectingAllChanges;
+        context.ChangeTracker.DetectedAllChanges += ChangeTracker_OnDetectedAllChanges;
+        context.ChangeTracker.DetectingEntityChanges += ChangeTracker_OnDetectingEntityChanges;
+        context.ChangeTracker.DetectedEntityChanges += ChangeTracker_OnDetectedEntityChanges;
         context.SavingChanges += Context_OnSavingChanges;
         context.SavedChanges += Context_OnSavedChanges;
         context.SaveChangesFailed += Context_OnSaveChangesFailed;
@@ -892,8 +904,10 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         Assert.False(_changeTracker_OnTracked);
         Assert.False(_changeTracker_OnStateChanging);
         Assert.False(_changeTracker_OnStateChanged);
-        Assert.False(_changeTracker_OnDetectingChanges);
-        Assert.False(_changeTracker_OnDetectedChanges);
+        Assert.False(_changeTracker_OnDetectingAllChanges);
+        Assert.False(_changeTracker_OnDetectedAllChanges);
+        Assert.False(_changeTracker_OnDetectingEntityChanges);
+        Assert.False(_changeTracker_OnDetectedEntityChanges);
 
         var customer = new Customer { CustomerId = "C" };
         context.Customers.Attach(customer).State = EntityState.Modified;
@@ -903,13 +917,17 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         Assert.True(_changeTracker_OnTracked);
         Assert.True(_changeTracker_OnStateChanging);
         Assert.True(_changeTracker_OnStateChanged);
-        Assert.False(_changeTracker_OnDetectingChanges);
-        Assert.False(_changeTracker_OnDetectedChanges);
+        Assert.False(_changeTracker_OnDetectingAllChanges);
+        Assert.False(_changeTracker_OnDetectedAllChanges);
+        Assert.False(_changeTracker_OnDetectingEntityChanges);
+        Assert.False(_changeTracker_OnDetectedEntityChanges);
 
         context.SaveChanges();
 
-        Assert.True(_changeTracker_OnDetectingChanges);
-        Assert.True(_changeTracker_OnDetectedChanges);
+        Assert.True(_changeTracker_OnDetectingAllChanges);
+        Assert.True(_changeTracker_OnDetectedAllChanges);
+        Assert.True(_changeTracker_OnDetectingEntityChanges);
+        Assert.True(_changeTracker_OnDetectedEntityChanges);
         Assert.True(_context_OnSavedChanges);
         Assert.True(_context_OnSavingChanges);
         Assert.False(_context_OnSaveChangesFailed);
@@ -950,15 +968,25 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
     private void ChangeTracker_OnStateChanged(object sender, EntityStateChangedEventArgs e)
         => _changeTracker_OnStateChanged = true;
 
-    private bool _changeTracker_OnDetectingChanges;
+    private bool _changeTracker_OnDetectingAllChanges;
 
-    private void ChangeTracker_OnDetectingChanges(object sender, DetectChangesEventArgs e)
-        => _changeTracker_OnDetectingChanges = true;
+    private void ChangeTracker_OnDetectingAllChanges(object sender, DetectChangesEventArgs e)
+        => _changeTracker_OnDetectingAllChanges = true;
 
-    private bool _changeTracker_OnDetectedChanges;
+    private bool _changeTracker_OnDetectedAllChanges;
 
-    private void ChangeTracker_OnDetectedChanges(object sender, DetectedChangesEventArgs e)
-        => _changeTracker_OnDetectedChanges = true;
+    private void ChangeTracker_OnDetectedAllChanges(object sender, DetectedChangesEventArgs e)
+        => _changeTracker_OnDetectedAllChanges = true;
+
+    private bool _changeTracker_OnDetectingEntityChanges;
+
+    private void ChangeTracker_OnDetectingEntityChanges(object sender, DetectEntityChangesEventArgs e)
+        => _changeTracker_OnDetectingEntityChanges = true;
+
+    private bool _changeTracker_OnDetectedEntityChanges;
+
+    private void ChangeTracker_OnDetectedEntityChanges(object sender, DetectedEntityChangesEventArgs e)
+        => _changeTracker_OnDetectedEntityChanges = true;
 
     [ConditionalTheory]
     [InlineData(false)]

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1573,322 +1573,438 @@ public class ChangeTrackerTest
     [ConditionalFact]
     public void DetectChanges_events_fire_for_no_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<LikeAZooContextPooled>();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         context.AttachRange(new Cat(1), new Cat(2));
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
 
         Assert.False(context.ChangeTracker.HasChanges());
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Single(detectingAll);
+        Assert.Single(detectedAll);
+        Assert.Equal(2, detectingEntity.Count);
+        Assert.Equal(2, detectedEntity.Count);
 
-        AssertDetectChangesEvent(context, changesFound: false, detecting[0], detected[0]);
+        Assert.False(detectedAll[0].ChangesFound);
+        Assert.False(detectedEntity[0].ChangesFound);
+        Assert.False(detectedEntity[1].ChangesFound);
     }
 
     [ConditionalFact]
     public void DetectChanges_events_fire_for_property_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<LikeAZooContextPooled>();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var cat = new Cat(1);
         context.AttachRange(cat, new Cat(2));
         cat.Name = "Alice";
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
 
         Assert.True(context.ChangeTracker.HasChanges());
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Single(detectingAll);
+        Assert.Single(detectedAll);
+        Assert.Equal(2, detectingEntity.Count);
+        Assert.Equal(2, detectedEntity.Count);
 
-        AssertDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        Assert.True(detectedAll[0].ChangesFound);
+        Assert.True(detectedEntity[0].ChangesFound);
+        Assert.False(detectedEntity[1].ChangesFound);
     }
 
     [ConditionalFact]
     public void DetectChanges_events_fire_for_fk_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         using var context = new EarlyLearningCenter();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var product = new Product { Category = new Category()};
         context.Attach(product);
         product.CategoryId = 2;
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
 
         Assert.True(context.ChangeTracker.HasChanges());
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Single(detectingAll);
+        Assert.Single(detectedAll);
+        Assert.Equal(2, detectingEntity.Count);
+        Assert.Equal(2, detectedEntity.Count);
 
-        AssertDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        Assert.True(detectedAll[0].ChangesFound);
+        Assert.True(detectedEntity[0].ChangesFound);
+        Assert.False(detectedEntity[1].ChangesFound);
     }
 
     [ConditionalFact]
     public void DetectChanges_events_fire_for_reference_navigation_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         using var context = new EarlyLearningCenter();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var product = new Product { Category = new Category()};
         context.Attach(product);
         product.Category = null;
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
 
         Assert.True(context.ChangeTracker.HasChanges());
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Single(detectingAll);
+        Assert.Single(detectedAll);
+        Assert.Equal(2, detectingEntity.Count);
+        Assert.Equal(2, detectedEntity.Count);
 
-        AssertDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        Assert.True(detectedAll[0].ChangesFound);
+        Assert.True(detectedEntity[0].ChangesFound);
+        Assert.False(detectedEntity[1].ChangesFound);
     }
 
     [ConditionalFact]
     public void DetectChanges_events_fire_for_collection_navigation_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         using var context = new EarlyLearningCenter();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var product = new Product { Category = new Category()};
         context.Attach(product);
         product.Category.Products.Clear();
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
 
         Assert.True(context.ChangeTracker.HasChanges());
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Single(detectingAll);
+        Assert.Single(detectedAll);
+        Assert.Equal(2, detectingEntity.Count);
+        Assert.Equal(2, detectedEntity.Count);
 
-        AssertDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        Assert.True(detectedAll[0].ChangesFound);
+        Assert.False(detectedEntity[0].ChangesFound);
+        Assert.True(detectedEntity[1].ChangesFound);
     }
 
     [ConditionalFact]
     public void DetectChanges_events_fire_for_skip_navigation_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<LikeAZooContextPooled>();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var cat = new Cat(1) { Hats = { new Hat(2) }};
         context.Attach(cat);
         cat.Hats.Clear();
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
 
         Assert.True(context.ChangeTracker.HasChanges());
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Single(detectingAll);
+        Assert.Single(detectedAll);
+        Assert.Equal(2, detectingEntity.Count);
+        Assert.Equal(2, detectedEntity.Count);
 
-        AssertDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        Assert.True(detectedAll[0].ChangesFound);
+        Assert.True(detectedEntity[0].ChangesFound);
+        Assert.False(detectedEntity[1].ChangesFound);
     }
 
     [ConditionalFact]
     public void Local_DetectChanges_events_fire_for_no_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<LikeAZooContextPooled>();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var cat = new Cat(1);
         context.AttachRange(cat, new Cat(2));
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingEntity);
+        Assert.Empty(detectedEntity);
 
         _ = context.Entry(cat);
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
+        Assert.Single(detectingEntity);
+        Assert.Single(detectedEntity);
 
-        AssertLocalDetectChangesEvent(context, changesFound: false, detecting[0], detected[0]);
+        AssertLocalDetectChangesEvent(changesFound: false, detectingEntity[0], detectedEntity[0]);
     }
 
     [ConditionalFact]
     public void Local_DetectChanges_events_fire_for_property_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<LikeAZooContextPooled>();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var cat = new Cat(1);
         context.AttachRange(cat, new Cat(2));
         cat.Name = "Alice";
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingEntity);
+        Assert.Empty(detectedEntity);
 
         _ = context.Entry(cat);
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
+        Assert.Single(detectingEntity);
+        Assert.Single(detectedEntity);
 
-        AssertLocalDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        AssertLocalDetectChangesEvent(changesFound: true, detectingEntity[0], detectedEntity[0]);
     }
 
     [ConditionalFact]
     public void Local_DetectChanges_events_fire_for_fk_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         using var context = new EarlyLearningCenter();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var product = new Product { Category = new Category()};
         context.Attach(product);
         product.CategoryId = 2;
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingEntity);
+        Assert.Empty(detectedEntity);
 
         _ = context.Entry(product);
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
+        Assert.Single(detectingEntity);
+        Assert.Single(detectedEntity);
 
-        AssertLocalDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        AssertLocalDetectChangesEvent(changesFound: true, detectingEntity[0], detectedEntity[0]);
     }
 
     [ConditionalFact]
     public void Local_DetectChanges_events_fire_for_reference_navigation_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         using var context = new EarlyLearningCenter();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var product = new Product { Category = new Category()};
         context.Attach(product);
         product.Category = null;
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingEntity);
+        Assert.Empty(detectedEntity);
 
         _ = context.Entry(product);
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
+        Assert.Equal(2, detectingEntity.Count);
+        Assert.Equal(2, detectedEntity.Count);
 
-        AssertLocalDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        AssertLocalDetectChangesEvent(changesFound: false, detectingEntity[0], detectedEntity[0]);
+        AssertLocalDetectChangesEvent(changesFound: true, detectingEntity[1], detectedEntity[1]);
     }
 
     [ConditionalFact]
     public void Local_DetectChanges_events_fire_for_collection_navigation_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         using var context = new EarlyLearningCenter();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var product = new Product { Category = new Category()};
         context.Attach(product);
         product.Category.Products.Clear();
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingEntity);
+        Assert.Empty(detectedEntity);
 
         _ = context.Entry(product.Category);
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
+        Assert.Single(detectingEntity);
+        Assert.Single(detectedEntity);
 
-        AssertLocalDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        AssertLocalDetectChangesEvent(changesFound: true, detectingEntity[0], detectedEntity[0]);
     }
 
     [ConditionalFact]
     public void Local_DetectChanges_events_fire_for_skip_navigation_change()
     {
-        var detecting = new List<DetectChangesEventArgs>();
-        var detected = new List<DetectedChangesEventArgs>();
+        var detectingAll = new List<DetectChangesEventArgs>();
+        var detectedAll = new List<DetectedChangesEventArgs>();
+        var detectingEntity = new List<DetectEntityChangesEventArgs>();
+        var detectedEntity = new List<DetectedEntityChangesEventArgs>();
 
         using var scope = _poolProvider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<LikeAZooContextPooled>();
 
-        RegisterEvents(context, detecting, detected);
+        RegisterDetectAllEvents(context, detectingAll, detectedAll);
+        RegisterDetectEntityEvents(context, detectingEntity, detectedEntity);
 
         var cat = new Cat(1) { Hats = { new Hat(2) }};
         context.Attach(cat);
         cat.Hats.Clear();
 
-        Assert.Empty(detecting);
-        Assert.Empty(detected);
+        Assert.Empty(detectingEntity);
+        Assert.Empty(detectedEntity);
 
         _ = context.Entry(cat);
 
-        Assert.Single(detecting);
-        Assert.Single(detected);
+        Assert.Empty(detectingAll);
+        Assert.Empty(detectedAll);
+        Assert.Single(detectingEntity);
+        Assert.Single(detectedEntity);
 
-        AssertLocalDetectChangesEvent(context, changesFound: true, detecting[0], detected[0]);
+        AssertLocalDetectChangesEvent(changesFound: true, detectingEntity[0], detectedEntity[0]);
+    }
+
+    [ConditionalFact] // Issue #26506
+    public void DetectChanges_event_can_be_used_to_know_when_all_properties_have_changed()
+    {
+        using var scope = _poolProvider.CreateScope();
+
+        var context = scope.ServiceProvider.GetRequiredService<LikeAZooContextPooled>();
+
+        var hat = new Hat(2) { Color = "Orange" };
+        var cat1 = new Cat(1) { Hats = { hat }};
+        var cat2 = new Cat(2);
+        context.AttachRange(cat1, cat2);
+
+        var stateChangedCalled = false;
+        context.ChangeTracker.StateChanged += (s, a) =>
+        {
+            stateChangedCalled = true;
+            Assert.Equal("Black", a.Entry.Property(nameof(Hat.Color)).CurrentValue);
+            Assert.Equal(1, a.Entry.Property(nameof(Hat.CatId)).CurrentValue);
+        };
+
+        var detectedChangesCalled = false;
+        context.ChangeTracker.DetectedEntityChanges += (s, a) =>
+        {
+            if (a.ChangesFound)
+            {
+                detectedChangesCalled = true;
+
+                Assert.Equal("Black", a.Entry.Property(nameof(Hat.Color)).CurrentValue);
+                Assert.Equal(2, a.Entry.Property(nameof(Hat.CatId)).CurrentValue);
+            }
+        };
+
+        hat.Cat = cat2;
+        hat.Color = "Black";
+
+        context.ChangeTracker.DetectChanges();
+
+        Assert.True(stateChangedCalled);
+        Assert.True(detectedChangesCalled);
+
+        Assert.Equal(2, hat.CatId);
     }
 
     private static void AssertTrackedEvent(
@@ -1928,26 +2044,13 @@ public class ChangeTrackerTest
         }
     }
 
-    private static void AssertDetectChangesEvent(
-        DbContext context,
-        bool changesFound,
-        DetectChangesEventArgs detecting,
-        DetectedChangesEventArgs detected)
-    {
-        Assert.Null(detecting.Entry);
-        Assert.Null(detected.Entry);
-        Assert.Equal(changesFound, detected.ChangesFound);
-    }
-
     private static void AssertLocalDetectChangesEvent(
-        DbContext context,
         bool changesFound,
-        DetectChangesEventArgs detecting,
-        DetectedChangesEventArgs detected)
+        DetectEntityChangesEventArgs detectingEntity,
+        DetectedEntityChangesEventArgs detectedEntity)
     {
-        Assert.NotNull(detecting.Entry);
-        Assert.Same(detecting.Entry!.Entity, detected.Entry!.Entity);
-        Assert.Equal(changesFound, detected.ChangesFound);
+        Assert.Same(detectingEntity.Entry.Entity, detectedEntity.Entry.Entity);
+        Assert.Equal(changesFound, detectedEntity.ChangesFound);
     }
 
     private static void RegisterEvents(
@@ -1984,21 +2087,45 @@ public class ChangeTrackerTest
         };
     }
 
-    private static void RegisterEvents(
+    private static void RegisterDetectAllEvents(
         DbContext context,
-        IList<DetectChangesEventArgs> detecting,
-        IList<DetectedChangesEventArgs> detected)
+        IList<DetectChangesEventArgs> detectingAll,
+        IList<DetectedChangesEventArgs> detectedAll)
     {
-        context.ChangeTracker.DetectingChanges += (s, e) =>
+        context.ChangeTracker.DetectingAllChanges += (s, e) =>
         {
+            _ = context.ChangeTracker.Entries().ToList(); // Should not recursively call DetectChanges
             Assert.Same(context.ChangeTracker, s);
-            detecting.Add(e);
+            detectingAll.Add(e);
         };
 
-        context.ChangeTracker.DetectedChanges += (s, e) =>
+        context.ChangeTracker.DetectedAllChanges += (s, e) =>
         {
+            _ = context.ChangeTracker.Entries().ToList(); // Should not recursively call DetectChanges
             Assert.Same(context.ChangeTracker, s);
-            detected.Add(e);
+            detectedAll.Add(e);
+        };
+    }
+
+    private static void RegisterDetectEntityEvents(
+        DbContext context,
+        IList<DetectEntityChangesEventArgs> detectingEntity,
+        IList<DetectedEntityChangesEventArgs> detectedEntity)
+    {
+        context.ChangeTracker.DetectingEntityChanges += (s, e) =>
+        {
+            _ = context.ChangeTracker.Entries().ToList(); // Should not recursively call DetectChanges
+            Assert.Same(context.ChangeTracker, s);
+            Assert.NotNull(e.Entry);
+            detectingEntity.Add(e);
+        };
+
+        context.ChangeTracker.DetectedEntityChanges += (s, e) =>
+        {
+            _ = context.ChangeTracker.Entries().ToList(); // Should not recursively call DetectChanges
+            Assert.Same(context.ChangeTracker, s);
+            Assert.NotNull(e.Entry);
+            detectedEntity.Add(e);
         };
     }
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -490,13 +490,40 @@ public class InternalEntryEntrySubscriberTest
         {
         }
 
-        public (EventHandler<DetectChangesEventArgs> DetectingChanges, EventHandler<DetectedChangesEventArgs> DetectedChanges)
-            CaptureEvents()
-            => (null, null);
+        public (EventHandler<DetectChangesEventArgs> DetectingAllChanges,
+            EventHandler<DetectedChangesEventArgs> DetectedAllChanges,
+            EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges,
+            EventHandler<DetectedEntityChangesEventArgs>
+            DetectedEntityChanges) CaptureEvents()
+            => (null, null, null, null);
 
-        public void SetEvents(EventHandler<DetectChangesEventArgs> detectingChanges, EventHandler<DetectedChangesEventArgs> detectedChanges)
+        public void SetEvents(
+            EventHandler<DetectChangesEventArgs> detectingAllChanges,
+            EventHandler<DetectedChangesEventArgs> detectedAllChanges,
+            EventHandler<DetectEntityChangesEventArgs> detectingEntityChanges,
+            EventHandler<DetectedEntityChangesEventArgs> detectedEntityChanges)
         {
         }
+
+        public event EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges;
+
+        public void OnDetectingEntityChanges(InternalEntityEntry internalEntityEntry)
+            => DetectingEntityChanges?.Invoke(null, null);
+
+        public event EventHandler<DetectChangesEventArgs> DetectingAllChanges;
+
+        public void OnDetectingAllChanges(IStateManager stateManager)
+            => DetectingAllChanges?.Invoke(null, null);
+
+        public event EventHandler<DetectedEntityChangesEventArgs> DetectedEntityChanges;
+
+        public void OnDetectedEntityChanges(InternalEntityEntry internalEntityEntry, bool changesFound)
+            => DetectedEntityChanges?.Invoke(null, null);
+
+        public event EventHandler<DetectedChangesEventArgs> DetectedAllChanges;
+
+        public void OnDetectedAllChanges(IStateManager stateManager, bool changesFound)
+            => DetectedAllChanges?.Invoke(null, null);
 
         public void Suspend()
         {
@@ -505,22 +532,6 @@ public class InternalEntryEntrySubscriberTest
         public void Resume()
         {
         }
-
-        public event EventHandler<DetectChangesEventArgs> DetectingChanges;
-
-        public void OnDetectingChanges(InternalEntityEntry internalEntityEntry)
-            => DetectingChanges?.Invoke(null, null);
-
-        public void OnDetectingChanges(IStateManager stateManager)
-            => DetectingChanges?.Invoke(null, null);
-
-        public event EventHandler<DetectedChangesEventArgs> DetectedChanges;
-
-        public void OnDetectedChanges(InternalEntityEntry internalEntityEntry, bool changesFound)
-            => DetectedChanges?.Invoke(null, null);
-
-        public void OnDetectedChanges(IStateManager stateManager, bool changesFound)
-            => DetectedChanges?.Invoke(null, null);
 
         public void ResetState()
         {

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -186,14 +186,6 @@ public partial class DbContextTest
         {
         }
 
-        public (EventHandler<DetectChangesEventArgs> DetectingChanges, EventHandler<DetectedChangesEventArgs> DetectedChanges)
-            CaptureEvents()
-            => (null, null);
-
-        public void SetEvents(EventHandler<DetectChangesEventArgs> detectingChanges, EventHandler<DetectedChangesEventArgs> detectedChanges)
-        {
-        }
-
         public void PropertyChanged(InternalEntityEntry entry, IPropertyBase property, bool setModifed)
         {
         }
@@ -210,21 +202,40 @@ public partial class DbContextTest
         {
         }
 
-        public event EventHandler<DetectChangesEventArgs> DetectingChanges;
+        public (EventHandler<DetectChangesEventArgs> DetectingAllChanges,
+            EventHandler<DetectedChangesEventArgs> DetectedAllChanges,
+            EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges,
+            EventHandler<DetectedEntityChangesEventArgs>
+            DetectedEntityChanges) CaptureEvents()
+            => (null, null, null, null);
 
-        public void OnDetectingChanges(InternalEntityEntry internalEntityEntry)
-            => DetectingChanges?.Invoke(null, null);
+        public void SetEvents(
+            EventHandler<DetectChangesEventArgs> detectingAllChanges,
+            EventHandler<DetectedChangesEventArgs> detectedAllChanges,
+            EventHandler<DetectEntityChangesEventArgs> detectingEntityChanges,
+            EventHandler<DetectedEntityChangesEventArgs> detectedEntityChanges)
+        {
+        }
 
-        public void OnDetectingChanges(IStateManager stateManager)
-            => DetectingChanges?.Invoke(null, null);
+        public event EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges;
 
-        public event EventHandler<DetectedChangesEventArgs> DetectedChanges;
+        public void OnDetectingEntityChanges(InternalEntityEntry internalEntityEntry)
+            => DetectingEntityChanges?.Invoke(null, null);
 
-        public void OnDetectedChanges(InternalEntityEntry internalEntityEntry, bool changesFound)
-            => DetectedChanges?.Invoke(null, null);
+        public event EventHandler<DetectChangesEventArgs> DetectingAllChanges;
 
-        public void OnDetectedChanges(IStateManager stateManager, bool changesFound)
-            => DetectedChanges?.Invoke(null, null);
+        public void OnDetectingAllChanges(IStateManager stateManager)
+            => DetectingAllChanges?.Invoke(null, null);
+
+        public event EventHandler<DetectedEntityChangesEventArgs> DetectedEntityChanges;
+
+        public void OnDetectedEntityChanges(InternalEntityEntry internalEntityEntry, bool changesFound)
+            => DetectedEntityChanges?.Invoke(null, null);
+
+        public event EventHandler<DetectedChangesEventArgs> DetectedAllChanges;
+
+        public void OnDetectedAllChanges(IStateManager stateManager, bool changesFound)
+            => DetectedAllChanges?.Invoke(null, null);
 
         public void ResetState()
         {


### PR DESCRIPTION
Fixes #26506

Also disable auto-DetectChanges when in the event to prevent infinite loop of recursive calls.
