### PR TITLE
Query: Entity splitting support for regular entities

### DIFF
--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -94,7 +94,7 @@ public class RelationalEntityShaperExpression : EntityShaperExpression
             return baseCondition;
         }
 
-        var table = entityType.GetViewOrTableMappings().SingleOrDefault()?.Table
+        var table = entityType.GetViewOrTableMappings().SingleOrDefault(e => e.IsSplitEntityTypePrincipal ?? true)?.Table
             ?? entityType.GetDefaultMappings().Single().Table;
         if (table.IsOptional(entityType))
         {

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1320,7 +1320,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                 return propertyAccess;
             }
 
-            var table = entityType.GetViewOrTableMappings().SingleOrDefault()?.Table
+            var table = entityType.GetViewOrTableMappings().SingleOrDefault(e => e.IsSplitEntityTypePrincipal ?? true)?.Table
                 ?? entityType.GetDefaultMappings().Single().Table;
             if (!table.IsOptional(entityType))
             {

--- a/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
@@ -11,10 +11,10 @@ public abstract class EntitySplittingTestBase : NonSharedModelTestBase
         //TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ConditionalFact(Skip = "Entity splitting query Issue #620")]
+    [ConditionalFact]
     public virtual async Task Can_roundtrip()
     {
-        await InitializeAsync(OnModelCreating, sensitiveLogEnabled: false);
+        await InitializeAsync(OnModelCreating, sensitiveLogEnabled: true);
 
         await using (var context = CreateContext())
         {

--- a/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryFixtureBase.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.EntitySplitting;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public abstract class EntitySplittingQueryFixtureBase : SharedStoreFixtureBase<EntitySplittingContext>, IQueryFixtureBase
+{
+    private SplitEntityData _expectedData;
+
+    protected EntitySplittingQueryFixtureBase()
+    {
+    }
+
+    protected override string StoreName { get; } = "EntitySplittingQueryTest";
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+       => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    public Func<DbContext> GetContextCreator() => () => CreateContext();
+
+    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
+        => new Dictionary<Type, Action<object, object>>
+        {
+            {
+                typeof(SplitEntityOne), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        var ee =(SplitEntityOne)e;
+                        var aa =(SplitEntityOne)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Value, aa.Value);
+                        Assert.Equal(ee.SharedValue, aa.SharedValue);
+                        Assert.Equal(ee.SplitValue, aa.SplitValue);
+                    }
+                }
+            }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> GetEntitySorters()
+        => new Dictionary<Type, Func<object, object>>
+        {
+            { typeof(SplitEntityOne), e => ((SplitEntityOne)e)?.Id },
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public ISetSource GetExpectedData()
+    {
+        if (_expectedData == null)
+        {
+            _expectedData = new SplitEntityData();
+        }
+
+        return _expectedData;
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        modelBuilder.Entity<SplitEntityOne>(b =>
+        {
+            b.ToTable("SplitEntityOneMain", tb =>
+            {
+                tb.Property(e => e.SharedValue);
+            });
+
+            b.SplitToTable("SplitEntityOneOther", tb =>
+            {
+                tb.Property(e => e.SharedValue).HasColumnName("OtherSharedValue");
+                tb.Property(e => e.SplitValue);
+            });
+        });
+
+        base.OnModelCreating(modelBuilder, context);
+    }
+
+    protected override void Seed(EntitySplittingContext context)
+    {
+        var _ = GetExpectedData();
+        _expectedData.Seed(context);
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/EntitySplittingQueryTestBase.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.EntitySplitting;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public abstract class EntitySplittingQueryTestBase<TFixture> : QueryTestBase<TFixture>
+    where TFixture : EntitySplittingQueryFixtureBase, new()
+{
+    public EntitySplittingQueryTestBase(TFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Can_query_entity_which_is_split(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<SplitEntityOne>());
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Can_query_entity_which_is_split_selecting_only_main_properties(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<SplitEntityOne>().Select(e => new { e.Id, e.SharedValue, e.Value }));
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/EntitySplitting/EntitySplittingContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/EntitySplitting/EntitySplittingContext.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.EntitySplitting;
+
+public class EntitySplittingContext : PoolableDbContext
+{
+    public EntitySplittingContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
+    public DbSet<SplitEntityOne> SplitEntityOnes { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/EntitySplitting/SplitEntityData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/EntitySplitting/SplitEntityData.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.EntitySplitting;
+
+public class SplitEntityData : ISetSource
+{
+    private readonly SplitEntityOne[] _splitEntityOnes;
+
+    public SplitEntityData()
+    {
+        _splitEntityOnes = CreateSplitEntityOnes();
+    }
+
+    public IQueryable<TEntity> Set<TEntity>()
+        where TEntity : class
+    {
+        if (typeof(TEntity) == typeof(SplitEntityOne))
+        {
+            return (IQueryable<TEntity>)_splitEntityOnes.AsQueryable();
+        }
+
+        throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
+    }
+
+    private static SplitEntityOne[] CreateSplitEntityOnes()
+        => new SplitEntityOne[]
+        {
+
+        };
+
+    public void Seed(EntitySplittingContext context)
+    {
+        context.AddRange(_splitEntityOnes);
+
+        context.SaveChanges();
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/EntitySplitting/SplitEntityOne.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/EntitySplitting/SplitEntityOne.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.EntitySplitting;
+
+public class SplitEntityOne
+{
+    public int Id { get; set; }
+    public string Value { get; set; }
+    public int SharedValue { get; set; }
+    public string SplitValue { get; set; }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -4355,10 +4355,10 @@ END IS NULL)");
             @"SELECT [l].[Id]
 FROM [Level1] AS [l]
 INNER JOIN (
-    SELECT [t].[Level1_Optional_Id]
+    SELECT [l0].[Id], [l0].[Date], [l0].[Name], [t].[Id] AS [Id0], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id]
     FROM [Level1] AS [l0]
     LEFT JOIN (
-        SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[OneToMany_Required_Inverse2Id]
+        SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id]
         FROM [Level1] AS [l1]
         WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL
     ) AS [t] ON [l0].[Id] = CASE

--- a/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerFixture.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class EntitySplittingQuerySqlServerFixture : EntitySplittingQueryFixtureBase
+{
+    protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/EntitySplittingQuerySqlServerTest.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class EntitySplittingQuerySqlServerTest : EntitySplittingQueryTestBase<EntitySplittingQuerySqlServerFixture>
+{
+    public EntitySplittingQuerySqlServerTest(EntitySplittingQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    public override async Task Can_query_entity_which_is_split(bool async)
+    {
+        await base.Can_query_entity_which_is_split(async);
+
+        AssertSql(
+            @"SELECT [s].[Id], [s].[SharedValue], [s0].[SplitValue], [s].[Value]
+FROM [SplitEntityOneMain] AS [s]
+INNER JOIN [SplitEntityOneOther] AS [s0] ON [s].[Id] = [s0].[Id]");
+    }
+
+    public override async Task Can_query_entity_which_is_split_selecting_only_main_properties(bool async)
+    {
+        await base.Can_query_entity_which_is_split_selecting_only_main_properties(async);
+
+        AssertSql(
+            @"SELECT [s].[Id], [s].[SharedValue], [s].[Value]
+FROM [SplitEntityOneMain] AS [s]");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1520,7 +1520,7 @@ INNER JOIN [Orders] AS [o0] ON [t].[LastOrderID] = [o0].[OrderID]");
             @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT [o].[CustomerID]
+    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [LastOrderID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
@@ -1634,7 +1634,7 @@ INNER JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     INNER JOIN (
-        SELECT [o0].[CustomerID]
+        SELECT [o0].[CustomerID], MAX([o0].[OrderID]) AS [LastOrderID]
         FROM [Orders] AS [o0]
         GROUP BY [o0].[CustomerID]
         HAVING COUNT(*) > 5

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -168,7 +168,7 @@ WHERE [c].[CustomerID] = @__entity_equality_local_0_CustomerID AND @__entity_equ
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT [c0].[CustomerID]
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] = @__entity_equality_local_0_CustomerID
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
@@ -358,12 +358,12 @@ LEFT JOIN (
     WHERE [e].[EmployeeID] = -1
 ) AS [t] ON 1 = 1
 INNER JOIN (
-    SELECT [t1].[EmployeeID]
+    SELECT [t1].[EmployeeID], [t1].[City], [t1].[Country], [t1].[FirstName], [t1].[ReportsTo], [t1].[Title]
     FROM (
         SELECT NULL AS [empty]
     ) AS [e1]
     LEFT JOIN (
-        SELECT [e2].[EmployeeID]
+        SELECT [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
         FROM [Employees] AS [e2]
         WHERE [e2].[EmployeeID] = -1
     ) AS [t1] ON 1 = 1

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -179,7 +179,10 @@ FROM [Users] AS [u]");
 SELECT [o].[Id], [o].[CancellationDate], [o].[OrderId], [o].[ShippingDate]
 FROM [OrderItems] AS [o]
 INNER JOIN (
-    SELECT [o0].[OrderId] AS [Key]
+    SELECT [o0].[OrderId] AS [Key], MAX(CASE
+        WHEN [o0].[ShippingDate] IS NULL AND [o0].[CancellationDate] IS NULL THEN [o0].[OrderId]
+        ELSE [o0].[OrderId] - 10000000
+    END) AS [IsPending]
     FROM [OrderItems] AS [o0]
     WHERE [o0].[OrderId] = @__orderId_0
     GROUP BY [o0].[OrderId]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -8302,10 +8302,10 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [t]
 INNER JOIN (
-    SELECT [g0].[Nickname]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
-    SELECT [o0].[Nickname]
+    SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
 ) AS [t0] ON [t].[Nickname] = [t0].[Nickname]");
     }
@@ -8324,10 +8324,10 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [t]
 INNER JOIN (
-    SELECT [g0].[Nickname]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], N'Gear' AS [Discriminator]
     FROM [Gears] AS [g0]
     UNION ALL
-    SELECT [o0].[Nickname]
+    SELECT [o0].[Nickname], [o0].[SquadId], [o0].[AssignedCityName], [o0].[CityOfBirthName], [o0].[FullName], [o0].[HasSoulPatch], [o0].[LeaderNickname], [o0].[LeaderSquadId], [o0].[Rank], N'Officer' AS [Discriminator]
     FROM [Officers] AS [o0]
 ) AS [t0] ON [t].[Nickname] = [t0].[Nickname]");
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -6943,8 +6943,11 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 INNER JOIN (
-    SELECT [g0].[Nickname]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], CASE
+        WHEN [o0].[Nickname] IS NOT NULL THEN N'Officer'
+    END AS [Discriminator]
     FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON [g0].[Nickname] = [o0].[Nickname] AND [g0].[SquadId] = [o0].[SquadId]
 ) AS [t] ON [g].[Nickname] = [t].[Nickname]");
     }
 
@@ -6959,8 +6962,11 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 INNER JOIN (
-    SELECT [g0].[Nickname]
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], CASE
+        WHEN [o0].[Nickname] IS NOT NULL THEN N'Officer'
+    END AS [Discriminator]
     FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON [g0].[Nickname] = [o0].[Nickname] AND [g0].[SquadId] = [o0].[SquadId]
 ) AS [t] ON [g].[Nickname] = [t].[Nickname]");
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -596,7 +596,7 @@ ORDER BY [c].[Id]");
             @"SELECT [o].[CustomerId], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
-    SELECT [g].[OrderId]
+    SELECT [c].[Id], [c].[FirstName], [c].[LastName], [g].[OrderId], [g].[CustomerId], [g].[OrderDate]
     FROM [Customers] AS [c]
     CROSS APPLY [dbo].[GetOrdersWithMultipleProducts]([c].[Id]) AS [g]
 ) AS [t] ON [o].[Id] = [t].[OrderId]");

--- a/test/EFCore.Sqlite.FunctionalTests/Query/EntitySplittingQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/EntitySplittingQuerySqliteFixture.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class EntitySplittingQuerySqliteFixture : EntitySplittingQueryFixtureBase
+{
+    protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/EntitySplittingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/EntitySplittingQuerySqliteTest.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class EntitySplittingQuerySqliteTest : EntitySplittingQueryTestBase<EntitySplittingQuerySqliteFixture>
+{
+    public EntitySplittingQuerySqliteTest(EntitySplittingQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}


### PR DESCRIPTION
Part of #620
