### PR TITLE
Add Entry method to DbSet to get entries for shared-type entity type instances

### DIFF
--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -56,6 +56,7 @@ public class LocalView<TEntity> :
     private ObservableBackedBindingList<TEntity>? _bindingList;
     private ObservableCollection<TEntity>? _observable;
     private readonly DbContext _context;
+    private readonly IEntityType _entityType;
     private int _countChanges;
     private int? _count;
     private bool _triggeringStateManagerChange;
@@ -72,6 +73,7 @@ public class LocalView<TEntity> :
     public LocalView(DbSet<TEntity> set)
     {
         _context = set.GetService<ICurrentDbContext>().Context;
+        _entityType = set.EntityType;
 
         set.GetService<ILocalViewListener>().RegisterView(StateManagerChangedHandler);
     }
@@ -208,7 +210,7 @@ public class LocalView<TEntity> :
         // to Add it again since doing so would change its state to Added, which is probably not what
         // was wanted in this case.
 
-        var entry = _context.GetDependencies().StateManager.GetOrCreateEntry(item);
+        var entry = _context.GetDependencies().StateManager.GetOrCreateEntry(item, _entityType);
         if (entry.EntityState == EntityState.Deleted
             || entry.EntityState == EntityState.Detached)
         {

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -591,6 +591,19 @@ public abstract class DbSet<TEntity> : IQueryable<TEntity>, IInfrastructure<ISer
         => throw new NotSupportedException();
 
     /// <summary>
+    ///     Gets an <see cref="EntityEntry{TEntity}" /> for the given entity. The entry provides
+    ///     access to change tracking information and operations for the entity.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see> for more information and
+    ///     examples.
+    /// </remarks>
+    /// <param name="entity">The entity to get the entry for.</param>
+    /// <returns>The entry for the given entity.</returns>
+    public virtual EntityEntry<TEntity> Entry(TEntity entity)
+        => throw new NotSupportedException();
+
+    /// <summary>
     ///     Returns an <see cref="IEnumerator{T}" /> which when enumerated will execute a query against the database
     ///     to load all entities from the database.
     /// </summary>

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -370,7 +370,7 @@ public class InternalDbSet<TEntity> :
         foreach (var entity in entities)
         {
             await SetEntityStateAsync(
-                    stateManager.GetOrCreateEntry(entity),
+                    stateManager.GetOrCreateEntry(entity, EntityType),
                     EntityState.Added,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -425,6 +425,26 @@ public class InternalDbSet<TEntity> :
     /// </summary>
     public override void UpdateRange(IEnumerable<TEntity> entities)
         => SetEntityStates(Check.NotNull(entities, nameof(entities)), EntityState.Modified);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override EntityEntry<TEntity> Entry(TEntity entity)
+    {
+        Check.NotNull(entity, nameof(entity));
+
+        var entry = EntryWithoutDetectChanges(entity);
+
+        if (_context.ChangeTracker.AutoDetectChangesEnabled)
+        {
+            entry.DetectChanges();
+        }
+
+        return entry;
+    }
 
     private IEntityFinder<TEntity> Finder
         => (IEntityFinder<TEntity>)_context.GetDependencies().EntityFinderFactory.Create(EntityType);


### PR DESCRIPTION
Fixes #25354

Also added some tests and fixed a couple of other issues with using shared-type entity type instances with tracking, etc.
