### PR TITLE
Fix scaffolding of reference navigations with NRT (#27616)

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -462,7 +462,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     _sb.AppendLine(
                         !_useNullableReferenceTypes || navigation.IsCollection
                             ? $"public virtual {navigationType} {navigation.Name} {{ get; set; }}"
-                            : navigation.ForeignKey.IsRequired
+                            : navigation.ForeignKey.IsRequired && navigation.IsOnDependent
                                 ? $"public virtual {navigationType} {navigation.Name} {{ get; set; }} = null!;"
                                 : $"public virtual {navigationType}? {navigation.Name} {{ get; set; }}");
                 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -785,10 +785,27 @@ namespace TestNamespace
                         {
                             x.Property<int>("Id");
 
-                            x.HasOne("Dependent1", "RequiredNavigationWithReferenceForeignKey").WithOne("Entity").IsRequired();
-                            x.HasOne("Dependent2", "OptionalNavigationWithReferenceForeignKey").WithOne("Entity");
-                            x.HasOne("Dependent3", "RequiredNavigationWithValueForeignKey").WithOne("Entity").IsRequired();
-                            x.HasOne("Dependent4", "OptionalNavigationWithValueForeignKey").WithOne("Entity");
+                            x
+                                .HasOne("Dependent1", "RequiredNavigationWithReferenceForeignKey")
+                                .WithOne("Entity")
+                                .HasForeignKey("Dependent1", "RequiredNavigationWithReferenceForeignKey")
+                                .IsRequired();
+
+                            x
+                                .HasOne("Dependent2", "OptionalNavigationWithReferenceForeignKey")
+                                .WithOne("Entity")
+                                .HasForeignKey("Dependent2", "OptionalNavigationWithReferenceForeignKey");
+
+                            x
+                                .HasOne("Dependent3", "RequiredNavigationWithValueForeignKey")
+                                .WithOne("Entity")
+                                .HasForeignKey("Dependent3", "RequiredNavigationWithValueForeignKey")
+                                .IsRequired();
+
+                            x
+                                .HasOne("Dependent4", "OptionalNavigationWithValueForeignKey")
+                                .WithOne("Entity")
+                                .HasForeignKey("Dependent4", "OptionalNavigationWithValueForeignKey");
                         })
                     .Entity("Dependent1", x => x.Property<string>("Id"))
                     .Entity("Dependent2", x => x.Property<string>("Id"))
@@ -810,23 +827,15 @@ namespace TestNamespace
     {
         [Key]
         public int Id { get; set; }
-        public string? OptionalNavigationWithReferenceForeignKeyId { get; set; }
-        public int? OptionalNavigationWithValueForeignKeyId { get; set; }
-        public string RequiredNavigationWithReferenceForeignKeyId { get; set; } = null!;
-        public int RequiredNavigationWithValueForeignKeyId { get; set; }
 
-        [ForeignKey(""OptionalNavigationWithReferenceForeignKeyId"")]
         [InverseProperty(""Entity"")]
         public virtual Dependent2? OptionalNavigationWithReferenceForeignKey { get; set; }
-        [ForeignKey(""OptionalNavigationWithValueForeignKeyId"")]
         [InverseProperty(""Entity"")]
         public virtual Dependent4? OptionalNavigationWithValueForeignKey { get; set; }
-        [ForeignKey(""RequiredNavigationWithReferenceForeignKeyId"")]
         [InverseProperty(""Entity"")]
-        public virtual Dependent1 RequiredNavigationWithReferenceForeignKey { get; set; } = null!;
-        [ForeignKey(""RequiredNavigationWithValueForeignKeyId"")]
+        public virtual Dependent1? RequiredNavigationWithReferenceForeignKey { get; set; }
         [InverseProperty(""Entity"")]
-        public virtual Dependent3 RequiredNavigationWithValueForeignKey { get; set; } = null!;
+        public virtual Dependent3? RequiredNavigationWithValueForeignKey { get; set; }
     }
 }
 ",
@@ -835,11 +844,6 @@ namespace TestNamespace
                 model =>
                 {
                     var entityType = model.FindEntityType("TestNamespace.Entity");
-
-                    Assert.False(entityType.GetProperty("RequiredNavigationWithReferenceForeignKeyId").IsNullable);
-                    Assert.True(entityType.GetProperty("OptionalNavigationWithReferenceForeignKeyId").IsNullable);
-                    Assert.False(entityType.GetProperty("RequiredNavigationWithValueForeignKeyId").IsNullable);
-                    Assert.True(entityType.GetProperty("OptionalNavigationWithValueForeignKeyId").IsNullable);
 
                     Assert.True(entityType.FindNavigation("RequiredNavigationWithReferenceForeignKey")!.ForeignKey.IsRequired);
                     Assert.False(entityType.FindNavigation("OptionalNavigationWithReferenceForeignKey")!.ForeignKey.IsRequired);


### PR DESCRIPTION
Fixes #27496

(cherry picked from commit ec9c6c235a5a04fcc48520c4585a375b2778600d)

**Description**

When scaffolding an existing database in a project with nullable reference types enabled, dependent navigations are incorrectly scaffolded as non-nullable.

**Customer impact**

An incorrect model is scaffolded and must be manually fixed up.

**How found**

Customer reported on 6.0

**Regression**

No, scaffolding NRT code was introduced in 6.0 (#15520)

**Testing**

Added.

**Risk**

Low - affects design-time scaffolding only.