### PR TITLE
Close the DbConnection when returning a context with a DbConnection to the pool

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -1036,14 +1036,18 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
         _openedCount = 0;
         _openedInternally = false;
 
-        if (disposeDbConnection
-            && _connectionOwned
+        if (_connectionOwned 
             && _connection is not null)
         {
-            DisposeDbConnection();
-            _connection = null;
-            _openedCount = 0;
-            _openedInternally = false;
+            CloseDbConnection();
+
+            if (disposeDbConnection)
+            {
+                DisposeDbConnection();
+                _connection = null;
+                _openedCount = 0;
+                _openedInternally = false;
+            }
         }
     }
 
@@ -1065,14 +1069,18 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
 
         _commandTimeout = _defaultCommandTimeout;
 
-        if (disposeDbConnection
-            && _connectionOwned
+        if (_connectionOwned
             && _connection is not null)
         {
-            await DisposeDbConnectionAsync().ConfigureAwait(false);
-            _connection = null;
-            _openedCount = 0;
-            _openedInternally = false;
+            await CloseDbConnectionAsync().ConfigureAwait(continueOnCapturedContext: false);
+
+            if (disposeDbConnection)
+            {
+                await DisposeDbConnectionAsync().ConfigureAwait(false);
+                _connection = null;
+                _openedCount = 0;
+                _openedInternally = false;
+            }
         }
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -1393,7 +1393,6 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
     [InlineData(true, true)]
     public async Task Handle_open_connection_when_returning_to_pool_for_owned_connection(bool async, bool openWithEf)
     {
-        //using var connection = new SqlConnection(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString);
         var serviceProvider = new ServiceCollection()
             .AddDbContextPool<PooledContext>(
                 ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)


### PR DESCRIPTION
Fixes #27308
