### PR TITLE
Some test perf low-hanging fruit

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryFixtureBase.cs
@@ -11,81 +11,79 @@ public abstract class NullSemanticsQueryFixtureBase : SharedStoreFixtureBase<Nul
         => () => CreateContext();
 
     public virtual ISetSource GetExpectedData()
-        => new NullSemanticsData();
+        => NullSemanticsData.Instance;
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(NullSemanticsEntity1), e => ((NullSemanticsEntity1)e)?.Id },
+        { typeof(NullSemanticsEntity2), e => ((NullSemanticsEntity2)e)?.Id }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
-            { typeof(NullSemanticsEntity1), e => ((NullSemanticsEntity1)e)?.Id },
-            { typeof(NullSemanticsEntity2), e => ((NullSemanticsEntity2)e)?.Id }
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            typeof(NullSemanticsEntity1), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+                if (a != null)
+                {
+                    var ee = (NullSemanticsEntity1)e;
+                    var aa = (NullSemanticsEntity1)a;
 
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.BoolA, aa.BoolA);
+                    Assert.Equal(ee.BoolB, aa.BoolB);
+                    Assert.Equal(ee.BoolC, aa.BoolC);
+                    Assert.Equal(ee.IntA, aa.IntA);
+                    Assert.Equal(ee.IntB, aa.IntB);
+                    Assert.Equal(ee.IntC, aa.IntC);
+                    Assert.Equal(ee.StringA, aa.StringA);
+                    Assert.Equal(ee.StringB, aa.StringB);
+                    Assert.Equal(ee.StringC, aa.StringC);
+                    Assert.Equal(ee.NullableBoolA, aa.NullableBoolA);
+                    Assert.Equal(ee.NullableBoolB, aa.NullableBoolB);
+                    Assert.Equal(ee.NullableBoolC, aa.NullableBoolC);
+                    Assert.Equal(ee.NullableIntA, aa.NullableIntA);
+                    Assert.Equal(ee.NullableIntB, aa.NullableIntB);
+                    Assert.Equal(ee.NullableIntC, aa.NullableIntC);
+                    Assert.Equal(ee.NullableStringA, aa.NullableStringA);
+                    Assert.Equal(ee.NullableStringB, aa.NullableStringB);
+                    Assert.Equal(ee.NullableStringC, aa.NullableStringC);
+                }
+            }
+        },
         {
+            typeof(NullSemanticsEntity2), (e, a) =>
             {
-                typeof(NullSemanticsEntity1), (e, a) =>
+                Assert.Equal(e == null, a == null);
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
-                    if (a != null)
-                    {
-                        var ee = (NullSemanticsEntity1)e;
-                        var aa = (NullSemanticsEntity1)a;
+                    var ee = (NullSemanticsEntity2)e;
+                    var aa = (NullSemanticsEntity2)a;
 
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.BoolA, aa.BoolA);
-                        Assert.Equal(ee.BoolB, aa.BoolB);
-                        Assert.Equal(ee.BoolC, aa.BoolC);
-                        Assert.Equal(ee.IntA, aa.IntA);
-                        Assert.Equal(ee.IntB, aa.IntB);
-                        Assert.Equal(ee.IntC, aa.IntC);
-                        Assert.Equal(ee.StringA, aa.StringA);
-                        Assert.Equal(ee.StringB, aa.StringB);
-                        Assert.Equal(ee.StringC, aa.StringC);
-                        Assert.Equal(ee.NullableBoolA, aa.NullableBoolA);
-                        Assert.Equal(ee.NullableBoolB, aa.NullableBoolB);
-                        Assert.Equal(ee.NullableBoolC, aa.NullableBoolC);
-                        Assert.Equal(ee.NullableIntA, aa.NullableIntA);
-                        Assert.Equal(ee.NullableIntB, aa.NullableIntB);
-                        Assert.Equal(ee.NullableIntC, aa.NullableIntC);
-                        Assert.Equal(ee.NullableStringA, aa.NullableStringA);
-                        Assert.Equal(ee.NullableStringB, aa.NullableStringB);
-                        Assert.Equal(ee.NullableStringC, aa.NullableStringC);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.BoolA, aa.BoolA);
+                    Assert.Equal(ee.BoolB, aa.BoolB);
+                    Assert.Equal(ee.BoolC, aa.BoolC);
+                    Assert.Equal(ee.IntA, aa.IntA);
+                    Assert.Equal(ee.IntB, aa.IntB);
+                    Assert.Equal(ee.IntC, aa.IntC);
+                    Assert.Equal(ee.StringA, aa.StringA);
+                    Assert.Equal(ee.StringB, aa.StringB);
+                    Assert.Equal(ee.StringC, aa.StringC);
+                    Assert.Equal(ee.NullableBoolA, aa.NullableBoolA);
+                    Assert.Equal(ee.NullableBoolB, aa.NullableBoolB);
+                    Assert.Equal(ee.NullableBoolC, aa.NullableBoolC);
+                    Assert.Equal(ee.NullableIntA, aa.NullableIntA);
+                    Assert.Equal(ee.NullableIntB, aa.NullableIntB);
+                    Assert.Equal(ee.NullableIntC, aa.NullableIntC);
+                    Assert.Equal(ee.NullableStringA, aa.NullableStringA);
+                    Assert.Equal(ee.NullableStringB, aa.NullableStringB);
+                    Assert.Equal(ee.NullableStringC, aa.NullableStringC);
                 }
-            },
-            {
-                typeof(NullSemanticsEntity2), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-                    if (a != null)
-                    {
-                        var ee = (NullSemanticsEntity2)e;
-                        var aa = (NullSemanticsEntity2)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.BoolA, aa.BoolA);
-                        Assert.Equal(ee.BoolB, aa.BoolB);
-                        Assert.Equal(ee.BoolC, aa.BoolC);
-                        Assert.Equal(ee.IntA, aa.IntA);
-                        Assert.Equal(ee.IntB, aa.IntB);
-                        Assert.Equal(ee.IntC, aa.IntC);
-                        Assert.Equal(ee.StringA, aa.StringA);
-                        Assert.Equal(ee.StringB, aa.StringB);
-                        Assert.Equal(ee.StringC, aa.StringC);
-                        Assert.Equal(ee.NullableBoolA, aa.NullableBoolA);
-                        Assert.Equal(ee.NullableBoolB, aa.NullableBoolB);
-                        Assert.Equal(ee.NullableBoolC, aa.NullableBoolC);
-                        Assert.Equal(ee.NullableIntA, aa.NullableIntA);
-                        Assert.Equal(ee.NullableIntB, aa.NullableIntB);
-                        Assert.Equal(ee.NullableIntC, aa.NullableIntC);
-                        Assert.Equal(ee.NullableStringA, aa.NullableStringA);
-                        Assert.Equal(ee.NullableStringB, aa.NullableStringB);
-                        Assert.Equal(ee.NullableStringC, aa.NullableStringC);
-                    }
-                }
-            },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override string StoreName
         => "NullSemanticsQueryTest";

--- a/test/EFCore.Relational.Specification.Tests/TestModels/EntitySplitting/SplitEntityData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/EntitySplitting/SplitEntityData.cs
@@ -5,9 +5,11 @@ namespace Microsoft.EntityFrameworkCore.TestModels.EntitySplitting;
 
 public class SplitEntityData : ISetSource
 {
+    public static readonly SplitEntityData Instance = new();
+
     private readonly SplitEntityOne[] _splitEntityOnes;
 
-    public SplitEntityData()
+    private SplitEntityData()
     {
         _splitEntityOnes = CreateSplitEntityOnes();
     }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
@@ -7,8 +7,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class ComplexNavigationsQueryFixtureBase : SharedStoreFixtureBase<ComplexNavigationsContext>, IQueryFixtureBase
 {
-    private ComplexNavigationsDefaultData _expectedData;
-
     protected override string StoreName
         => "ComplexNavigations";
 
@@ -16,14 +14,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : SharedStoreFixtureBas
         => () => CreateContext();
 
     public virtual ISetSource GetExpectedData()
-    {
-        if (_expectedData == null)
-        {
-            _expectedData = new ComplexNavigationsDefaultData();
-        }
-
-        return _expectedData;
-    }
+        => ComplexNavigationsDefaultData.Instance;
 
     public virtual Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
     {
@@ -191,183 +182,181 @@ public abstract class ComplexNavigationsQueryFixtureBase : SharedStoreFixtureBas
         };
     }
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(Level1), e => ((Level1)e)?.Id },
+        { typeof(Level2), e => ((Level2)e)?.Id },
+        { typeof(Level3), e => ((Level3)e)?.Id },
+        { typeof(Level4), e => ((Level4)e)?.Id },
+        { typeof(InheritanceBase1), e => ((InheritanceBase1)e)?.Id },
+        { typeof(InheritanceBase2), e => ((InheritanceBase2)e)?.Id },
+        { typeof(InheritanceDerived1), e => ((InheritanceDerived1)e)?.Id },
+        { typeof(InheritanceDerived2), e => ((InheritanceDerived2)e)?.Id },
+        { typeof(InheritanceLeaf1), e => ((InheritanceLeaf1)e)?.Id },
+        { typeof(InheritanceLeaf2), e => ((InheritanceLeaf2)e)?.Id }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
-            { typeof(Level1), e => ((Level1)e)?.Id },
-            { typeof(Level2), e => ((Level2)e)?.Id },
-            { typeof(Level3), e => ((Level3)e)?.Id },
-            { typeof(Level4), e => ((Level4)e)?.Id },
-            { typeof(InheritanceBase1), e => ((InheritanceBase1)e)?.Id },
-            { typeof(InheritanceBase2), e => ((InheritanceBase2)e)?.Id },
-            { typeof(InheritanceDerived1), e => ((InheritanceDerived1)e)?.Id },
-            { typeof(InheritanceDerived2), e => ((InheritanceDerived2)e)?.Id },
-            { typeof(InheritanceLeaf1), e => ((InheritanceLeaf1)e)?.Id },
-            { typeof(InheritanceLeaf2), e => ((InheritanceLeaf2)e)?.Id }
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
-
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
-        {
+            typeof(Level1), (e, a) =>
             {
-                typeof(Level1), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Level1)e;
+                    var aa = (Level1)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Level1)e;
-                        var aa = (Level1)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Date, aa.Date);
-                    }
-                }
-            },
-            {
-                typeof(Level2), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Level2)e;
-                        var aa = (Level2)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Date, aa.Date);
-                        Assert.Equal(ee.Level1_Optional_Id, aa.Level1_Optional_Id);
-                        Assert.Equal(ee.Level1_Required_Id, aa.Level1_Required_Id);
-                    }
-                }
-            },
-            {
-                typeof(Level3), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Level3)e;
-                        var aa = (Level3)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Level2_Optional_Id, aa.Level2_Optional_Id);
-                        Assert.Equal(ee.Level2_Required_Id, aa.Level2_Required_Id);
-                    }
-                }
-            },
-            {
-                typeof(Level4), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Level4)e;
-                        var aa = (Level4)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Level3_Optional_Id, aa.Level3_Optional_Id);
-                        Assert.Equal(ee.Level3_Required_Id, aa.Level3_Required_Id);
-                    }
-                }
-            },
-            {
-                typeof(InheritanceBase1), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (InheritanceBase1)e;
-                        var aa = (InheritanceBase1)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
-                }
-            },
-            {
-                typeof(InheritanceBase2), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (InheritanceBase2)e;
-                        var aa = (InheritanceBase2)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
-                }
-            },
-            {
-                typeof(InheritanceDerived1), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (InheritanceDerived1)e;
-                        var aa = (InheritanceDerived1)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
-                }
-            },
-            {
-                typeof(InheritanceDerived2), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (InheritanceDerived2)e;
-                        var aa = (InheritanceDerived2)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
-                }
-            },
-            {
-                typeof(InheritanceLeaf1), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (InheritanceLeaf1)e;
-                        var aa = (InheritanceLeaf1)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
-                }
-            },
-            {
-                typeof(InheritanceLeaf2), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (InheritanceLeaf2)e;
-                        var aa = (InheritanceLeaf2)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Date, aa.Date);
                 }
             }
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+        },
+        {
+            typeof(Level2), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Level2)e;
+                    var aa = (Level2)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Date, aa.Date);
+                    Assert.Equal(ee.Level1_Optional_Id, aa.Level1_Optional_Id);
+                    Assert.Equal(ee.Level1_Required_Id, aa.Level1_Required_Id);
+                }
+            }
+        },
+        {
+            typeof(Level3), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Level3)e;
+                    var aa = (Level3)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Level2_Optional_Id, aa.Level2_Optional_Id);
+                    Assert.Equal(ee.Level2_Required_Id, aa.Level2_Required_Id);
+                }
+            }
+        },
+        {
+            typeof(Level4), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Level4)e;
+                    var aa = (Level4)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Level3_Optional_Id, aa.Level3_Optional_Id);
+                    Assert.Equal(ee.Level3_Required_Id, aa.Level3_Required_Id);
+                }
+            }
+        },
+        {
+            typeof(InheritanceBase1), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (InheritanceBase1)e;
+                    var aa = (InheritanceBase1)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        },
+        {
+            typeof(InheritanceBase2), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (InheritanceBase2)e;
+                    var aa = (InheritanceBase2)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        },
+        {
+            typeof(InheritanceDerived1), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (InheritanceDerived1)e;
+                    var aa = (InheritanceDerived1)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        },
+        {
+            typeof(InheritanceDerived2), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (InheritanceDerived2)e;
+                    var aa = (InheritanceDerived2)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        },
+        {
+            typeof(InheritanceLeaf1), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (InheritanceLeaf1)e;
+                    var aa = (InheritanceLeaf1)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        },
+        {
+            typeof(InheritanceLeaf2), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (InheritanceLeaf2)e;
+                    var aa = (InheritanceLeaf2)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
@@ -497,6 +486,12 @@ public abstract class ComplexNavigationsQueryFixtureBase : SharedStoreFixtureBas
 
     protected class ComplexNavigationsDefaultData : ComplexNavigationsData
     {
+        public static readonly ComplexNavigationsDefaultData Instance = new();
+
+        private ComplexNavigationsDefaultData()
+        {
+        }
+
         public override IQueryable<TEntity> Set<TEntity>()
         {
             if (typeof(TEntity) == typeof(Level1))

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryFixtureBase.cs
@@ -8,20 +8,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class ComplexNavigationsSharedTypeQueryFixtureBase : ComplexNavigationsQueryFixtureBase, IQueryFixtureBase
 {
-    private ComplexNavigationsWeakData _expectedData;
-
     protected override string StoreName
         => "ComplexNavigationsOwned";
 
     public override ISetSource GetExpectedData()
-    {
-        if (_expectedData == null)
-        {
-            _expectedData = new ComplexNavigationsWeakData();
-        }
-
-        return _expectedData;
-    }
+        => ComplexNavigationsWeakData.Instance;
 
     Func<DbContext, ISetSource> IQueryFixtureBase.GetSetSourceCreator()
         => context => new ComplexNavigationsWeakSetExtractor(context);
@@ -290,6 +281,12 @@ public abstract class ComplexNavigationsSharedTypeQueryFixtureBase : ComplexNavi
 
     private class ComplexNavigationsWeakData : ComplexNavigationsData
     {
+        public static readonly ComplexNavigationsWeakData Instance = new();
+
+        private ComplexNavigationsWeakData()
+        {
+        }
+
         public override IQueryable<TEntity> Set<TEntity>()
         {
             if (typeof(TEntity) == typeof(Level1))

--- a/test/EFCore.Specification.Tests/Query/CompositeKeysQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/CompositeKeysQueryFixtureBase.cs
@@ -7,8 +7,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class CompositeKeysQueryFixtureBase : SharedStoreFixtureBase<CompositeKeysContext>, IQueryFixtureBase
 {
-    private CompositeKeysDefaultData _expectedData;
-
     protected override string StoreName
         => "CompositeKeys";
 
@@ -16,14 +14,7 @@ public abstract class CompositeKeysQueryFixtureBase : SharedStoreFixtureBase<Com
         => () => CreateContext();
 
     public virtual ISetSource GetExpectedData()
-    {
-        if (_expectedData == null)
-        {
-            _expectedData = new CompositeKeysDefaultData();
-        }
-
-        return _expectedData;
-    }
+        => CompositeKeysDefaultData.Instance;
 
     public virtual Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
     {
@@ -205,97 +196,95 @@ public abstract class CompositeKeysQueryFixtureBase : SharedStoreFixtureBase<Com
         };
     }
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(CompositeOne), e => (((CompositeOne)e)?.Id1, ((CompositeOne)e)?.Id2) },
+        { typeof(CompositeTwo), e => (((CompositeTwo)e)?.Id1, ((CompositeTwo)e)?.Id2) },
+        { typeof(CompositeThree), e => (((CompositeThree)e)?.Id1, ((CompositeThree)e)?.Id2) },
+        { typeof(CompositeFour), e => (((CompositeFour)e)?.Id1, ((CompositeFour)e)?.Id2) },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
-            { typeof(CompositeOne), e => (((CompositeOne)e)?.Id1, ((CompositeOne)e)?.Id2) },
-            { typeof(CompositeTwo), e => (((CompositeTwo)e)?.Id1, ((CompositeTwo)e)?.Id2) },
-            { typeof(CompositeThree), e => (((CompositeThree)e)?.Id1, ((CompositeThree)e)?.Id2) },
-            { typeof(CompositeFour), e => (((CompositeFour)e)?.Id1, ((CompositeFour)e)?.Id2) },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            typeof(CompositeOne), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
 
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+                if (a != null)
+                {
+                    var ee = (CompositeOne)e;
+                    var aa = (CompositeOne)a;
+
+                    Assert.Equal(ee.Id1, aa.Id1);
+                    Assert.Equal(ee.Id2, aa.Id2);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Date, aa.Date);
+                }
+            }
+        },
         {
+            typeof(CompositeTwo), (e, a) =>
             {
-                typeof(CompositeOne), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (CompositeTwo)e;
+                    var aa = (CompositeTwo)a;
 
-                    if (a != null)
-                    {
-                        var ee = (CompositeOne)e;
-                        var aa = (CompositeOne)a;
-
-                        Assert.Equal(ee.Id1, aa.Id1);
-                        Assert.Equal(ee.Id2, aa.Id2);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Date, aa.Date);
-                    }
+                    Assert.Equal(ee.Id1, aa.Id1);
+                    Assert.Equal(ee.Id2, aa.Id2);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Date, aa.Date);
+                    Assert.Equal(ee.Level1_Optional_Id1, aa.Level1_Optional_Id1);
+                    Assert.Equal(ee.Level1_Optional_Id2, aa.Level1_Optional_Id2);
+                    Assert.Equal(ee.Level1_Required_Id1, aa.Level1_Required_Id1);
+                    Assert.Equal(ee.Level1_Required_Id2, aa.Level1_Required_Id2);
                 }
-            },
+            }
+        },
+        {
+            typeof(CompositeThree), (e, a) =>
             {
-                typeof(CompositeTwo), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (CompositeThree)e;
+                    var aa = (CompositeThree)a;
 
-                    if (a != null)
-                    {
-                        var ee = (CompositeTwo)e;
-                        var aa = (CompositeTwo)a;
-
-                        Assert.Equal(ee.Id1, aa.Id1);
-                        Assert.Equal(ee.Id2, aa.Id2);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Date, aa.Date);
-                        Assert.Equal(ee.Level1_Optional_Id1, aa.Level1_Optional_Id1);
-                        Assert.Equal(ee.Level1_Optional_Id2, aa.Level1_Optional_Id2);
-                        Assert.Equal(ee.Level1_Required_Id1, aa.Level1_Required_Id1);
-                        Assert.Equal(ee.Level1_Required_Id2, aa.Level1_Required_Id2);
-                    }
+                    Assert.Equal(ee.Id1, aa.Id1);
+                    Assert.Equal(ee.Id2, aa.Id2);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Level2_Optional_Id1, aa.Level2_Optional_Id1);
+                    Assert.Equal(ee.Level2_Optional_Id2, aa.Level2_Optional_Id2);
+                    Assert.Equal(ee.Level2_Required_Id1, aa.Level2_Required_Id1);
+                    Assert.Equal(ee.Level2_Required_Id2, aa.Level2_Required_Id2);
                 }
-            },
+            }
+        },
+        {
+            typeof(CompositeFour), (e, a) =>
             {
-                typeof(CompositeThree), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (CompositeFour)e;
+                    var aa = (CompositeFour)a;
 
-                    if (a != null)
-                    {
-                        var ee = (CompositeThree)e;
-                        var aa = (CompositeThree)a;
-
-                        Assert.Equal(ee.Id1, aa.Id1);
-                        Assert.Equal(ee.Id2, aa.Id2);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Level2_Optional_Id1, aa.Level2_Optional_Id1);
-                        Assert.Equal(ee.Level2_Optional_Id2, aa.Level2_Optional_Id2);
-                        Assert.Equal(ee.Level2_Required_Id1, aa.Level2_Required_Id1);
-                        Assert.Equal(ee.Level2_Required_Id2, aa.Level2_Required_Id2);
-                    }
+                    Assert.Equal(ee.Id1, aa.Id1);
+                    Assert.Equal(ee.Id2, aa.Id2);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Level3_Optional_Id1, aa.Level3_Optional_Id1);
+                    Assert.Equal(ee.Level3_Optional_Id2, aa.Level3_Optional_Id2);
+                    Assert.Equal(ee.Level3_Required_Id1, aa.Level3_Required_Id1);
+                    Assert.Equal(ee.Level3_Required_Id2, aa.Level3_Required_Id2);
                 }
-            },
-            {
-                typeof(CompositeFour), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (CompositeFour)e;
-                        var aa = (CompositeFour)a;
-
-                        Assert.Equal(ee.Id1, aa.Id1);
-                        Assert.Equal(ee.Id2, aa.Id2);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Level3_Optional_Id1, aa.Level3_Optional_Id1);
-                        Assert.Equal(ee.Level3_Optional_Id2, aa.Level3_Optional_Id2);
-                        Assert.Equal(ee.Level3_Required_Id1, aa.Level3_Required_Id1);
-                        Assert.Equal(ee.Level3_Required_Id2, aa.Level3_Required_Id2);
-                    }
-                }
-            },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
@@ -390,6 +379,12 @@ public abstract class CompositeKeysQueryFixtureBase : SharedStoreFixtureBase<Com
 
     protected class CompositeKeysDefaultData : CompositeKeysData
     {
+        public static readonly CompositeKeysDefaultData Instance = new();
+
+        private CompositeKeysDefaultData()
+        {
+        }
+
         public override IQueryable<TEntity> Set<TEntity>()
         {
             if (typeof(TEntity) == typeof(CompositeOne))

--- a/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
@@ -815,101 +815,99 @@ public abstract class Ef6GroupByTestBase<TFixture> : QueryTestBase<TFixture>
         public virtual ISetSource GetExpectedData()
             => new ArubaData();
 
-        public IReadOnlyDictionary<Type, object> GetEntitySorters()
-            => new Dictionary<Type, Func<object, object>>
+        public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+        {
+            { typeof(CustomerForLinq), e => ((CustomerForLinq)e)?.Id },
+            { typeof(OrderForLinq), e => ((OrderForLinq)e)?.Id },
+            { typeof(Person), e => ((Person)e)?.Id },
+            { typeof(Shoes), e => ((Shoes)e)?.Id },
+            { typeof(Feet), e => ((Feet)e)?.Id }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+        public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+        {
             {
-                { typeof(CustomerForLinq), e => ((CustomerForLinq)e)?.Id },
-                { typeof(OrderForLinq), e => ((OrderForLinq)e)?.Id },
-                { typeof(Person), e => ((Person)e)?.Id },
-                { typeof(Shoes), e => ((Shoes)e)?.Id },
-                { typeof(Feet), e => ((Feet)e)?.Id }
-            }.ToDictionary(e => e.Key, e => (object)e.Value);
-
-        public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-            => new Dictionary<Type, Action<object, object>>
-            {
+                typeof(CustomerForLinq), (e, a) =>
                 {
-                    typeof(CustomerForLinq), (e, a) =>
+                    Assert.Equal(e == null, a == null);
+
+                    if (a != null)
                     {
-                        Assert.Equal(e == null, a == null);
+                        var ee = (CustomerForLinq)e;
+                        var aa = (CustomerForLinq)a;
 
-                        if (a != null)
-                        {
-                            var ee = (CustomerForLinq)e;
-                            var aa = (CustomerForLinq)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Region, aa.Region);
-                            Assert.Equal(ee.CompanyName, aa.CompanyName);
-                        }
-                    }
-                },
-                {
-                    typeof(OrderForLinq), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            var ee = (OrderForLinq)e;
-                            var aa = (OrderForLinq)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Total, aa.Total);
-                            Assert.Equal(ee.OrderDate, aa.OrderDate);
-                        }
-                    }
-                },
-                {
-                    typeof(Person), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            var ee = (Person)e;
-                            var aa = (Person)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Age, aa.Age);
-                            Assert.Equal(ee.FirstName, aa.FirstName);
-                            Assert.Equal(ee.MiddleInitial, aa.MiddleInitial);
-                            Assert.Equal(ee.LastName, aa.LastName);
-                        }
-                    }
-                },
-                {
-                    typeof(Shoes), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            var ee = (Shoes)e;
-                            var aa = (Shoes)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Age, aa.Age);
-                            Assert.Equal(ee.Style, aa.Style);
-                        }
-                    }
-                },
-                {
-                    typeof(Feet), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-
-                        if (a != null)
-                        {
-                            var ee = (Feet)e;
-                            var aa = (Feet)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Size, aa.Size);
-                        }
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Region, aa.Region);
+                        Assert.Equal(ee.CompanyName, aa.CompanyName);
                     }
                 }
-            }.ToDictionary(e => e.Key, e => (object)e.Value);
+            },
+            {
+                typeof(OrderForLinq), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+
+                    if (a != null)
+                    {
+                        var ee = (OrderForLinq)e;
+                        var aa = (OrderForLinq)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Total, aa.Total);
+                        Assert.Equal(ee.OrderDate, aa.OrderDate);
+                    }
+                }
+            },
+            {
+                typeof(Person), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+
+                    if (a != null)
+                    {
+                        var ee = (Person)e;
+                        var aa = (Person)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Age, aa.Age);
+                        Assert.Equal(ee.FirstName, aa.FirstName);
+                        Assert.Equal(ee.MiddleInitial, aa.MiddleInitial);
+                        Assert.Equal(ee.LastName, aa.LastName);
+                    }
+                }
+            },
+            {
+                typeof(Shoes), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+
+                    if (a != null)
+                    {
+                        var ee = (Shoes)e;
+                        var aa = (Shoes)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Age, aa.Age);
+                        Assert.Equal(ee.Style, aa.Style);
+                    }
+                }
+            },
+            {
+                typeof(Feet), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+
+                    if (a != null)
+                    {
+                        var ee = (Feet)e;
+                        var aa = (Feet)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Size, aa.Size);
+                    }
+                }
+            }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
     }
 
     public class ArubaContext : PoolableDbContext

--- a/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
@@ -519,32 +519,31 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
             => () => CreateContext();
 
         public virtual ISetSource GetExpectedData()
-            => new FunkyDataData();
+            => FunkyDataData.Instance;
 
-        public IReadOnlyDictionary<Type, object> GetEntitySorters()
-            => new Dictionary<Type, Func<object, object>> { { typeof(FunkyCustomer), e => ((FunkyCustomer)e)?.Id } }
+        public IReadOnlyDictionary<Type, object> EntitySorters { get; } =
+            new Dictionary<Type, Func<object, object>> { { typeof(FunkyCustomer), e => ((FunkyCustomer)e)?.Id } }
                 .ToDictionary(e => e.Key, e => (object)e.Value);
 
-        public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-            => new Dictionary<Type, Action<object, object>>
+        public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+        {
             {
+                typeof(FunkyCustomer), (e, a) =>
                 {
-                    typeof(FunkyCustomer), (e, a) =>
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
                     {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (FunkyCustomer)e;
-                            var aa = (FunkyCustomer)a;
+                        var ee = (FunkyCustomer)e;
+                        var aa = (FunkyCustomer)a;
 
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.FirstName, aa.FirstName);
-                            Assert.Equal(ee.LastName, aa.LastName);
-                            Assert.Equal(ee.NullableBool, aa.NullableBool);
-                        }
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.FirstName, aa.FirstName);
+                        Assert.Equal(ee.LastName, aa.LastName);
+                        Assert.Equal(ee.NullableBool, aa.NullableBool);
                     }
                 }
-            }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
 
         protected override string StoreName
             => "FunkyDataQueryTest";

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -7,8 +7,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class GearsOfWarQueryFixtureBase : SharedStoreFixtureBase<GearsOfWarContext>, IQueryFixtureBase
 {
-    private GearsOfWarData _expectedData;
-
     protected override string StoreName
         => "GearsOfWarQueryTest";
 
@@ -16,14 +14,7 @@ public abstract class GearsOfWarQueryFixtureBase : SharedStoreFixtureBase<GearsO
         => () => CreateContext();
 
     public virtual ISetSource GetExpectedData()
-    {
-        if (_expectedData == null)
-        {
-            _expectedData = new GearsOfWarData();
-        }
-
-        return _expectedData;
-    }
+        => GearsOfWarData.Instance;
 
     public virtual Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
         => new()
@@ -35,278 +26,276 @@ public abstract class GearsOfWarQueryFixtureBase : SharedStoreFixtureBase<GearsO
             },
         };
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(City), e => ((City)e)?.Name },
+        { typeof(CogTag), e => ((CogTag)e)?.Id },
+        { typeof(Faction), e => ((Faction)e)?.Id },
+        { typeof(LocustHorde), e => ((LocustHorde)e)?.Id },
+        { typeof(Gear), e => (((Gear)e)?.SquadId, ((Gear)e)?.Nickname) },
+        { typeof(Officer), e => (((Officer)e)?.SquadId, ((Officer)e)?.Nickname) },
+        { typeof(LocustLeader), e => ((LocustLeader)e)?.Name },
+        { typeof(LocustCommander), e => ((LocustCommander)e)?.Name },
+        { typeof(Mission), e => ((Mission)e)?.Id },
+        { typeof(Squad), e => ((Squad)e)?.Id },
+        { typeof(SquadMission), e => (((SquadMission)e)?.SquadId, ((SquadMission)e)?.MissionId) },
+        { typeof(Weapon), e => ((Weapon)e)?.Id },
+        { typeof(LocustHighCommand), e => ((LocustHighCommand)e)?.Id }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
-            { typeof(City), e => ((City)e)?.Name },
-            { typeof(CogTag), e => ((CogTag)e)?.Id },
-            { typeof(Faction), e => ((Faction)e)?.Id },
-            { typeof(LocustHorde), e => ((LocustHorde)e)?.Id },
-            { typeof(Gear), e => (((Gear)e)?.SquadId, ((Gear)e)?.Nickname) },
-            { typeof(Officer), e => (((Officer)e)?.SquadId, ((Officer)e)?.Nickname) },
-            { typeof(LocustLeader), e => ((LocustLeader)e)?.Name },
-            { typeof(LocustCommander), e => ((LocustCommander)e)?.Name },
-            { typeof(Mission), e => ((Mission)e)?.Id },
-            { typeof(Squad), e => ((Squad)e)?.Id },
-            { typeof(SquadMission), e => (((SquadMission)e)?.SquadId, ((SquadMission)e)?.MissionId) },
-            { typeof(Weapon), e => ((Weapon)e)?.Id },
-            { typeof(LocustHighCommand), e => ((LocustHighCommand)e)?.Id }
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            typeof(City), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
 
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+                if (a != null)
+                {
+                    var ee = (City)e;
+                    var aa = (City)a;
+
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Location, aa.Location);
+                    Assert.Equal(ee.Nation, aa.Nation);
+                }
+            }
+        },
         {
+            typeof(CogTag), (e, a) =>
             {
-                typeof(City), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (CogTag)e;
+                    var aa = (CogTag)a;
 
-                    if (a != null)
-                    {
-                        var ee = (City)e;
-                        var aa = (City)a;
-
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Location, aa.Location);
-                        Assert.Equal(ee.Nation, aa.Nation);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Note, aa.Note);
+                    Assert.Equal(ee.GearNickName, aa.GearNickName);
+                    Assert.Equal(ee.GearSquadId, aa.GearSquadId);
                 }
-            },
+            }
+        },
+        {
+            typeof(Faction), (e, a) =>
             {
-                typeof(CogTag), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Faction)e;
+                    var aa = (Faction)a;
 
-                    if (a != null)
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CapitalName, aa.CapitalName);
+                    if (ee is LocustHorde locustHorde)
                     {
-                        var ee = (CogTag)e;
-                        var aa = (CogTag)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Note, aa.Note);
-                        Assert.Equal(ee.GearNickName, aa.GearNickName);
-                        Assert.Equal(ee.GearSquadId, aa.GearSquadId);
-                    }
-                }
-            },
-            {
-                typeof(Faction), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Faction)e;
-                        var aa = (Faction)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CapitalName, aa.CapitalName);
-                        if (ee is LocustHorde locustHorde)
-                        {
-                            var actualLocustHorde = (LocustHorde)aa;
-                            Assert.Equal(locustHorde.CommanderName, actualLocustHorde.CommanderName);
-                            Assert.Equal(locustHorde.Eradicated, actualLocustHorde.Eradicated);
-                        }
-                    }
-                }
-            },
-            {
-                typeof(LocustHorde), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (LocustHorde)e;
-                        var aa = (LocustHorde)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CapitalName, aa.CapitalName);
-                        Assert.Equal(ee.CommanderName, aa.CommanderName);
-                        Assert.Equal(ee.Eradicated, aa.Eradicated);
-                    }
-                }
-            },
-            {
-                typeof(Gear), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Gear)e;
-                        var aa = (Gear)a;
-
-                        Assert.Equal(ee.Nickname, aa.Nickname);
-                        Assert.Equal(ee.SquadId, aa.SquadId);
-                        Assert.Equal(ee.CityOfBirthName, aa.CityOfBirthName);
-                        Assert.Equal(ee.FullName, aa.FullName);
-                        Assert.Equal(ee.HasSoulPatch, aa.HasSoulPatch);
-                        Assert.Equal(ee.LeaderNickname, aa.LeaderNickname);
-                        Assert.Equal(ee.LeaderSquadId, aa.LeaderSquadId);
-                        Assert.Equal(ee.Rank, aa.Rank);
-                    }
-                }
-            },
-            {
-                typeof(Officer), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Officer)e;
-                        var aa = (Officer)a;
-
-                        Assert.Equal(ee.Nickname, aa.Nickname);
-                        Assert.Equal(ee.SquadId, aa.SquadId);
-                        Assert.Equal(ee.CityOfBirthName, aa.CityOfBirthName);
-                        Assert.Equal(ee.FullName, aa.FullName);
-                        Assert.Equal(ee.HasSoulPatch, aa.HasSoulPatch);
-                        Assert.Equal(ee.LeaderNickname, aa.LeaderNickname);
-                        Assert.Equal(ee.LeaderSquadId, aa.LeaderSquadId);
-                        Assert.Equal(ee.Rank, aa.Rank);
-                    }
-                }
-            },
-            {
-                typeof(LocustLeader), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (LocustLeader)e;
-                        var aa = (LocustLeader)a;
-
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ThreatLevel, aa.ThreatLevel);
-                        Assert.Equal(ee.ThreatLevelByte, aa.ThreatLevelByte);
-                        Assert.Equal(ee.ThreatLevelNullableByte, aa.ThreatLevelNullableByte);
-
-                        if (e is LocustCommander locustCommander)
-                        {
-                            var actualLocustCommander = (LocustCommander)aa;
-                            Assert.Equal(locustCommander.DefeatedByNickname, actualLocustCommander.DefeatedByNickname);
-                            Assert.Equal(locustCommander.DefeatedBySquadId, actualLocustCommander.DefeatedBySquadId);
-                        }
-                    }
-                }
-            },
-            {
-                typeof(LocustCommander), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (LocustCommander)e;
-                        var aa = (LocustCommander)a;
-
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ThreatLevel, aa.ThreatLevel);
-                        Assert.Equal(ee.ThreatLevelByte, aa.ThreatLevelByte);
-                        Assert.Equal(ee.ThreatLevelNullableByte, aa.ThreatLevelNullableByte);
-                        Assert.Equal(ee.DefeatedByNickname, aa.DefeatedByNickname);
-                        Assert.Equal(ee.DefeatedBySquadId, aa.DefeatedBySquadId);
-                    }
-                }
-            },
-            {
-                typeof(Mission), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Mission)e;
-                        var aa = (Mission)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.CodeName, aa.CodeName);
-                        Assert.Equal(ee.Rating, aa.Rating);
-                        Assert.Equal(ee.Timeline, aa.Timeline);
-                    }
-                }
-            },
-            {
-                typeof(Squad), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Squad)e;
-                        var aa = (Squad)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Banner == null, aa.Banner == null);
-                        if (ee.Banner != null)
-                        {
-                            Assert.True(ee.Banner.SequenceEqual(aa.Banner));
-                        }
-
-                        Assert.Equal(ee.Banner5 == null, aa.Banner5 == null);
-                        if (ee.Banner5 != null)
-                        {
-                            Assert.True(ee.Banner5.SequenceEqual(aa.Banner5));
-                        }
-                    }
-                }
-            },
-            {
-                typeof(SquadMission), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (SquadMission)e;
-                        var aa = (SquadMission)a;
-
-                        Assert.Equal(ee.SquadId, aa.SquadId);
-                        Assert.Equal(ee.MissionId, aa.MissionId);
-                    }
-                }
-            },
-            {
-                typeof(Weapon), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Weapon)e;
-                        var aa = (Weapon)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.IsAutomatic, aa.IsAutomatic);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.OwnerFullName, aa.OwnerFullName);
-                        Assert.Equal(ee.SynergyWithId, aa.SynergyWithId);
-                    }
-                }
-            },
-            {
-                typeof(LocustHighCommand), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (LocustHighCommand)e;
-                        var aa = (LocustHighCommand)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.IsOperational, aa.IsOperational);
-                        Assert.Equal(ee.Name, aa.Name);
+                        var actualLocustHorde = (LocustHorde)aa;
+                        Assert.Equal(locustHorde.CommanderName, actualLocustHorde.CommanderName);
+                        Assert.Equal(locustHorde.Eradicated, actualLocustHorde.Eradicated);
                     }
                 }
             }
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+        },
+        {
+            typeof(LocustHorde), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (LocustHorde)e;
+                    var aa = (LocustHorde)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CapitalName, aa.CapitalName);
+                    Assert.Equal(ee.CommanderName, aa.CommanderName);
+                    Assert.Equal(ee.Eradicated, aa.Eradicated);
+                }
+            }
+        },
+        {
+            typeof(Gear), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Gear)e;
+                    var aa = (Gear)a;
+
+                    Assert.Equal(ee.Nickname, aa.Nickname);
+                    Assert.Equal(ee.SquadId, aa.SquadId);
+                    Assert.Equal(ee.CityOfBirthName, aa.CityOfBirthName);
+                    Assert.Equal(ee.FullName, aa.FullName);
+                    Assert.Equal(ee.HasSoulPatch, aa.HasSoulPatch);
+                    Assert.Equal(ee.LeaderNickname, aa.LeaderNickname);
+                    Assert.Equal(ee.LeaderSquadId, aa.LeaderSquadId);
+                    Assert.Equal(ee.Rank, aa.Rank);
+                }
+            }
+        },
+        {
+            typeof(Officer), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Officer)e;
+                    var aa = (Officer)a;
+
+                    Assert.Equal(ee.Nickname, aa.Nickname);
+                    Assert.Equal(ee.SquadId, aa.SquadId);
+                    Assert.Equal(ee.CityOfBirthName, aa.CityOfBirthName);
+                    Assert.Equal(ee.FullName, aa.FullName);
+                    Assert.Equal(ee.HasSoulPatch, aa.HasSoulPatch);
+                    Assert.Equal(ee.LeaderNickname, aa.LeaderNickname);
+                    Assert.Equal(ee.LeaderSquadId, aa.LeaderSquadId);
+                    Assert.Equal(ee.Rank, aa.Rank);
+                }
+            }
+        },
+        {
+            typeof(LocustLeader), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (LocustLeader)e;
+                    var aa = (LocustLeader)a;
+
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ThreatLevel, aa.ThreatLevel);
+                    Assert.Equal(ee.ThreatLevelByte, aa.ThreatLevelByte);
+                    Assert.Equal(ee.ThreatLevelNullableByte, aa.ThreatLevelNullableByte);
+
+                    if (e is LocustCommander locustCommander)
+                    {
+                        var actualLocustCommander = (LocustCommander)aa;
+                        Assert.Equal(locustCommander.DefeatedByNickname, actualLocustCommander.DefeatedByNickname);
+                        Assert.Equal(locustCommander.DefeatedBySquadId, actualLocustCommander.DefeatedBySquadId);
+                    }
+                }
+            }
+        },
+        {
+            typeof(LocustCommander), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (LocustCommander)e;
+                    var aa = (LocustCommander)a;
+
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ThreatLevel, aa.ThreatLevel);
+                    Assert.Equal(ee.ThreatLevelByte, aa.ThreatLevelByte);
+                    Assert.Equal(ee.ThreatLevelNullableByte, aa.ThreatLevelNullableByte);
+                    Assert.Equal(ee.DefeatedByNickname, aa.DefeatedByNickname);
+                    Assert.Equal(ee.DefeatedBySquadId, aa.DefeatedBySquadId);
+                }
+            }
+        },
+        {
+            typeof(Mission), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Mission)e;
+                    var aa = (Mission)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.CodeName, aa.CodeName);
+                    Assert.Equal(ee.Rating, aa.Rating);
+                    Assert.Equal(ee.Timeline, aa.Timeline);
+                }
+            }
+        },
+        {
+            typeof(Squad), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Squad)e;
+                    var aa = (Squad)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Banner == null, aa.Banner == null);
+                    if (ee.Banner != null)
+                    {
+                        Assert.True(ee.Banner.SequenceEqual(aa.Banner));
+                    }
+
+                    Assert.Equal(ee.Banner5 == null, aa.Banner5 == null);
+                    if (ee.Banner5 != null)
+                    {
+                        Assert.True(ee.Banner5.SequenceEqual(aa.Banner5));
+                    }
+                }
+            }
+        },
+        {
+            typeof(SquadMission), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (SquadMission)e;
+                    var aa = (SquadMission)a;
+
+                    Assert.Equal(ee.SquadId, aa.SquadId);
+                    Assert.Equal(ee.MissionId, aa.MissionId);
+                }
+            }
+        },
+        {
+            typeof(Weapon), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (Weapon)e;
+                    var aa = (Weapon)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.IsAutomatic, aa.IsAutomatic);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.OwnerFullName, aa.OwnerFullName);
+                    Assert.Equal(ee.SynergyWithId, aa.SynergyWithId);
+                }
+            }
+        },
+        {
+            typeof(LocustHighCommand), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (LocustHighCommand)e;
+                    var aa = (LocustHighCommand)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.IsOperational, aa.IsOperational);
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {

--- a/test/EFCore.Specification.Tests/Query/IQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/IQueryFixtureBase.cs
@@ -12,9 +12,9 @@ public interface IQueryFixtureBase
 
     ISetSource GetExpectedData();
 
-    IReadOnlyDictionary<Type, object> GetEntitySorters();
+    IReadOnlyDictionary<Type, object> EntitySorters { get; }
 
-    IReadOnlyDictionary<Type, object> GetEntityAsserters();
+    IReadOnlyDictionary<Type, object> EntityAsserters { get; }
 
     private class DefaultSetSource : ISetSource
     {

--- a/test/EFCore.Specification.Tests/Query/InheritanceQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceQueryFixtureBase.cs
@@ -25,7 +25,7 @@ public abstract class InheritanceQueryFixtureBase : SharedStoreFixtureBase<Inher
         => () => CreateContext();
 
     public virtual ISetSource GetExpectedData()
-        => new InheritanceData();
+        => InheritanceData.Instance;
 
     public virtual ISetSource GetFilteredExpectedData(DbContext context)
     {
@@ -34,7 +34,7 @@ public abstract class InheritanceQueryFixtureBase : SharedStoreFixtureBase<Inher
             return cachedResult;
         }
 
-        var expectedData = new InheritanceData();
+        var expectedData = InheritanceData.Instance;
         if (EnableFilters)
         {
             var animals = expectedData.Animals.Where(a => a.CountryId == 1).ToList();
@@ -48,315 +48,313 @@ public abstract class InheritanceQueryFixtureBase : SharedStoreFixtureBase<Inher
         return expectedData;
     }
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(Animal), e => ((Animal)e)?.Species },
+        { typeof(Bird), e => ((Bird)e)?.Species },
+        { typeof(Kiwi), e => ((Kiwi)e)?.Species },
+        { typeof(Eagle), e => ((Eagle)e)?.Species },
+        { typeof(AnimalQuery), e => ((AnimalQuery)e)?.Name },
+        { typeof(BirdQuery), e => ((BirdQuery)e)?.Name },
+        { typeof(KiwiQuery), e => ((KiwiQuery)e)?.Name },
+        { typeof(EagleQuery), e => ((EagleQuery)e)?.Name },
+        { typeof(Plant), e => ((Plant)e)?.Species },
+        { typeof(Flower), e => ((Flower)e)?.Species },
+        { typeof(Daisy), e => ((Daisy)e)?.Species },
+        { typeof(Rose), e => ((Rose)e)?.Species },
+        { typeof(Country), e => ((Country)e)?.Id },
+        { typeof(Drink), e => ((Drink)e)?.Id },
+        { typeof(Coke), e => ((Coke)e)?.Id },
+        { typeof(Lilt), e => ((Lilt)e)?.Id },
+        { typeof(Tea), e => ((Tea)e)?.Id },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
-            { typeof(Animal), e => ((Animal)e)?.Species },
-            { typeof(Bird), e => ((Bird)e)?.Species },
-            { typeof(Kiwi), e => ((Kiwi)e)?.Species },
-            { typeof(Eagle), e => ((Eagle)e)?.Species },
-            { typeof(AnimalQuery), e => ((AnimalQuery)e)?.Name },
-            { typeof(BirdQuery), e => ((BirdQuery)e)?.Name },
-            { typeof(KiwiQuery), e => ((KiwiQuery)e)?.Name },
-            { typeof(EagleQuery), e => ((EagleQuery)e)?.Name },
-            { typeof(Plant), e => ((Plant)e)?.Species },
-            { typeof(Flower), e => ((Flower)e)?.Species },
-            { typeof(Daisy), e => ((Daisy)e)?.Species },
-            { typeof(Rose), e => ((Rose)e)?.Species },
-            { typeof(Country), e => ((Country)e)?.Id },
-            { typeof(Drink), e => ((Drink)e)?.Id },
-            { typeof(Coke), e => ((Coke)e)?.Id },
-            { typeof(Lilt), e => ((Lilt)e)?.Id },
-            { typeof(Tea), e => ((Tea)e)?.Id },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            typeof(Animal), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
 
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+                if (a != null)
+                {
+                    var ee = (Animal)e;
+                    var aa = (Animal)a;
+
+                    Assert.Equal(ee.Species, aa.Species);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CountryId, aa.CountryId);
+                }
+            }
+        },
         {
+            typeof(Bird), (e, a) =>
             {
-                typeof(Animal), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Bird)e;
+                    var aa = (Bird)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Animal)e;
-                        var aa = (Animal)a;
-
-                        Assert.Equal(ee.Species, aa.Species);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CountryId, aa.CountryId);
-                    }
+                    Assert.Equal(ee.Species, aa.Species);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CountryId, aa.CountryId);
+                    Assert.Equal(ee.IsFlightless, aa.IsFlightless);
+                    Assert.Equal(ee.EagleId, aa.EagleId);
                 }
-            },
+            }
+        },
+        {
+            typeof(Eagle), (e, a) =>
             {
-                typeof(Bird), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Eagle)e;
+                    var aa = (Eagle)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Bird)e;
-                        var aa = (Bird)a;
-
-                        Assert.Equal(ee.Species, aa.Species);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CountryId, aa.CountryId);
-                        Assert.Equal(ee.IsFlightless, aa.IsFlightless);
-                        Assert.Equal(ee.EagleId, aa.EagleId);
-                    }
+                    Assert.Equal(ee.Species, aa.Species);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CountryId, aa.CountryId);
+                    Assert.Equal(ee.IsFlightless, aa.IsFlightless);
+                    Assert.Equal(ee.EagleId, aa.EagleId);
+                    Assert.Equal(ee.Group, aa.Group);
                 }
-            },
+            }
+        },
+        {
+            typeof(Kiwi), (e, a) =>
             {
-                typeof(Eagle), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Kiwi)e;
+                    var aa = (Kiwi)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Eagle)e;
-                        var aa = (Eagle)a;
-
-                        Assert.Equal(ee.Species, aa.Species);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CountryId, aa.CountryId);
-                        Assert.Equal(ee.IsFlightless, aa.IsFlightless);
-                        Assert.Equal(ee.EagleId, aa.EagleId);
-                        Assert.Equal(ee.Group, aa.Group);
-                    }
+                    Assert.Equal(ee.Species, aa.Species);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CountryId, aa.CountryId);
+                    Assert.Equal(ee.IsFlightless, aa.IsFlightless);
+                    Assert.Equal(ee.EagleId, aa.EagleId);
+                    Assert.Equal(ee.FoundOn, aa.FoundOn);
                 }
-            },
+            }
+        },
+        {
+            typeof(AnimalQuery), (e, a) =>
             {
-                typeof(Kiwi), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (AnimalQuery)e;
+                    var aa = (AnimalQuery)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Kiwi)e;
-                        var aa = (Kiwi)a;
-
-                        Assert.Equal(ee.Species, aa.Species);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CountryId, aa.CountryId);
-                        Assert.Equal(ee.IsFlightless, aa.IsFlightless);
-                        Assert.Equal(ee.EagleId, aa.EagleId);
-                        Assert.Equal(ee.FoundOn, aa.FoundOn);
-                    }
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CountryId, aa.CountryId);
                 }
-            },
+            }
+        },
+        {
+            typeof(BirdQuery), (e, a) =>
             {
-                typeof(AnimalQuery), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (BirdQuery)e;
+                    var aa = (BirdQuery)a;
 
-                    if (a != null)
-                    {
-                        var ee = (AnimalQuery)e;
-                        var aa = (AnimalQuery)a;
-
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CountryId, aa.CountryId);
-                    }
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CountryId, aa.CountryId);
+                    Assert.Equal(ee.IsFlightless, aa.IsFlightless);
+                    Assert.Equal(ee.EagleId, aa.EagleId);
                 }
-            },
+            }
+        },
+        {
+            typeof(EagleQuery), (e, a) =>
             {
-                typeof(BirdQuery), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EagleQuery)e;
+                    var aa = (EagleQuery)a;
 
-                    if (a != null)
-                    {
-                        var ee = (BirdQuery)e;
-                        var aa = (BirdQuery)a;
-
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CountryId, aa.CountryId);
-                        Assert.Equal(ee.IsFlightless, aa.IsFlightless);
-                        Assert.Equal(ee.EagleId, aa.EagleId);
-                    }
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CountryId, aa.CountryId);
+                    Assert.Equal(ee.IsFlightless, aa.IsFlightless);
+                    Assert.Equal(ee.EagleId, aa.EagleId);
+                    Assert.Equal(ee.Group, aa.Group);
                 }
-            },
+            }
+        },
+        {
+            typeof(KiwiQuery), (e, a) =>
             {
-                typeof(EagleQuery), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (KiwiQuery)e;
+                    var aa = (KiwiQuery)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EagleQuery)e;
-                        var aa = (EagleQuery)a;
-
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CountryId, aa.CountryId);
-                        Assert.Equal(ee.IsFlightless, aa.IsFlightless);
-                        Assert.Equal(ee.EagleId, aa.EagleId);
-                        Assert.Equal(ee.Group, aa.Group);
-                    }
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.CountryId, aa.CountryId);
+                    Assert.Equal(ee.IsFlightless, aa.IsFlightless);
+                    Assert.Equal(ee.EagleId, aa.EagleId);
+                    Assert.Equal(ee.FoundOn, aa.FoundOn);
                 }
-            },
+            }
+        },
+        {
+            typeof(Plant), (e, a) =>
             {
-                typeof(KiwiQuery), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Plant)e;
+                    var aa = (Plant)a;
 
-                    if (a != null)
-                    {
-                        var ee = (KiwiQuery)e;
-                        var aa = (KiwiQuery)a;
-
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.CountryId, aa.CountryId);
-                        Assert.Equal(ee.IsFlightless, aa.IsFlightless);
-                        Assert.Equal(ee.EagleId, aa.EagleId);
-                        Assert.Equal(ee.FoundOn, aa.FoundOn);
-                    }
+                    Assert.Equal(ee.Species, aa.Species);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Genus, aa.Genus);
                 }
-            },
+            }
+        },
+        {
+            typeof(Flower), (e, a) =>
             {
-                typeof(Plant), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Flower)e;
+                    var aa = (Flower)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Plant)e;
-                        var aa = (Plant)a;
-
-                        Assert.Equal(ee.Species, aa.Species);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Genus, aa.Genus);
-                    }
+                    Assert.Equal(ee.Species, aa.Species);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Genus, aa.Genus);
                 }
-            },
+            }
+        },
+        {
+            typeof(Daisy), (e, a) =>
             {
-                typeof(Flower), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Daisy)e;
+                    var aa = (Daisy)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Flower)e;
-                        var aa = (Flower)a;
-
-                        Assert.Equal(ee.Species, aa.Species);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Genus, aa.Genus);
-                    }
+                    Assert.Equal(ee.Species, aa.Species);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Genus, aa.Genus);
                 }
-            },
+            }
+        },
+        {
+            typeof(Rose), (e, a) =>
             {
-                typeof(Daisy), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Rose)e;
+                    var aa = (Rose)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Daisy)e;
-                        var aa = (Daisy)a;
-
-                        Assert.Equal(ee.Species, aa.Species);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Genus, aa.Genus);
-                    }
+                    Assert.Equal(ee.Species, aa.Species);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Genus, aa.Genus);
+                    Assert.Equal(ee.HasThorns, aa.HasThorns);
                 }
-            },
+            }
+        },
+        {
+            typeof(Country), (e, a) =>
             {
-                typeof(Rose), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Country)e;
+                    var aa = (Country)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Rose)e;
-                        var aa = (Rose)a;
-
-                        Assert.Equal(ee.Species, aa.Species);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Genus, aa.Genus);
-                        Assert.Equal(ee.HasThorns, aa.HasThorns);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(Drink), (e, a) =>
             {
-                typeof(Country), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Drink)e;
+                    var aa = (Drink)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Country)e;
-                        var aa = (Country)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
                 }
-            },
+            }
+        },
+        {
+            typeof(Coke), (e, a) =>
             {
-                typeof(Drink), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Coke)e;
+                    var aa = (Coke)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Drink)e;
-                        var aa = (Drink)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.SugarGrams, aa.SugarGrams);
+                    Assert.Equal(ee.CaffeineGrams, aa.CaffeineGrams);
+                    Assert.Equal(ee.Carbonation, aa.Carbonation);
                 }
-            },
+            }
+        },
+        {
+            typeof(Lilt), (e, a) =>
             {
-                typeof(Coke), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Lilt)e;
+                    var aa = (Lilt)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Coke)e;
-                        var aa = (Coke)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.SugarGrams, aa.SugarGrams);
-                        Assert.Equal(ee.CaffeineGrams, aa.CaffeineGrams);
-                        Assert.Equal(ee.Carbonation, aa.Carbonation);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.SugarGrams, aa.SugarGrams);
+                    Assert.Equal(ee.Carbonation, aa.Carbonation);
                 }
-            },
+            }
+        },
+        {
+            typeof(Tea), (e, a) =>
             {
-                typeof(Lilt), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Tea)e;
+                    var aa = (Tea)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Lilt)e;
-                        var aa = (Lilt)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.SugarGrams, aa.SugarGrams);
-                        Assert.Equal(ee.Carbonation, aa.Carbonation);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.HasMilk, aa.HasMilk);
+                    Assert.Equal(ee.CaffeineGrams, aa.CaffeineGrams);
                 }
-            },
-            {
-                typeof(Tea), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (Tea)e;
-                        var aa = (Tea)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.HasMilk, aa.HasMilk);
-                        Assert.Equal(ee.CaffeineGrams, aa.CaffeineGrams);
-                    }
-                }
-            },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {

--- a/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryFixtureBase.cs
@@ -15,420 +15,418 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : SharedStoreFixt
         => () => CreateContext();
 
     public virtual ISetSource GetExpectedData()
-        => new InheritanceRelationshipsData();
+        => InheritanceRelationshipsData.Instance;
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(BaseCollectionOnBase), e => ((BaseCollectionOnBase)e)?.Id },
+        { typeof(DerivedCollectionOnBase), e => ((DerivedCollectionOnBase)e)?.Id },
+        { typeof(BaseCollectionOnDerived), e => ((BaseCollectionOnDerived)e)?.Id },
+        { typeof(DerivedCollectionOnDerived), e => ((DerivedCollectionOnDerived)e)?.Id },
+        { typeof(BaseInheritanceRelationshipEntity), e => ((BaseInheritanceRelationshipEntity)e)?.Id },
+        { typeof(DerivedInheritanceRelationshipEntity), e => ((DerivedInheritanceRelationshipEntity)e)?.Id },
+        { typeof(BaseReferenceOnBase), e => ((BaseReferenceOnBase)e)?.Id },
+        { typeof(DerivedReferenceOnBase), e => ((DerivedReferenceOnBase)e)?.Id },
+        { typeof(BaseReferenceOnDerived), e => ((BaseReferenceOnDerived)e)?.Id },
+        { typeof(DerivedReferenceOnDerived), e => ((DerivedReferenceOnDerived)e)?.Id },
+        { typeof(CollectionOnBase), e => ((CollectionOnBase)e)?.Id },
+        { typeof(CollectionOnDerived), e => ((CollectionOnDerived)e)?.Id },
+        { typeof(NestedCollectionBase), e => ((NestedCollectionBase)e)?.Id },
+        { typeof(NestedCollectionDerived), e => ((NestedCollectionDerived)e)?.Id },
+        { typeof(NestedReferenceBase), e => ((NestedReferenceBase)e)?.Id },
+        { typeof(NonEntityBase), e => ((NonEntityBase)e)?.Id },
+        { typeof(PrincipalEntity), e => ((PrincipalEntity)e)?.Id },
+        { typeof(OwnedEntity), e => ((OwnedEntity)e)?.Id },
+        { typeof(ReferencedEntity), e => ((ReferencedEntity)e)?.Id },
+        { typeof(ReferenceOnBase), e => ((ReferenceOnBase)e)?.Id },
+        { typeof(ReferenceOnDerived), e => ((ReferenceOnDerived)e)?.Id },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
-            { typeof(BaseCollectionOnBase), e => ((BaseCollectionOnBase)e)?.Id },
-            { typeof(DerivedCollectionOnBase), e => ((DerivedCollectionOnBase)e)?.Id },
-            { typeof(BaseCollectionOnDerived), e => ((BaseCollectionOnDerived)e)?.Id },
-            { typeof(DerivedCollectionOnDerived), e => ((DerivedCollectionOnDerived)e)?.Id },
-            { typeof(BaseInheritanceRelationshipEntity), e => ((BaseInheritanceRelationshipEntity)e)?.Id },
-            { typeof(DerivedInheritanceRelationshipEntity), e => ((DerivedInheritanceRelationshipEntity)e)?.Id },
-            { typeof(BaseReferenceOnBase), e => ((BaseReferenceOnBase)e)?.Id },
-            { typeof(DerivedReferenceOnBase), e => ((DerivedReferenceOnBase)e)?.Id },
-            { typeof(BaseReferenceOnDerived), e => ((BaseReferenceOnDerived)e)?.Id },
-            { typeof(DerivedReferenceOnDerived), e => ((DerivedReferenceOnDerived)e)?.Id },
-            { typeof(CollectionOnBase), e => ((CollectionOnBase)e)?.Id },
-            { typeof(CollectionOnDerived), e => ((CollectionOnDerived)e)?.Id },
-            { typeof(NestedCollectionBase), e => ((NestedCollectionBase)e)?.Id },
-            { typeof(NestedCollectionDerived), e => ((NestedCollectionDerived)e)?.Id },
-            { typeof(NestedReferenceBase), e => ((NestedReferenceBase)e)?.Id },
-            { typeof(NonEntityBase), e => ((NonEntityBase)e)?.Id },
-            { typeof(PrincipalEntity), e => ((PrincipalEntity)e)?.Id },
-            { typeof(OwnedEntity), e => ((OwnedEntity)e)?.Id },
-            { typeof(ReferencedEntity), e => ((ReferencedEntity)e)?.Id },
-            { typeof(ReferenceOnBase), e => ((ReferenceOnBase)e)?.Id },
-            { typeof(ReferenceOnDerived), e => ((ReferenceOnDerived)e)?.Id },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            typeof(BaseCollectionOnBase), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
 
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+                if (a != null)
+                {
+                    var ee = (BaseCollectionOnBase)e;
+                    var aa = (BaseCollectionOnBase)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.BaseParentId, aa.BaseParentId);
+                }
+            }
+        },
         {
+            typeof(DerivedCollectionOnBase), (e, a) =>
             {
-                typeof(BaseCollectionOnBase), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (DerivedCollectionOnBase)e;
+                    var aa = (DerivedCollectionOnBase)a;
 
-                    if (a != null)
-                    {
-                        var ee = (BaseCollectionOnBase)e;
-                        var aa = (BaseCollectionOnBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.BaseParentId, aa.BaseParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.BaseParentId, aa.BaseParentId);
+                    Assert.Equal(ee.DerivedProperty, aa.DerivedProperty);
                 }
-            },
+            }
+        },
+        {
+            typeof(BaseCollectionOnDerived), (e, a) =>
             {
-                typeof(DerivedCollectionOnBase), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (BaseCollectionOnDerived)e;
+                    var aa = (BaseCollectionOnDerived)a;
 
-                    if (a != null)
-                    {
-                        var ee = (DerivedCollectionOnBase)e;
-                        var aa = (DerivedCollectionOnBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.BaseParentId, aa.BaseParentId);
-                        Assert.Equal(ee.DerivedProperty, aa.DerivedProperty);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentId, aa.ParentId);
                 }
-            },
+            }
+        },
+        {
+            typeof(DerivedCollectionOnDerived), (e, a) =>
             {
-                typeof(BaseCollectionOnDerived), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (DerivedCollectionOnDerived)e;
+                    var aa = (DerivedCollectionOnDerived)a;
 
-                    if (a != null)
-                    {
-                        var ee = (BaseCollectionOnDerived)e;
-                        var aa = (BaseCollectionOnDerived)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentId, aa.ParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentId, aa.ParentId);
                 }
-            },
+            }
+        },
+        {
+            typeof(BaseInheritanceRelationshipEntity), (e, a) =>
             {
-                typeof(DerivedCollectionOnDerived), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (BaseInheritanceRelationshipEntity)e;
+                    var aa = (BaseInheritanceRelationshipEntity)a;
 
-                    if (a != null)
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+
+                    Assert.Equal(ee.OwnedReferenceOnBase?.Id, aa.OwnedReferenceOnBase?.Id);
+                    Assert.Equal(ee.OwnedReferenceOnBase?.Name, aa.OwnedReferenceOnBase?.Name);
+
+                    Assert.Equal(ee.OwnedCollectionOnBase?.Count, aa.OwnedCollectionOnBase?.Count);
+                    if (ee.OwnedCollectionOnBase?.Count > 0)
                     {
-                        var ee = (DerivedCollectionOnDerived)e;
-                        var aa = (DerivedCollectionOnDerived)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentId, aa.ParentId);
-                    }
-                }
-            },
-            {
-                typeof(BaseInheritanceRelationshipEntity), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (BaseInheritanceRelationshipEntity)e;
-                        var aa = (BaseInheritanceRelationshipEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-
-                        Assert.Equal(ee.OwnedReferenceOnBase?.Id, aa.OwnedReferenceOnBase?.Id);
-                        Assert.Equal(ee.OwnedReferenceOnBase?.Name, aa.OwnedReferenceOnBase?.Name);
-
-                        Assert.Equal(ee.OwnedCollectionOnBase?.Count, aa.OwnedCollectionOnBase?.Count);
-                        if (ee.OwnedCollectionOnBase?.Count > 0)
+                        var orderedExpected = ee.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
+                        var orderedActual = aa.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
+                        for (var i = 0; i < orderedExpected.Count; i++)
                         {
-                            var orderedExpected = ee.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
-                            var orderedActual = aa.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
-                            for (var i = 0; i < orderedExpected.Count; i++)
-                            {
-                                Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
-                                Assert.Equal(orderedExpected[i].Name, orderedActual[i].Name);
-                            }
+                            Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
+                            Assert.Equal(orderedExpected[i].Name, orderedActual[i].Name);
                         }
                     }
                 }
-            },
+            }
+        },
+        {
+            typeof(DerivedInheritanceRelationshipEntity), (e, a) =>
             {
-                typeof(DerivedInheritanceRelationshipEntity), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (DerivedInheritanceRelationshipEntity)e;
+                    var aa = (DerivedInheritanceRelationshipEntity)a;
 
-                    if (a != null)
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.BaseId, aa.BaseId);
+
+                    Assert.Equal(ee.OwnedReferenceOnBase?.Id, aa.OwnedReferenceOnBase?.Id);
+                    Assert.Equal(ee.OwnedReferenceOnBase?.Name, aa.OwnedReferenceOnBase?.Name);
+
+                    Assert.Equal(ee.OwnedReferenceOnDerived?.Id, aa.OwnedReferenceOnDerived?.Id);
+                    Assert.Equal(ee.OwnedReferenceOnDerived?.Name, aa.OwnedReferenceOnDerived?.Name);
+
+                    Assert.Equal(ee.OwnedCollectionOnBase?.Count, aa.OwnedCollectionOnBase?.Count);
+                    if (ee.OwnedCollectionOnBase?.Count > 0)
                     {
-                        var ee = (DerivedInheritanceRelationshipEntity)e;
-                        var aa = (DerivedInheritanceRelationshipEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.BaseId, aa.BaseId);
-
-                        Assert.Equal(ee.OwnedReferenceOnBase?.Id, aa.OwnedReferenceOnBase?.Id);
-                        Assert.Equal(ee.OwnedReferenceOnBase?.Name, aa.OwnedReferenceOnBase?.Name);
-
-                        Assert.Equal(ee.OwnedReferenceOnDerived?.Id, aa.OwnedReferenceOnDerived?.Id);
-                        Assert.Equal(ee.OwnedReferenceOnDerived?.Name, aa.OwnedReferenceOnDerived?.Name);
-
-                        Assert.Equal(ee.OwnedCollectionOnBase?.Count, aa.OwnedCollectionOnBase?.Count);
-                        if (ee.OwnedCollectionOnBase?.Count > 0)
+                        var orderedExpected = ee.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
+                        var orderedActual = aa.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
+                        for (var i = 0; i < orderedExpected.Count; i++)
                         {
-                            var orderedExpected = ee.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
-                            var orderedActual = aa.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
-                            for (var i = 0; i < orderedExpected.Count; i++)
-                            {
-                                Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
-                                Assert.Equal(orderedExpected[i].Name, orderedActual[i].Name);
-                            }
-                        }
-
-                        Assert.Equal(ee.OwnedCollectionOnDerived?.Count, aa.OwnedCollectionOnDerived?.Count);
-                        if (ee.OwnedCollectionOnDerived?.Count > 0)
-                        {
-                            var orderedExpected = ee.OwnedCollectionOnDerived.OrderBy(x => x.Id).ToList();
-                            var orderedActual = aa.OwnedCollectionOnDerived.OrderBy(x => x.Id).ToList();
-                            for (var i = 0; i < orderedExpected.Count; i++)
-                            {
-                                Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
-                                Assert.Equal(orderedExpected[i].Name, orderedActual[i].Name);
-                            }
+                            Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
+                            Assert.Equal(orderedExpected[i].Name, orderedActual[i].Name);
                         }
                     }
-                }
-            },
-            {
-                typeof(BaseReferenceOnBase), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
 
-                    if (a != null)
+                    Assert.Equal(ee.OwnedCollectionOnDerived?.Count, aa.OwnedCollectionOnDerived?.Count);
+                    if (ee.OwnedCollectionOnDerived?.Count > 0)
                     {
-                        var ee = (BaseReferenceOnBase)e;
-                        var aa = (BaseReferenceOnBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.BaseParentId, aa.BaseParentId);
+                        var orderedExpected = ee.OwnedCollectionOnDerived.OrderBy(x => x.Id).ToList();
+                        var orderedActual = aa.OwnedCollectionOnDerived.OrderBy(x => x.Id).ToList();
+                        for (var i = 0; i < orderedExpected.Count; i++)
+                        {
+                            Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
+                            Assert.Equal(orderedExpected[i].Name, orderedActual[i].Name);
+                        }
                     }
                 }
-            },
+            }
+        },
+        {
+            typeof(BaseReferenceOnBase), (e, a) =>
             {
-                typeof(DerivedReferenceOnBase), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (BaseReferenceOnBase)e;
+                    var aa = (BaseReferenceOnBase)a;
 
-                    if (a != null)
-                    {
-                        var ee = (DerivedReferenceOnBase)e;
-                        var aa = (DerivedReferenceOnBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.BaseParentId, aa.BaseParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.BaseParentId, aa.BaseParentId);
                 }
-            },
+            }
+        },
+        {
+            typeof(DerivedReferenceOnBase), (e, a) =>
             {
-                typeof(BaseReferenceOnDerived), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (DerivedReferenceOnBase)e;
+                    var aa = (DerivedReferenceOnBase)a;
 
-                    if (a != null)
-                    {
-                        var ee = (BaseReferenceOnDerived)e;
-                        var aa = (BaseReferenceOnDerived)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.BaseParentId, aa.BaseParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.BaseParentId, aa.BaseParentId);
                 }
-            },
+            }
+        },
+        {
+            typeof(BaseReferenceOnDerived), (e, a) =>
             {
-                typeof(DerivedReferenceOnDerived), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (BaseReferenceOnDerived)e;
+                    var aa = (BaseReferenceOnDerived)a;
 
-                    if (a != null)
-                    {
-                        var ee = (DerivedReferenceOnDerived)e;
-                        var aa = (DerivedReferenceOnDerived)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.BaseParentId, aa.BaseParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.BaseParentId, aa.BaseParentId);
                 }
-            },
+            }
+        },
+        {
+            typeof(DerivedReferenceOnDerived), (e, a) =>
             {
-                typeof(CollectionOnBase), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (DerivedReferenceOnDerived)e;
+                    var aa = (DerivedReferenceOnDerived)a;
 
-                    if (a != null)
-                    {
-                        var ee = (CollectionOnBase)e;
-                        var aa = (CollectionOnBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentId, aa.ParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.BaseParentId, aa.BaseParentId);
                 }
-            },
+            }
+        },
+        {
+            typeof(CollectionOnBase), (e, a) =>
             {
-                typeof(CollectionOnDerived), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (CollectionOnBase)e;
+                    var aa = (CollectionOnBase)a;
 
-                    if (a != null)
-                    {
-                        var ee = (CollectionOnDerived)e;
-                        var aa = (CollectionOnDerived)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentId, aa.ParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentId, aa.ParentId);
                 }
-            },
+            }
+        },
+        {
+            typeof(CollectionOnDerived), (e, a) =>
             {
-                typeof(NestedCollectionBase), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (CollectionOnDerived)e;
+                    var aa = (CollectionOnDerived)a;
 
-                    if (a != null)
-                    {
-                        var ee = (NestedCollectionBase)e;
-                        var aa = (NestedCollectionBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
-                        Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentId, aa.ParentId);
                 }
-            },
+            }
+        },
+        {
+            typeof(NestedCollectionBase), (e, a) =>
             {
-                typeof(NestedCollectionDerived), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (NestedCollectionBase)e;
+                    var aa = (NestedCollectionBase)a;
 
-                    if (a != null)
-                    {
-                        var ee = (NestedCollectionDerived)e;
-                        var aa = (NestedCollectionDerived)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
-                        Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
+                    Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
                 }
-            },
+            }
+        },
+        {
+            typeof(NestedCollectionDerived), (e, a) =>
             {
-                typeof(NestedReferenceBase), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (NestedCollectionDerived)e;
+                    var aa = (NestedCollectionDerived)a;
 
-                    if (a != null)
-                    {
-                        var ee = (NestedReferenceBase)e;
-                        var aa = (NestedReferenceBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
-                        Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
+                    Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
                 }
-            },
+            }
+        },
+        {
+            typeof(NestedReferenceBase), (e, a) =>
             {
-                typeof(NestedReferenceDerived), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (NestedReferenceBase)e;
+                    var aa = (NestedReferenceBase)a;
 
-                    if (a != null)
-                    {
-                        var ee = (NestedReferenceDerived)e;
-                        var aa = (NestedReferenceDerived)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
-                        Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
+                    Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
                 }
-            },
+            }
+        },
+        {
+            typeof(NestedReferenceDerived), (e, a) =>
             {
-                typeof(NonEntityBase), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (NestedReferenceDerived)e;
+                    var aa = (NestedReferenceDerived)a;
 
-                    if (a != null)
-                    {
-                        var ee = (NonEntityBase)e;
-                        var aa = (NonEntityBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
+                    Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
                 }
-            },
+            }
+        },
+        {
+            typeof(NonEntityBase), (e, a) =>
             {
-                typeof(PrincipalEntity), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (NonEntityBase)e;
+                    var aa = (NonEntityBase)a;
 
-                    if (a != null)
-                    {
-                        var ee = (PrincipalEntity)e;
-                        var aa = (PrincipalEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(PrincipalEntity), (e, a) =>
             {
-                typeof(ReferencedEntity), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (PrincipalEntity)e;
+                    var aa = (PrincipalEntity)a;
 
-                    if (a != null)
-                    {
-                        var ee = (ReferencedEntity)e;
-                        var aa = (ReferencedEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(ReferencedEntity), (e, a) =>
             {
-                typeof(ReferenceOnBase), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (ReferencedEntity)e;
+                    var aa = (ReferencedEntity)a;
 
-                    if (a != null)
-                    {
-                        var ee = (ReferenceOnBase)e;
-                        var aa = (ReferenceOnBase)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentId, aa.ParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(ReferenceOnBase), (e, a) =>
             {
-                typeof(ReferenceOnDerived), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (ReferenceOnBase)e;
+                    var aa = (ReferenceOnBase)a;
 
-                    if (a != null)
-                    {
-                        var ee = (ReferenceOnDerived)e;
-                        var aa = (ReferenceOnDerived)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.ParentId, aa.ParentId);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentId, aa.ParentId);
                 }
-            },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        },
+        {
+            typeof(ReferenceOnDerived), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (ReferenceOnDerived)e;
+                    var aa = (ReferenceOnDerived)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentId, aa.ParentId);
+                }
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {

--- a/test/EFCore.Specification.Tests/Query/ManyToManyFieldsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyFieldsQueryFixtureBase.cs
@@ -28,135 +28,133 @@ public abstract class ManyToManyFieldsQueryFixtureBase : SharedStoreFixtureBase<
         return _data;
     }
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(EntityOne), e => ((EntityOne)e)?.Id },
+        { typeof(EntityTwo), e => ((EntityTwo)e)?.Id },
+        { typeof(EntityThree), e => ((EntityThree)e)?.Id },
         {
-            { typeof(EntityOne), e => ((EntityOne)e)?.Id },
-            { typeof(EntityTwo), e => ((EntityTwo)e)?.Id },
-            { typeof(EntityThree), e => ((EntityThree)e)?.Id },
-            {
-                typeof(EntityCompositeKey),
-                e => (((EntityCompositeKey)e)?.Key1, ((EntityCompositeKey)e)?.Key2, ((EntityCompositeKey)e)?.Key3)
-            },
-            { typeof(EntityRoot), e => ((EntityRoot)e)?.Id },
-            { typeof(EntityBranch), e => ((EntityBranch)e)?.Id },
-            { typeof(EntityLeaf), e => ((EntityLeaf)e)?.Id },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            typeof(EntityCompositeKey),
+            e => (((EntityCompositeKey)e)?.Key1, ((EntityCompositeKey)e)?.Key2, ((EntityCompositeKey)e)?.Key3)
+        },
+        { typeof(EntityRoot), e => ((EntityRoot)e)?.Id },
+        { typeof(EntityBranch), e => ((EntityBranch)e)?.Id },
+        { typeof(EntityLeaf), e => ((EntityLeaf)e)?.Id },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
+            typeof(EntityOne), (e, a) =>
             {
-                typeof(EntityOne), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityOne)e;
+                    var aa = (EntityOne)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityOne)e;
-                        var aa = (EntityOne)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityTwo), (e, a) =>
             {
-                typeof(EntityTwo), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityTwo)e;
+                    var aa = (EntityTwo)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityTwo)e;
-                        var aa = (EntityTwo)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityThree), (e, a) =>
             {
-                typeof(EntityThree), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityThree)e;
+                    var aa = (EntityThree)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityThree)e;
-                        var aa = (EntityThree)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityCompositeKey), (e, a) =>
             {
-                typeof(EntityCompositeKey), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityCompositeKey)e;
+                    var aa = (EntityCompositeKey)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityCompositeKey)e;
-                        var aa = (EntityCompositeKey)a;
-
-                        Assert.Equal(ee.Key1, aa.Key1);
-                        Assert.Equal(ee.Key2, aa.Key2);
-                        Assert.Equal(ee.Key3, aa.Key3);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Key1, aa.Key1);
+                    Assert.Equal(ee.Key2, aa.Key2);
+                    Assert.Equal(ee.Key3, aa.Key3);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityRoot), (e, a) =>
             {
-                typeof(EntityRoot), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityRoot)e;
+                    var aa = (EntityRoot)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityRoot)e;
-                        var aa = (EntityRoot)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityBranch), (e, a) =>
             {
-                typeof(EntityBranch), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityBranch)e;
+                    var aa = (EntityBranch)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityBranch)e;
-                        var aa = (EntityBranch)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Number, aa.Number);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Number, aa.Number);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityLeaf), (e, a) =>
             {
-                typeof(EntityLeaf), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityLeaf)e;
+                    var aa = (EntityLeaf)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityLeaf)e;
-                        var aa = (EntityLeaf)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Number, aa.Number);
-                        Assert.Equal(ee.IsGreen, aa.IsGreen);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Number, aa.Number);
+                    Assert.Equal(ee.IsGreen, aa.IsGreen);
                 }
-            },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
@@ -28,257 +28,254 @@ public abstract class ManyToManyQueryFixtureBase : SharedStoreFixtureBase<ManyTo
         return _data;
     }
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(EntityOne), e => ((EntityOne)e)?.Id },
+        { typeof(EntityTwo), e => ((EntityTwo)e)?.Id },
+        { typeof(EntityThree), e => ((EntityThree)e)?.Id },
         {
-            { typeof(EntityOne), e => ((EntityOne)e)?.Id },
-            { typeof(EntityTwo), e => ((EntityTwo)e)?.Id },
-            { typeof(EntityThree), e => ((EntityThree)e)?.Id },
-            {
-                typeof(EntityCompositeKey),
-                e => (((EntityCompositeKey)e)?.Key1, ((EntityCompositeKey)e)?.Key2, ((EntityCompositeKey)e)?.Key3)
-            },
-            { typeof(EntityRoot), e => ((EntityRoot)e)?.Id },
-            { typeof(EntityBranch), e => ((EntityBranch)e)?.Id },
-            { typeof(EntityLeaf), e => ((EntityLeaf)e)?.Id },
-            { typeof(UnidirectionalEntityOne), e => ((UnidirectionalEntityOne)e)?.Id },
-            { typeof(UnidirectionalEntityTwo), e => ((UnidirectionalEntityTwo)e)?.Id },
-            { typeof(UnidirectionalEntityThree), e => ((UnidirectionalEntityThree)e)?.Id },
-            {
-                typeof(UnidirectionalEntityCompositeKey),
-                e => (((UnidirectionalEntityCompositeKey)e)?.Key1,
-                    ((UnidirectionalEntityCompositeKey)e)?.Key2,
-                    ((UnidirectionalEntityCompositeKey)e)?.Key3)
-            },
-            { typeof(UnidirectionalEntityRoot), e => ((UnidirectionalEntityRoot)e)?.Id },
-            { typeof(UnidirectionalEntityBranch), e => ((UnidirectionalEntityBranch)e)?.Id },
-            { typeof(UnidirectionalEntityLeaf), e => ((UnidirectionalEntityLeaf)e)?.Id },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
-
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+            typeof(EntityCompositeKey),
+            e => (((EntityCompositeKey)e)?.Key1, ((EntityCompositeKey)e)?.Key2, ((EntityCompositeKey)e)?.Key3)
+        },
+        { typeof(EntityRoot), e => ((EntityRoot)e)?.Id },
+        { typeof(EntityBranch), e => ((EntityBranch)e)?.Id },
+        { typeof(EntityLeaf), e => ((EntityLeaf)e)?.Id },
+        { typeof(UnidirectionalEntityOne), e => ((UnidirectionalEntityOne)e)?.Id },
+        { typeof(UnidirectionalEntityTwo), e => ((UnidirectionalEntityTwo)e)?.Id },
+        { typeof(UnidirectionalEntityThree), e => ((UnidirectionalEntityThree)e)?.Id },
         {
+            typeof(UnidirectionalEntityCompositeKey), e => (((UnidirectionalEntityCompositeKey)e)?.Key1,
+                ((UnidirectionalEntityCompositeKey)e)?.Key2,
+                ((UnidirectionalEntityCompositeKey)e)?.Key3)
+        },
+        { typeof(UnidirectionalEntityRoot), e => ((UnidirectionalEntityRoot)e)?.Id },
+        { typeof(UnidirectionalEntityBranch), e => ((UnidirectionalEntityBranch)e)?.Id },
+        { typeof(UnidirectionalEntityLeaf), e => ((UnidirectionalEntityLeaf)e)?.Id },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
+        {
+            typeof(EntityOne), (e, a) =>
             {
-                typeof(EntityOne), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityOne)e;
+                    var aa = (EntityOne)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityOne)e;
-                        var aa = (EntityOne)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityTwo), (e, a) =>
             {
-                typeof(EntityTwo), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityTwo)e;
+                    var aa = (EntityTwo)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityTwo)e;
-                        var aa = (EntityTwo)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityThree), (e, a) =>
             {
-                typeof(EntityThree), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityThree)e;
+                    var aa = (EntityThree)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityThree)e;
-                        var aa = (EntityThree)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityCompositeKey), (e, a) =>
             {
-                typeof(EntityCompositeKey), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityCompositeKey)e;
+                    var aa = (EntityCompositeKey)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityCompositeKey)e;
-                        var aa = (EntityCompositeKey)a;
-
-                        Assert.Equal(ee.Key1, aa.Key1);
-                        Assert.Equal(ee.Key2, aa.Key2);
-                        Assert.Equal(ee.Key3, aa.Key3);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Key1, aa.Key1);
+                    Assert.Equal(ee.Key2, aa.Key2);
+                    Assert.Equal(ee.Key3, aa.Key3);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityRoot), (e, a) =>
             {
-                typeof(EntityRoot), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityRoot)e;
+                    var aa = (EntityRoot)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityRoot)e;
-                        var aa = (EntityRoot)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityBranch), (e, a) =>
             {
-                typeof(EntityBranch), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityBranch)e;
+                    var aa = (EntityBranch)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityBranch)e;
-                        var aa = (EntityBranch)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Number, aa.Number);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Number, aa.Number);
                 }
-            },
+            }
+        },
+        {
+            typeof(EntityLeaf), (e, a) =>
             {
-                typeof(EntityLeaf), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (EntityLeaf)e;
+                    var aa = (EntityLeaf)a;
 
-                    if (a != null)
-                    {
-                        var ee = (EntityLeaf)e;
-                        var aa = (EntityLeaf)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Number, aa.Number);
-                        Assert.Equal(ee.IsGreen, aa.IsGreen);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Number, aa.Number);
+                    Assert.Equal(ee.IsGreen, aa.IsGreen);
                 }
-            },
+            }
+        },
+        {
+            typeof(UnidirectionalEntityOne), (e, a) =>
             {
-                typeof(UnidirectionalEntityOne), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (UnidirectionalEntityOne)e;
+                    var aa = (UnidirectionalEntityOne)a;
 
-                    if (a != null)
-                    {
-                        var ee = (UnidirectionalEntityOne)e;
-                        var aa = (UnidirectionalEntityOne)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(UnidirectionalEntityTwo), (e, a) =>
             {
-                typeof(UnidirectionalEntityTwo), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (UnidirectionalEntityTwo)e;
+                    var aa = (UnidirectionalEntityTwo)a;
 
-                    if (a != null)
-                    {
-                        var ee = (UnidirectionalEntityTwo)e;
-                        var aa = (UnidirectionalEntityTwo)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(UnidirectionalEntityThree), (e, a) =>
             {
-                typeof(UnidirectionalEntityThree), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (UnidirectionalEntityThree)e;
+                    var aa = (UnidirectionalEntityThree)a;
 
-                    if (a != null)
-                    {
-                        var ee = (UnidirectionalEntityThree)e;
-                        var aa = (UnidirectionalEntityThree)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(UnidirectionalEntityCompositeKey), (e, a) =>
             {
-                typeof(UnidirectionalEntityCompositeKey), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (UnidirectionalEntityCompositeKey)e;
+                    var aa = (UnidirectionalEntityCompositeKey)a;
 
-                    if (a != null)
-                    {
-                        var ee = (UnidirectionalEntityCompositeKey)e;
-                        var aa = (UnidirectionalEntityCompositeKey)a;
-
-                        Assert.Equal(ee.Key1, aa.Key1);
-                        Assert.Equal(ee.Key2, aa.Key2);
-                        Assert.Equal(ee.Key3, aa.Key3);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Key1, aa.Key1);
+                    Assert.Equal(ee.Key2, aa.Key2);
+                    Assert.Equal(ee.Key3, aa.Key3);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(UnidirectionalEntityRoot), (e, a) =>
             {
-                typeof(UnidirectionalEntityRoot), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (UnidirectionalEntityRoot)e;
+                    var aa = (UnidirectionalEntityRoot)a;
 
-                    if (a != null)
-                    {
-                        var ee = (UnidirectionalEntityRoot)e;
-                        var aa = (UnidirectionalEntityRoot)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
                 }
-            },
+            }
+        },
+        {
+            typeof(UnidirectionalEntityBranch), (e, a) =>
             {
-                typeof(UnidirectionalEntityBranch), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (UnidirectionalEntityBranch)e;
+                    var aa = (UnidirectionalEntityBranch)a;
 
-                    if (a != null)
-                    {
-                        var ee = (UnidirectionalEntityBranch)e;
-                        var aa = (UnidirectionalEntityBranch)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Number, aa.Number);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Number, aa.Number);
                 }
-            },
+            }
+        },
+        {
+            typeof(UnidirectionalEntityLeaf), (e, a) =>
             {
-                typeof(UnidirectionalEntityLeaf), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (UnidirectionalEntityLeaf)e;
+                    var aa = (UnidirectionalEntityLeaf)a;
 
-                    if (a != null)
-                    {
-                        var ee = (UnidirectionalEntityLeaf)e;
-                        var aa = (UnidirectionalEntityLeaf)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Name, aa.Name);
-                        Assert.Equal(ee.Number, aa.Number);
-                        Assert.Equal(ee.IsGreen, aa.IsGreen);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Number, aa.Number);
+                    Assert.Equal(ee.IsGreen, aa.IsGreen);
                 }
-            },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
@@ -14,7 +14,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : SharedStoreF
     private readonly Dictionary<(bool, string, string), ISetSource> _expectedDataCache = new();
 
     public virtual ISetSource GetExpectedData()
-        => new NorthwindData();
+        => NorthwindData.Instance;
 
     public virtual ISetSource GetFilteredExpectedData(DbContext context)
     {
@@ -71,198 +71,196 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : SharedStoreF
         return expectedData;
     }
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(Customer), e => ((Customer)e)?.CustomerID },
+        { typeof(CustomerQuery), e => ((CustomerQuery)e)?.CompanyName },
+        { typeof(CustomerQueryWithQueryFilter), e => ((CustomerQueryWithQueryFilter)e)?.CompanyName },
+        { typeof(Order), e => ((Order)e)?.OrderID },
+        { typeof(OrderQuery), e => ((OrderQuery)e)?.CustomerID },
+        { typeof(Employee), e => ((Employee)e)?.EmployeeID },
+        { typeof(Product), e => ((Product)e)?.ProductID },
+        { typeof(ProductQuery), e => ((ProductQuery)e)?.ProductID },
+        { typeof(ProductView), e => ((ProductView)e)?.ProductID },
+        { typeof(OrderDetail), e => (((OrderDetail)e)?.OrderID.ToString(), ((OrderDetail)e)?.ProductID.ToString()) }
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
-            { typeof(Customer), e => ((Customer)e)?.CustomerID },
-            { typeof(CustomerQuery), e => ((CustomerQuery)e)?.CompanyName },
-            { typeof(CustomerQueryWithQueryFilter), e => ((CustomerQueryWithQueryFilter)e)?.CompanyName },
-            { typeof(Order), e => ((Order)e)?.OrderID },
-            { typeof(OrderQuery), e => ((OrderQuery)e)?.CustomerID },
-            { typeof(Employee), e => ((Employee)e)?.EmployeeID },
-            { typeof(Product), e => ((Product)e)?.ProductID },
-            { typeof(ProductQuery), e => ((ProductQuery)e)?.ProductID },
-            { typeof(ProductView), e => ((ProductView)e)?.ProductID },
-            { typeof(OrderDetail), e => (((OrderDetail)e)?.OrderID.ToString(), ((OrderDetail)e)?.ProductID.ToString()) }
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            typeof(Customer), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
 
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+                if (a != null)
+                {
+                    var ee = (Customer)e;
+                    var aa = (Customer)a;
+
+                    Assert.Equal(ee.CustomerID, aa.CustomerID);
+                    Assert.Equal(ee.Address, aa.Address);
+                    Assert.Equal(ee.CompanyName, aa.CompanyName);
+                    Assert.Equal(ee.ContactName, aa.ContactName);
+                    Assert.Equal(ee.ContactTitle, aa.ContactTitle);
+                    Assert.Equal(ee.Country, aa.Country);
+                    Assert.Equal(ee.Fax, aa.Fax);
+                    Assert.Equal(ee.Phone, aa.Phone);
+                    Assert.Equal(ee.PostalCode, aa.PostalCode);
+                }
+            }
+        },
         {
+            typeof(CustomerQuery), (e, a) =>
             {
-                typeof(Customer), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (CustomerQuery)e;
+                    var aa = (CustomerQuery)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Customer)e;
-                        var aa = (Customer)a;
-
-                        Assert.Equal(ee.CustomerID, aa.CustomerID);
-                        Assert.Equal(ee.Address, aa.Address);
-                        Assert.Equal(ee.CompanyName, aa.CompanyName);
-                        Assert.Equal(ee.ContactName, aa.ContactName);
-                        Assert.Equal(ee.ContactTitle, aa.ContactTitle);
-                        Assert.Equal(ee.Country, aa.Country);
-                        Assert.Equal(ee.Fax, aa.Fax);
-                        Assert.Equal(ee.Phone, aa.Phone);
-                        Assert.Equal(ee.PostalCode, aa.PostalCode);
-                    }
+                    Assert.Equal(ee.CompanyName, aa.CompanyName);
+                    Assert.Equal(ee.Address, aa.Address);
+                    Assert.Equal(ee.City, aa.City);
+                    Assert.Equal(ee.ContactName, aa.ContactName);
+                    Assert.Equal(ee.ContactTitle, aa.ContactTitle);
                 }
-            },
+            }
+        },
+        {
+            typeof(CustomerQueryWithQueryFilter), (e, a) =>
             {
-                typeof(CustomerQuery), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (CustomerQueryWithQueryFilter)e;
+                    var aa = (CustomerQueryWithQueryFilter)a;
 
-                    if (a != null)
-                    {
-                        var ee = (CustomerQuery)e;
-                        var aa = (CustomerQuery)a;
-
-                        Assert.Equal(ee.CompanyName, aa.CompanyName);
-                        Assert.Equal(ee.Address, aa.Address);
-                        Assert.Equal(ee.City, aa.City);
-                        Assert.Equal(ee.ContactName, aa.ContactName);
-                        Assert.Equal(ee.ContactTitle, aa.ContactTitle);
-                    }
+                    Assert.Equal(ee.CompanyName, aa.CompanyName);
+                    Assert.Equal(ee.SearchTerm, aa.SearchTerm);
+                    Assert.Equal(ee.OrderCount, aa.OrderCount);
                 }
-            },
+            }
+        },
+        {
+            typeof(Order), (e, a) =>
             {
-                typeof(CustomerQueryWithQueryFilter), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Order)e;
+                    var aa = (Order)a;
 
-                    if (a != null)
-                    {
-                        var ee = (CustomerQueryWithQueryFilter)e;
-                        var aa = (CustomerQueryWithQueryFilter)a;
-
-                        Assert.Equal(ee.CompanyName, aa.CompanyName);
-                        Assert.Equal(ee.SearchTerm, aa.SearchTerm);
-                        Assert.Equal(ee.OrderCount, aa.OrderCount);
-                    }
+                    Assert.Equal(ee.OrderID, aa.OrderID);
+                    Assert.Equal(ee.CustomerID, aa.CustomerID);
+                    Assert.Equal(ee.EmployeeID, aa.EmployeeID);
+                    Assert.Equal(ee.OrderDate, aa.OrderDate);
                 }
-            },
+            }
+        },
+        {
+            typeof(OrderQuery), (e, a) =>
             {
-                typeof(Order), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (OrderQuery)e;
+                    var aa = (OrderQuery)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Order)e;
-                        var aa = (Order)a;
-
-                        Assert.Equal(ee.OrderID, aa.OrderID);
-                        Assert.Equal(ee.CustomerID, aa.CustomerID);
-                        Assert.Equal(ee.EmployeeID, aa.EmployeeID);
-                        Assert.Equal(ee.OrderDate, aa.OrderDate);
-                    }
+                    Assert.Equal(ee.CustomerID, aa.CustomerID);
                 }
-            },
+            }
+        },
+        {
+            typeof(Employee), (e, a) =>
             {
-                typeof(OrderQuery), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Employee)e;
+                    var aa = (Employee)a;
 
-                    if (a != null)
-                    {
-                        var ee = (OrderQuery)e;
-                        var aa = (OrderQuery)a;
-
-                        Assert.Equal(ee.CustomerID, aa.CustomerID);
-                    }
+                    Assert.Equal(ee.EmployeeID, aa.EmployeeID);
+                    Assert.Equal(ee.Title, aa.Title);
+                    Assert.Equal(ee.City, aa.City);
+                    Assert.Equal(ee.Country, aa.Country);
+                    Assert.Equal(ee.FirstName, aa.FirstName);
                 }
-            },
+            }
+        },
+        {
+            typeof(Product), (e, a) =>
             {
-                typeof(Employee), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (Product)e;
+                    var aa = (Product)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Employee)e;
-                        var aa = (Employee)a;
-
-                        Assert.Equal(ee.EmployeeID, aa.EmployeeID);
-                        Assert.Equal(ee.Title, aa.Title);
-                        Assert.Equal(ee.City, aa.City);
-                        Assert.Equal(ee.Country, aa.Country);
-                        Assert.Equal(ee.FirstName, aa.FirstName);
-                    }
+                    Assert.Equal(ee.ProductID, aa.ProductID);
+                    Assert.Equal(ee.ProductName, aa.ProductName);
+                    Assert.Equal(ee.SupplierID, aa.SupplierID);
+                    Assert.Equal(ee.UnitPrice, aa.UnitPrice);
+                    Assert.Equal(ee.UnitsInStock, aa.UnitsInStock);
                 }
-            },
+            }
+        },
+        {
+            typeof(ProductQuery), (e, a) =>
             {
-                typeof(Product), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (ProductQuery)e;
+                    var aa = (ProductQuery)a;
 
-                    if (a != null)
-                    {
-                        var ee = (Product)e;
-                        var aa = (Product)a;
-
-                        Assert.Equal(ee.ProductID, aa.ProductID);
-                        Assert.Equal(ee.ProductName, aa.ProductName);
-                        Assert.Equal(ee.SupplierID, aa.SupplierID);
-                        Assert.Equal(ee.UnitPrice, aa.UnitPrice);
-                        Assert.Equal(ee.UnitsInStock, aa.UnitsInStock);
-                    }
+                    Assert.Equal(ee.ProductID, aa.ProductID);
+                    Assert.Equal(ee.CategoryName, aa.CategoryName);
+                    Assert.Equal(ee.ProductName, aa.ProductName);
                 }
-            },
+            }
+        },
+        {
+            typeof(ProductView), (e, a) =>
             {
-                typeof(ProductQuery), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (ProductView)e;
+                    var aa = (ProductView)a;
 
-                    if (a != null)
-                    {
-                        var ee = (ProductQuery)e;
-                        var aa = (ProductQuery)a;
-
-                        Assert.Equal(ee.ProductID, aa.ProductID);
-                        Assert.Equal(ee.CategoryName, aa.CategoryName);
-                        Assert.Equal(ee.ProductName, aa.ProductName);
-                    }
+                    Assert.Equal(ee.ProductID, aa.ProductID);
+                    Assert.Equal(ee.CategoryName, aa.CategoryName);
+                    Assert.Equal(ee.ProductName, aa.ProductName);
                 }
-            },
+            }
+        },
+        {
+            typeof(OrderDetail), (e, a) =>
             {
-                typeof(ProductView), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (OrderDetail)e;
+                    var aa = (OrderDetail)a;
 
-                    if (a != null)
-                    {
-                        var ee = (ProductView)e;
-                        var aa = (ProductView)a;
-
-                        Assert.Equal(ee.ProductID, aa.ProductID);
-                        Assert.Equal(ee.CategoryName, aa.CategoryName);
-                        Assert.Equal(ee.ProductName, aa.ProductName);
-                    }
+                    Assert.Equal(ee.OrderID, aa.OrderID);
+                    Assert.Equal(ee.ProductID, aa.ProductID);
+                    Assert.Equal(ee.Quantity, aa.Quantity);
+                    Assert.Equal(ee.UnitPrice, aa.UnitPrice);
+                    Assert.Equal(ee.Discount, aa.Discount);
                 }
-            },
-            {
-                typeof(OrderDetail), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (OrderDetail)e;
-                        var aa = (OrderDetail)a;
-
-                        Assert.Equal(ee.OrderID, aa.OrderID);
-                        Assert.Equal(ee.ProductID, aa.ProductID);
-                        Assert.Equal(ee.Quantity, aa.Quantity);
-                        Assert.Equal(ee.UnitPrice, aa.UnitPrice);
-                        Assert.Equal(ee.Discount, aa.Discount);
-                    }
-                }
-            },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     protected override string StoreName
         => "Northwind";

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -843,261 +843,254 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
         public virtual ISetSource GetExpectedData()
             => new OwnedQueryData();
 
-        public IReadOnlyDictionary<Type, object> GetEntitySorters()
-            => new Dictionary<Type, Func<object, object>>
+        public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+        {
+            { typeof(OwnedPerson), e => ((OwnedPerson)e)?.Id },
+            { typeof(Branch), e => ((Branch)e)?.Id },
+            { typeof(LeafA), e => ((LeafA)e)?.Id },
+            { typeof(LeafB), e => ((LeafB)e)?.Id },
+            { typeof(Planet), e => ((Planet)e)?.Id },
+            { typeof(Star), e => ((Star)e)?.Id },
+            { typeof(Moon), e => ((Moon)e)?.Id },
+            { typeof(Fink), e => ((Fink)e)?.Id },
+            { typeof(Barton), e => ((Barton)e)?.Id },
+
+            // owned entities - still need comparers in case they are projected directly
+            { typeof(Order), e => ((Order)e)?.Id },
+            { typeof(OrderDetail), e => ((OrderDetail)e)?.Detail },
+            { typeof(OwnedAddress), e => ((OwnedAddress)e)?.Country.Name },
+            { typeof(OwnedCountry), e => ((OwnedCountry)e)?.Name },
+            { typeof(Element), e => ((Element)e)?.Id },
+            { typeof(Throned), e => ((Throned)e)?.Property }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+        public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+        {
             {
-                { typeof(OwnedPerson), e => ((OwnedPerson)e)?.Id },
-                { typeof(Branch), e => ((Branch)e)?.Id },
-                { typeof(LeafA), e => ((LeafA)e)?.Id },
-                { typeof(LeafB), e => ((LeafB)e)?.Id },
-                { typeof(Planet), e => ((Planet)e)?.Id },
-                { typeof(Star), e => ((Star)e)?.Id },
-                { typeof(Moon), e => ((Moon)e)?.Id },
-                { typeof(Fink), e => ((Fink)e)?.Id },
-                { typeof(Barton), e => ((Barton)e)?.Id },
+                typeof(OwnedPerson), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        var ee = (OwnedPerson)e;
+                        var aa = (OwnedPerson)a;
 
-                // owned entities - still need comparers in case they are projected directly
-                { typeof(Order), e => ((Order)e)?.Id },
-                { typeof(OrderDetail), e => ((OrderDetail)e)?.Detail },
-                { typeof(OwnedAddress), e => ((OwnedAddress)e)?.Country.Name },
-                { typeof(OwnedCountry), e => ((OwnedCountry)e)?.Name },
-                { typeof(Element), e => ((Element)e)?.Id },
-                { typeof(Throned), e => ((Throned)e)?.Property }
-            }.ToDictionary(e => e.Key, e => (object)e.Value);
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee["Name"], aa["Name"]);
+                        AssertAddress(ee.PersonAddress, aa.PersonAddress);
+                        AssertOrders(ee.Orders, aa.Orders);
+                    }
 
-        public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-            => new Dictionary<Type, Action<object, object>>
+                    if (e is Branch branch)
+                    {
+                        AssertAddress(branch.BranchAddress, ((Branch)a).BranchAddress);
+                    }
+
+                    if (e is LeafA leafA)
+                    {
+                        AssertAddress(leafA.LeafAAddress, ((LeafA)a).LeafAAddress);
+                    }
+
+                    if (e is LeafB leafB)
+                    {
+                        AssertAddress(leafB.LeafBAddress, ((LeafB)a).LeafBAddress);
+                    }
+                }
+            },
             {
+                typeof(Branch), (e, a) =>
                 {
-                    typeof(OwnedPerson), (e, a) =>
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
                     {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (OwnedPerson)e;
-                            var aa = (OwnedPerson)a;
+                        var ee = (Branch)e;
+                        var aa = (Branch)a;
 
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee["Name"], aa["Name"]);
-                            AssertAddress(ee.PersonAddress, aa.PersonAddress);
-                            AssertOrders(ee.Orders, aa.Orders);
-                        }
-
-                        if (e is Branch branch)
-                        {
-                            AssertAddress(branch.BranchAddress, ((Branch)a).BranchAddress);
-                        }
-
-                        if (e is LeafA leafA)
-                        {
-                            AssertAddress(leafA.LeafAAddress, ((LeafA)a).LeafAAddress);
-                        }
-
-                        if (e is LeafB leafB)
-                        {
-                            AssertAddress(leafB.LeafBAddress, ((LeafB)a).LeafBAddress);
-                        }
+                        Assert.Equal(ee.Id, aa.Id);
+                        AssertAddress(ee.PersonAddress, aa.PersonAddress);
+                        AssertAddress(ee.BranchAddress, aa.BranchAddress);
+                        AssertOrders(ee.Orders, aa.Orders);
                     }
-                },
-                {
-                    typeof(Branch), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (Branch)e;
-                            var aa = (Branch)a;
 
-                            Assert.Equal(ee.Id, aa.Id);
-                            AssertAddress(ee.PersonAddress, aa.PersonAddress);
-                            AssertAddress(ee.BranchAddress, aa.BranchAddress);
-                            AssertOrders(ee.Orders, aa.Orders);
-                        }
+                    if (e is LeafA leafA)
+                    {
+                        AssertAddress(leafA.LeafAAddress, ((LeafA)a).LeafAAddress);
+                    }
+                }
+            },
+            {
+                typeof(LeafA), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        var ee = (LeafA)e;
+                        var aa = (LeafA)a;
 
-                        if (e is LeafA leafA)
-                        {
-                            AssertAddress(leafA.LeafAAddress, ((LeafA)a).LeafAAddress);
-                        }
+                        Assert.Equal(ee.Id, aa.Id);
+                        AssertAddress(ee.PersonAddress, aa.PersonAddress);
+                        AssertAddress(ee.BranchAddress, aa.BranchAddress);
+                        AssertAddress(ee.LeafAAddress, aa.LeafAAddress);
+                        AssertOrders(ee.Orders, aa.Orders);
                     }
-                },
+                }
+            },
+            {
+                typeof(LeafB), (e, a) =>
                 {
-                    typeof(LeafA), (e, a) =>
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
                     {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (LeafA)e;
-                            var aa = (LeafA)a;
+                        var ee = (LeafB)e;
+                        var aa = (LeafB)a;
 
-                            Assert.Equal(ee.Id, aa.Id);
-                            AssertAddress(ee.PersonAddress, aa.PersonAddress);
-                            AssertAddress(ee.BranchAddress, aa.BranchAddress);
-                            AssertAddress(ee.LeafAAddress, aa.LeafAAddress);
-                            AssertOrders(ee.Orders, aa.Orders);
-                        }
+                        Assert.Equal(ee.Id, aa.Id);
+                        AssertAddress(ee.PersonAddress, aa.PersonAddress);
+                        AssertAddress(ee.LeafBAddress, aa.LeafBAddress);
+                        AssertOrders(ee.Orders, aa.Orders);
                     }
-                },
+                }
+            },
+            {
+                typeof(Planet), (e, a) =>
                 {
-                    typeof(LeafB), (e, a) =>
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
                     {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (LeafB)e;
-                            var aa = (LeafB)a;
+                        var ee = (Planet)e;
+                        var aa = (Planet)a;
 
-                            Assert.Equal(ee.Id, aa.Id);
-                            AssertAddress(ee.PersonAddress, aa.PersonAddress);
-                            AssertAddress(ee.LeafBAddress, aa.LeafBAddress);
-                            AssertOrders(ee.Orders, aa.Orders);
-                        }
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Name, aa.Name);
+                        Assert.Equal(ee.StarId, aa.StarId);
                     }
-                },
+                }
+            },
+            {
+                typeof(Star), (e, a) =>
                 {
-                    typeof(Planet), (e, a) =>
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
                     {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (Planet)e;
-                            var aa = (Planet)a;
+                        var ee = (Star)e;
+                        var aa = (Star)a;
 
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Name, aa.Name);
-                            Assert.Equal(ee.StarId, aa.StarId);
-                        }
-                    }
-                },
-                {
-                    typeof(Star), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Name, aa.Name);
+                        Assert.Equal(ee.Composition.Count, aa.Composition.Count);
+                        foreach (var (eec, aac) in ee.Composition.OrderBy(eec => eec.Id).Zip(aa.Composition.OrderBy(aac => aac.Id)))
                         {
-                            var ee = (Star)e;
-                            var aa = (Star)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Name, aa.Name);
-                            Assert.Equal(ee.Composition.Count, aa.Composition.Count);
-                            foreach (var (eec, aac) in ee.Composition.OrderBy(eec => eec.Id).Zip(aa.Composition.OrderBy(aac => aac.Id)))
-                            {
-                                Assert.Equal(eec.Id, aac.Id);
-                                Assert.Equal(eec.Name, aac.Name);
-                                Assert.Equal(eec.StarId, aac.StarId);
-                            }
-                        }
-                    }
-                },
-                {
-                    typeof(Moon), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (Moon)e;
-                            var aa = (Moon)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.PlanetId, aa.PlanetId);
-                            Assert.Equal(ee.Diameter, aa.Diameter);
-                        }
-                    }
-                },
-                {
-                    typeof(Fink), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            Assert.Equal(((Fink)e).Id, ((Fink)a).Id);
-                        }
-                    }
-                },
-                {
-                    typeof(Barton), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (Barton)e;
-                            var aa = (Barton)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Simple, aa.Simple);
-                            Assert.Equal(ee.Throned.Property, aa.Throned.Property);
-                        }
-                    }
-                },
-
-                // owned entities - still need comparers in case they are projected directly
-                {
-                    typeof(Order), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            Assert.Equal(((Order)e).Id, ((Order)a).Id);
-                        }
-                    }
-                },
-                {
-                    typeof(OrderDetail), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            Assert.Equal(((OrderDetail)e).Detail, ((OrderDetail)a).Detail);
-                        }
-                    }
-                },
-                {
-                    typeof(OwnedAddress), (e, a) =>
-                    {
-                        AssertAddress(((OwnedAddress)e), ((OwnedAddress)a));
-                    }
-                },
-                {
-                    typeof(OwnedCountry), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (OwnedCountry)e;
-                            var aa = (OwnedCountry)a;
-
-                            Assert.Equal(ee.Name, aa.Name);
-                            Assert.Equal(ee.PlanetId, aa.PlanetId);
-                        }
-                    }
-                },
-                {
-                    typeof(Element), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            var ee = (Element)e;
-                            var aa = (Element)a;
-
-                            Assert.Equal(ee.Id, aa.Id);
-                            Assert.Equal(ee.Name, aa.Name);
-                            Assert.Equal(ee.StarId, aa.StarId);
-                        }
-                    }
-                },
-                {
-                    typeof(Throned), (e, a) =>
-                    {
-                        Assert.Equal(e == null, a == null);
-                        if (a != null)
-                        {
-                            Assert.Equal(((Throned)e).Value, ((Throned)a).Value);
-                            Assert.Equal(((Throned)e).Property, ((Throned)a).Property);
+                            Assert.Equal(eec.Id, aac.Id);
+                            Assert.Equal(eec.Name, aac.Name);
+                            Assert.Equal(eec.StarId, aac.StarId);
                         }
                     }
                 }
-            }.ToDictionary(e => e.Key, e => (object)e.Value);
+            },
+            {
+                typeof(Moon), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        var ee = (Moon)e;
+                        var aa = (Moon)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.PlanetId, aa.PlanetId);
+                        Assert.Equal(ee.Diameter, aa.Diameter);
+                    }
+                }
+            },
+            {
+                typeof(Fink), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        Assert.Equal(((Fink)e).Id, ((Fink)a).Id);
+                    }
+                }
+            },
+            {
+                typeof(Barton), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        var ee = (Barton)e;
+                        var aa = (Barton)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Simple, aa.Simple);
+                        Assert.Equal(ee.Throned.Property, aa.Throned.Property);
+                    }
+                }
+            },
+
+            // owned entities - still need comparers in case they are projected directly
+            {
+                typeof(Order), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        Assert.Equal(((Order)e).Id, ((Order)a).Id);
+                    }
+                }
+            },
+            {
+                typeof(OrderDetail), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        Assert.Equal(((OrderDetail)e).Detail, ((OrderDetail)a).Detail);
+                    }
+                }
+            },
+            { typeof(OwnedAddress), (e, a) => { AssertAddress(((OwnedAddress)e), ((OwnedAddress)a)); } },
+            {
+                typeof(OwnedCountry), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        var ee = (OwnedCountry)e;
+                        var aa = (OwnedCountry)a;
+
+                        Assert.Equal(ee.Name, aa.Name);
+                        Assert.Equal(ee.PlanetId, aa.PlanetId);
+                    }
+                }
+            },
+            {
+                typeof(Element), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        var ee = (Element)e;
+                        var aa = (Element)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Name, aa.Name);
+                        Assert.Equal(ee.StarId, aa.StarId);
+                    }
+                }
+            },
+            {
+                typeof(Throned), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a != null)
+                    {
+                        Assert.Equal(((Throned)e).Value, ((Throned)a).Value);
+                        Assert.Equal(((Throned)e).Property, ((Throned)a).Property);
+                    }
+                }
+            }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
 
         protected override string StoreName
             => "OwnedQueryTest";

--- a/test/EFCore.Specification.Tests/Query/SpatialQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SpatialQueryFixtureBase.cs
@@ -17,109 +17,107 @@ public abstract class SpatialQueryFixtureBase : SharedStoreFixtureBase<SpatialCo
     public virtual ISetSource GetExpectedData()
         => new SpatialData(GeometryFactory);
 
-    public IReadOnlyDictionary<Type, object> GetEntitySorters()
-        => new Dictionary<Type, Func<object, object>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    {
+        { typeof(PointEntity), e => ((PointEntity)e)?.Id },
+        { typeof(LineStringEntity), e => ((LineStringEntity)e)?.Id },
+        { typeof(PolygonEntity), e => ((PolygonEntity)e)?.Id },
+        { typeof(MultiLineStringEntity), e => ((MultiLineStringEntity)e)?.Id },
+        { typeof(GeoPointEntity), e => ((GeoPointEntity)e)?.Id },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    {
         {
-            { typeof(PointEntity), e => ((PointEntity)e)?.Id },
-            { typeof(LineStringEntity), e => ((LineStringEntity)e)?.Id },
-            { typeof(PolygonEntity), e => ((PolygonEntity)e)?.Id },
-            { typeof(MultiLineStringEntity), e => ((MultiLineStringEntity)e)?.Id },
-            { typeof(GeoPointEntity), e => ((GeoPointEntity)e)?.Id },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            typeof(PointEntity), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
 
-    public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-        => new Dictionary<Type, Action<object, object>>
+                if (a != null)
+                {
+                    var ee = (PointEntity)e;
+                    var aa = (PointEntity)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Geometry, aa.Geometry, GeometryComparer.Instance);
+                    Assert.Equal(ee.Point, aa.Point, GeometryComparer.Instance);
+                    Assert.Equal(ee.PointZ, aa.PointZ, GeometryComparer.Instance);
+                    Assert.Equal(ee.PointM, aa.PointM, GeometryComparer.Instance);
+                    Assert.Equal(ee.PointZM, aa.PointZM, GeometryComparer.Instance);
+                }
+            }
+        },
         {
+            typeof(LineStringEntity), (e, a) =>
             {
-                typeof(PointEntity), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (LineStringEntity)e;
+                    var aa = (LineStringEntity)a;
 
-                    if (a != null)
-                    {
-                        var ee = (PointEntity)e;
-                        var aa = (PointEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Geometry, aa.Geometry, GeometryComparer.Instance);
-                        Assert.Equal(ee.Point, aa.Point, GeometryComparer.Instance);
-                        Assert.Equal(ee.PointZ, aa.PointZ, GeometryComparer.Instance);
-                        Assert.Equal(ee.PointM, aa.PointM, GeometryComparer.Instance);
-                        Assert.Equal(ee.PointZM, aa.PointZM, GeometryComparer.Instance);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.LineString, aa.LineString, GeometryComparer.Instance);
                 }
-            },
+            }
+        },
+        {
+            typeof(PolygonEntity), (e, a) =>
             {
-                typeof(LineStringEntity), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (PolygonEntity)e;
+                    var aa = (PolygonEntity)a;
 
-                    if (a != null)
-                    {
-                        var ee = (LineStringEntity)e;
-                        var aa = (LineStringEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.LineString, aa.LineString, GeometryComparer.Instance);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Polygon, aa.Polygon, GeometryComparer.Instance);
                 }
-            },
+            }
+        },
+        {
+            typeof(MultiLineStringEntity), (e, a) =>
             {
-                typeof(PolygonEntity), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (MultiLineStringEntity)e;
+                    var aa = (MultiLineStringEntity)a;
 
-                    if (a != null)
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.MultiLineString != null, aa.MultiLineString != null);
+                    if (ee.MultiLineString != null)
                     {
-                        var ee = (PolygonEntity)e;
-                        var aa = (PolygonEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Polygon, aa.Polygon, GeometryComparer.Instance);
-                    }
-                }
-            },
-            {
-                typeof(MultiLineStringEntity), (e, a) =>
-                {
-                    Assert.Equal(e == null, a == null);
-
-                    if (a != null)
-                    {
-                        var ee = (MultiLineStringEntity)e;
-                        var aa = (MultiLineStringEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.MultiLineString != null, aa.MultiLineString != null);
-                        if (ee.MultiLineString != null)
+                        Assert.Equal(ee.MultiLineString.Count, aa.MultiLineString.Count);
+                        Assert.Equal(ee.MultiLineString.Area, aa.MultiLineString.Area);
+                        for (var i = 0; i < ee.MultiLineString.Count; i++)
                         {
-                            Assert.Equal(ee.MultiLineString.Count, aa.MultiLineString.Count);
-                            Assert.Equal(ee.MultiLineString.Area, aa.MultiLineString.Area);
-                            for (var i = 0; i < ee.MultiLineString.Count; i++)
-                            {
-                                Assert.Equal(ee.MultiLineString[i], aa.MultiLineString[i], GeometryComparer.Instance);
-                            }
+                            Assert.Equal(ee.MultiLineString[i], aa.MultiLineString[i], GeometryComparer.Instance);
                         }
                     }
                 }
-            },
+            }
+        },
+        {
+            typeof(GeoPointEntity), (e, a) =>
             {
-                typeof(GeoPointEntity), (e, a) =>
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
                 {
-                    Assert.Equal(e == null, a == null);
+                    var ee = (GeoPointEntity)e;
+                    var aa = (GeoPointEntity)a;
 
-                    if (a != null)
-                    {
-                        var ee = (GeoPointEntity)e;
-                        var aa = (GeoPointEntity)a;
-
-                        Assert.Equal(ee.Id, aa.Id);
-                        Assert.Equal(ee.Location.Lat, aa.Location.Lat);
-                        Assert.Equal(ee.Location.Lon, aa.Location.Lon);
-                    }
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Location.Lat, aa.Location.Lat);
+                    Assert.Equal(ee.Location.Lon, aa.Location.Lon);
                 }
-            },
-        }.ToDictionary(e => e.Key, e => (object)e.Value);
+            }
+        },
+    }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public virtual GeometryFactory GeometryFactory
         => LazyInitializer.EnsureInitialized(

--- a/test/EFCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataData.cs
@@ -5,9 +5,11 @@ namespace Microsoft.EntityFrameworkCore.TestModels.FunkyDataModel;
 
 public class FunkyDataData : ISetSource
 {
+    public static readonly FunkyDataData Instance = new();
+
     public IReadOnlyList<FunkyCustomer> FunkyCustomers { get; }
 
-    public FunkyDataData()
+    private FunkyDataData()
     {
         FunkyCustomers = CreateFunkyCustomers();
     }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -5,6 +5,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
 public class GearsOfWarData : ISetSource
 {
+    public static readonly GearsOfWarData Instance = new();
+
     public IReadOnlyList<City> Cities { get; }
     public IReadOnlyList<CogTag> Tags { get; }
     public IReadOnlyList<Faction> Factions { get; }
@@ -16,7 +18,7 @@ public class GearsOfWarData : ISetSource
     public IReadOnlyList<LocustLeader> LocustLeaders { get; }
     public IReadOnlyList<LocustHighCommand> LocustHighCommands { get; }
 
-    public GearsOfWarData()
+    private GearsOfWarData()
     {
         Squads = CreateSquads();
         Missions = CreateMissions();

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/InheritanceData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/InheritanceData.cs
@@ -5,13 +5,15 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 public class InheritanceData : ISetSource
 {
+    public static readonly InheritanceData Instance = new();
+
     public IReadOnlyList<Animal> Animals { get; }
     public IReadOnlyList<AnimalQuery> AnimalQueries { get; }
     public IReadOnlyList<Country> Countries { get; }
     public IReadOnlyList<Drink> Drinks { get; }
     public IReadOnlyList<Plant> Plants { get; }
 
-    public InheritanceData()
+    private InheritanceData()
     {
         Animals = CreateAnimals();
         Countries = CreateCountries();

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/InheritanceRelationshipsData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/InheritanceRelationshipsData.cs
@@ -5,6 +5,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel
 
 public class InheritanceRelationshipsData : ISetSource
 {
+    public static readonly InheritanceRelationshipsData Instance = new();
+
     public IReadOnlyList<BaseInheritanceRelationshipEntity> BaseEntities { get; set; }
     public IReadOnlyList<BaseReferenceOnBase> BaseReferencesOnBase { get; set; }
     public IReadOnlyList<BaseReferenceOnDerived> BaseReferencesOnDerived { get; set; }
@@ -19,7 +21,7 @@ public class InheritanceRelationshipsData : ISetSource
     public IReadOnlyList<PrincipalEntity> PrincipalEntities { get; set; }
     public IReadOnlyList<ReferencedEntity> ReferencedEntities { get; set; }
 
-    public InheritanceRelationshipsData()
+    private InheritanceRelationshipsData()
     {
         BaseEntities = CreateBaseEntities();
         BaseReferencesOnBase = CreateBaseReferencesOnBase();
@@ -642,7 +644,7 @@ public class InheritanceRelationshipsData : ISetSource
         collectionsOnBase[4].Parent = baseEntities[3];
         collectionsOnBase[4].ParentId = baseEntities[3].Id;
 
-        // DerivedInheritanceRelationshipEntity navigations 
+        // DerivedInheritanceRelationshipEntity navigations
         baseEntities[0].DerivedSefReferenceOnBase = (DerivedInheritanceRelationshipEntity)baseEntities[3];
         ((DerivedInheritanceRelationshipEntity)baseEntities[3]).BaseSelfReferenceOnDerived = baseEntities[0];
         ((DerivedInheritanceRelationshipEntity)baseEntities[3]).BaseId = baseEntities[0].Id;

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.cs
@@ -5,6 +5,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 public partial class NorthwindData : ISetSource
 {
+    public static readonly NorthwindData Instance = new();
+
     public Customer[] Customers { get; }
     public CustomerQuery[] CustomerQueries { get; }
     public CustomerQueryWithQueryFilter[] CustomerQueriesWithQueryFilter { get; }

--- a/test/EFCore.Specification.Tests/TestModels/NullSemanticsModel/NullSemanticsData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/NullSemanticsModel/NullSemanticsData.cs
@@ -5,7 +5,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.NullSemanticsModel;
 
 public class NullSemanticsData : ISetSource
 {
-    public NullSemanticsData()
+    public static readonly NullSemanticsData Instance = new();
+
+    private NullSemanticsData()
     {
         Entities1 = CreateEntities1();
         Entities2 = CreateEntities2();

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -38,8 +38,8 @@ public class QueryAsserter
         QueryFixture = queryFixture;
         _contextCreator = queryFixture.GetContextCreator();
         _expectedData = queryFixture.GetExpectedData();
-        _entitySorters = queryFixture.GetEntitySorters() ?? new Dictionary<Type, object>();
-        _entityAsserters = queryFixture.GetEntityAsserters() ?? new Dictionary<Type, object>();
+        _entitySorters = queryFixture.EntitySorters ?? new Dictionary<Type, object>();
+        _entityAsserters = queryFixture.EntityAsserters ?? new Dictionary<Type, object>();
         SetSourceCreator = queryFixture.GetSetSourceCreator();
 
         _rewriteExpectedQueryExpression = rewriteExpectedQueryExpression;


### PR DESCRIPTION
~20% improvement in total test run time on my machine

Basically, the changes are to avoid re-creating test data, entity asserters, and entity sorters.

