### PR TITLE
remove extra duplicate migration existence check

### DIFF
--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -68,6 +68,11 @@ public class MigrationsScaffolder : IMigrationsScaffolder
         string? subNamespace = null,
         string? language = null)
     {
+        if (string.Equals(migrationName, "migration", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new OperationException(DesignStrings.CircularBaseClassDependency);
+        }
+    
         if (Dependencies.MigrationsAssembly.FindMigrationId(migrationName) != null)
         {
             throw new OperationException(DesignStrings.DuplicateMigrationName(migrationName));
@@ -79,16 +84,6 @@ public class MigrationsScaffolder : IMigrationsScaffolder
         {
             subNamespaceDefaulted = true;
             subNamespace = "Migrations";
-        }
-
-        if (string.Equals(migrationName, "migration", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new OperationException(DesignStrings.CircularBaseClassDependency);
-        }
-
-        if (Dependencies.MigrationsAssembly.FindMigrationId(migrationName) != null)
-        {
-            throw new OperationException(DesignStrings.DuplicateMigrationName(migrationName));
         }
         
         var (key, typeInfo) = Dependencies.MigrationsAssembly.Migrations.LastOrDefault();


### PR DESCRIPTION
This PR removes extra duplicate migration existence check in `MigrationsScaffolder`. No breaking changes.