### PR TITLE
Store null table name and TPH mapping strategy in the snapshot

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -845,8 +845,8 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
         var table = StoreObjectIdentifier.Create(entityType, StoreObjectType.Table);
         var tableName = (string?)tableNameAnnotation?.Value ?? table?.Name;
         if (tableNameAnnotation == null
-            && (tableName == null
-                || entityType.BaseType?.GetTableName() == tableName))
+            && entityType.BaseType != null
+            && entityType.BaseType.GetTableName() == tableName)
         {
             return;
         }

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -19,6 +19,9 @@ public static partial class RelationalEntityTypeBuilderExtensions
     ///     Configures TPC as the mapping strategy for the derived types. Each type will be mapped to a different database object.
     ///     All properties will be mapped to columns on the corresponding object.
     /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-inheritance">Entity type hierarchy mapping</see> for more information and examples.
+    /// </remarks>
     /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static EntityTypeBuilder UseTpcMappingStrategy(this EntityTypeBuilder entityTypeBuilder)
@@ -32,6 +35,9 @@ public static partial class RelationalEntityTypeBuilderExtensions
     ///     Configures TPH as the mapping strategy for the derived types. All types will be mapped to the same database object.
     ///     This is the default mapping strategy.
     /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-inheritance">Entity type hierarchy mapping</see> for more information and examples.
+    /// </remarks>
     /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static EntityTypeBuilder UseTphMappingStrategy(this EntityTypeBuilder entityTypeBuilder)
@@ -45,6 +51,9 @@ public static partial class RelationalEntityTypeBuilderExtensions
     ///     Configures TPT as the mapping strategy for the derived types. Each type will be mapped to a different database object.
     ///     Only the declared properties will be mapped to columns on the corresponding object.
     /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-inheritance">Entity type hierarchy mapping</see> for more information and examples.
+    /// </remarks>
     /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static EntityTypeBuilder UseTptMappingStrategy(this EntityTypeBuilder entityTypeBuilder)
@@ -58,6 +67,9 @@ public static partial class RelationalEntityTypeBuilderExtensions
     ///     Configures TPC as the mapping strategy for the derived types. Each type will be mapped to a different database object.
     ///     All properties will be mapped to columns on the corresponding object.
     /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-inheritance">Entity type hierarchy mapping</see> for more information and examples.
+    /// </remarks>
     /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static EntityTypeBuilder<TEntity> UseTpcMappingStrategy<TEntity>(this EntityTypeBuilder<TEntity> entityTypeBuilder)
@@ -68,6 +80,9 @@ public static partial class RelationalEntityTypeBuilderExtensions
     ///     Configures TPH as the mapping strategy for the derived types. All types will be mapped to the same database object.
     ///     This is the default mapping strategy.
     /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-inheritance">Entity type hierarchy mapping</see> for more information and examples.
+    /// </remarks>
     /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static EntityTypeBuilder<TEntity> UseTphMappingStrategy<TEntity>(this EntityTypeBuilder<TEntity> entityTypeBuilder)
@@ -78,11 +93,59 @@ public static partial class RelationalEntityTypeBuilderExtensions
     ///     Configures TPT as the mapping strategy for the derived types. Each type will be mapped to a different database object.
     ///     Only the declared properties will be mapped to columns on the corresponding object.
     /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-inheritance">Entity type hierarchy mapping</see> for more information and examples.
+    /// </remarks>
     /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static EntityTypeBuilder<TEntity> UseTptMappingStrategy<TEntity>(this EntityTypeBuilder<TEntity> entityTypeBuilder)
         where TEntity : class
         => (EntityTypeBuilder<TEntity>)((EntityTypeBuilder)entityTypeBuilder).UseTptMappingStrategy();
+
+    /// <summary>
+    ///     Sets the hierarchy mapping strategy.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-inheritance">Entity type hierarchy mapping</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="strategy">The mapping strategy for the derived types.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionEntityTypeBuilder? UseMappingStrategy(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        string? strategy,
+        bool fromDataAnnotation = false)
+    {
+        if (!entityTypeBuilder.CanSetMappingStrategy(strategy, fromDataAnnotation))
+        {
+            return null;
+        }
+
+        entityTypeBuilder.Metadata.SetMappingStrategy(strategy, fromDataAnnotation);
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    ///     Returns a value indicating whether the hierarchy mapping strategy can be configured
+    ///     using the specified configuration source.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+    /// </remarks>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="strategy">The mapping strategy for the derived types.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the configuration can be applied.</returns>
+    public static bool CanSetMappingStrategy(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        string? strategy,
+        bool fromDataAnnotation = false)
+        => entityTypeBuilder.CanSetAnnotation
+            (RelationalAnnotationNames.MappingStrategy, strategy, fromDataAnnotation);
 
     /// <summary>
     ///     Mark the table that this entity type is mapped to as excluded from migrations.

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -1451,7 +1451,7 @@ public static class RelationalPropertyExtensions
     /// <param name="property">The property.</param>
     /// <returns>The property facet overrides.</returns>
     public static IEnumerable<IMutableRelationalPropertyOverrides> GetOverrides(this IMutableProperty property)
-        => ((IEnumerable<IMutableRelationalPropertyOverrides>?)RelationalPropertyOverrides.Get(property))
+        => RelationalPropertyOverrides.Get(property)?.Cast<IMutableRelationalPropertyOverrides>()
         ?? Enumerable.Empty<IMutableRelationalPropertyOverrides>();
 
     /// <summary>
@@ -1466,7 +1466,7 @@ public static class RelationalPropertyExtensions
     /// <param name="property">The property.</param>
     /// <returns>The property facet overrides.</returns>
     public static IEnumerable<IConventionRelationalPropertyOverrides> GetOverrides(this IConventionProperty property)
-        => ((IEnumerable<IConventionRelationalPropertyOverrides>?)RelationalPropertyOverrides.Get(property))
+        => RelationalPropertyOverrides.Get(property)?.Cast<IConventionRelationalPropertyOverrides>()
         ?? Enumerable.Empty<IConventionRelationalPropertyOverrides>();
 
     /// <summary>
@@ -1481,7 +1481,7 @@ public static class RelationalPropertyExtensions
     /// <param name="property">The property.</param>
     /// <returns>The property facet overrides.</returns>
     public static IEnumerable<IRelationalPropertyOverrides> GetOverrides(this IProperty property)
-        => ((IEnumerable<IRelationalPropertyOverrides>?)RelationalPropertyOverrides.Get(property))
+        => RelationalPropertyOverrides.Get(property)?.Cast<IRelationalPropertyOverrides>()
         ?? Enumerable.Empty<IRelationalPropertyOverrides>();
 
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Conventions/EntityTypeHierarchyMappingConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/EntityTypeHierarchyMappingConvention.cs
@@ -40,6 +40,7 @@ public class EntityTypeHierarchyMappingConvention : IModelFinalizingConvention
         IConventionModelBuilder modelBuilder,
         IConventionContext<IConventionModelBuilder> context)
     {
+        var allRoots = new HashSet<IConventionEntityType>();
         var nonTphRoots = new HashSet<IConventionEntityType>();
 
         foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
@@ -49,15 +50,24 @@ public class EntityTypeHierarchyMappingConvention : IModelFinalizingConvention
                 continue;
             }
 
+            var root = entityType.GetRootType();
+            allRoots.Add(root);
             var mappingStrategy = (string?)entityType[RelationalAnnotationNames.MappingStrategy];
             if (mappingStrategy == null)
             {
-                mappingStrategy = (string?)entityType.GetRootType()[RelationalAnnotationNames.MappingStrategy];
+                mappingStrategy = (string?)root[RelationalAnnotationNames.MappingStrategy];
+                if (mappingStrategy == null
+                    && root.GetDiscriminatorPropertyConfigurationSource() == ConfigurationSource.Explicit)
+                {
+                    mappingStrategy = RelationalAnnotationNames.TphMappingStrategy;
+                    root.Builder.UseMappingStrategy(RelationalAnnotationNames.TphMappingStrategy);
+                    continue;
+                }
             }
             
             if (mappingStrategy == RelationalAnnotationNames.TpcMappingStrategy)
             {
-                nonTphRoots.Add(entityType.GetRootType());
+                nonTphRoots.Add(root);
                 continue;
             }
 
@@ -70,6 +80,7 @@ public class EntityTypeHierarchyMappingConvention : IModelFinalizingConvention
                         || entityType.GetSchema() != entityType.BaseType.GetSchema())
                     {
                         mappingStrategy = RelationalAnnotationNames.TptMappingStrategy;
+                        root.Builder.UseMappingStrategy(mappingStrategy);
                     }
                 }
 
@@ -96,7 +107,7 @@ public class EntityTypeHierarchyMappingConvention : IModelFinalizingConvention
                         }
                     }
 
-                    nonTphRoots.Add(entityType.GetRootType());
+                    nonTphRoots.Add(root);
                     continue;
                 }
             }
@@ -106,13 +117,20 @@ public class EntityTypeHierarchyMappingConvention : IModelFinalizingConvention
                 && (viewName != entityType.BaseType.GetViewName()
                     || entityType.GetViewSchema() != entityType.BaseType.GetViewSchema()))
             {
-                nonTphRoots.Add(entityType.GetRootType());
+                nonTphRoots.Add(root);
+                continue;
             }
         }
 
         foreach (var root in nonTphRoots)
         {
+            allRoots.Remove(root);
             root.Builder.HasNoDiscriminator();
+        }
+        
+        foreach (var root in allRoots)
+        {
+            root.Builder.UseMappingStrategy(RelationalAnnotationNames.TphMappingStrategy);
         }
     }
 }

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -83,6 +83,8 @@ public abstract class RelationalConventionSetBuilder : ProviderConventionSetBuil
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(checkConstraintConvention);
         conventionSet.EntityTypeBaseTypeChangedConventions.Add(triggerConvention);
 
+        conventionSet.EntityTypeAnnotationChangedConventions.Add(tableNameFromDbSetConvention);
+
         ReplaceConvention(conventionSet.ForeignKeyPropertiesChangedConventions, valueGenerationConvention);
 
         ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, valueGenerationConvention);

--- a/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
@@ -12,6 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 public class TableNameFromDbSetConvention :
     IEntityTypeAddedConvention,
     IEntityTypeBaseTypeChangedConvention,
+    IEntityTypeAnnotationChangedConvention,
     IModelFinalizingConvention
 {
     private readonly IDictionary<Type, string> _sets;
@@ -63,13 +64,7 @@ public class TableNameFromDbSetConvention :
     /// </summary>
     protected virtual RelationalConventionSetBuilderDependencies RelationalDependencies { get; }
 
-    /// <summary>
-    ///     Called after the base type of an entity type changes.
-    /// </summary>
-    /// <param name="entityTypeBuilder">The builder for the entity type.</param>
-    /// <param name="newBaseType">The new base entity type.</param>
-    /// <param name="oldBaseType">The old base entity type.</param>
-    /// <param name="context">Additional information associated with convention execution.</param>
+    /// <inheritdoc />
     public virtual void ProcessEntityTypeBaseTypeChanged(
         IConventionEntityTypeBuilder entityTypeBuilder,
         IConventionEntityType? newBaseType,
@@ -79,7 +74,9 @@ public class TableNameFromDbSetConvention :
         var entityType = entityTypeBuilder.Metadata;
 
         if (oldBaseType == null
-            && newBaseType != null)
+            && newBaseType != null
+            && (entityType.GetMappingStrategy() ?? RelationalAnnotationNames.TphMappingStrategy)
+                == RelationalAnnotationNames.TphMappingStrategy)
         {
             entityTypeBuilder.HasNoAnnotation(RelationalAnnotationNames.TableName);
         }
@@ -92,21 +89,43 @@ public class TableNameFromDbSetConvention :
         }
     }
 
-    /// <summary>
-    ///     Called after an entity type is added to the model.
-    /// </summary>
-    /// <param name="entityTypeBuilder">The builder for the entity type.</param>
-    /// <param name="context">Additional information associated with convention execution.</param>
+    /// <inheritdoc />
     public virtual void ProcessEntityTypeAdded(
         IConventionEntityTypeBuilder entityTypeBuilder,
         IConventionContext<IConventionEntityTypeBuilder> context)
     {
         var entityType = entityTypeBuilder.Metadata;
-        if (entityType.BaseType == null
-            && !entityType.HasSharedClrType
+        if (!entityType.HasSharedClrType
+            && (entityType.BaseType == null
+                || (entityType.GetMappingStrategy() ?? RelationalAnnotationNames.TphMappingStrategy)
+                    != RelationalAnnotationNames.TphMappingStrategy)
             && _sets.TryGetValue(entityType.ClrType, out var setName))
         {
             entityTypeBuilder.ToTable(setName);
+        }
+    }
+
+    /// <inheritdoc />
+    public virtual void ProcessEntityTypeAnnotationChanged(
+        IConventionEntityTypeBuilder entityTypeBuilder,
+        string name,
+        IConventionAnnotation? annotation,
+        IConventionAnnotation? oldAnnotation,
+        IConventionContext<IConventionAnnotation> context)
+    {
+        if (name == RelationalAnnotationNames.MappingStrategy
+            && annotation != null
+            && (entityTypeBuilder.Metadata.GetMappingStrategy() ?? RelationalAnnotationNames.TphMappingStrategy)
+                != RelationalAnnotationNames.TphMappingStrategy)
+        {
+            foreach (var deriverEntityType in entityTypeBuilder.Metadata.GetDerivedTypesInclusive())
+            {
+                if (!deriverEntityType.HasSharedClrType
+                    && _sets.TryGetValue(deriverEntityType.ClrType, out var setName))
+                {
+                    deriverEntityType.Builder.ToTable(setName);
+                }
+            }
         }
     }
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -18,6 +18,7 @@ public class CSharpMigrationsGeneratorTest
 {
     private static readonly string _nl = Environment.NewLine;
     private static readonly string _toTable = _nl + @"entityTypeBuilder.ToTable(""WithAnnotations"")";
+    private static readonly string _toNullTable = _nl + @"entityTypeBuilder.ToTable((string)null)";
 
     [ConditionalFact]
     public void Test_new_annotations_handled_for_entity_types()
@@ -139,19 +140,22 @@ public class CSharpMigrationsGeneratorTest
 #pragma warning disable CS0612 // Type or member is obsolete
                 CoreAnnotationNames.DefiningQuery,
 #pragma warning restore CS0612 // Type or member is obsolete
-                (Expression.Lambda(Expression.Constant(null)), "")
+                (Expression.Lambda(Expression.Constant(null)), _toNullTable)
             },
             {
                 RelationalAnnotationNames.ViewName,
-                ("MyView", _nl + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToView) + @"(""MyView"")")
+                ("MyView", _toNullTable + ";" + _nl + _nl
+                    + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToView) + @"(""MyView"")")
             },
             {
                 RelationalAnnotationNames.FunctionName,
-                (null, _nl + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToFunction) + @"(null)")
+                (null, _toNullTable + ";" + _nl + _nl
+                    + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToFunction) + @"(null)")
             },
             {
                 RelationalAnnotationNames.SqlQuery,
-                (null, _nl + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToSqlQuery) + @"(null)")
+                (null, _toNullTable + ";" + _nl + _nl
+                    + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToSqlQuery) + @"(null)")
             }
         };
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -1048,6 +1048,7 @@ namespace TestNamespace
         {
             runtimeEntityType.AddAnnotation(""DiscriminatorMappingComplete"", false);
             runtimeEntityType.AddAnnotation(""Relational:FunctionName"", null);
+            runtimeEntityType.AddAnnotation(""Relational:MappingStrategy"", ""TPH"");
             runtimeEntityType.AddAnnotation(""Relational:Schema"", null);
             runtimeEntityType.AddAnnotation(""Relational:SqlQuery"", null);
             runtimeEntityType.AddAnnotation(""Relational:TableName"", ""PrincipalDerived"");
@@ -1166,6 +1167,7 @@ namespace TestNamespace
         public static void CreateAnnotations(RuntimeEntityType runtimeEntityType)
         {
             runtimeEntityType.AddAnnotation(""Relational:FunctionName"", null);
+            runtimeEntityType.AddAnnotation(""Relational:MappingStrategy"", ""TPT"");
             runtimeEntityType.AddAnnotation(""Relational:Schema"", ""mySchema"");
             runtimeEntityType.AddAnnotation(""Relational:SqlQuery"", null);
             runtimeEntityType.AddAnnotation(""Relational:TableName"", ""PrincipalBase"");

--- a/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
@@ -63,15 +63,21 @@ public abstract class EntitySplittingTestBase : NonSharedModelTestBase
             });
     }
 
-    protected async Task InitializeAsync(Action<ModelBuilder> onModelCreating, bool sensitiveLogEnabled = true)
-        => ContextFactory = await InitializeAsync<EntitySplittingContext>(
+    protected async Task InitializeAsync(
+        Action<ModelBuilder> onModelCreating,
+        Action<DbContextOptionsBuilder> onConfiguring = null,
+        Action<EntitySplittingContext> seed = null,
+        bool sensitiveLogEnabled = true)
+        => ContextFactory = await InitializeAsync(
             onModelCreating,
+            seed: seed,
             shouldLogCategory: _ => true,
             onConfiguring: options =>
             {
                 options.ConfigureWarnings(w => w.Log(RelationalEventId.OptionalDependentWithAllNullPropertiesWarning))
                     .ConfigureWarnings(w => w.Log(RelationalEventId.OptionalDependentWithoutIdentifyingPropertyWarning))
                     .EnableSensitiveDataLogging(sensitiveLogEnabled);
+                onConfiguring?.Invoke(options);
             }
         );
 

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCGearsOfWarQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCGearsOfWarQueryRelationalFixture.cs
@@ -20,8 +20,7 @@ public abstract class TPCGearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtu
 
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
         => base.AddOptions(builder).ConfigureWarnings(
-            w =>
-                w.Log(RelationalEventId.ForeignKeyTpcPrincipalWarning));
+            w => w.Log(RelationalEventId.ForeignKeyTpcPrincipalWarning));
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
@@ -31,12 +30,8 @@ public abstract class TPCGearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtu
         modelBuilder.Entity<Faction>().UseTpcMappingStrategy();
         modelBuilder.Entity<LocustLeader>().UseTpcMappingStrategy();
 
-        modelBuilder.Entity<Gear>().ToTable("Gears");
-        modelBuilder.Entity<Officer>().ToTable("Officers");
-
         modelBuilder.Entity<LocustHorde>().ToTable("LocustHordes");
 
-        modelBuilder.Entity<LocustLeader>().ToTable("LocustLeaders");
         modelBuilder.Entity<LocustCommander>().ToTable("LocustCommanders");
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCInheritanceQueryFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCInheritanceQueryFixture.cs
@@ -20,7 +20,7 @@ public abstract class TPCInheritanceQueryFixture : InheritanceQueryFixtureBase
     {
         base.OnModelCreating(modelBuilder, context);
 
-        // Configure TPT for hierarchies
+        // Configure TPC for hierarchies
         modelBuilder.Entity<Plant>().UseTpcMappingStrategy();
         modelBuilder.Entity<Animal>().UseTpcMappingStrategy();
         modelBuilder.Entity<Drink>().UseTpcMappingStrategy();
@@ -31,12 +31,10 @@ public abstract class TPCInheritanceQueryFixture : InheritanceQueryFixtureBase
         modelBuilder.Entity<Country>().Property(e => e.Id).ValueGeneratedNever();
 
         modelBuilder.Entity<Bird>().ToTable("Birds");
-        modelBuilder.Entity<Eagle>().ToTable("Eagle");
         modelBuilder.Entity<Kiwi>().ToTable("Kiwi");
         modelBuilder.Entity<Animal>().Property(e => e.Species).HasMaxLength(100);
         modelBuilder.Entity<Eagle>().HasMany(e => e.Prey).WithOne().HasForeignKey(e => e.EagleId).IsRequired(false);
 
-        modelBuilder.Entity<Drink>().ToTable("Drinks");
         modelBuilder.Entity<Coke>().ToTable("Coke");
         modelBuilder.Entity<Lilt>().ToTable("Lilt");
         modelBuilder.Entity<Tea>().ToTable("Tea");

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTGearsOfWarQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTGearsOfWarQueryRelationalFixture.cs
@@ -22,13 +22,10 @@ public abstract class TPTGearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtu
     {
         base.OnModelCreating(modelBuilder, context);
 
-        modelBuilder.Entity<Gear>().ToTable("Gears");
-        modelBuilder.Entity<Officer>().ToTable("Officers");
+        modelBuilder.Entity<Gear>().UseTptMappingStrategy();
 
-        modelBuilder.Entity<Faction>().ToTable("Factions");
         modelBuilder.Entity<LocustHorde>().ToTable("LocustHordes");
 
-        modelBuilder.Entity<LocustLeader>().ToTable("LocustLeaders");
         modelBuilder.Entity<LocustCommander>().ToTable("LocustCommanders");
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTInheritanceQueryFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTInheritanceQueryFixture.cs
@@ -20,20 +20,16 @@ public abstract class TPTInheritanceQueryFixture : InheritanceQueryFixtureBase
     {
         base.OnModelCreating(modelBuilder, context);
 
-        modelBuilder.Entity<Plant>().ToTable("Plants");
         modelBuilder.Entity<Flower>().ToTable("Flowers");
         modelBuilder.Entity<Rose>().ToTable("Roses");
         modelBuilder.Entity<Daisy>().ToTable("Daisies");
         modelBuilder.Entity<Country>().Property(e => e.Id).ValueGeneratedNever();
 
-        modelBuilder.Entity<Animal>().ToTable("Animals");
         modelBuilder.Entity<Bird>().ToTable("Birds");
-        modelBuilder.Entity<Eagle>().ToTable("Eagle");
         modelBuilder.Entity<Kiwi>().ToTable("Kiwi");
         modelBuilder.Entity<Animal>().Property(e => e.Species).HasMaxLength(100);
         modelBuilder.Entity<Eagle>().HasMany(e => e.Prey).WithOne().HasForeignKey(e => e.EagleId).IsRequired(false);
 
-        modelBuilder.Entity<Drink>().ToTable("Drinks");
         modelBuilder.Entity<Coke>().ToTable("Coke");
         modelBuilder.Entity<Lilt>().ToTable("Lilt");
         modelBuilder.Entity<Tea>().ToTable("Tea");

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
@@ -11,6 +11,7 @@ public class GearsOfWarContext : PoolableDbContext
     }
 
     public DbSet<Gear> Gears { get; set; }
+    public DbSet<Officer> Officers { get; set; }
     public DbSet<Squad> Squads { get; set; }
     public DbSet<CogTag> Tags { get; set; }
     public DbSet<Weapon> Weapons { get; set; }

--- a/test/EFCore.SqlServer.FunctionalTests/EntitySplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EntitySplittingSqlServerTest.cs
@@ -9,12 +9,59 @@ public class EntitySplittingSqlServerTest : EntitySplittingTestBase
         : base(testOutputHelper)
     {
     }
+    
+    [ConditionalFact(Skip = "Entity splitting query Issue #620")]
+    public virtual async Task Can_roundtrip_with_triggers()
+    {
+        await InitializeAsync(modelBuilder =>
+            {
+                OnModelCreating(modelBuilder);
+                
+                modelBuilder.Entity<MeterReading>(
+                    ob =>
+                    {
+                        ob.SplitToTable(
+                            "MeterReadingDetails", t =>
+                            {
+                                t.HasTrigger("MeterReadingsDetails_Trigger");
+                            });
+                    });
+            },
+            sensitiveLogEnabled: false,
+            seed: c =>
+                {
+                    c.Database.ExecuteSqlRaw($@"
+CREATE OR ALTER TRIGGER [MeterReadingsDetails_Trigger]
+ON [MeterReadingDetails]
+FOR INSERT, UPDATE, DELETE AS
+BEGIN
+	IF @@ROWCOUNT = 0
+		return
+END");
+                });
+
+        await using (var context = CreateContext())
+        {
+            var meterReading = new MeterReading { ReadingStatus = MeterReadingStatus.NotAccesible, CurrentRead = "100" };
+
+            context.Add(meterReading);
+
+            TestSqlLoggerFactory.Clear();
+
+            await context.SaveChangesAsync();
+
+            Assert.Empty(TestSqlLoggerFactory.Log.Where(l => l.Level == LogLevel.Warning));
+        }
+
+        await using (var context = CreateContext())
+        {
+            var reading = await context.MeterReadings.SingleAsync();
+
+            Assert.Equal(MeterReadingStatus.NotAccesible, reading.ReadingStatus);
+            Assert.Equal("100", reading.CurrentRead);
+        }
+    }
 
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;
-    
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerTriggersTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerTriggersTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-
 // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerTestModelBuilderExtensions.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerTestModelBuilderExtensions.cs
@@ -64,18 +64,18 @@ public static class SqlServerTestModelBuilderExtensions
 
     public static RelationalModelBuilderTest.TestTableBuilder<TEntity> IsTemporal<TEntity>(
         this RelationalModelBuilderTest.TestTableBuilder<TEntity> builder,
-        Action<SqlServerModelBuilderGenericTest.TestTemporalTableBuilder<TEntity>> buildAction)
+        Action<SqlServerModelBuilderTestBase.TestTemporalTableBuilder<TEntity>> buildAction)
         where TEntity : class
     {
         switch (builder)
         {
             case IInfrastructure<TableBuilder<TEntity>> genericBuilder:
                 genericBuilder.Instance.IsTemporal(
-                    b => buildAction(new SqlServerModelBuilderGenericTest.GenericTestTemporalTableBuilder<TEntity>(b)));
+                    b => buildAction(new SqlServerModelBuilderTestBase.GenericTestTemporalTableBuilder<TEntity>(b)));
                 break;
             case IInfrastructure<TableBuilder> nongenericBuilder:
                 nongenericBuilder.Instance.IsTemporal(
-                    b => buildAction(new SqlServerModelBuilderGenericTest.NonGenericTestTemporalTableBuilder<TEntity>(b)));
+                    b => buildAction(new SqlServerModelBuilderTestBase.NonGenericTestTemporalTableBuilder<TEntity>(b)));
                 break;
         }
 


### PR DESCRIPTION
Use DbSet names for TPC and TPT entity types

Fixes #28193
Fixes #28298