### PR TITLE
Make Select_nested_collection_with_groupby have deterministic ordering

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -1988,7 +1988,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture> : QueryTestBase<TF
                         ? c.Orders.GroupBy(o => o.OrderID).Select(g => g.Key).ToArray()
                         : Array.Empty<int>()),
             assertOrder: true,
-            elementAsserter: (e, a) => Assert.True(e.SequenceEqual(a)));
+            elementAsserter: (e, a) => Assert.True(e.OrderBy(x => x).SequenceEqual(a.OrderBy(x => x))));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]


### PR DESCRIPTION
Test starting failing after upgrading PG version to 15.