### PR TITLE
Update broken link to xunit.net

### DIFF
--- a/docs/getting-and-building-the-code.md
+++ b/docs/getting-and-building-the-code.md
@@ -68,7 +68,7 @@ If you install the latest preview release of the [.NET SDK](https://dotnet.micro
 
 ### Run tests
 
-Our tests are written using [xUnit.net](http://xunit.github.io/), and can be run with most test runners we have tried.
+Our tests are written using [xUnit.net](https://xunit.net/), and can be run with most test runners we have tried.
 Tests can be run on the command line (after build) by running `test`:
 
 ```console


### PR DESCRIPTION
<!--
Please check whether the PR fulfills these requirements
-->

The original link to xunit was broken, it pointed to [Broken XUnit](http://xunit.github.io/) which does not exist. This PR replaces the link with the current link [Xunit](https://xunit.net/)

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

