### PR TITLE
API review bundle

### DIFF
--- a/src/EFCore.Abstractions/IndexAttribute.cs
+++ b/src/EFCore.Abstractions/IndexAttribute.cs
@@ -22,7 +22,22 @@ public sealed class IndexAttribute : Attribute
     /// <summary>
     ///     Initializes a new instance of the <see cref="IndexAttribute" /> class.
     /// </summary>
+    /// <param name="propertyName">The first (or only) property in the index.</param>
+    /// <param name="additionalPropertyNames">The additional properties which constitute the index, if any, in order.</param>
+    public IndexAttribute(string propertyName, params string[] additionalPropertyNames)
+    {
+        Check.NotEmpty(propertyName, nameof(propertyName));
+        Check.HasNoEmptyElements(additionalPropertyNames, nameof(additionalPropertyNames));
+
+        PropertyNames = new List<string> { propertyName };
+        ((List<string>)PropertyNames).AddRange(additionalPropertyNames);
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="IndexAttribute" /> class.
+    /// </summary>
     /// <param name="propertyNames">The properties which constitute the index, in order (there must be at least one).</param>
+    [Obsolete("Use the other constructor")]
     public IndexAttribute(params string[] propertyNames)
     {
         Check.NotEmpty(propertyNames, nameof(propertyNames));

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingInterceptor.cs
@@ -36,8 +36,9 @@ public class ProxyBindingInterceptor : IInstantiationBindingInterceptor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual InstantiationBinding ModifyBinding(IEntityType entityType, string entityInstanceName, InstantiationBinding binding)
+    public virtual InstantiationBinding ModifyBinding(InstantiationBindingInterceptionData interceptionData, InstantiationBinding binding)
     {
+        var entityType = interceptionData.EntityType;
         var proxyType = _proxyFactory.CreateProxyType(entityType);
 
         if ((bool?)entityType.Model[ProxyAnnotationNames.LazyLoading] == true)

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -781,6 +781,7 @@ public class StateManager : IStateManager
     {
         if (_resolutionInterceptor != null)
         {
+            var interceptionData = new IdentityResolutionInterceptionData(Context);
             var needsTracking = false;
             foreach (var key in newEntry.EntityType.GetKeys())
             {
@@ -788,7 +789,7 @@ public class StateManager : IStateManager
                 if (existingEntry != null)
                 {
                     _resolutionInterceptor.UpdateTrackedInstance(
-                        Context,
+                        interceptionData,
                         new EntityEntry(existingEntry),
                         newEntry.Entity);
 

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -479,7 +479,7 @@ public static class CoreLoggerExtensions
 
             if (interceptor != null)
             {
-                return (interceptor.ProcessingQuery(queryExpression, eventData), eventData);
+                return (interceptor.QueryCompilationStarting(queryExpression, eventData), eventData);
             }
         }
 

--- a/src/EFCore/Diagnostics/IIdentityResolutionInterceptor.cs
+++ b/src/EFCore/Diagnostics/IIdentityResolutionInterceptor.cs
@@ -35,8 +35,8 @@ public interface IIdentityResolutionInterceptor : IInterceptor
     ///     an already tracked instance. This method must apply any property values and relationship changes from the new instance
     ///     into the existing instance. The new instance is then discarded.
     /// </summary>
-    /// <param name="context">The <see cref="DbContext"/> is use.</param>
+    /// <param name="interceptionData">Contextual information about the identity resolution.</param>
     /// <param name="existingEntry">The entry for the existing tracked entity instance.</param>
-    /// <param name="newInstance">The new entity instance, which will be discarded after this call.</param>
-    void UpdateTrackedInstance(DbContext context, EntityEntry existingEntry, object newInstance);
+    /// <param name="newEntity">The new entity instance, which will be discarded after this call.</param>
+    void UpdateTrackedInstance(IdentityResolutionInterceptionData interceptionData, EntityEntry existingEntry, object newEntity);
 }

--- a/src/EFCore/Diagnostics/IInstantiationBindingInterceptor.cs
+++ b/src/EFCore/Diagnostics/IInstantiationBindingInterceptor.cs
@@ -17,9 +17,8 @@ public interface IInstantiationBindingInterceptor : ISingletonInterceptor
     /// <summary>
     ///     Returns a new <see cref="InstantiationBinding" /> for the given entity type, potentially modified from the given binding.
     /// </summary>
-    /// <param name="entityType">The entity type for which the binding is being used.</param>
-    /// <param name="entityInstanceName">The name of the instance being materialized.</param>
+    /// <param name="interceptionData">Contextual information about the binding.</param>
     /// <param name="binding">The current binding.</param>
     /// <returns>A new binding.</returns>
-    InstantiationBinding ModifyBinding(IEntityType entityType, string entityInstanceName, InstantiationBinding binding);
+    InstantiationBinding ModifyBinding(InstantiationBindingInterceptionData interceptionData, InstantiationBinding binding);
 }

--- a/src/EFCore/Diagnostics/IMaterializationInterceptor.cs
+++ b/src/EFCore/Diagnostics/IMaterializationInterceptor.cs
@@ -37,24 +37,24 @@ public interface IMaterializationInterceptor : ISingletonInterceptor
     ///     any properties values not set by the constructor have been set.
     /// </summary>
     /// <param name="materializationData">Contextual information about the materialization happening.</param>
-    /// <param name="instance">
+    /// <param name="entity">
     ///     The entity instance that has been created.
     ///     This value is typically used as the return value for the implementation of this method.
     /// </param>
     /// <returns>
     ///     The entity instance that EF will use.
     ///     An implementation of this method for any interceptor that is not attempting to change the instance used
-    ///     must return the <paramref name="instance" /> value passed in.
+    ///     must return the <paramref name="entity" /> value passed in.
     /// </returns>
-    object CreatedInstance(MaterializationInterceptionData materializationData, object instance)
-        => instance;
+    object CreatedInstance(MaterializationInterceptionData materializationData, object entity)
+        => entity;
 
     /// <summary>
     ///     Called immediately before EF is going to set property values of an entity that has just been created. Note that property values
     ///     set by the constructor will already have been set.
     /// </summary>
     /// <param name="materializationData">Contextual information about the materialization happening.</param>
-    /// <param name="instance">The entity instance for which property values will be set.</param>
+    /// <param name="entity">The entity instance for which property values will be set.</param>
     /// <param name="result">
     ///     Represents the current result if one exists.
     ///     This value will have <see cref="InterceptionResult.IsSuppressed" /> set to <see langword="true" /> if some previous
@@ -67,22 +67,22 @@ public interface IMaterializationInterceptor : ISingletonInterceptor
     ///     An implementation of this method for any interceptor that is not attempting to suppress
     ///     setting property values must return the <paramref name="result" /> value passed in.
     /// </returns>
-    InterceptionResult InitializingInstance(MaterializationInterceptionData materializationData, object instance, InterceptionResult result)
+    InterceptionResult InitializingInstance(MaterializationInterceptionData materializationData, object entity, InterceptionResult result)
         => result;
 
     /// <summary>
     ///     Called immediately after EF has set property values of an entity that has just been created.
     /// </summary>
     /// <param name="materializationData">Contextual information about the materialization happening.</param>
-    /// <param name="instance">
+    /// <param name="entity">
     ///     The entity instance that has been created.
     ///     This value is typically used as the return value for the implementation of this method.
     /// </param>
     /// <returns>
     ///     The entity instance that EF will use.
     ///     An implementation of this method for any interceptor that is not attempting to change the instance used
-    ///     must return the <paramref name="instance" /> value passed in.
+    ///     must return the <paramref name="entity" /> value passed in.
     /// </returns>
-    object InitializedInstance(MaterializationInterceptionData materializationData, object instance)
-        => instance;
+    object InitializedInstance(MaterializationInterceptionData materializationData, object entity)
+        => entity;
 }

--- a/src/EFCore/Diagnostics/IQueryExpressionInterceptor.cs
+++ b/src/EFCore/Diagnostics/IQueryExpressionInterceptor.cs
@@ -28,36 +28,8 @@ public interface IQueryExpressionInterceptor : IInterceptor
     /// <param name="queryExpression">The query expression.</param>
     /// <param name="eventData">Contextual information about the query environment.</param>
     /// <returns>The query expression tree to continue with, which may have been changed by the interceptor.</returns>
-    Expression ProcessingQuery(
+    Expression QueryCompilationStarting(
         Expression queryExpression,
         QueryExpressionEventData eventData)
         => queryExpression;
-
-    /// <summary>
-    ///     Called when EF is about to compile the query delegate that will be used to execute the query.
-    /// </summary>
-    /// <param name="queryExpression">The query expression.</param>
-    /// <param name="queryExecutorExpression">The expression that will be compiled into the execution delegate.</param>
-    /// <param name="eventData">Contextual information about the query environment.</param>
-    /// <typeparam name="TResult">The return type of the execution delegate.</typeparam>
-    /// <returns>The expression that will be compiled into the execution delegate, which may have been changed by the interceptor.</returns>
-    Expression<Func<QueryContext, TResult>> CompilingQuery<TResult>(
-        Expression queryExpression,
-        Expression<Func<QueryContext, TResult>> queryExecutorExpression,
-        QueryExpressionEventData eventData)
-        => queryExecutorExpression;
-
-    /// <summary>
-    ///     Called when EF is about to compile the query delegate that will be used to execute the query.
-    /// </summary>
-    /// <param name="queryExpression">The query expression.</param>
-    /// <param name="eventData">Contextual information about the query environment.</param>
-    /// <param name="queryExecutor">The delegate that will be used to execute the query.</param>
-    /// <typeparam name="TResult">The return type of the execution delegate.</typeparam>
-    /// <returns>The delegate that will be used to execute the query, which may have been changed by the interceptor.</returns>
-    Func<QueryContext, TResult> CompiledQuery<TResult>(
-        Expression queryExpression,
-        QueryExpressionEventData eventData,
-        Func<QueryContext, TResult> queryExecutor)
-        => queryExecutor;
 }

--- a/src/EFCore/Diagnostics/IdentityResolutionInterceptionData.cs
+++ b/src/EFCore/Diagnostics/IdentityResolutionInterceptionData.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+///     A parameter object passed to <see cref="IIdentityResolutionInterceptor" /> methods.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
+/// </remarks>
+public readonly struct IdentityResolutionInterceptionData
+{
+    /// <summary>
+    ///     Constructs the parameter object.
+    /// </summary>
+    /// <param name="context">The <see cref="DbContext"/> in use.</param>
+    public IdentityResolutionInterceptionData(DbContext context)
+    {
+        Context = context;
+    }
+    
+    /// <summary>
+    ///     The current <see cref="DbContext" /> instance being used.
+    /// </summary>
+    public DbContext Context { get; }
+}

--- a/src/EFCore/Diagnostics/IgnoringIdentityResolutionInterceptor.cs
+++ b/src/EFCore/Diagnostics/IgnoringIdentityResolutionInterceptor.cs
@@ -7,17 +7,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics;
 ///     A <see cref="IIdentityResolutionInterceptor"/> that ignores the new instance and retains property values from the existing
 ///     tracked instance.
 /// </summary>
-public class SkippingIdentityResolutionInterceptor : IIdentityResolutionInterceptor
+public class IgnoringIdentityResolutionInterceptor : IIdentityResolutionInterceptor
 {
     /// <summary>
     ///     Called when a <see cref="DbContext"/> attempts to track a new instance of an entity with the same primary key value as
     ///     an already tracked instance. This implementation does nothing, such that property values from the existing tracked
     ///     instance are retained.
     /// </summary>
-    /// <param name="context">The <see cref="DbContext"/> is use.</param>
+    /// <param name="interceptionData">Contextual information about the identity resolution.</param>
     /// <param name="existingEntry">The entry for the existing tracked entity instance.</param>
-    /// <param name="newInstance">The new entity instance, which will be discarded after this call.</param>
-    public virtual void UpdateTrackedInstance(DbContext context, EntityEntry existingEntry, object newInstance)
+    /// <param name="newEntity">The new entity instance, which will be discarded after this call.</param>
+    public virtual void UpdateTrackedInstance(IdentityResolutionInterceptionData interceptionData, EntityEntry existingEntry, object newEntity)
     {
     }
 }

--- a/src/EFCore/Diagnostics/InstantiationBindingInterceptionData.cs
+++ b/src/EFCore/Diagnostics/InstantiationBindingInterceptionData.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+///     A parameter object passed to <see cref="IInstantiationBindingInterceptor" /> methods.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
+/// </remarks>
+public readonly struct InstantiationBindingInterceptionData
+{
+
+    /// <summary>
+    ///     Constructs the parameter object.
+    /// </summary>
+    /// <param name="entityType">The entity type for which the binding is being used.</param>
+    public InstantiationBindingInterceptionData(IEntityType entityType)
+    {
+        EntityType = entityType;
+    }
+    
+    /// <summary>
+    ///     The entity type for which the binding is being used.
+    /// </summary>
+    public IEntityType EntityType { get; }
+}

--- a/src/EFCore/Diagnostics/Internal/IdentityResolutionInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/IdentityResolutionInterceptorAggregator.cs
@@ -24,11 +24,11 @@ public class IdentityResolutionInterceptorAggregator : InterceptorAggregator<IId
             _interceptors = interceptors.ToArray();
         }
 
-        public void UpdateTrackedInstance(DbContext context, EntityEntry existingEntry, object newInstance)
+        public void UpdateTrackedInstance(IdentityResolutionInterceptionData interceptionData, EntityEntry existingEntry, object newEntity)
         {
             for (var i = 0; i < _interceptors.Length; i++)
             {
-                _interceptors[i].UpdateTrackedInstance(context, existingEntry, newInstance);
+                _interceptors[i].UpdateTrackedInstance(interceptionData, existingEntry, newEntity);
             }
         }
     }

--- a/src/EFCore/Diagnostics/Internal/MaterializationInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/MaterializationInterceptorAggregator.cs
@@ -42,24 +42,24 @@ public class MaterializationInterceptorAggregator : InterceptorAggregator<IMater
 
         public object CreatedInstance(
             MaterializationInterceptionData materializationData,
-            object instance)
+            object entity)
         {
             for (var i = 0; i < _interceptors.Length; i++)
             {
-                instance = _interceptors[i].CreatedInstance(materializationData, instance);
+                entity = _interceptors[i].CreatedInstance(materializationData, entity);
             }
 
-            return instance;
+            return entity;
         }
 
         public InterceptionResult InitializingInstance(
             MaterializationInterceptionData materializationData,
-            object instance,
+            object entity,
             InterceptionResult result)
         {
             for (var i = 0; i < _interceptors.Length; i++)
             {
-                result = _interceptors[i].InitializingInstance(materializationData, instance, result);
+                result = _interceptors[i].InitializingInstance(materializationData, entity, result);
             }
 
             return result;
@@ -67,14 +67,14 @@ public class MaterializationInterceptorAggregator : InterceptorAggregator<IMater
 
         public object InitializedInstance(
             MaterializationInterceptionData materializationData,
-            object instance)
+            object entity)
         {
             for (var i = 0; i < _interceptors.Length; i++)
             {
-                instance = _interceptors[i].InitializedInstance(materializationData, instance);
+                entity = _interceptors[i].InitializedInstance(materializationData, entity);
             }
 
-            return instance;
+            return entity;
         }
     }
 }

--- a/src/EFCore/Diagnostics/Internal/QueryExpressionInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/QueryExpressionInterceptorAggregator.cs
@@ -24,42 +24,16 @@ public class QueryExpressionInterceptorAggregator : InterceptorAggregator<IQuery
             _interceptors = interceptors.ToArray();
         }
 
-        public Expression ProcessingQuery(
+        public Expression QueryCompilationStarting(
             Expression queryExpression,
             QueryExpressionEventData eventData)
         {
             for (var i = 0; i < _interceptors.Length; i++)
             {
-                queryExpression = _interceptors[i].ProcessingQuery(queryExpression, eventData);
+                queryExpression = _interceptors[i].QueryCompilationStarting(queryExpression, eventData);
             }
 
             return queryExpression;
-        }
-            
-        public Expression<Func<QueryContext, TResult>> CompilingQuery<TResult>(
-            Expression queryExpression,
-            Expression<Func<QueryContext, TResult>> queryExecutorExpression,
-            QueryExpressionEventData eventData)
-        {
-            for (var i = 0; i < _interceptors.Length; i++)
-            {
-                queryExecutorExpression = _interceptors[i].CompilingQuery(queryExpression, queryExecutorExpression, eventData);
-            }
-
-            return queryExecutorExpression;
-        }
-
-        public Func<QueryContext, TResult> CompiledQuery<TResult>(
-            Expression queryExpression,
-            QueryExpressionEventData eventData,
-            Func<QueryContext, TResult> queryExecutor)
-        {
-            for (var i = 0; i < _interceptors.Length; i++)
-            {
-                queryExecutor = _interceptors[i].CompiledQuery(queryExpression, eventData, queryExecutor);
-            }
-
-            return queryExecutor;
         }
     }
 }

--- a/src/EFCore/Diagnostics/UpdatingIdentityResolutionInterceptor.cs
+++ b/src/EFCore/Diagnostics/UpdatingIdentityResolutionInterceptor.cs
@@ -36,12 +36,12 @@ public class UpdatingIdentityResolutionInterceptor : IIdentityResolutionIntercep
     ///     an already tracked instance. This implementation copies property values from the new entity instance into the
     ///     tracked entity instance.
     /// </summary>
-    /// <param name="context">The <see cref="DbContext" /> is use.</param>
+    /// <param name="interceptionData">Contextual information about the identity resolution.</param>
     /// <param name="existingEntry">The entry for the existing tracked entity instance.</param>
-    /// <param name="newInstance">The new entity instance, which will be discarded after this call.</param>
-    public virtual void UpdateTrackedInstance(DbContext context, EntityEntry existingEntry, object newInstance)
+    /// <param name="newEntity">The new entity instance, which will be discarded after this call.</param>
+    public virtual void UpdateTrackedInstance(IdentityResolutionInterceptionData interceptionData, EntityEntry existingEntry, object newEntity)
     {
-        var tempEntry = context.Entry(newInstance);
+        var tempEntry = interceptionData.Context.Entry(newEntity);
 
         if (existingEntry.State == EntityState.Added)
         {

--- a/src/EFCore/Query/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/EntityMaterializerSource.cs
@@ -56,7 +56,7 @@ public class EntityMaterializerSource : IEntityMaterializerSource
             throw new InvalidOperationException(CoreStrings.CannotMaterializeAbstractType(entityType.DisplayName()));
         }
 
-        var constructorBinding = ModifyBindings(entityType, entityInstanceName, entityType.ConstructorBinding!);
+        var constructorBinding = ModifyBindings(entityType, entityType.ConstructorBinding!);
 
         var bindingInfo = new ParameterBindingInfo(
             entityType,
@@ -405,7 +405,7 @@ public class EntityMaterializerSource : IEntityMaterializerSource
                     }
                 }
 
-                binding = self.ModifyBindings(e, "v", binding);
+                binding = self.ModifyBindings(e, binding);
 
                 var materializationContextExpression = Expression.Parameter(typeof(MaterializationContext), "mc");
                 var bindingInfo = new ParameterBindingInfo(e, materializationContextExpression);
@@ -429,11 +429,12 @@ public class EntityMaterializerSource : IEntityMaterializerSource
             },
             this);
 
-    private InstantiationBinding ModifyBindings(IEntityType entityType, string entityInstanceName, InstantiationBinding binding)
+    private InstantiationBinding ModifyBindings(IEntityType entityType, InstantiationBinding binding)
     {
+        var interceptionData = new InstantiationBindingInterceptionData(entityType);
         foreach (var bindingInterceptor in _bindingInterceptors)
         {
-            binding = bindingInterceptor.ModifyBinding(entityType, entityInstanceName, binding);
+            binding = bindingInterceptor.ModifyBinding(interceptionData, binding);
         }
 
         return binding;

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -178,20 +178,9 @@ public class QueryCompilationContext
             query,
             QueryContextParameter);
 
-        if (_queryExpressionInterceptor != null)
-        {
-            queryExecutorExpression = _queryExpressionInterceptor.CompilingQuery(
-                queryAndEventData.Query, queryExecutorExpression, queryAndEventData.EventData!);
-        }
-
         try
         {
-            var queryExecutor = queryExecutorExpression.Compile();
-
-            return _queryExpressionInterceptor != null
-                ? _queryExpressionInterceptor.CompiledQuery(
-                    queryAndEventData.Query, queryAndEventData.EventData!, queryExecutor)
-                : queryExecutor;
+            return queryExecutorExpression.Compile();
         }
         finally
         {

--- a/test/EFCore.Specification.Tests/F1MaterializationInterceptor.cs
+++ b/test/EFCore.Specification.Tests/F1MaterializationInterceptor.cs
@@ -87,25 +87,25 @@ public class F1MaterializationInterceptor : IMaterializationInterceptor
             _ => result
         };
 
-    public object CreatedInstance(MaterializationInterceptionData materializationData, object instance)
+    public object CreatedInstance(MaterializationInterceptionData materializationData, object entity)
     {
-        Assert.True(instance is IF1Proxy);
+        Assert.True(entity is IF1Proxy);
 
-        ((IF1Proxy)instance).CreatedCalled = true;
+        ((IF1Proxy)entity).CreatedCalled = true;
 
-        return instance;
+        return entity;
     }
 
     public InterceptionResult InitializingInstance(
         MaterializationInterceptionData materializationData,
-        object instance,
+        object entity,
         InterceptionResult result)
     {
-        Assert.True(instance is IF1Proxy);
+        Assert.True(entity is IF1Proxy);
 
-        ((IF1Proxy)instance).InitializingCalled = true;
+        ((IF1Proxy)entity).InitializingCalled = true;
 
-        if (instance is Sponsor sponsor)
+        if (entity is Sponsor sponsor)
         {
             sponsor.Id = materializationData.GetPropertyValue<int>(nameof(sponsor.Id));
             sponsor.Name = "Intercepted: " + materializationData.GetPropertyValue<string>(nameof(sponsor.Name));
@@ -116,17 +116,17 @@ public class F1MaterializationInterceptor : IMaterializationInterceptor
         return result;
     }
 
-    public object InitializedInstance(MaterializationInterceptionData materializationData, object instance)
+    public object InitializedInstance(MaterializationInterceptionData materializationData, object entity)
     {
-        Assert.True(instance is IF1Proxy);
+        Assert.True(entity is IF1Proxy);
 
-        ((IF1Proxy)instance).InitializedCalled = true;
+        ((IF1Proxy)entity).InitializedCalled = true;
 
-        if (instance is Sponsor.SponsorProxy sponsor)
+        if (entity is Sponsor.SponsorProxy sponsor)
         {
             return new Sponsor.SponsorDoubleProxy(sponsor);
         }
 
-        return instance;
+        return entity;
     }
 }

--- a/test/EFCore.Specification.Tests/MaterializationInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/MaterializationInterceptionTestBase.cs
@@ -321,7 +321,7 @@ public abstract class MaterializationInterceptionTestBase : SingletonInterceptor
         protected Book BookFactory()
             => new() { MaterializedBy = _id };
 
-        public InstantiationBinding ModifyBinding(IEntityType entityType, string entityInstanceName, InstantiationBinding binding)
+        public InstantiationBinding ModifyBinding(InstantiationBindingInterceptionData interceptionData, InstantiationBinding binding)
         {
             CalledCount++;
 
@@ -329,7 +329,7 @@ public abstract class MaterializationInterceptionTestBase : SingletonInterceptor
                 this,
                 typeof(TestBindingInterceptor).GetTypeInfo().GetDeclaredMethod(nameof(BookFactory))!,
                 new List<ParameterBinding>(),
-                entityType.ClrType);
+                interceptionData.EntityType.ClrType);
         }
     }
 
@@ -352,27 +352,27 @@ public abstract class MaterializationInterceptionTestBase : SingletonInterceptor
         }
 
         public object CreatedInstance(
-            MaterializationInterceptionData materializationData, object instance)
+            MaterializationInterceptionData materializationData, object entity)
         {
-            _validate(materializationData, instance, nameof(CreatedInstance));
+            _validate(materializationData, entity, nameof(CreatedInstance));
 
-            return instance;
+            return entity;
         }
 
         public InterceptionResult InitializingInstance(
-            MaterializationInterceptionData materializationData, object instance, InterceptionResult result)
+            MaterializationInterceptionData materializationData, object entity, InterceptionResult result)
         {
-            _validate(materializationData, instance, nameof(InitializingInstance));
+            _validate(materializationData, entity, nameof(InitializingInstance));
 
             return result;
         }
 
         public object InitializedInstance(
-            MaterializationInterceptionData materializationData, object instance)
+            MaterializationInterceptionData materializationData, object entity)
         {
-            _validate(materializationData, instance, nameof(InitializedInstance));
+            _validate(materializationData, entity, nameof(InitializedInstance));
 
-            return instance;
+            return entity;
         }
     }
 
@@ -390,24 +390,24 @@ public abstract class MaterializationInterceptionTestBase : SingletonInterceptor
             => result;
 
         public object CreatedInstance(
-            MaterializationInterceptionData materializationData, object instance)
+            MaterializationInterceptionData materializationData, object entity)
         {
-            ((Book)instance).CreatedBy += _id;
-            return instance;
+            ((Book)entity).CreatedBy += _id;
+            return entity;
         }
 
         public InterceptionResult InitializingInstance(
-            MaterializationInterceptionData materializationData, object instance, InterceptionResult result)
+            MaterializationInterceptionData materializationData, object entity, InterceptionResult result)
         {
-            ((Book)instance).InitializingBy += _id;
+            ((Book)entity).InitializingBy += _id;
             return result;
         }
 
         public object InitializedInstance(
-            MaterializationInterceptionData materializationData, object instance)
+            MaterializationInterceptionData materializationData, object entity)
         {
-            ((Book)instance).InitializedBy += _id;
-            return instance;
+            ((Book)entity).InitializedBy += _id;
+            return entity;
         }
     }
 }

--- a/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
+++ b/test/EFCore.Specification.Tests/PropertyValuesTestBase.cs
@@ -2436,49 +2436,49 @@ public abstract class PropertyValuesTestBase<TFixture> : IClassFixture<TFixture>
             MaterializationInterceptionData materializationData, InterceptionResult<object> result)
             => result;
 
-        public object CreatedInstance(MaterializationInterceptionData materializationData, object instance)
+        public object CreatedInstance(MaterializationInterceptionData materializationData, object entity)
         {
-            if (instance is IDictionary<string, object> joinEntity)
+            if (entity is IDictionary<string, object> joinEntity)
             {
                 joinEntity["CreatedCalled"] = true;
             }
             else
             {
-                ((PropertyValuesBase)instance).CreatedCalled = true;
+                ((PropertyValuesBase)entity).CreatedCalled = true;
             }
 
-            return instance;
+            return entity;
         }
 
         public InterceptionResult InitializingInstance(
             MaterializationInterceptionData materializationData,
-            object instance,
+            object entity,
             InterceptionResult result)
         {
-            if (instance is IDictionary<string, object> joinEntity)
+            if (entity is IDictionary<string, object> joinEntity)
             {
                 joinEntity["InitializingCalled"] = true;
             }
             else
             {
-                ((PropertyValuesBase)instance).InitializingCalled = true;
+                ((PropertyValuesBase)entity).InitializingCalled = true;
             }
 
             return result;
         }
 
-        public object InitializedInstance(MaterializationInterceptionData materializationData, object instance)
+        public object InitializedInstance(MaterializationInterceptionData materializationData, object entity)
         {
-            if (instance is IDictionary<string, object> joinEntity)
+            if (entity is IDictionary<string, object> joinEntity)
             {
                 joinEntity["InitializedCalled"] = true;
             }
             else
             {
-                ((PropertyValuesBase)instance).InitializedCalled = true;
+                ((PropertyValuesBase)entity).InitializedCalled = true;
             }
 
-            return instance;
+            return entity;
         }
     }
 }

--- a/test/EFCore.Specification.Tests/QueryExpressionInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/QueryExpressionInterceptionTestBase.cs
@@ -43,8 +43,8 @@ public abstract class QueryExpressionInterceptionTestBase : InterceptionTestBase
     {
         var interceptor1 = new TestQueryExpressionInterceptor();
         var interceptor2 = new QueryChangingExpressionInterceptor();
-        var interceptor3 = new QueryCompilationChangingExpressionInterceptor();
-        var interceptor4 = new QueryCompilationDelegateChangingInterceptor();
+        var interceptor3 = new TestQueryExpressionInterceptor();
+        var interceptor4 = new TestQueryExpressionInterceptor();
 
         using var context = CreateContext(
             new IInterceptor[] { new TestQueryExpressionInterceptor(), interceptor1, interceptor2 },
@@ -67,13 +67,7 @@ public abstract class QueryExpressionInterceptionTestBase : InterceptionTestBase
             CoreEventId.QueryCompilationStarting.Name,
             CoreEventId.QueryExecutionPlanned.Name);
 
-        Assert.Equal(1, interceptor3.ExecutionCount);
-        Assert.Equal(1, interceptor4.ExecutionCount);
-
         _ = async ? await query.ToListAsync() : query.ToList();
-
-        Assert.Equal(2, interceptor3.ExecutionCount);
-        Assert.Equal(2, interceptor4.ExecutionCount);
     }
 
     [ConditionalTheory]
@@ -100,10 +94,10 @@ public abstract class QueryExpressionInterceptionTestBase : InterceptionTestBase
 
     protected class QueryChangingExpressionInterceptor : TestQueryExpressionInterceptor
     {
-        public override Expression ProcessingQuery(
+        public override Expression QueryCompilationStarting(
             Expression queryExpression,
             QueryExpressionEventData eventData)
-            => base.ProcessingQuery(new SingularityTypeExpressionVisitor().Visit(queryExpression), eventData);
+            => base.QueryCompilationStarting(new SingularityTypeExpressionVisitor().Visit(queryExpression), eventData);
 
         private class SingularityTypeExpressionVisitor : ExpressionVisitor
         {
@@ -114,151 +108,28 @@ public abstract class QueryExpressionInterceptionTestBase : InterceptionTestBase
         }
     }
 
-    [ConditionalTheory]
-    [InlineData(false, false)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(true, true)]
-    public virtual async Task Intercept_to_change_query_compilation_expression(bool async, bool inject)
-    {
-        var (context, interceptor) = CreateContext<QueryCompilationChangingExpressionInterceptor>(inject);
-
-        using var __ = context;
-
-        var query = context.Set<Singularity>().OrderBy(e => e.Type);
-        var results = async ? await query.ToListAsync() : query.ToList();
-
-        Assert.Equal(2, results.Count);
-        Assert.Equal("Bing Bang", results[0].Type);
-        Assert.Equal("Black Hole", results[1].Type);
-
-        AssertNormalOutcome(context, interceptor);
-        Assert.Equal(1, interceptor.ExecutionCount);
-
-        _ = async ? await query.ToListAsync() : query.ToList();
-
-        AssertNormalOutcome(context, interceptor);
-        Assert.Equal(2, interceptor.ExecutionCount);
-    }
-
-    protected class QueryCompilationChangingExpressionInterceptor : TestQueryExpressionInterceptor
-    {
-        public int ExecutionCount { get; set; }
-
-        public override Expression<Func<QueryContext, TResult>> CompilingQuery<TResult>(
-            Expression queryExpression,
-            Expression<Func<QueryContext, TResult>> queryExecutorExpression,
-            QueryExpressionEventData eventData)
-            => base.CompilingQuery(
-                queryExpression, Expression.Lambda<Func<QueryContext, TResult>>(
-                    Expression.Block(
-                        Expression.Assign(
-                            Expression.Property(
-                                Expression.Constant(this),
-                                nameof(ExecutionCount)),
-                            Expression.Add(
-                                Expression.Property(
-                                    Expression.Constant(this),
-                                    nameof(ExecutionCount)),
-                                Expression.Constant(1))),
-                        queryExecutorExpression.Body),
-                    queryExecutorExpression.Parameters),
-                eventData);
-    }
-
-    [ConditionalTheory]
-    [InlineData(false, false)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(true, true)]
-    public virtual async Task Intercept_to_change_query_compilation_delegate(bool async, bool inject)
-    {
-        var (context, interceptor) = CreateContext<QueryCompilationDelegateChangingInterceptor>(inject);
-
-        using var __ = context;
-
-        var query = context.Set<Singularity>().OrderBy(e => e.Type);
-        var results = async ? await query.ToListAsync() : query.ToList();
-
-        Assert.Equal(2, results.Count);
-        Assert.Equal("Bing Bang", results[0].Type);
-        Assert.Equal("Black Hole", results[1].Type);
-
-        AssertNormalOutcome(context, interceptor);
-        Assert.Equal(1, interceptor.ExecutionCount);
-
-        _ = async ? await query.ToListAsync() : query.ToList();
-
-        AssertNormalOutcome(context, interceptor);
-        Assert.Equal(2, interceptor.ExecutionCount);
-    }
-
-    protected class QueryCompilationDelegateChangingInterceptor : TestQueryExpressionInterceptor
-    {
-        public int ExecutionCount { get; set; }
-
-        public override Func<QueryContext, TResult> CompiledQuery<TResult>(
-            Expression queryExpression,
-            QueryExpressionEventData eventData,
-            Func<QueryContext, TResult> queryExecutor)
-            => base.CompiledQuery(
-                queryExpression, eventData, queryContext =>
-                {
-                    ExecutionCount++;
-                    return queryExecutor(queryContext);
-                });
-    }
-
     protected static void AssertNormalOutcome(DbContext context,TestQueryExpressionInterceptor interceptor)
     {
         Assert.Same(context, interceptor.Context);
-        Assert.True(interceptor.ProcessingQueryCalled);
-        Assert.True(interceptor.ProcessingQueryCalled);
-        Assert.True(interceptor.CompilingQueryCalled);
-        Assert.True(interceptor.CompiledQueryCalled);
+        Assert.True(interceptor.QueryCompilationStartingCalled);
+        Assert.True(interceptor.QueryCompilationStartingCalled);
     }
 
     protected class TestQueryExpressionInterceptor : IQueryExpressionInterceptor
     {
-        public bool ProcessingQueryCalled { get; set; }
-        public bool CompilingQueryCalled { get; set; }
-        public bool CompiledQueryCalled { get; set; }
+        public bool QueryCompilationStartingCalled { get; set; }
         public string QueryExpression { get; set; }
         public DbContext Context { get; set; }
 
-        public virtual Expression ProcessingQuery(
+        public virtual Expression QueryCompilationStarting(
             Expression queryExpression,
             QueryExpressionEventData eventData)
         {
-            ProcessingQueryCalled = true;
+            QueryCompilationStartingCalled = true;
             Context = eventData.Context;
             QueryExpression = eventData.ExpressionPrinter.Print(queryExpression);
 
             return queryExpression;
-        }
-
-        public virtual Expression<Func<QueryContext, TResult>> CompilingQuery<TResult>(
-            Expression queryExpression,
-            Expression<Func<QueryContext, TResult>> queryExecutorExpression,
-            QueryExpressionEventData eventData)
-        {
-            CompilingQueryCalled = true;
-            Assert.Equal(QueryExpression, eventData.ExpressionPrinter.Print(queryExpression));
-            Assert.Same(Context, eventData.Context);
-
-            return queryExecutorExpression;
-        }
-
-        public virtual Func<QueryContext, TResult> CompiledQuery<TResult>(
-            Expression queryExpression,
-            QueryExpressionEventData eventData,
-            Func<QueryContext, TResult> queryExecutor)
-        {
-            CompiledQueryCalled = true;
-            Assert.Equal(QueryExpression, eventData.ExpressionPrinter.Print(queryExpression));
-            Assert.Same(Context, eventData.Context);
-
-            return queryExecutor;
         }
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -2237,7 +2237,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalCategory = new Category(1) { Value1 = "Original", Value2 = "Original"};
         var originalProduct = new Product(1, 0) { Value1 = "Original", Value2 = "Original"};
@@ -2296,7 +2296,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalCategory = new Category(1) { Value1 = "Original", Value2 = "Original" };
         var originalProduct = new Product(1, 0) { Value1 = "Original", Value2 = "Original" };
@@ -2348,7 +2348,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalCategory = new Category(1) { Value1 = "Original", Value2 = "Original" };
         var originalProduct = new Product(1, 0) { Value1 = "Original", Value2 = "Original" };
@@ -2413,7 +2413,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalCategory = new Category(1) { Value1 = "Original", Value2 = "Original" };
         var originalProduct = new Product(1, 0) { Value1 = "Original", Value2 = "Original" };
@@ -2465,7 +2465,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalParent = new Parent(1) { Value1 = "Original", Value2 = "Original" };
         var originalChild = new Child(1, 0) { Value1 = "Original", Value2 = "Original" };
@@ -2519,7 +2519,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalParent = new Parent(1) { Value1 = "Original", Value2 = "Original" };
         var originalChild = new Child(1, 0) { Value1 = "Original", Value2 = "Original" };
@@ -2570,7 +2570,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalParent = new Parent(1) { Value1 = "Original", Value2 = "Original" };
         var originalChild = new Child(1, 0) { Value1 = "Original", Value2 = "Original" };
@@ -2626,7 +2626,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalParent = new Parent(1) { Value1 = "Original", Value2 = "Original" };
         var originalChild = new Child(1, 0) { Value1 = "Original", Value2 = "Original" };
@@ -2683,7 +2683,7 @@ public class FixupTest
         using var context = new FixupContext(
             copy
                 ? new UpdatingIdentityResolutionInterceptor(preserveModified, updateOriginal)
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var originalHumans = new Human[]
         {
@@ -3252,7 +3252,7 @@ public class FixupTest
         using var context = new BadBeeContext(
             nameof(BadBeeContext), copy
                 ? new UpdatingIdentityResolutionInterceptor()
-                : new SkippingIdentityResolutionInterceptor());
+                : new IgnoringIdentityResolutionInterceptor());
 
         var b1 = new EntityB { EntityBId = 1, Value = "b1" };
         context.BEntities.Attach(b1);

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -48,7 +48,7 @@ public class StateManagerTest
     {
         using var context = new IdentityConflictContext(copy
             ? new UpdatingIdentityResolutionInterceptor()
-            : new SkippingIdentityResolutionInterceptor());
+            : new IgnoringIdentityResolutionInterceptor());
 
         var entity = new SingleKey { Id = 77, AlternateId = 66, Value = "Existing" };
         context.Attach(entity);
@@ -76,7 +76,7 @@ public class StateManagerTest
     [ConditionalFact]
     public void Resolving_identity_conflict_for_primary_key_throws_if_alternate_key_changes()
     {
-        using var context = new IdentityConflictContext(new SkippingIdentityResolutionInterceptor());
+        using var context = new IdentityConflictContext(new IgnoringIdentityResolutionInterceptor());
 
         context.Attach(new SingleKey { Id = 77, AlternateId = 66 });
 
@@ -116,16 +116,16 @@ public class StateManagerTest
 
     private class NaiveCopyingIdentityResolutionInterceptor : IIdentityResolutionInterceptor
     {
-        public void UpdateTrackedInstance(DbContext context, EntityEntry existingEntry, object newInstance)
+        public void UpdateTrackedInstance(IdentityResolutionInterceptionData interceptionData, EntityEntry existingEntry, object newEntity)
         {
-            existingEntry.CurrentValues.SetValues(newInstance);
+            existingEntry.CurrentValues.SetValues(newEntity);
         }
     }
 
     [ConditionalFact]
     public void Resolving_identity_conflict_for_alternate_key_throws_if_primary_key_changes()
     {
-        using var context = new IdentityConflictContext(new SkippingIdentityResolutionInterceptor());
+        using var context = new IdentityConflictContext(new IgnoringIdentityResolutionInterceptor());
 
         context.Attach(new SingleKey { Id = 77, AlternateId = 66 });
         Assert.Equal(
@@ -169,7 +169,7 @@ public class StateManagerTest
     {
         using var context = new IdentityConflictContext(copy
             ? new UpdatingIdentityResolutionInterceptor()
-            : new SkippingIdentityResolutionInterceptor());
+            : new IgnoringIdentityResolutionInterceptor());
 
         var owned = new SingleKeyOwned { Value = "Existing" };
         context.Attach(
@@ -229,7 +229,7 @@ public class StateManagerTest
     {
         using var context = new IdentityConflictContext(copy
             ? new UpdatingIdentityResolutionInterceptor()
-            : new SkippingIdentityResolutionInterceptor());
+            : new IgnoringIdentityResolutionInterceptor());
 
         var entity = new CompositeKey
         {

--- a/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
@@ -92,7 +92,7 @@ public class IndexAttributeConventionTest
         var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
 
         Assert.Equal(
-            AbstractionsStrings.CollectionArgumentHasEmptyElements("propertyNames"),
+            AbstractionsStrings.CollectionArgumentHasEmptyElements("additionalPropertyNames"),
             Assert.Throws<ArgumentException>(
                 () => modelBuilder.Entity(entityTypeWithInvalidIndex)).Message);
     }
@@ -356,7 +356,9 @@ public class IndexAttributeConventionTest
         public int D { get; set; }
     }
 
+#pragma warning disable CS0618
     [Index]
+#pragma warning restore CS0618
     private class EntityWithInvalidEmptyIndex
     {
         public int Id { get; set; }
@@ -364,7 +366,7 @@ public class IndexAttributeConventionTest
         public int B { get; set; }
     }
 
-    [Index(nameof(A), null, Name = "IndexOnAAndNull")]
+    [Index(nameof(A), (string)null, Name = "IndexOnAAndNull")]
     private class EntityWithInvalidNullIndexProperty
     {
         public int Id { get; set; }


### PR DESCRIPTION
Part of #27588.

- Remove params, Obsolete, and add a new ctor to IndexAttribute
- Use entity instead of instance in IIdentityResolutionInterceptor and IMaterializationInterceptor
- Use parameter objects in IIdentityResolutionInterceptor and IInstantiationBindingInterceptor
- Remove entityInstanceName parameter in IInstantiationBindingInterceptor.ModifyBinding
- Rename SkippingIdentityResolutionInterceptor to IgnoringIdentityResolutionInterceptor
- Remove IQueryExpressionInterceptor.CompilingQuery and CompiledQuery
- Rename IQueryExpressionInterceptor.ProcessingQuery to QueryCompilationStarting

