### PR TITLE
Allow index IsDescending to get empty array for all-descending

### DIFF
--- a/src/EFCore.Abstractions/IndexAttribute.cs
+++ b/src/EFCore.Abstractions/IndexAttribute.cs
@@ -18,6 +18,7 @@ public sealed class IndexAttribute : Attribute
     private string? _name;
     private bool? _isUnique;
     private bool[]? _isDescending;
+    private bool _allDescending;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="IndexAttribute" /> class.
@@ -63,13 +64,38 @@ public sealed class IndexAttribute : Attribute
         get => _isDescending;
         set
         {
-            if (value is not null && value.Length != PropertyNames.Count)
+            if (value is not null)
             {
-                throw new ArgumentException(
-                    AbstractionsStrings.InvalidNumberOfIndexSortOrderValues(value.Length, PropertyNames.Count), nameof(IsDescending));
+                if (value.Length != PropertyNames.Count)
+                {
+                    throw new ArgumentException(
+                        AbstractionsStrings.InvalidNumberOfIndexSortOrderValues(value.Length, PropertyNames.Count), nameof(IsDescending));
+                }
+
+                if (_allDescending)
+                {
+                    throw new ArgumentException(AbstractionsStrings.CannotSpecifyBothIsDescendingAndAllDescending);
+                }
             }
 
             _isDescending = value;
+        }
+    }
+
+    /// <summary>
+    ///     Whether all index columns have descending sort order.
+    /// </summary>
+    public bool AllDescending
+    {
+        get => _allDescending;
+        set
+        {
+            if (IsDescending is not null)
+            {
+                throw new ArgumentException(AbstractionsStrings.CannotSpecifyBothIsDescendingAndAllDescending);
+            }
+
+            _allDescending = value;
         }
     }
 

--- a/src/EFCore.Abstractions/Properties/AbstractionsStrings.Designer.cs
+++ b/src/EFCore.Abstractions/Properties/AbstractionsStrings.Designer.cs
@@ -39,6 +39,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 argumentName);
 
         /// <summary>
+        ///     IsDescending and AllDescending cannot both be specified on the [Index] attribute.
+        /// </summary>
+        public static string CannotSpecifyBothIsDescendingAndAllDescending
+            => GetString("CannotSpecifyBothIsDescendingAndAllDescending");
+
+        /// <summary>
         ///     The collection argument '{argumentName}' must not contain any empty elements.
         /// </summary>
         public static string CollectionArgumentHasEmptyElements(object? argumentName)

--- a/src/EFCore.Abstractions/Properties/AbstractionsStrings.resx
+++ b/src/EFCore.Abstractions/Properties/AbstractionsStrings.resx
@@ -123,6 +123,9 @@
   <data name="ArgumentIsNegativeNumber" xml:space="preserve">
     <value>The number argument '{argumentName}' cannot be negative number.</value>
   </data>
+  <data name="CannotSpecifyBothIsDescendingAndAllDescending" xml:space="preserve">
+    <value>IsDescending and AllDescending cannot both be specified on the [Index] attribute.</value>
+  </data>
   <data name="CollectionArgumentHasEmptyElements" xml:space="preserve">
     <value>The collection argument '{argumentName}' must not contain any empty elements.</value>
   </data>

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -215,7 +215,10 @@ public class CSharpEntityTypeGenerator
 
                 if (index.IsDescending is not null)
                 {
-                    indexAttribute.AddParameter($"{nameof(IndexAttribute.IsDescending)} = {_code.UnknownLiteral(index.IsDescending)}");
+                    indexAttribute.AddParameter(
+                        index.IsDescending.Count == 0
+                            ? $"{nameof(IndexAttribute.AllDescending)} = true"
+                            : $"{nameof(IndexAttribute.IsDescending)} = {_code.UnknownLiteral(index.IsDescending)}");
                 }
 
                 _sb.AppendLine(indexAttribute.ToString());

--- a/src/EFCore.Relational/Metadata/ITableIndex.cs
+++ b/src/EFCore.Relational/Metadata/ITableIndex.cs
@@ -84,11 +84,10 @@ public interface ITableIndex : IAnnotatable
                             $@"'{Columns[i].Name}'{(
                                 MappedIndexes.First() is not RuntimeIndex
                                 && IsDescending is not null
-                                && i < IsDescending.Count
-                                && IsDescending[i]
+                                && (IsDescending.Count == 0 || IsDescending[i])
                                     ? " Desc"
                                     : ""
-                                )}"))
+                            )}"))
             .Append('}');
 
         if (IsUnique)

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -604,6 +604,7 @@ public class MigrationBuilder
     /// <param name="descending">
     ///     A set of values indicating whether each corresponding index column has descending sort order.
     ///     If <see langword="null" />, all columns will have ascending order.
+    ///     If an empty array, all columns will have descending order.
     /// </param>
     /// <returns>A builder to allow annotations to be added to the operation.</returns>
     public virtual OperationBuilder<CreateIndexOperation> CreateIndex(

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -1688,7 +1688,7 @@ public class MigrationsSqlGenerator : IMigrationsSqlGenerator
 
             builder.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Columns[i]));
 
-            if (operation.IsDescending is not null && i < operation.IsDescending.Length && operation.IsDescending[i])
+            if (operation.IsDescending is not null && (operation.IsDescending.Length == 0 || operation.IsDescending[i]))
             {
                 builder.Append(" DESC");
             }

--- a/src/EFCore.Relational/Migrations/Operations/CreateIndexOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/CreateIndexOperation.cs
@@ -38,7 +38,7 @@ public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
         get => _columns!;
         set
         {
-            if (_isDescending is not null && value.Length != _isDescending.Length)
+            if (_isDescending is not null && _isDescending.Length > 0 && value.Length != _isDescending.Length)
             {
                 throw new ArgumentException(RelationalStrings.CreateIndexOperationWithInvalidSortOrder(_isDescending.Length, value.Length));
             }
@@ -60,7 +60,7 @@ public class CreateIndexOperation : MigrationOperation, ITableMigrationOperation
         get => _isDescending;
         set
         {
-            if (value is not null && _columns is not null && value.Length != _columns.Length)
+            if (value is not null && value.Length > 0 && _columns is not null && value.Length != _columns.Length)
             {
                 throw new ArgumentException(RelationalStrings.CreateIndexOperationWithInvalidSortOrder(value.Length, _columns.Length));
             }

--- a/src/EFCore/Metadata/Builders/IndexBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IndexBuilder.cs
@@ -80,7 +80,10 @@ public class IndexBuilder : IInfrastructure<IConventionIndexBuilder>
     /// <summary>
     ///     Configures the sort order(s) for the columns of this index (ascending or descending).
     /// </summary>
-    /// <param name="descending">A set of values indicating whether each corresponding index column has descending sort order.</param>
+    /// <param name="descending">
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     An empty list indicates that all index columns will have descending sort order.
+    /// </param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
     public virtual IndexBuilder IsDescending(params bool[] descending)
     {

--- a/src/EFCore/Metadata/Builders/IndexBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/IndexBuilder`.cs
@@ -53,7 +53,10 @@ public class IndexBuilder<T> : IndexBuilder
     /// <summary>
     ///     Configures the sort order(s) for the columns of this index (ascending or descending).
     /// </summary>
-    /// <param name="descending">A set of values indicating whether each corresponding index column has descending sort order.</param>
+    /// <param name="descending">
+    ///     A set of values indicating whether each corresponding index column has descending sort order.
+    ///     An empty list indicates that all index columns will have descending sort order.
+    /// </param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
     public new virtual IndexBuilder<T> IsDescending(params bool[] descending)
         => (IndexBuilder<T>)base.IsDescending(descending);

--- a/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
@@ -120,9 +120,16 @@ public class IndexAttributeConvention : IEntityTypeAddedConvention, IEntityTypeB
                     indexBuilder = indexBuilder.IsUnique(indexAttribute.IsUnique, fromDataAnnotation: true);
                 }
 
-                if (indexBuilder is not null && indexAttribute.IsDescending is not null)
+                if (indexBuilder is not null)
                 {
-                    indexBuilder.IsDescending(indexAttribute.IsDescending, fromDataAnnotation: true);
+                    if (indexAttribute.AllDescending)
+                    {
+                        indexBuilder.IsDescending(Array.Empty<bool>(), fromDataAnnotation: true);
+                    }
+                    else if (indexAttribute.IsDescending is not null)
+                    {
+                        indexBuilder.IsDescending(indexAttribute.IsDescending, fromDataAnnotation: true);
+                    }
                 }
             }
         }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -219,7 +219,7 @@ public class ModelSnapshotSqlServerTest
     {
         public int Id { get; set; }
     }
-    
+
     private class BaseEntity : AbstractBase
     {
         public string Discriminator { get; set; }
@@ -1227,7 +1227,7 @@ public class ModelSnapshotSqlServerTest
             model =>
             {
                 Assert.Equal(5, model.GetAnnotations().Count());
-                
+
                 var sequence = model.GetSequences().Single();
                 Assert.Equal(2, sequence.StartValue);
                 Assert.Equal(1, sequence.MinValue);
@@ -4881,7 +4881,9 @@ namespace RootNamespace
                 builder.Entity<EntityWithThreeProperties>(
                     e =>
                     {
-                        e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_empty");
+                        e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_unspecified");
+                        e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_empty")
+                            .IsDescending();
                         e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_all_ascending")
                             .IsDescending(false, false, false);
                         e.HasIndex(t => new { t.X, t.Y, t.Z }, "IX_all_descending")
@@ -4912,32 +4914,37 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_all_ascending"")
-                        .IsDescending(false, false, false);
+                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_all_ascending"");
 
                     b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_all_descending"")
-                        .IsDescending(true, true, true);
+                        .IsDescending();
 
-                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_empty"");
+                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_empty"")
+                        .IsDescending();
 
                     b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_mixed"")
                         .IsDescending(false, true, false);
+
+                    b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_unspecified"");
 
                     b.ToTable(""EntityWithThreeProperties"");
                 });"),
             o =>
             {
                 var entityType = o.GetEntityTypes().Single();
-                Assert.Equal(4, entityType.GetIndexes().Count());
+                Assert.Equal(5, entityType.GetIndexes().Count());
+
+                var unspecifiedIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_unspecified");
+                Assert.Null(unspecifiedIndex.IsDescending);
 
                 var emptyIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_empty");
-                Assert.Null(emptyIndex.IsDescending);
+                Assert.Equal(Array.Empty<bool>(), emptyIndex.IsDescending);
 
                 var allAscendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_ascending");
-                Assert.Equal(new[] { false, false, false}, allAscendingIndex.IsDescending);
+                Assert.Null(allAscendingIndex.IsDescending);
 
                 var allDescendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_descending");
-                Assert.Equal(new[] { true, true, true }, allDescendingIndex.IsDescending);
+                Assert.Equal(Array.Empty<bool>(), allDescendingIndex.IsDescending);
 
                 var mixedIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_mixed");
                 Assert.Equal(new[] { false, true, false }, mixedIndex.IsDescending);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -1439,7 +1439,7 @@ public class RelationalScaffoldingModelFactoryTest
             new DatabaseIndex
             {
                 Table = Table,
-                Name = "IX_empty",
+                Name = "IX_unspecified",
                 Columns = { table.Columns[0], table.Columns[1], table.Columns[2] }
             });
 
@@ -1476,14 +1476,14 @@ public class RelationalScaffoldingModelFactoryTest
 
         var entityType = model.FindEntityType("SomeTable")!;
 
-        var emptyIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_empty");
-        Assert.Null(emptyIndex.IsDescending);
+        var unspecifiedIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_unspecified");
+        Assert.Null(unspecifiedIndex.IsDescending);
 
         var allAscendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_ascending");
         Assert.Null(allAscendingIndex.IsDescending);
 
         var allDescendingIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_all_descending");
-        Assert.Equal(new[] { true, true, true }, allDescendingIndex.IsDescending);
+        Assert.Equal(Array.Empty<bool>(), allDescendingIndex.IsDescending);
 
         var mixedIndex = Assert.Single(entityType.GetIndexes(), i => i.Name == "IX_mixed");
         Assert.Equal(new[] { false, true, false }, mixedIndex.IsDescending);

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -1080,7 +1080,7 @@ public abstract class MigrationsTestBase<TFixture> : IClassFixture<TFixture>
                     e.Property<int>("X");
                 }),
             builder => { },
-            builder => builder.Entity("People").HasIndex("X").IsDescending(true),
+            builder => builder.Entity("People").HasIndex("X").IsDescending(),
             model =>
             {
                 var table = Assert.Single(model.Tables);

--- a/test/EFCore.Relational.Tests/Migrations/Operations/CreateIndexOperationTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Operations/CreateIndexOperationTest.cs
@@ -18,4 +18,16 @@ public class CreateIndexOperationTest
         operation.Columns = new[] { "X", "Y" };
         Assert.Throws<ArgumentException>(() => operation.IsDescending = new[] { true });
     }
+
+    [ConditionalFact]
+    public void IsDescending_accepts_empty_array()
+    {
+        var operation = new CreateIndexOperation();
+
+        operation.IsDescending = Array.Empty<bool>();
+        operation.Columns = new[] { "X", "Y" };
+
+        operation.IsDescending = null;
+        operation.IsDescending = Array.Empty<bool>();
+    }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -3008,11 +3008,11 @@ public class ConventionDispatcherTest
 
         if (useBuilder)
         {
-            index.Builder.IsDescending(new[] { true }, ConfigurationSource.Convention);
+            index.Builder.IsDescending(Array.Empty<bool>(), ConfigurationSource.Convention);
         }
         else
         {
-            index.IsDescending = new[] { true };
+            index.IsDescending = Array.Empty<bool>();
         }
 
         if (useScope)
@@ -3022,34 +3022,34 @@ public class ConventionDispatcherTest
             scope!.Dispose();
         }
 
-        Assert.Equal(new[] { new[] { true } }, convention1.Calls);
-        Assert.Equal(new[] { new[] { true } }, convention2.Calls);
+        Assert.Equal(new[] { Array.Empty<bool>() }, convention1.Calls);
+        Assert.Equal(new[] { Array.Empty<bool>() }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
         {
-            index.Builder.IsDescending(new[] { true }, ConfigurationSource.Convention);
+            index.Builder.IsDescending(Array.Empty<bool>(), ConfigurationSource.Convention);
         }
         else
         {
-            index.IsDescending = new[] { true };
+            index.IsDescending = Array.Empty<bool>();
         }
 
-        Assert.Equal(new[] { new[] { true } }, convention1.Calls);
-        Assert.Equal(new[] { new[] { true } }, convention2.Calls);
+        Assert.Equal(new[] { Array.Empty<bool>() }, convention1.Calls);
+        Assert.Equal(new[] { Array.Empty<bool>() }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
         {
-            index.Builder.IsDescending(new[] { false }, ConfigurationSource.Convention);
+            index.Builder.IsDescending(null, ConfigurationSource.Convention);
         }
         else
         {
-            index.IsDescending = new[] { false };
+            index.IsDescending = null;
         }
 
-        Assert.Equal(new[] { new[] { true }, new[] { false } }, convention1.Calls);
-        Assert.Equal(new[] { new[] { true }, new[] { false } }, convention2.Calls);
+        Assert.Equal(new[] { Array.Empty<bool>(), null }, convention1.Calls);
+        Assert.Equal(new[] { Array.Empty<bool>(), null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         Assert.Same(index, entityBuilder.Metadata.RemoveIndex(index.Properties));

--- a/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
@@ -98,6 +98,17 @@ public class IndexAttributeConventionTest
     }
 
     [ConditionalFact]
+    public void IndexAttribute_AllDescending_is_applied()
+    {
+        var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+        var entityBuilder = modelBuilder.Entity<EntityWithTwoIndexes>();
+        modelBuilder.Model.FinalizeModel();
+
+        var allDescendingIndex = entityBuilder.Metadata.FindIndex("IndexOnBAndC")!;
+        Assert.Equal(Array.Empty<bool>(), allDescendingIndex.IsDescending);
+    }
+
+    [ConditionalFact]
     public void IndexAttribute_can_be_applied_more_than_once_per_entity_type()
     {
         var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
@@ -332,7 +343,7 @@ public class IndexAttributeConventionTest
     }
 
     [Index(nameof(A), nameof(B), Name = "IndexOnAAndB", IsUnique = true)]
-    [Index(nameof(B), nameof(C), Name = "IndexOnBAndC", IsUnique = false)]
+    [Index(nameof(B), nameof(C), Name = "IndexOnBAndC", IsUnique = false, AllDescending = true)]
     private class EntityWithTwoIndexes
     {
         public int Id { get; set; }

--- a/test/EFCore.Tests/Metadata/Internal/IndexTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/IndexTest.cs
@@ -60,6 +60,48 @@ public class IndexTest
         Assert.True(index.IsUnique);
     }
 
+    [ConditionalFact]
+    public void IsDescending_all_ascending_is_normalized_to_null()
+    {
+        var entityType = CreateModel().AddEntityType(typeof(Customer));
+        var property1 = entityType.AddProperty(Customer.IdProperty);
+        var property2 = entityType.AddProperty(Customer.NameProperty);
+
+        var index = entityType.AddIndex(new[] { property1, property2 });
+        index.IsDescending = new[] { false, false };
+
+        Assert.True(new[] { property1, property2 }.SequenceEqual(index.Properties));
+        Assert.Null(index.IsDescending);
+    }
+
+    [ConditionalFact]
+    public void IsDescending_all_descending_is_normalized_to_empty()
+    {
+        var entityType = CreateModel().AddEntityType(typeof(Customer));
+        var property1 = entityType.AddProperty(Customer.IdProperty);
+        var property2 = entityType.AddProperty(Customer.NameProperty);
+
+        var index = entityType.AddIndex(new[] { property1, property2 });
+        index.IsDescending = new[] { true, true };
+
+        Assert.True(new[] { property1, property2 }.SequenceEqual(index.Properties));
+        Assert.Equal(Array.Empty<bool>(), index.IsDescending);
+    }
+
+    [ConditionalFact]
+    public void IsDescending_invalid_number_of_columns_throws()
+    {
+        var entityType = CreateModel().AddEntityType(typeof(Customer));
+        var property1 = entityType.AddProperty(Customer.IdProperty);
+        var property2 = entityType.AddProperty(Customer.NameProperty);
+
+        var index = entityType.AddIndex(new[] { property1, property2 });
+        var exception = Assert.Throws<ArgumentException>(() => index.IsDescending = new[] { true });
+        Assert.Equal(
+            CoreStrings.InvalidNumberOfIndexSortOrderValues("{'Id', 'Name'}", 1, 2) + " (Parameter 'descending')",
+            exception.Message);
+    }
+
     private static IMutableModel CreateModel()
         => new Model();
 

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -829,12 +829,12 @@ public abstract partial class ModelBuilderTest
             var entityType = (IReadOnlyEntityType)model.FindEntityType(typeof(Quarks));
 
             Assert.Null(entityType.FindProperty("Up").GetValueConverter());
-            
+
             var down = entityType.FindProperty("Down");
             Assert.Same(stringConverter, down.GetValueConverter());
             Assert.IsType<ValueComparer.DefaultValueComparer<string>>(down.GetValueComparer());
             Assert.IsType<ValueComparer<byte[]>>(down.GetProviderValueComparer());
-            
+
             var charm = entityType.FindProperty("Charm");
             Assert.Same(intConverter, charm.GetValueConverter());
             Assert.IsType<ValueComparer.DefaultValueComparer<int>>(charm.GetValueComparer());
@@ -915,7 +915,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
             var entityType = model.FindEntityType(typeof(Quarks));
-            
+
             var up = entityType.FindProperty("Up");
             Assert.Null(up.GetProviderClrType());
             Assert.Null(up.GetValueConverter());
@@ -937,7 +937,7 @@ public abstract partial class ModelBuilderTest
             Assert.IsType<CustomValueComparer<float>>(strange.GetValueComparer());
             Assert.IsType<CustomValueComparer<double>>(strange.GetProviderValueComparer());
         }
-        
+
         [ConditionalFact]
         public virtual void Properties_can_have_value_converter_set()
         {
@@ -1809,7 +1809,7 @@ public abstract partial class ModelBuilderTest
             entityBuilder.HasIndex(ix => ix.Id).IsUnique();
             entityBuilder.HasIndex(ix => ix.Name).HasAnnotation("A1", "V1");
             entityBuilder.HasIndex(ix => ix.Id, "Named");
-            entityBuilder.HasIndex(ix => ix.Id, "Descending").IsDescending(true);
+            entityBuilder.HasIndex(ix => ix.Id, "Descending").IsDescending();
 
             var model = modelBuilder.FinalizeModel();
 
@@ -1826,7 +1826,7 @@ public abstract partial class ModelBuilderTest
             var namedIndex = entityType.FindIndex("Named");
             Assert.False(namedIndex.IsUnique);
             var descendingIndex = entityType.FindIndex("Descending");
-            Assert.Equal(new[] { true }, descendingIndex.IsDescending);
+            Assert.Equal(Array.Empty<bool>(), descendingIndex.IsDescending);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Improves #27210 by allowing aan empty list parameter to IsDescending, meaning that all index columns should be descending.
Also normalizes explicitly-set all-ascending/all-descending to null/empty array respectively.

(addresses API review, #27588)