### PR TITLE
Workaround for Sqlite/InMemory test failures on OSX (again)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,6 +132,7 @@ stages:
               - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine $(_InternalRuntimeDownloadArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
+                  COMPlus_EnableWriteXorExecute: 0 # Work-around for https://github.com/dotnet/runtime/issues/70758
                 name: Build
               - task: PublishBuildArtifacts@1
                 displayName: Upload TestResults
@@ -238,6 +239,7 @@ stages:
                   HelixAccessToken: $(_HelixAccessToken)
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
                   MSSQL_SA_PASSWORD: "Password12!"
+                  COMPlus_EnableWriteXorExecute: 0 # Work-around for https://github.com/dotnet/runtime/issues/70758
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -37,6 +37,13 @@
     </XUnitProject>
   </ItemGroup>
 
+  <!-- Work-around for https://github.com/dotnet/runtime/issues/70758 -->
+  <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`OSX`))'">
+    <XUnitProject Update="$(RepoRoot)/test/EFCore.InMemory.FunctionalTests/*.csproj;$(RepoRoot)/test/EFCore.Sqlite.FunctionalTests/*.csproj">
+      <PreCommands>$(PreCommands); export COMPlus_EnableWriteXorExecute=0</PreCommands>
+    </XUnitProject>
+  </ItemGroup>
+
   <!-- Start SqlServer instance for test projects which uses SqlServer on docker. Also remove other projects as they will be run outside of docker. -->
   <ItemGroup Condition = "'$(HelixTargetQueue.Contains(`ubuntu-18.04-helix-sqlserver-amd64`))'">
     <XUnitProject Remove="$(RepoRoot)/test/**/*.csproj"/>


### PR DESCRIPTION
Reverted in c54353ce130b3d400a8c6bf0c87cb2e3895eafea, but is still a problem.
