### PR TITLE
Change from sequence-per-model to sequence-per-hierarchy when using sequences for key generation

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -401,15 +401,18 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
 
             case SqlServerValueGenerationStrategy.Sequence:
             {
-                var name = GetAndRemove<string>(annotations, SqlServerAnnotationNames.KeySequenceName);
-                var schema = GetAndRemove<string>(annotations, SqlServerAnnotationNames.KeySequenceSchema);
+                var nameOrSuffix = GetAndRemove<string>(
+                    annotations,
+                    onModel ? SqlServerAnnotationNames.SequenceNameSuffix : SqlServerAnnotationNames.SequenceName);
+
+                var schema = GetAndRemove<string>(annotations, SqlServerAnnotationNames.SequenceSchema);
                 return new MethodCallCodeFragment(
                     onModel ? ModelUseKeySequencesMethodInfo : PropertyUseSequenceMethodInfo,
-                    (name, schema) switch
+                    (name: nameOrSuffix, schema) switch
                     {
                         (null, null) => Array.Empty<object>(),
-                        (_, null) => new object[] { name },
-                        _ => new object[] { name!, schema }
+                        (_, null) => new object[] { nameOrSuffix },
+                        _ => new object[] { nameOrSuffix!, schema }
                     });
             }
 

--- a/src/EFCore.SqlServer/Extensions/SqlServerModelBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerModelBuilderExtensions.cs
@@ -49,8 +49,8 @@ public static class SqlServerModelBuilderExtensions
         model.SetValueGenerationStrategy(SqlServerValueGenerationStrategy.SequenceHiLo);
         model.SetHiLoSequenceName(name);
         model.SetHiLoSequenceSchema(schema);
-        model.SetKeySequenceName(null);
-        model.SetKeySequenceSchema(null);
+        model.SetSequenceNameSuffix(null);
+        model.SetSequenceSchema(null);
         model.SetIdentitySeed(null);
         model.SetIdentityIncrement(null);
 
@@ -115,7 +115,7 @@ public static class SqlServerModelBuilderExtensions
     }
 
     /// <summary>
-    ///     Configures the model to use a sequence to generate values for key properties
+    ///     Configures the model to use a sequence per hierarchy to generate values for key properties
     ///     marked as <see cref="ValueGenerated.OnAdd" />, when targeting SQL Server.
     /// </summary>
     /// <remarks>
@@ -124,29 +124,24 @@ public static class SqlServerModelBuilderExtensions
     ///     for more information and examples.
     /// </remarks>
     /// <param name="modelBuilder">The model builder.</param>
-    /// <param name="name">The name of the sequence.</param>
+    /// <param name="nameSuffix">The name that will suffix the table name for each sequence created automatically.</param>
     /// <param name="schema">The schema of the sequence.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static ModelBuilder UseKeySequences(
         this ModelBuilder modelBuilder,
-        string? name = null,
+        string? nameSuffix = null,
         string? schema = null)
     {
-        Check.NullButNotEmpty(name, nameof(name));
+        Check.NullButNotEmpty(nameSuffix, nameof(nameSuffix));
         Check.NullButNotEmpty(schema, nameof(schema));
 
         var model = modelBuilder.Model;
 
-        name ??= SqlServerModelExtensions.DefaultKeySequenceName;
-
-        if (model.FindSequence(name, schema) == null)
-        {
-            modelBuilder.HasSequence(name, schema);
-        }
+        nameSuffix ??= SqlServerModelExtensions.DefaultSequenceNameSuffix;
 
         model.SetValueGenerationStrategy(SqlServerValueGenerationStrategy.Sequence);
-        model.SetKeySequenceName(name);
-        model.SetKeySequenceSchema(schema);
+        model.SetSequenceNameSuffix(nameSuffix);
+        model.SetSequenceSchema(schema);
         model.SetHiLoSequenceName(null);
         model.SetHiLoSequenceSchema(null);
         model.SetIdentitySeed(null);
@@ -180,10 +175,10 @@ public static class SqlServerModelBuilderExtensions
             return null;
         }
 
-        modelBuilder.Metadata.SetKeySequenceName(name, fromDataAnnotation);
-        modelBuilder.Metadata.SetKeySequenceSchema(schema, fromDataAnnotation);
+        modelBuilder.Metadata.SetSequenceNameSuffix(name, fromDataAnnotation);
+        modelBuilder.Metadata.SetSequenceSchema(schema, fromDataAnnotation);
 
-        return name == null ? null : modelBuilder.HasSequence(name, schema, fromDataAnnotation);
+        return null;
     }
 
     /// <summary>
@@ -195,21 +190,21 @@ public static class SqlServerModelBuilderExtensions
     ///     for more information and examples.
     /// </remarks>
     /// <param name="modelBuilder">The model builder.</param>
-    /// <param name="name">The name of the sequence.</param>
+    /// <param name="nameSuffix">The name of the sequence.</param>
     /// <param name="schema">The schema of the sequence.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the given name and schema can be set for the hi-lo sequence.</returns>
     public static bool CanSetKeySequences(
         this IConventionModelBuilder modelBuilder,
-        string? name,
+        string? nameSuffix,
         string? schema,
         bool fromDataAnnotation = false)
     {
-        Check.NullButNotEmpty(name, nameof(name));
+        Check.NullButNotEmpty(nameSuffix, nameof(nameSuffix));
         Check.NullButNotEmpty(schema, nameof(schema));
 
-        return modelBuilder.CanSetAnnotation(SqlServerAnnotationNames.KeySequenceName, name, fromDataAnnotation)
-            && modelBuilder.CanSetAnnotation(SqlServerAnnotationNames.KeySequenceSchema, schema, fromDataAnnotation);
+        return modelBuilder.CanSetAnnotation(SqlServerAnnotationNames.SequenceNameSuffix, nameSuffix, fromDataAnnotation)
+            && modelBuilder.CanSetAnnotation(SqlServerAnnotationNames.SequenceSchema, schema, fromDataAnnotation);
     }
 
     /// <summary>
@@ -236,8 +231,8 @@ public static class SqlServerModelBuilderExtensions
         model.SetValueGenerationStrategy(SqlServerValueGenerationStrategy.IdentityColumn);
         model.SetIdentitySeed(seed);
         model.SetIdentityIncrement(increment);
-        model.SetKeySequenceName(null);
-        model.SetKeySequenceSchema(null);
+        model.SetSequenceNameSuffix(null);
+        model.SetSequenceSchema(null);
         model.SetHiLoSequenceName(null);
         model.SetHiLoSequenceSchema(null);
 

--- a/src/EFCore.SqlServer/Extensions/SqlServerModelExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerModelExtensions.cs
@@ -22,9 +22,9 @@ public static class SqlServerModelExtensions
     public const string DefaultHiLoSequenceName = "EntityFrameworkHiLoSequence";
 
     /// <summary>
-    ///     The default name for the hi-lo sequence.
+    ///     The default prefix for sequences applied to properties.
     /// </summary>
-    public const string DefaultKeySequenceName = "EntityFrameworkKeySequence";
+    public const string DefaultSequenceNameSuffix = "Sequence";
 
     /// <summary>
     ///     Returns the name to use for the default hi-lo sequence.
@@ -124,72 +124,72 @@ public static class SqlServerModelExtensions
 
 
     /// <summary>
-    ///     Returns the name to use for the default key value generation sequence.
+    ///     Returns the suffix to append to the name of automatically created sequences.
     /// </summary>
     /// <param name="model">The model.</param>
     /// <returns>The name to use for the default key value generation sequence.</returns>
-    public static string GetKeySequenceName(this IReadOnlyModel model)
-        => (string?)model[SqlServerAnnotationNames.KeySequenceName]
-            ?? DefaultKeySequenceName;
+    public static string GetSequenceNameSuffix(this IReadOnlyModel model)
+        => (string?)model[SqlServerAnnotationNames.SequenceNameSuffix]
+            ?? DefaultSequenceNameSuffix;
 
     /// <summary>
-    ///     Sets the name to use for the default key value generation sequence.
+    ///     Sets the suffix to append to the name of automatically created sequences.
     /// </summary>
     /// <param name="model">The model.</param>
     /// <param name="name">The value to set.</param>
-    public static void SetKeySequenceName(this IMutableModel model, string? name)
+    public static void SetSequenceNameSuffix(this IMutableModel model, string? name)
     {
         Check.NullButNotEmpty(name, nameof(name));
 
-        model.SetOrRemoveAnnotation(SqlServerAnnotationNames.KeySequenceName, name);
+        model.SetOrRemoveAnnotation(SqlServerAnnotationNames.SequenceNameSuffix, name);
     }
 
     /// <summary>
-    ///     Sets the name to use for the default key value generation sequence.
+    ///     Sets the suffix to append to the name of automatically created sequences.
     /// </summary>
     /// <param name="model">The model.</param>
     /// <param name="name">The value to set.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
-    public static string? SetKeySequenceName(
+    public static string? SetSequenceNameSuffix(
         this IConventionModel model,
         string? name,
         bool fromDataAnnotation = false)
     {
         Check.NullButNotEmpty(name, nameof(name));
 
-        model.SetOrRemoveAnnotation(SqlServerAnnotationNames.KeySequenceName, name, fromDataAnnotation);
+        model.SetOrRemoveAnnotation(SqlServerAnnotationNames.SequenceNameSuffix, name, fromDataAnnotation);
 
         return name;
     }
 
     /// <summary>
-    ///     Returns the <see cref="ConfigurationSource" /> for the default key value generation sequence name.
+    ///     Returns the <see cref="ConfigurationSource" /> for the default value generation sequence name suffix.
     /// </summary>
     /// <param name="model">The model.</param>
     /// <returns>The <see cref="ConfigurationSource" /> for the default key value generation sequence name.</returns>
-    public static ConfigurationSource? GetKeySequenceNameConfigurationSource(this IConventionModel model)
-        => model.FindAnnotation(SqlServerAnnotationNames.KeySequenceName)?.GetConfigurationSource();
+    public static ConfigurationSource? GetSequenceNameSuffixConfigurationSource(this IConventionModel model)
+        => model.FindAnnotation(SqlServerAnnotationNames.SequenceNameSuffix)?.GetConfigurationSource();
 
     /// <summary>
-    ///     Returns the schema to use for the default hi-lo sequence.
+    ///     Returns the schema to use for the default value generation sequence.
     ///     <see cref="SqlServerPropertyBuilderExtensions.UseSequence" />
     /// </summary>
     /// <param name="model">The model.</param>
     /// <returns>The schema to use for the default key value generation sequence.</returns>
-    public static string? GetKeySequenceSchema(this IReadOnlyModel model)
-        => (string?)model[SqlServerAnnotationNames.KeySequenceSchema];
+    public static string? GetSequenceSchema(this IReadOnlyModel model)
+        => (string?)model[SqlServerAnnotationNames.SequenceSchema];
 
     /// <summary>
     ///     Sets the schema to use for the default key value generation sequence.
     /// </summary>
     /// <param name="model">The model.</param>
     /// <param name="value">The value to set.</param>
-    public static void SetKeySequenceSchema(this IMutableModel model, string? value)
+    public static void SetSequenceSchema(this IMutableModel model, string? value)
     {
         Check.NullButNotEmpty(value, nameof(value));
 
-        model.SetOrRemoveAnnotation(SqlServerAnnotationNames.KeySequenceSchema, value);
+        model.SetOrRemoveAnnotation(SqlServerAnnotationNames.SequenceSchema, value);
     }
 
     /// <summary>
@@ -199,14 +199,14 @@ public static class SqlServerModelExtensions
     /// <param name="value">The value to set.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
-    public static string? SetKeySequenceSchema(
+    public static string? SetSequenceSchema(
         this IConventionModel model,
         string? value,
         bool fromDataAnnotation = false)
     {
         Check.NullButNotEmpty(value, nameof(value));
 
-        model.SetOrRemoveAnnotation(SqlServerAnnotationNames.KeySequenceSchema, value, fromDataAnnotation);
+        model.SetOrRemoveAnnotation(SqlServerAnnotationNames.SequenceSchema, value, fromDataAnnotation);
 
         return value;
     }
@@ -216,8 +216,8 @@ public static class SqlServerModelExtensions
     /// </summary>
     /// <param name="model">The model.</param>
     /// <returns>The <see cref="ConfigurationSource" /> for the default key value generation sequence schema.</returns>
-    public static ConfigurationSource? GetKeySequenceSchemaConfigurationSource(this IConventionModel model)
-        => model.FindAnnotation(SqlServerAnnotationNames.HiLoSequenceSchema)?.GetConfigurationSource();
+    public static ConfigurationSource? GetSequenceSchemaConfigurationSource(this IConventionModel model)
+        => model.FindAnnotation(SqlServerAnnotationNames.SequenceSchema)?.GetConfigurationSource();
 
     /// <summary>
     ///     Returns the default identity seed.

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -159,15 +160,6 @@ public static class SqlServerPropertyBuilderExtensions
 
         var property = propertyBuilder.Metadata;
 
-        name ??= SqlServerModelExtensions.DefaultKeySequenceName;
-
-        var model = property.DeclaringEntityType.Model;
-
-        if (model.FindSequence(name, schema) == null)
-        {
-            model.AddSequence(name, schema).IncrementBy = 1;
-        }
-
         property.SetValueGenerationStrategy(SqlServerValueGenerationStrategy.Sequence);
         property.SetSequenceName(name);
         property.SetSequenceSchema(schema);
@@ -254,8 +246,8 @@ public static class SqlServerPropertyBuilderExtensions
         Check.NullButNotEmpty(name, nameof(name));
         Check.NullButNotEmpty(schema, nameof(schema));
 
-        return propertyBuilder.CanSetAnnotation(SqlServerAnnotationNames.KeySequenceName, name, fromDataAnnotation)
-            && propertyBuilder.CanSetAnnotation(SqlServerAnnotationNames.KeySequenceSchema, schema, fromDataAnnotation);
+        return propertyBuilder.CanSetAnnotation(SqlServerAnnotationNames.SequenceName, name, fromDataAnnotation)
+            && propertyBuilder.CanSetAnnotation(SqlServerAnnotationNames.SequenceSchema, schema, fromDataAnnotation);
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -203,7 +203,7 @@ public static class SqlServerPropertyExtensions
     /// <param name="property">The property.</param>
     /// <returns>The name to use for the key value generation sequence.</returns>
     public static string? GetSequenceName(this IReadOnlyProperty property)
-        => (string?)property[SqlServerAnnotationNames.KeySequenceName];
+        => (string?)property[SqlServerAnnotationNames.SequenceName];
 
     /// <summary>
     ///     Returns the name to use for the key value generation sequence.
@@ -213,7 +213,7 @@ public static class SqlServerPropertyExtensions
     /// <returns>The name to use for the key value generation sequence.</returns>
     public static string? GetSequenceName(this IReadOnlyProperty property, in StoreObjectIdentifier storeObject)
     {
-        var annotation = property.FindAnnotation(SqlServerAnnotationNames.KeySequenceName);
+        var annotation = property.FindAnnotation(SqlServerAnnotationNames.SequenceName);
         if (annotation != null)
         {
             return (string?)annotation.Value;
@@ -229,7 +229,7 @@ public static class SqlServerPropertyExtensions
     /// <param name="name">The sequence name to use.</param>
     public static void SetSequenceName(this IMutableProperty property, string? name)
         => property.SetOrRemoveAnnotation(
-            SqlServerAnnotationNames.KeySequenceName,
+            SqlServerAnnotationNames.SequenceName,
             Check.NullButNotEmpty(name, nameof(name)));
 
     /// <summary>
@@ -245,7 +245,7 @@ public static class SqlServerPropertyExtensions
         bool fromDataAnnotation = false)
     {
         property.SetOrRemoveAnnotation(
-            SqlServerAnnotationNames.KeySequenceName,
+            SqlServerAnnotationNames.SequenceName,
             Check.NullButNotEmpty(name, nameof(name)),
             fromDataAnnotation);
 
@@ -258,7 +258,7 @@ public static class SqlServerPropertyExtensions
     /// <param name="property">The property.</param>
     /// <returns>The <see cref="ConfigurationSource" /> for the key value generation sequence name.</returns>
     public static ConfigurationSource? GetSequenceNameConfigurationSource(this IConventionProperty property)
-        => property.FindAnnotation(SqlServerAnnotationNames.KeySequenceName)?.GetConfigurationSource();
+        => property.FindAnnotation(SqlServerAnnotationNames.SequenceName)?.GetConfigurationSource();
 
     /// <summary>
     ///     Returns the schema to use for the key value generation sequence.
@@ -266,7 +266,7 @@ public static class SqlServerPropertyExtensions
     /// <param name="property">The property.</param>
     /// <returns>The schema to use for the key value generation sequence.</returns>
     public static string? GetSequenceSchema(this IReadOnlyProperty property)
-        => (string?)property[SqlServerAnnotationNames.KeySequenceSchema];
+        => (string?)property[SqlServerAnnotationNames.SequenceSchema];
 
     /// <summary>
     ///     Returns the schema to use for the key value generation sequence.
@@ -276,7 +276,7 @@ public static class SqlServerPropertyExtensions
     /// <returns>The schema to use for the key value generation sequence.</returns>
     public static string? GetSequenceSchema(this IReadOnlyProperty property, in StoreObjectIdentifier storeObject)
     {
-        var annotation = property.FindAnnotation(SqlServerAnnotationNames.KeySequenceSchema);
+        var annotation = property.FindAnnotation(SqlServerAnnotationNames.SequenceSchema);
         if (annotation != null)
         {
             return (string?)annotation.Value;
@@ -292,7 +292,7 @@ public static class SqlServerPropertyExtensions
     /// <param name="schema">The schema to use.</param>
     public static void SetSequenceSchema(this IMutableProperty property, string? schema)
         => property.SetOrRemoveAnnotation(
-            SqlServerAnnotationNames.KeySequenceSchema,
+            SqlServerAnnotationNames.SequenceSchema,
             Check.NullButNotEmpty(schema, nameof(schema)));
 
     /// <summary>
@@ -308,7 +308,7 @@ public static class SqlServerPropertyExtensions
         bool fromDataAnnotation = false)
     {
         property.SetOrRemoveAnnotation(
-            SqlServerAnnotationNames.KeySequenceSchema,
+            SqlServerAnnotationNames.SequenceSchema,
             Check.NullButNotEmpty(schema, nameof(schema)),
             fromDataAnnotation);
 
@@ -321,7 +321,7 @@ public static class SqlServerPropertyExtensions
     /// <param name="property">The property.</param>
     /// <returns>The <see cref="ConfigurationSource" /> for the key value generation sequence schema.</returns>
     public static ConfigurationSource? GetSequenceSchemaConfigurationSource(this IConventionProperty property)
-        => property.FindAnnotation(SqlServerAnnotationNames.KeySequenceSchema)?.GetConfigurationSource();
+        => property.FindAnnotation(SqlServerAnnotationNames.SequenceSchema)?.GetConfigurationSource();
 
     /// <summary>
     ///     Finds the <see cref="ISequence" /> in the model to use for the key value generation pattern.
@@ -333,10 +333,10 @@ public static class SqlServerPropertyExtensions
         var model = property.DeclaringEntityType.Model;
 
         var sequenceName = property.GetSequenceName()
-            ?? model.GetKeySequenceName();
+            ?? model.GetSequenceNameSuffix();
 
         var sequenceSchema = property.GetSequenceSchema()
-            ?? model.GetKeySequenceSchema();
+            ?? model.GetSequenceSchema();
 
         return model.FindSequence(sequenceName, sequenceSchema);
     }
@@ -352,10 +352,10 @@ public static class SqlServerPropertyExtensions
         var model = property.DeclaringEntityType.Model;
 
         var sequenceName = property.GetSequenceName(storeObject)
-            ?? model.GetKeySequenceName();
+            ?? model.GetSequenceNameSuffix();
 
         var sequenceSchema = property.GetSequenceSchema(storeObject)
-            ?? model.GetKeySequenceSchema();
+            ?? model.GetSequenceSchema();
 
         return model.FindSequence(sequenceName, sequenceSchema);
     }

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // ReSharper disable once CheckNamespace
+
+using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
@@ -90,7 +93,11 @@ public class SqlServerValueGenerationStrategyConvention : IModelInitializedConve
 
                     if (strategy == SqlServerValueGenerationStrategy.Sequence)
                     {
-                        var sequence = property.FindSequence(declaringTable)!;
+                        var sequence = modelBuilder.HasSequence(
+                            property.GetSequenceName(declaringTable)
+                            ?? entityType.GetRootType().ShortName() + modelBuilder.Metadata.GetSequenceNameSuffix(),
+                            property.GetSequenceSchema(declaringTable)
+                            ?? modelBuilder.Metadata.GetSequenceSchema()).Metadata;
 
                         property.Builder.HasDefaultValueSql(
                             RelationalDependencies.UpdateSqlGenerator.GenerateObtainNextSequenceValueOperation(

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
@@ -73,7 +73,7 @@ public static class SqlServerAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public const string KeySequenceName = Prefix + "KeySequenceName";
+    public const string SequenceNameSuffix = Prefix + "SequenceNameSuffix";
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -81,7 +81,15 @@ public static class SqlServerAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public const string KeySequenceSchema = Prefix + "KeySequenceSchema";
+    public const string SequenceName = Prefix + "SequenceName";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public const string SequenceSchema = Prefix + "SequenceSchema";
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -390,16 +390,16 @@ public class ModelSnapshotSqlServerTest
                 @"
             modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
-            SqlServerModelBuilderExtensions.UseKeySequences(modelBuilder, ""EntityFrameworkKeySequence"");
+            SqlServerModelBuilderExtensions.UseKeySequences(modelBuilder, ""Sequence"");
 
-            modelBuilder.HasSequence(""EntityFrameworkKeySequence"");
+            modelBuilder.HasSequence(""EntityWithOnePropertySequence"");
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasDefaultValueSql(""NEXT VALUE FOR [EntityFrameworkKeySequence]"");
+                        .HasDefaultValueSql(""NEXT VALUE FOR [EntityWithOnePropertySequence]"");
 
                     SqlServerPropertyBuilderExtensions.UseSequence(b.Property<int>(""Id""));
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -3603,8 +3603,8 @@ namespace TestNamespace
                 valueGenerated: ValueGenerated.OnAdd,
                 afterSaveBehavior: PropertySaveBehavior.Throw);
             id.AddAnnotation(""Relational:DefaultValueSql"", ""NEXT VALUE FOR [KeySeqSchema].[KeySeq]"");
-            id.AddAnnotation(""SqlServer:KeySequenceName"", ""KeySeq"");
-            id.AddAnnotation(""SqlServer:KeySequenceSchema"", ""KeySeqSchema"");
+            id.AddAnnotation(""SqlServer:SequenceName"", ""KeySeq"");
+            id.AddAnnotation(""SqlServer:SequenceSchema"", ""KeySeqSchema"");
             id.AddAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.Sequence);
 
             var blob = runtimeEntityType.AddProperty(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCFiltersInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCFiltersInheritanceQuerySqlServerTest.cs
@@ -181,7 +181,7 @@ WHERE [e].[CountryId] = 1");
             @"SELECT TOP(2) [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group]
 FROM [Eagle] AS [e]",
             //
-            @"@__p_0='4'
+            @"@__p_0='1'
 
 SELECT TOP(1) [e].[Id], [e].[CountryId], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group]
 FROM [Eagle] AS [e]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCInheritanceQuerySqlServerTest.cs
@@ -418,7 +418,7 @@ ORDER BY [k].[Name]");
 FROM [Kiwi] AS [k]",
             //
             @"@p0='0'
-@p1='5' (Nullable = true)
+@p1='2' (Nullable = true)
 @p2='1'
 @p3='False'
 @p4='Bald eagle' (Size = 4000)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTFiltersInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTFiltersInheritanceQuerySqlServerTest.cs
@@ -180,7 +180,7 @@ FROM [Animals] AS [a]
 INNER JOIN [Birds] AS [b] ON [a].[Id] = [b].[Id]
 INNER JOIN [Eagle] AS [e] ON [a].[Id] = [e].[Id]",
             //
-            @"@__p_0='4'
+            @"@__p_0='1'
 
 SELECT TOP(1) [a].[Id], [a].[CountryId], [a].[Name], [a].[Species], [b].[EagleId], [b].[IsFlightless], [e].[Group]
 FROM [Animals] AS [a]

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -199,6 +199,7 @@ public class SqlServerModelValidatorTest : RelationalModelValidatorTest
     public virtual void Passes_for_duplicate_column_names_with_KeySequence()
     {
         var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<Animal>();
         modelBuilder.Entity<Cat>(
             cb =>
             {
@@ -224,13 +225,13 @@ public class SqlServerModelValidatorTest : RelationalModelValidatorTest
             cb =>
             {
                 cb.ToTable("Animal");
-                cb.Property(c => c.Id).UseSequence("foo");
+                cb.Property(c => c.Id).HasColumnName("Id").UseSequence("foo");
             });
         modelBuilder.Entity<Dog>(
             db =>
             {
                 db.ToTable("Animal");
-                db.Property(d => d.Id).UseSequence();
+                db.Property(d => d.Id).HasColumnName("Id").UseSequence("bar");
                 db.HasOne<Cat>().WithOne().HasForeignKey<Dog>(d => d.Id);
             });
 
@@ -238,7 +239,7 @@ public class SqlServerModelValidatorTest : RelationalModelValidatorTest
             RelationalStrings.DuplicateColumnNameDefaultSqlMismatch(
                 nameof(Cat), nameof(Cat.Id), nameof(Dog), nameof(Dog.Id), nameof(Cat.Id), nameof(Animal),
                 "NEXT VALUE FOR [foo]",
-                "NEXT VALUE FOR [EntityFrameworkKeySequence]"),
+                "NEXT VALUE FOR [bar]"),
             modelBuilder);
     }
 

--- a/test/EFCore.SqlServer.Tests/Metadata/Conventions/SqlServerValueGenerationStrategyConventionTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/Conventions/SqlServerValueGenerationStrategyConventionTest.cs
@@ -58,19 +58,14 @@ public class SqlServerValueGenerationStrategyConventionTest
         model.RemoveAnnotation(CoreAnnotationNames.ProductVersion);
 
         var annotations = model.GetAnnotations().OrderBy(a => a.Name).ToList();
-        Assert.Equal(4, annotations.Count);
+        Assert.Equal(3, annotations.Count);
 
         Assert.Equal(RelationalAnnotationNames.MaxIdentifierLength, annotations[0].Name);
 
-        Assert.Equal(
-            RelationalAnnotationNames.Sequences,
-            annotations[1].Name);
-        Assert.NotNull(annotations[1].Value);
+        Assert.Equal(SqlServerAnnotationNames.SequenceNameSuffix, annotations[1].Name);
+        Assert.Equal(SqlServerModelExtensions.DefaultSequenceNameSuffix, annotations[1].Value);
 
-        Assert.Equal(SqlServerAnnotationNames.KeySequenceName, annotations[2].Name);
-        Assert.Equal(SqlServerModelExtensions.DefaultKeySequenceName, annotations[2].Value);
-
-        Assert.Equal(SqlServerAnnotationNames.ValueGenerationStrategy, annotations[3].Name);
-        Assert.Equal(SqlServerValueGenerationStrategy.Sequence, annotations[3].Value);
+        Assert.Equal(SqlServerAnnotationNames.ValueGenerationStrategy, annotations[2].Name);
+        Assert.Equal(SqlServerValueGenerationStrategy.Sequence, annotations[2].Value);
     }
 }

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -462,12 +462,12 @@ public class SqlServerModelDifferTest : MigrationsModelDifferTestBase
                 {
                     var operation = Assert.IsType<CreateSequenceOperation>(o);
                     Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal("EntityFrameworkKeySequence", operation.Name);
+                    Assert.Equal("FireflySequence", operation.Name);
                 },
                 o =>
                 {
                     var operation = Assert.IsType<AlterColumnOperation>(o);
-                    Assert.Equal("NEXT VALUE FOR [dbo].[EntityFrameworkKeySequence]", operation.DefaultValueSql);
+                    Assert.Equal("NEXT VALUE FOR [dbo].[FireflySequence]", operation.DefaultValueSql);
                 },
                 o =>
                 {
@@ -489,7 +489,7 @@ public class SqlServerModelDifferTest : MigrationsModelDifferTestBase
                 {
                     var operation = Assert.IsType<DropSequenceOperation>(o);
                     Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal("EntityFrameworkKeySequence", operation.Name);
+                    Assert.Equal("FireflySequence", operation.Name);
                 },
                 o =>
                 {

--- a/test/EFCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -48,7 +48,6 @@ public class SqlServerValueGeneratorSelectorTest
         if (useKeySequence)
         {
             builder.UseKeySequences();
-            Assert.NotNull(builder.Model.FindSequence(SqlServerModelExtensions.DefaultKeySequenceName));
         }
 
         var model = builder.FinalizeModel();


### PR DESCRIPTION
Part of #28096
