### PR TITLE
    Implement stored procedure update mapping

### DIFF
--- a/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
@@ -491,8 +491,7 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
             .Append(parameters.TargetName).AppendLine(",")
             .Append(code.Literal(storedProcedure.Name)).AppendLine(",")
             .Append(code.Literal(storedProcedure.Schema)).AppendLine(",")
-            .Append(code.Literal(storedProcedure.IsRowsAffectedReturned)).AppendLine(",")
-            .Append(code.Literal(storedProcedure.AreTransactionsSuppressed))
+            .Append(code.Literal(storedProcedure.IsRowsAffectedReturned))
             .AppendLine(");")
             .DecrementIndent()
             .AppendLine();

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -1153,7 +1153,7 @@ public static class RelationalPropertyExtensions
 
         return optional ?? (entityType.BaseType != null && entityType.FindDiscriminatorProperty() != null);
     }
-    
+
     /// <summary>
     ///     Returns the comment for the column this property is mapped to.
     /// </summary>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -361,6 +361,16 @@ public class RelationalModelValidator : ModelValidator
             _ => new Dictionary<string, IProperty>()
         };
 
+        if (mappingStrategy == RelationalAnnotationNames.TptMappingStrategy
+            && storeObjectIdentifier.StoreObjectType == StoreObjectType.InsertStoredProcedure
+            && entityType.BaseType?.GetInsertStoredProcedure() != null)
+        {
+            foreach (var property in primaryKey.Properties)
+            {
+                storeGeneratedProperties.Remove(property.Name);
+            }
+        }
+
         var resultColumnNames = new HashSet<string>();
         foreach (var resultColumn in sproc.ResultColumns)
         {

--- a/src/EFCore.Relational/Metadata/Builders/IConventionStoredProcedureBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionStoredProcedureBuilder.cs
@@ -156,20 +156,4 @@ public interface IConventionStoredProcedureBuilder : IConventionAnnotatableBuild
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the column of the result can be used for the stored procedure.</returns>
     bool CanHaveRowsAffectedResultColumn(string propertyName, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Prevents automatically creating a transaction when executing this stored procedure.
-    /// </summary>
-    /// <param name="suppress">A value indicating whether the automatic transactions should be prevented.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    IConventionStoredProcedureBuilder? SuppressTransactions(bool suppress, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Returns a value indicating whether the transaction suppression can be set for stored procedure.
-    /// </summary>
-    /// <param name="suppress">A value indicating whether the automatic transactions should be prevented.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns><see langword="true" /> if the column of the result can be used for the stored procedure.</returns>
-    bool CanSetSuppressTransactions(bool suppress, bool fromDataAnnotation = false);
 }

--- a/src/EFCore.Relational/Metadata/Builders/OwnedNavigationStoredProcedureBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/OwnedNavigationStoredProcedureBuilder.cs
@@ -220,17 +220,6 @@ public class OwnedNavigationStoredProcedureBuilder :
     }
 
     /// <summary>
-    ///     Prevents automatically creating a transaction when executing this stored procedure.
-    /// </summary>
-    /// <param name="suppress">A value indicating whether the automatic transactions should be prevented.</param>
-    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual OwnedNavigationStoredProcedureBuilder SuppressTransactions(bool suppress = true)
-    {
-        Builder.SuppressTransactions(suppress, ConfigurationSource.Explicit);
-        return this;
-    }
-
-    /// <summary>
     ///     Adds or updates an annotation on the stored procedure. If an annotation with the key specified in
     ///     <paramref name="annotation" /> already exists, its value will be updated.
     /// </summary>

--- a/src/EFCore.Relational/Metadata/Builders/OwnedNavigationStoredProcedureBuilder``.cs
+++ b/src/EFCore.Relational/Metadata/Builders/OwnedNavigationStoredProcedureBuilder``.cs
@@ -232,14 +232,6 @@ public class OwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntit
         => (OwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity>)base.HasRowsAffectedReturnValue(rowsAffectedReturned);
 
     /// <summary>
-    ///     Prevents automatically creating a transaction when executing this stored procedure.
-    /// </summary>
-    /// <param name="suppress">A value indicating whether the automatic transactions should be prevented.</param>
-    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual OwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> SuppressTransactions(bool suppress = true)
-        => (OwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity>)base.SuppressTransactions(suppress);
-
-    /// <summary>
     ///     Adds or updates an annotation on the stored procedure. If an annotation with the key specified in
     ///     <paramref name="annotation" /> already exists, its value will be updated.
     /// </summary>

--- a/src/EFCore.Relational/Metadata/Builders/StoredProcedureBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/StoredProcedureBuilder.cs
@@ -183,17 +183,6 @@ public class StoredProcedureBuilder : IInfrastructure<EntityTypeBuilder>, IInfra
     }
 
     /// <summary>
-    ///     Prevents automatically creating a transaction when executing this stored procedure.
-    /// </summary>
-    /// <param name="suppress">A value indicating whether the automatic transactions should be prevented.</param>
-    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual StoredProcedureBuilder SuppressTransactions(bool suppress = true)
-    {
-        Builder.SuppressTransactions(suppress, ConfigurationSource.Explicit);
-        return this;
-    }
-    
-    /// <summary>
     ///     Adds or updates an annotation on the stored procedure. If an annotation with the key specified in
     ///     <paramref name="annotation" /> already exists, its value will be updated.
     /// </summary>

--- a/src/EFCore.Relational/Metadata/Builders/StoredProcedureBuilder`.cs
+++ b/src/EFCore.Relational/Metadata/Builders/StoredProcedureBuilder`.cs
@@ -315,14 +315,6 @@ public class StoredProcedureBuilder<TEntity> : StoredProcedureBuilder, IInfrastr
         => (StoredProcedureBuilder<TEntity>)base.HasRowsAffectedReturnValue(rowsAffectedReturned);
 
     /// <summary>
-    ///     Prevents automatically creating a transaction when executing this stored procedure.
-    /// </summary>
-    /// <param name="suppress">A value indicating whether the automatic transactions should be prevented.</param>
-    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual StoredProcedureBuilder<TEntity> SuppressTransactions(bool suppress = true)
-        => (StoredProcedureBuilder<TEntity>)base.SuppressTransactions(suppress);
-
-    /// <summary>
     ///     Adds or updates an annotation on the stored procedure. If an annotation with the key specified in
     ///     <paramref name="annotation" /> already exists, its value will be updated.
     /// </summary>

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
@@ -498,8 +498,7 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
             runtimeEntityType,
             storedProcedure.Name,
             storedProcedure.Schema,
-            storedProcedure.IsRowsAffectedReturned,
-            storedProcedure.AreTransactionsSuppressed);
+            storedProcedure.IsRowsAffectedReturned);
 
         foreach (var parameter in storedProcedure.Parameters)
         {

--- a/src/EFCore.Relational/Metadata/IColumn.cs
+++ b/src/EFCore.Relational/Metadata/IColumn.cs
@@ -148,14 +148,6 @@ public interface IColumn : IColumnBase
             .GetCollation(StoreObjectIdentifier.Table(Table.Name, Table.Schema));
 
     /// <summary>
-    ///     Gets the <see cref="ValueComparer" /> for this column.
-    /// </summary>
-    /// <returns>The comparer.</returns>
-    ValueComparer ProviderValueComparer
-        => PropertyMappings.First().Property
-            .GetProviderValueComparer();
-
-    /// <summary>
     ///     Returns the property mapping for the given entity type.
     /// </summary>
     /// <param name="entityType">An entity type.</param>

--- a/src/EFCore.Relational/Metadata/IColumnBase.cs
+++ b/src/EFCore.Relational/Metadata/IColumnBase.cs
@@ -47,6 +47,14 @@ public interface IColumnBase : IAnnotatable
     IReadOnlyList<IColumnMappingBase> PropertyMappings { get; }
 
     /// <summary>
+    ///     Gets the <see cref="ValueComparer" /> for this column.
+    /// </summary>
+    /// <returns>The comparer.</returns>
+    ValueComparer ProviderValueComparer
+        => PropertyMappings.First().Property
+            .GetProviderValueComparer();
+
+    /// <summary>
     ///     Returns the property mapping for the given entity type.
     /// </summary>
     /// <param name="entityType">An entity type.</param>

--- a/src/EFCore.Relational/Metadata/IConventionStoredProcedure.cs
+++ b/src/EFCore.Relational/Metadata/IConventionStoredProcedure.cs
@@ -146,18 +146,4 @@ public interface IConventionStoredProcedure : IReadOnlyStoredProcedure, IConvent
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
     bool SetIsRowsAffectedReturned(bool rowsAffectedReturned, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Prevents automatically creating a transaction when executing this stored procedure.
-    /// </summary>
-    /// <param name="areTransactionsSuppressed">A value indicating whether the automatic transactions should be prevented.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>The configured value.</returns>
-    bool SetAreTransactionsSuppressed(bool areTransactionsSuppressed, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Gets the configuration source for <see cref="IReadOnlyStoredProcedure.Schema" />.
-    /// </summary>
-    /// <returns>The configuration source for <see cref="IReadOnlyStoredProcedure.Schema" />.</returns>
-    ConfigurationSource? GetAreTransactionsSuppressedConfigurationSource();
 }

--- a/src/EFCore.Relational/Metadata/IMutableStoredProcedure.cs
+++ b/src/EFCore.Relational/Metadata/IMutableStoredProcedure.cs
@@ -27,12 +27,6 @@ public interface IMutableStoredProcedure : IReadOnlyStoredProcedure, IMutableAnn
     new IMutableEntityType EntityType { get; }
 
     /// <summary>
-    ///     Returns a value indicating whether automatic creation of transactions is disabled when executing this stored procedure.
-    /// </summary>
-    /// <returns>The configured value.</returns>
-    new bool AreTransactionsSuppressed { get; set; }
-
-    /// <summary>
     ///     Gets or sets a value indicating whether this stored procedure returns the number of rows affected.
     /// </summary>
     new bool IsRowsAffectedReturned { get; set; }

--- a/src/EFCore.Relational/Metadata/IReadOnlyStoredProcedure.cs
+++ b/src/EFCore.Relational/Metadata/IReadOnlyStoredProcedure.cs
@@ -26,11 +26,6 @@ public interface IReadOnlyStoredProcedure : IReadOnlyAnnotatable
     IReadOnlyEntityType EntityType { get; }
 
     /// <summary>
-    ///     Returns a value indicating whether automatic creation of transactions is disabled when executing this stored procedure.
-    /// </summary>
-    bool AreTransactionsSuppressed { get; }
-    
-    /// <summary>
     ///     Gets a value indicating whether this stored procedure returns the number of rows affected.
     /// </summary>
     bool IsRowsAffectedReturned { get; }

--- a/src/EFCore.Relational/Metadata/IStoreStoredProcedureParameter.cs
+++ b/src/EFCore.Relational/Metadata/IStoreStoredProcedureParameter.cs
@@ -20,7 +20,7 @@ public interface IStoreStoredProcedureParameter : IColumnBase
     ///     Gets the property mappings.
     /// </summary>
     new IReadOnlyList<IStoredProcedureParameterMapping> PropertyMappings { get; }
-    
+
     /// <summary>
     ///     Gets the direction of the parameter.
     /// </summary>

--- a/src/EFCore.Relational/Metadata/IStoreStoredProcedureResultColumn.cs
+++ b/src/EFCore.Relational/Metadata/IStoreStoredProcedureResultColumn.cs
@@ -21,6 +21,11 @@ public interface IStoreStoredProcedureResultColumn : IColumnBase
     new IReadOnlyList<IStoredProcedureResultColumnMapping> PropertyMappings { get; }
 
     /// <summary>
+    ///     Gets the 0-based position of the result column in the declaring stored procedure's result set.
+    /// </summary>
+    int Position { get; }
+
+    /// <summary>
     ///     Returns the property mapping for the given entity type.
     /// </summary>
     /// <param name="entityType">An entity type.</param>

--- a/src/EFCore.Relational/Metadata/Internal/InternalStoredProcedureBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalStoredProcedureBuilder.cs
@@ -410,33 +410,6 @@ public class InternalStoredProcedureBuilder :
         => Metadata.IsRowsAffectedReturned == rowsAffectedReturned
             || configurationSource.Overrides(Metadata.GetConfigurationSource());
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual InternalStoredProcedureBuilder? SuppressTransactions(bool suppress, ConfigurationSource configurationSource)
-    {
-        if (!CanSuppressTransactions(suppress, configurationSource))
-        {
-            return null;
-        }
-
-        Metadata.SetAreTransactionsSuppressed(suppress, configurationSource);
-        return this;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual bool CanSuppressTransactions(bool suppress, ConfigurationSource configurationSource)
-        => Metadata.AreTransactionsSuppressed == suppress
-            || configurationSource.Overrides(Metadata.GetAreTransactionsSuppressedConfigurationSource());
-
     IConventionStoredProcedure IConventionStoredProcedureBuilder.Metadata
     {
         [DebuggerStepThrough]
@@ -524,15 +497,4 @@ public class InternalStoredProcedureBuilder :
     [DebuggerStepThrough]
     bool IConventionStoredProcedureBuilder.CanHaveRowsAffectedResultColumn(string propertyName, bool fromDataAnnotation)
         => CanHaveRowsAffectedResultColumn(fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-    /// <inheritdoc />
-    [DebuggerStepThrough]
-    IConventionStoredProcedureBuilder? IConventionStoredProcedureBuilder.SuppressTransactions(bool suppress, bool fromDataAnnotation)
-        => SuppressTransactions(suppress, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-    /// <inheritdoc />
-    [DebuggerStepThrough]
-    bool IConventionStoredProcedureBuilder.CanSetSuppressTransactions(bool suppress, bool fromDataAnnotation)
-        => CanSuppressTransactions(suppress,
-            fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 }

--- a/src/EFCore.Relational/Metadata/Internal/JsonColumn.cs
+++ b/src/EFCore.Relational/Metadata/Internal/JsonColumn.cs
@@ -148,7 +148,7 @@ public class JsonColumn : Column, IColumn
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    ValueComparer IColumn.ProviderValueComparer
+    ValueComparer IColumnBase.ProviderValueComparer
         => _providerValueComparer;
 
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/StoreStoredProcedureResultColumn.cs
+++ b/src/EFCore.Relational/Metadata/Internal/StoreStoredProcedureResultColumn.cs
@@ -23,10 +23,12 @@ public class StoreStoredProcedureResultColumn
     public StoreStoredProcedureResultColumn(
         string name,
         string type,
+        int position,
         StoreStoredProcedure storedProcedure,
         RelationalTypeMapping? storeTypeMapping = null)
         : base(name, type, storedProcedure)
     {
+        Position = position;
         _storeTypeMapping = storeTypeMapping;
     }
 
@@ -38,7 +40,15 @@ public class StoreStoredProcedureResultColumn
     /// </summary>
     public virtual StoreStoredProcedure StoredProcedure
         => (StoreStoredProcedure)Table;
-    
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual int Position { get; }
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.Relational/Metadata/Internal/StoredProcedure.cs
+++ b/src/EFCore.Relational/Metadata/Internal/StoredProcedure.cs
@@ -22,14 +22,12 @@ public class StoredProcedure :
     private string? _schema;
     private string? _name;
     private InternalStoredProcedureBuilder? _builder;
-    private bool _areTransactionsSuppressed;
     private bool _isRowsAffectedReturned;
     private IStoreStoredProcedure? _storeStoredProcedure;
 
     private ConfigurationSource _configurationSource;
     private ConfigurationSource? _schemaConfigurationSource;
     private ConfigurationSource? _nameConfigurationSource;
-    private ConfigurationSource? _areTransactionsSuppressedConfigurationSource;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -424,30 +422,6 @@ public class StoredProcedure :
     public virtual ConfigurationSource? GetNameConfigurationSource()
         => _nameConfigurationSource;
 
-    /// <inheritdoc />
-    public virtual bool AreTransactionsSuppressed
-    {
-        get => _areTransactionsSuppressed;
-        set => SetAreTransactionsSuppressed(value, ConfigurationSource.Explicit);
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual bool SetAreTransactionsSuppressed(bool areTransactionsSuppressed, ConfigurationSource configurationSource)
-    {
-        EnsureMutable();
-
-        _areTransactionsSuppressed = areTransactionsSuppressed;
-
-        _areTransactionsSuppressedConfigurationSource = configurationSource.Max(_areTransactionsSuppressedConfigurationSource);
-
-        return areTransactionsSuppressed;
-    }
-    
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -480,15 +454,6 @@ public class StoredProcedure :
         
         return rowsAffectedReturned;
     }
-    
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public virtual ConfigurationSource? GetAreTransactionsSuppressedConfigurationSource()
-        => _areTransactionsSuppressedConfigurationSource;
 
     private static void UpdateOverrides(
         StoreObjectIdentifier oldId,
@@ -835,15 +800,9 @@ public class StoredProcedure :
 
     /// <inheritdoc />
     [DebuggerStepThrough]
-    bool IConventionStoredProcedure.SetAreTransactionsSuppressed(bool areTransactionsSuppressed, bool fromDataAnnotation)
-        => SetAreTransactionsSuppressed(
-            areTransactionsSuppressed, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-    
-    /// <inheritdoc />
-    [DebuggerStepThrough]
     bool IConventionStoredProcedure.SetIsRowsAffectedReturned(bool rowsAffectedReturned, bool fromDataAnnotation)
         => SetIsRowsAffectedReturned(rowsAffectedReturned);
-    
+
     /// <inheritdoc />
     [DebuggerStepThrough]
     IReadOnlyStoredProcedureParameter? IReadOnlyStoredProcedure.FindParameter(string propertyName)

--- a/src/EFCore.Relational/Metadata/RuntimeStoredProcedure.cs
+++ b/src/EFCore.Relational/Metadata/RuntimeStoredProcedure.cs
@@ -19,7 +19,6 @@ public class RuntimeStoredProcedure : AnnotatableBase, IRuntimeStoredProcedure
     private readonly string? _schema;
     private readonly string _name;
     private readonly bool _isRowsAffectedReturned;
-    private readonly bool _areTransactionsSuppressed;
     private IStoreStoredProcedure? _storeStoredProcedure;
 
     /// <summary>
@@ -29,19 +28,16 @@ public class RuntimeStoredProcedure : AnnotatableBase, IRuntimeStoredProcedure
     /// <param name="name">The name.</param>
     /// <param name="schema">The schema.</param>
     /// <param name="rowsAffectedReturned">Whether this stored procedure returns the number of rows affected.</param>
-    /// <param name="transactionsSuppressed">Whether the automatic transactions are surpressed.</param>
     public RuntimeStoredProcedure(
         RuntimeEntityType entityType,
         string name,
         string? schema,
-        bool rowsAffectedReturned,
-        bool transactionsSuppressed)
+        bool rowsAffectedReturned)
     {
         EntityType = entityType;
         _name = name;
         _schema = schema;
         _isRowsAffectedReturned = rowsAffectedReturned;
-        _areTransactionsSuppressed = transactionsSuppressed;
     }
 
     /// <summary>
@@ -151,13 +147,6 @@ public class RuntimeStoredProcedure : AnnotatableBase, IRuntimeStoredProcedure
         get => _schema;
     }
 
-    /// <inheritdoc />
-    bool IReadOnlyStoredProcedure.AreTransactionsSuppressed
-    {
-        [DebuggerStepThrough]
-        get => _areTransactionsSuppressed;
-    }
-    
     /// <inheritdoc />
     bool IReadOnlyStoredProcedure.IsRowsAffectedReturned
     {

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -2073,7 +2073,9 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
                 var anyColumnsModified = false;
                 foreach (var targetColumnModification in targetRow.ColumnModifications)
                 {
-                    var targetColumn = targetColumnModification.Column!;
+                    var targetColumnBase = targetColumnModification.Column!;
+                    Check.DebugAssert(targetColumnBase is IColumn, "Non-IColumn columns not allowed");
+                    var targetColumn = (IColumn)targetColumnBase;
                     var targetMapping = targetColumn.PropertyMappings.First();
                     var targetProperty = targetMapping.Property;
 
@@ -2281,7 +2283,7 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
                         Check.DebugAssert(forSource, "Delete using the target model");
 
                         var keyColumns = command.ColumnModifications.Where(col => col.IsKey)
-                            .Select(c => c.Column!);
+                            .Select(c => (IColumn)c.Column!);
                         var anyKeyColumnDropped = keyColumns.Any(c => diffContext.FindDrop(c) != null);
 
                         yield return new DeleteDataOperation

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1546,6 +1546,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property, sproc);
 
         /// <summary>
+        ///     Stored procedure '{sproc]' was configured with a rows affected output parameter or return value, but a valid value was not found when executing the procedure.
+        /// </summary>
+        public static string StoredProcedureRowsAffectedNotPopulated(object? sproc)
+            => string.Format(
+                GetString("StoredProcedureRowsAffectedNotPopulated", nameof(sproc)),
+                sproc);
+
+        /// <summary>
         ///     The property '{propertySpecification}' has specific configuration for the stored procedure '{sproc}', but it isn't mapped to a parameter or a result column on that stored procedure. Remove the specific configuration, or map an entity type that contains this property to '{sproc}'.
         /// </summary>
         public static string StoredProcedureOverrideMismatch(object? propertySpecification, object? sproc)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -996,6 +996,9 @@
   <data name="StoredProcedureOutputParameterNotGenerated" xml:space="preserve">
     <value>The property '{entityType}.{property}' is mapped to an output parameter of the stored procedure '{sproc}', but it is not configured as store-generated. Either configure it as store-generated or don't configure the parameter as output.</value>
   </data>
+  <data name="StoredProcedureRowsAffectedNotPopulated" xml:space="preserve">
+    <value>Stored procedure '{sproc}' was configured with a rows affected output parameter or return value, but a valid value was not found when executing the procedure.</value>
+  </data>
   <data name="StoredProcedureOverrideMismatch" xml:space="preserve">
     <value>The property '{propertySpecification}' has specific configuration for the stored procedure '{sproc}', but it isn't mapped to a parameter or a result column on that stored procedure. Remove the specific configuration, or map an entity type that contains this property to '{sproc}'.</value>
   </data>

--- a/src/EFCore.Relational/Storage/IRelationalParameter.cs
+++ b/src/EFCore.Relational/Storage/IRelationalParameter.cs
@@ -37,5 +37,5 @@ public interface IRelationalParameter
     /// </summary>
     /// <param name="command">The command to add the parameter to.</param>
     /// <param name="parameterValues">The map of parameter values</param>
-    void AddDbParameter(DbCommand command, IReadOnlyDictionary<string, object?> parameterValues);
+    void AddDbParameter(DbCommand command, IReadOnlyDictionary<string, object?>? parameterValues);
 }

--- a/src/EFCore.Relational/Storage/Internal/RawRelationalParameter.cs
+++ b/src/EFCore.Relational/Storage/Internal/RawRelationalParameter.cs
@@ -35,7 +35,7 @@ public class RawRelationalParameter : RelationalParameterBase
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public override void AddDbParameter(DbCommand command, IReadOnlyDictionary<string, object?> parameterValues)
+    public override void AddDbParameter(DbCommand command, IReadOnlyDictionary<string, object?>? parameterValues)
         => AddDbParameter(command, _parameter);
 
     /// <summary>

--- a/src/EFCore.Relational/Storage/Internal/RelationalParameterBase.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalParameterBase.cs
@@ -44,9 +44,9 @@ public abstract class RelationalParameterBase : IRelationalParameter
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void AddDbParameter(DbCommand command, IReadOnlyDictionary<string, object?> parameterValues)
+    public virtual void AddDbParameter(DbCommand command, IReadOnlyDictionary<string, object?>? parameterValues)
     {
-        if (parameterValues.TryGetValue(InvariantName, out var parameterValue))
+        if (parameterValues is not null && parameterValues.TryGetValue(InvariantName, out var parameterValue))
         {
             AddDbParameter(command, parameterValue);
         }

--- a/src/EFCore.Relational/Storage/Internal/TypeMappedRelationalParameter.cs
+++ b/src/EFCore.Relational/Storage/Internal/TypeMappedRelationalParameter.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data;
+
 namespace Microsoft.EntityFrameworkCore.Storage.Internal;
 
 /// <summary>
@@ -21,12 +23,14 @@ public class TypeMappedRelationalParameter : RelationalParameterBase
         string invariantName,
         string name,
         RelationalTypeMapping relationalTypeMapping,
-        bool? nullable)
+        bool? nullable,
+        ParameterDirection direction = ParameterDirection.Input)
         : base(invariantName)
     {
         Name = name;
         RelationalTypeMapping = relationalTypeMapping;
         IsNullable = nullable;
+        Direction = direction;
     }
 
     /// <summary>
@@ -36,6 +40,14 @@ public class TypeMappedRelationalParameter : RelationalParameterBase
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual string Name { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual ParameterDirection Direction { get; }
 
     // internal for testing
     internal RelationalTypeMapping RelationalTypeMapping { get; }
@@ -51,5 +63,5 @@ public class TypeMappedRelationalParameter : RelationalParameterBase
     /// </summary>
     public override void AddDbParameter(DbCommand command, object? value)
         => command.Parameters.Add(
-               RelationalTypeMapping.CreateParameter(command, Name, value, IsNullable));
+            RelationalTypeMapping.CreateParameter(command, Name, value, IsNullable, Direction));
 }

--- a/src/EFCore.Relational/Storage/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommand.cs
@@ -817,20 +817,9 @@ public class RelationalCommand : IRelationalCommand
             command.CommandTimeout = (int)connection.CommandTimeout;
         }
 
-        if (Parameters.Count > 0)
+        for (var i = 0; i < Parameters.Count; i++)
         {
-            var parameterValues = parameterObject.ParameterValues;
-            if (parameterValues == null)
-            {
-                throw new InvalidOperationException(
-                    RelationalStrings.MissingParameterValue(
-                        Parameters[0].InvariantName));
-            }
-
-            for (var i = 0; i < Parameters.Count; i++)
-            {
-                Parameters[i].AddDbParameter(command, parameterValues);
-            }
+            Parameters[i].AddDbParameter(command, parameterObject.ParameterValues);
         }
 
         if (logCommandCreate)

--- a/src/EFCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage;
@@ -114,19 +115,22 @@ public static class RelationalCommandBuilderExtensions
     /// </param>
     /// <param name="relationalTypeMapping">The relational type mapping for this parameter.</param>
     /// <param name="nullable">A value indicating whether the parameter could contain a null value.</param>
+    /// <param name="direction">The parameter direction.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static IRelationalCommandBuilder AddParameter(
         this IRelationalCommandBuilder commandBuilder,
         string invariantName,
         string name,
         RelationalTypeMapping relationalTypeMapping,
-        bool? nullable)
+        bool? nullable,
+        ParameterDirection direction = ParameterDirection.Input)
         => commandBuilder.AddParameter(
             new TypeMappedRelationalParameter(
                 invariantName,
                 name,
                 relationalTypeMapping,
-                nullable));
+                nullable,
+                direction));
 
     /// <summary>
     ///     Adds a parameter that is ultimately represented as multiple <see cref="DbParameter" />s in the

--- a/src/EFCore.Relational/Storage/RelationalGeometryTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalGeometryTypeMapping.cs
@@ -70,15 +70,13 @@ public abstract class RelationalGeometryTypeMapping<TGeometry, TProvider> : Rela
     /// </summary>
     protected virtual ValueConverter<TGeometry, TProvider>? SpatialConverter { get; }
 
-    /// <summary>
-    ///     Creates a <see cref="DbParameter" /> with the appropriate type information configured.
-    /// </summary>
-    /// <param name="command">The command the parameter should be created on.</param>
-    /// <param name="name">The name of the parameter.</param>
-    /// <param name="value">The value to be assigned to the parameter.</param>
-    /// <param name="nullable">A value indicating whether the parameter should be a nullable type.</param>
-    /// <returns>The newly created parameter.</returns>
-    public override DbParameter CreateParameter(DbCommand command, string name, object? value, bool? nullable = null)
+    /// <inheritdoc />
+    public override DbParameter CreateParameter(
+        DbCommand command,
+        string name,
+        object? value,
+        bool? nullable = null,
+        ParameterDirection direction = ParameterDirection.Input)
     {
         var parameter = command.CreateParameter();
         parameter.Direction = ParameterDirection.Input;

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -483,29 +483,37 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
     /// <param name="name">The name of the parameter.</param>
     /// <param name="value">The value to be assigned to the parameter.</param>
     /// <param name="nullable">A value indicating whether the parameter should be a nullable type.</param>
+    /// <param name="direction">The direction of the parameter.</param>
     /// <returns>The newly created parameter.</returns>
     public virtual DbParameter CreateParameter(
         DbCommand command,
         string name,
         object? value,
-        bool? nullable = null)
+        bool? nullable = null,
+        ParameterDirection direction = ParameterDirection.Input)
     {
         var parameter = command.CreateParameter();
-        parameter.Direction = ParameterDirection.Input;
+        parameter.Direction = direction;
         parameter.ParameterName = name;
 
-        value = NormalizeEnumValue(value);
-
-        if (Converter != null)
+        if (direction.HasFlag(ParameterDirection.Input))
         {
-            value = Converter.ConvertToProvider(value);
-        }
+            value = NormalizeEnumValue(value);
 
-        parameter.Value = value ?? DBNull.Value;
+            if (Converter != null)
+            {
+                value = Converter.ConvertToProvider(value);
+            }
+
+            parameter.Value = value ?? DBNull.Value;
+        }
 
         if (nullable.HasValue)
         {
-            Check.DebugAssert(nullable.Value || value != null, "Null value in a non-nullable parameter");
+            Check.DebugAssert(nullable.Value
+                || !direction.HasFlag(ParameterDirection.Input)
+                || value != null,
+                "Null value in a non-nullable input parameter");
 
             parameter.IsNullable = nullable.Value;
         }

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data;
+
 namespace Microsoft.EntityFrameworkCore.Update;
 
 /// <summary>
@@ -63,7 +65,7 @@ public class ColumnModification : IColumnModification
     public virtual IProperty? Property { get; }
 
     /// <inheritdoc />
-    public virtual IColumn? Column { get; }
+    public virtual IColumnBase? Column { get; }
 
     /// <inheritdoc />
     public virtual RelationalTypeMapping? TypeMapping { get; }
@@ -89,7 +91,7 @@ public class ColumnModification : IColumnModification
 
     /// <inheritdoc />
     public virtual bool UseCurrentValueParameter
-        => UseParameter && UseCurrentValue;
+        => (UseParameter && UseCurrentValue) || (IsRead && Column is IStoreStoredProcedureParameter or IStoreStoredProcedureReturnValue);
 
     /// <inheritdoc />
     public virtual bool UseOriginalValue

--- a/src/EFCore.Relational/Update/ColumnModificationParameters.cs
+++ b/src/EFCore.Relational/Update/ColumnModificationParameters.cs
@@ -80,7 +80,7 @@ public readonly record struct ColumnModificationParameters
     /// <summary>
     ///     The column.
     /// </summary>
-    public IColumn? Column { get; init; }
+    public IColumnBase? Column { get; init; }
 
     /// <summary>
     ///     The name of the column.
@@ -199,8 +199,8 @@ public readonly record struct ColumnModificationParameters
     /// <param name="sensitiveLoggingEnabled">Indicates whether potentially sensitive data (e.g. database values) can be logged.</param>
     public ColumnModificationParameters(
         IUpdateEntry entry,
-        IProperty property,
-        IColumn column,
+        IProperty? property,
+        IColumnBase column,
         Func<string> generateParameterName,
         RelationalTypeMapping typeMapping,
         bool valueIsRead,

--- a/src/EFCore.Relational/Update/IColumnModification.cs
+++ b/src/EFCore.Relational/Update/IColumnModification.cs
@@ -33,7 +33,7 @@ public interface IColumnModification
     /// <summary>
     ///     The column.
     /// </summary>
-    public IColumn? Column { get; }
+    public IColumnBase? Column { get; }
 
     /// <summary>
     ///     The relational type mapping for the column.

--- a/src/EFCore.Relational/Update/IReadOnlyModificationCommand.cs
+++ b/src/EFCore.Relational/Update/IReadOnlyModificationCommand.cs
@@ -23,6 +23,11 @@ public interface IReadOnlyModificationCommand
     public ITable? Table { get; }
 
     /// <summary>
+    ///     The stored procedure to use for updating the data.
+    /// </summary>
+    public IStoreStoredProcedure? StoreStoredProcedure { get; }
+
+    /// <summary>
     ///     The name of the table containing the data to be modified.
     /// </summary>
     public string TableName { get; }
@@ -57,9 +62,24 @@ public interface IReadOnlyModificationCommand
     public EntityState EntityState { get; }
 
     /// <summary>
-    ///     Reads values returned from the database in the given <paramref name="relationalReader" /> and propagates them back to into the
-    ///     appropriate <see cref="IColumnModification" /> from which the values can be propagated on to tracked entities.
+    ///     When using a stored procedure, this optionally points to the output parameter or result column containing the rows affected.
+    /// </summary>
+    public IColumnBase? RowsAffectedColumn { get; }
+
+    /// <summary>
+    ///     Reads result set columns returned from the database in the given <paramref name="relationalReader" /> and propagates them back
+    ///     to into the appropriate <see cref="IColumnModification" /> from which the values can be propagated on to tracked entities.
     /// </summary>
     /// <param name="relationalReader">The relational reader containing the values read from the database.</param>
     public void PropagateResults(RelationalDataReader relationalReader);
+
+    /// <summary>
+    ///     Reads output parameters returned from the database in the given <paramref name="parameterCollection" /> and propagates them back
+    ///     to into the appropriate <see cref="IColumnModification" /> from which the values can be propagated on to tracked entities.
+    /// </summary>
+    /// <param name="parameterCollection">The parameter collection from which to propagate output values.</param>
+    /// <param name="baseParameterIndex">
+    /// The index in <paramref name="parameterCollection" /> on which parameters for this <see cref="ModificationCommand" /> begin.
+    /// </param>
+    public void PropagateOutputParameters(DbParameterCollection parameterCollection, int baseParameterIndex);
 }

--- a/src/EFCore.Relational/Update/IUpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/IUpdateSqlGenerator.cs
@@ -160,4 +160,18 @@ public interface IUpdateSqlGenerator
         IReadOnlyModificationCommand command,
         int commandPosition)
         => AppendUpdateOperation(commandStringBuilder, command, commandPosition, out _);
+
+    /// <summary>
+    ///     Appends SQL for calling a stored procedure.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="command">The command that represents the stored procedure call.</param>
+    /// <param name="commandPosition">The ordinal of this command in the batch.</param>
+    /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
+    ResultSetMapping AppendStoredProcedureCall(
+        StringBuilder commandStringBuilder,
+        IReadOnlyModificationCommand command,
+        int commandPosition,
+        out bool requiresTransaction);
 }

--- a/src/EFCore.Relational/Update/ModificationCommandParameters.cs
+++ b/src/EFCore.Relational/Update/ModificationCommandParameters.cs
@@ -21,6 +21,36 @@ public readonly record struct ModificationCommandParameters
     ///     Creates a new <see cref="ModificationCommandParameters" /> instance.
     /// </summary>
     /// <param name="table">The table containing the data to be modified.</param>
+    /// <param name="storeStoredProcedure">The stored procedure to use for updating the data.</param>
+    /// <param name="sensitiveLoggingEnabled">Indicates whether potentially sensitive data (e.g. database values) can be logged.</param>
+    /// <param name="detailedErrorsEnabled">Indicates whether detailed errors should be logged.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}" /> for <see cref="IUpdateEntry" />.</param>
+    /// <param name="generateParameterName">A delegate to generate parameter names.</param>
+    /// <param name="logger">An <see cref="IDiagnosticsLogger{TLoggerCategory}" /> for <see cref="DbLoggerCategory.Update" />.</param>
+    public ModificationCommandParameters(
+        ITable table,
+        IStoreStoredProcedure? storeStoredProcedure,
+        bool sensitiveLoggingEnabled,
+        bool detailedErrorsEnabled = false,
+        IComparer<IUpdateEntry>? comparer = null,
+        Func<string>? generateParameterName = null,
+        IDiagnosticsLogger<DbLoggerCategory.Update>? logger = null)
+    {
+        Table = table;
+        TableName = table.Name;
+        Schema = table.Schema;
+        StoreStoredProcedure = storeStoredProcedure;
+        GenerateParameterName = generateParameterName;
+        SensitiveLoggingEnabled = sensitiveLoggingEnabled;
+        DetailedErrorsEnabled = detailedErrorsEnabled;
+        Comparer = comparer;
+        Logger = logger;
+    }
+
+    /// <summary>
+    ///     Creates a new <see cref="ModificationCommandParameters" /> instance.
+    /// </summary>
+    /// <param name="table">The table containing the data to be modified.</param>
     /// <param name="sensitiveLoggingEnabled">Indicates whether potentially sensitive data (e.g. database values) can be logged.</param>
     /// <param name="detailedErrorsEnabled">Indicates whether detailed errors should be logged.</param>
     /// <param name="comparer">An <see cref="IComparer{T}" /> for <see cref="IUpdateEntry" />.</param>
@@ -33,15 +63,8 @@ public readonly record struct ModificationCommandParameters
         IComparer<IUpdateEntry>? comparer = null,
         Func<string>? generateParameterName = null,
         IDiagnosticsLogger<DbLoggerCategory.Update>? logger = null)
+        : this(table, storeStoredProcedure: null, sensitiveLoggingEnabled, detailedErrorsEnabled, comparer, generateParameterName, logger)
     {
-        Table = table;
-        TableName = table.Name;
-        Schema = table.Schema;
-        GenerateParameterName = generateParameterName;
-        SensitiveLoggingEnabled = sensitiveLoggingEnabled;
-        DetailedErrorsEnabled = detailedErrorsEnabled;
-        Comparer = comparer;
-        Logger = logger;
     }
 
     /// <summary>
@@ -58,6 +81,11 @@ public readonly record struct ModificationCommandParameters
     ///     The table containing the data to be modified.
     /// </summary>
     public ITable? Table { get; init; }
+
+    /// <summary>
+    ///     The stored procedure to use for updating the data.
+    /// </summary>
+    public IStoreStoredProcedure? StoreStoredProcedure { get; }
 
     /// <summary>
     ///     A delegate to generate parameter names.

--- a/src/EFCore.Relational/Update/ResultSetMapping.cs
+++ b/src/EFCore.Relational/Update/ResultSetMapping.cs
@@ -15,20 +15,38 @@ namespace Microsoft.EntityFrameworkCore.Update;
 ///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
 ///     for more information and examples.
 /// </remarks>
+[Flags]
 public enum ResultSetMapping
 {
     /// <summary>
-    ///     The command does not have any result set mapping.
+    ///     The command does not have any results, neither as rows nor as output parameters.
     /// </summary>
-    NoResultSet,
+    NoResults = 0,
 
     /// <summary>
-    ///     The command maps to a result in the result set, but this is not the last result.
+    ///     The command maps to a row in the result set.
     /// </summary>
-    NotLastInResultSet,
+    HasResultRow = 1,
+
+    /// <summary>
+    ///     The command maps to a non-last row in the result set.
+    /// </summary>
+    NotLastInResultSet = 3,
 
     /// <summary>
     ///     The command maps to the last result in the result set.
     /// </summary>
-    LastInResultSet
+    LastInResultSet = 5,
+
+    /// <summary>
+    ///     When rows with database-generated values are returned in non-deterministic ordering, it is necessary to project out a synthetic
+    ///     position value, in order to look up the correct <see cref="ModificationCommand" /> and propagate the values. When this bit is
+    ///     enabled, the current result row contains such a position value.
+    /// </summary>
+    IsPositionalResultMappingEnabled = 9,
+
+    /// <summary>
+    ///     The command has output parameters.
+    /// </summary>
+    HasOutputParameters = 16
 }

--- a/src/EFCore.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
+++ b/src/EFCore.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
@@ -36,7 +36,7 @@ public enum SqlServerValueGenerationStrategy
     IdentityColumn,
 
     /// <summary>
-    ///     A pattern that uses a database sequence to generate values for the key.
+    ///     A pattern that uses a database sequence to generate values for the column.
     /// </summary>
     Sequence
 }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
@@ -152,13 +152,11 @@ public class SqlServerStringTypeMapping : StringTypeMapping
             // 8000 bytes if no size facet specified, if the data will fit so as to avoid query cache
             // fragmentation by setting lots of different Size values otherwise set to the max bounded length
             // if the value will fit, otherwise set to -1 (unbounded) to avoid SQL client size inference.
-            if (length != null
-                && length <= _maxSpecificSize)
+            if (length <= _maxSpecificSize)
             {
                 parameter.Size = _maxSpecificSize;
             }
-            else if (length != null
-                     && length <= _maxSize)
+            else if (length <= _maxSize)
             {
                 parameter.Size = _maxSize;
             }

--- a/src/EFCore.SqlServer/Update/Internal/ISqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/ISqlServerUpdateSqlGenerator.cs
@@ -28,7 +28,6 @@ public interface ISqlServerUpdateSqlGenerator : IUpdateSqlGenerator
         StringBuilder commandStringBuilder,
         IReadOnlyList<IReadOnlyModificationCommand> modificationCommands,
         int commandPosition,
-        out bool resultsContainPositionMapping,
         out bool requiresTransaction);
 
     /// <summary>
@@ -41,5 +40,5 @@ public interface ISqlServerUpdateSqlGenerator : IUpdateSqlGenerator
         StringBuilder commandStringBuilder,
         IReadOnlyList<IReadOnlyModificationCommand> modificationCommands,
         int commandPosition)
-        => AppendBulkInsertOperation(commandStringBuilder, modificationCommands, commandPosition, out _, out _);
+        => AppendBulkInsertOperation(commandStringBuilder, modificationCommands, commandPosition, out _);
 }

--- a/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteModelValidator.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteModelValidator.cs
@@ -38,6 +38,7 @@ public class SqliteModelValidator : RelationalModelValidator
 
         ValidateNoSchemas(model, logger);
         ValidateNoSequences(model, logger);
+        ValidateNoStoredProcedures(model, logger);
     }
 
     /// <summary>
@@ -69,6 +70,27 @@ public class SqliteModelValidator : RelationalModelValidator
         foreach (var sequence in model.GetSequences())
         {
             logger.SequenceConfiguredWarning(sequence);
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual void ValidateNoStoredProcedures(
+        IModel model,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            if (entityType.GetInsertStoredProcedure() is not null
+                || entityType.GetUpdateStoredProcedure() is not null
+                || entityType.GetDeleteStoredProcedure() is not null)
+            {
+                throw new InvalidOperationException(SqliteStrings.StoredProceduresNotSupported(entityType.DisplayName()));
+            }
         }
     }
 

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -73,6 +73,14 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         public static string SequencesNotSupported
             => GetString("SequencesNotSupported");
 
+        /// <summary>
+        ///     SQLite does not support stored procedures. See http://go.microsoft.com/fwlink/?LinkId=723262 for more information and examples.
+        /// </summary>
+        public static string StoredProceduresNotSupported(object? entityType)
+            => string.Format(
+                GetString("StoredProceduresNotSupported", nameof(entityType)),
+                entityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name)!;

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
@@ -198,4 +198,7 @@
   <data name="SequencesNotSupported" xml:space="preserve">
     <value>SQLite does not support sequences. See http://go.microsoft.com/fwlink/?LinkId=723262 for more information and examples.</value>
   </data>
+  <data name="StoredProceduresNotSupported" xml:space="preserve">
+    <value>SQLite does not support stored procedures, but one has been configured on entity type '{entityType}'. See http://go.microsoft.com/fwlink/?LinkId=723262 for more information and examples.</value>
+  </data>
 </root>

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1693,7 +1693,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
                     || HasTemporaryValue(property)
                     || HasDefaultValue(property)))
             || (property.ValueGenerated.ForUpdate()
-                && (EntityState == EntityState.Modified || EntityState == EntityState.Deleted)
+                && (EntityState is EntityState.Modified or EntityState.Deleted)
                 && (property.GetAfterSaveBehavior() == PropertySaveBehavior.Ignore
                     || !IsModified(property)));
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -2632,8 +2632,7 @@ namespace TestNamespace
                 runtimeEntityType,
                 ""PrincipalBase_Insert"",
                 ""TPC"",
-                false,
-                true);
+                false);
 
             var principalBaseId = insertSproc.AddParameter(
                 ""PrincipalBaseId"", ParameterDirection.Input, false, ""PrincipalBaseId"", false);
@@ -2649,8 +2648,7 @@ namespace TestNamespace
                 runtimeEntityType,
                 ""PrincipalBase_Delete"",
                 ""TPC"",
-                true,
-                false);
+                true);
 
             var id = deleteSproc.AddParameter(
                 ""Id"", ParameterDirection.Input, false, ""Id"", false);
@@ -2660,7 +2658,6 @@ namespace TestNamespace
                 runtimeEntityType,
                 ""PrincipalBase_Update"",
                 ""TPC"",
-                false,
                 false);
 
             var principalBaseId0 = updateSproc.AddParameter(
@@ -2719,7 +2716,6 @@ namespace TestNamespace
                 runtimeEntityType,
                 ""Derived_Insert"",
                 ""TPC"",
-                false,
                 false);
 
             var principalBaseId = insertSproc.AddParameter(
@@ -2735,7 +2731,6 @@ namespace TestNamespace
                 runtimeEntityType,
                 ""Derived_Delete"",
                 ""TPC"",
-                false,
                 false);
 
             var id = deleteSproc.AddParameter(
@@ -2746,7 +2741,6 @@ namespace TestNamespace
                 runtimeEntityType,
                 ""Derived_Update"",
                 ""Derived"",
-                false,
                 false);
 
             var principalBaseId0 = updateSproc.AddParameter(
@@ -2796,7 +2790,6 @@ namespace TestNamespace
                     Assert.Equal("TPC", insertSproc.Schema);
                     Assert.Equal(new[] { "PrincipalBaseId", "PrincipalDerivedId", "Id" }, insertSproc.Parameters.Select(p => p.PropertyName));
                     Assert.Empty(insertSproc.ResultColumns);
-                    Assert.True(insertSproc.AreTransactionsSuppressed);
                     Assert.False(insertSproc.IsRowsAffectedReturned);
                     Assert.Equal("bar1", insertSproc["foo"]);
                     Assert.Same(principalBase, insertSproc.EntityType);
@@ -2809,7 +2802,6 @@ namespace TestNamespace
                     Assert.Equal("TPC", updateSproc.Schema);
                     Assert.Equal(new[] { "PrincipalBaseId", "PrincipalDerivedId", "Id" }, updateSproc.Parameters.Select(p => p.PropertyName));
                     Assert.Empty(updateSproc.ResultColumns);
-                    Assert.False(updateSproc.AreTransactionsSuppressed);
                     Assert.False(updateSproc.IsRowsAffectedReturned);
                     Assert.Empty(updateSproc.GetAnnotations());
                     Assert.Same(principalBase, updateSproc.EntityType);
@@ -2821,7 +2813,6 @@ namespace TestNamespace
                     Assert.Equal("TPC", deleteSproc.Schema);
                     Assert.Equal(new[] { "Id" }, deleteSproc.Parameters.Select(p => p.Name));
                     Assert.Empty(deleteSproc.ResultColumns);
-                    Assert.False(deleteSproc.AreTransactionsSuppressed);
                     Assert.True(deleteSproc.IsRowsAffectedReturned);
                     Assert.Same(principalBase, deleteSproc.EntityType);
                     Assert.Equal("Id", deleteSproc.Parameters.Last().Name);
@@ -2851,7 +2842,6 @@ namespace TestNamespace
                     Assert.Equal("TPC", insertSproc.Schema);
                     Assert.Equal(new[] { "PrincipalBaseId", "PrincipalDerivedId" }, insertSproc.Parameters.Select(p => p.PropertyName));
                     Assert.Equal(new[] { "Id" }, insertSproc.ResultColumns.Select(p => p.PropertyName));
-                    Assert.False(insertSproc.AreTransactionsSuppressed);
                     Assert.Null(insertSproc["foo"]);
                     Assert.Same(principalDerived, insertSproc.EntityType);
                     Assert.Equal("DerivedId", insertSproc.ResultColumns.Last().Name);
@@ -2864,7 +2854,6 @@ namespace TestNamespace
                     Assert.Equal("Derived", updateSproc.Schema);
                     Assert.Equal(new[] { "PrincipalBaseId", "PrincipalDerivedId", "Id" }, updateSproc.Parameters.Select(p => p.PropertyName));
                     Assert.Empty(updateSproc.ResultColumns);
-                    Assert.False(updateSproc.AreTransactionsSuppressed);
                     Assert.Empty(updateSproc.GetAnnotations());
                     Assert.Same(principalDerived, updateSproc.EntityType);
                     Assert.Equal("Id", updateSproc.Parameters.Last().Name);
@@ -2875,7 +2864,6 @@ namespace TestNamespace
                     Assert.Equal("TPC", deleteSproc.Schema);
                     Assert.Equal(new[] { "Id" }, deleteSproc.Parameters.Select(p => p.PropertyName));
                     Assert.Empty(deleteSproc.ResultColumns);
-                    Assert.False(deleteSproc.AreTransactionsSuppressed);
                     Assert.Same(principalDerived, deleteSproc.EntityType);
                     Assert.Equal("Id", deleteSproc.Parameters.Last().Name);
                     Assert.Null(id.FindOverrides(StoreObjectIdentifier.Create(principalDerived, StoreObjectType.DeleteStoredProcedure).Value));
@@ -2949,7 +2937,7 @@ namespace TestNamespace
                         eb.ToTable("PrincipalBase");
                         eb.ToView("PrincipalBaseView", tb => tb.Property(e => e.Id).HasAnnotation("foo", "bar2"));
 
-                        eb.InsertUsingStoredProcedure(s => s.SuppressTransactions()
+                        eb.InsertUsingStoredProcedure(s => s
                             .HasParameter("PrincipalBaseId")
                             .HasParameter("PrincipalDerivedId")
                             .HasParameter(p => p.Id, pb => pb.HasName("BaseId").IsOutput().HasAnnotation("foo", "bar"))

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/Entity.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/Entity.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class Entity
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/EntityWithAdditionalProperty.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/EntityWithAdditionalProperty.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class EntityWithAdditionalProperty
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public int AdditionalProperty { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/EntityWithTwoAdditionalProperties.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/EntityWithTwoAdditionalProperties.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class EntityWithTwoAdditionalProperties
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public int AdditionalProperty1 { get; set; }
+    public int AdditionalProperty2 { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/StoredProcedureUpdateContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/StoredProcedureUpdateContext.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class StoredProcedureUpdateContext : PoolableDbContext
+{
+    public StoredProcedureUpdateContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Entity> WithOutputParameter
+        => Set<Entity>(nameof(WithOutputParameter));
+
+    public DbSet<Entity> WithResultColumn
+        => Set<Entity>(nameof(WithResultColumn));
+
+    public DbSet<EntityWithAdditionalProperty> WithTwoResultColumns
+        => Set<EntityWithAdditionalProperty>(nameof(WithTwoResultColumns));
+
+    public DbSet<EntityWithAdditionalProperty> WithOutputParameterAndResultColumn
+        => Set<EntityWithAdditionalProperty>(nameof(WithOutputParameterAndResultColumn));
+
+    public DbSet<EntityWithTwoAdditionalProperties> WithOutputParameterAndResultColumnAndResultValue
+        => Set<EntityWithTwoAdditionalProperties>(nameof(WithOutputParameterAndResultColumnAndResultValue));
+
+    public DbSet<EntityWithAdditionalProperty> WithTwoOutputParameters
+        => Set<EntityWithAdditionalProperty>(nameof(WithTwoOutputParameters));
+
+    public DbSet<Entity> WithRowsAffectedParameter
+        => Set<Entity>(nameof(WithRowsAffectedParameter));
+
+    public DbSet<Entity> WithRowsAffectedResultColumn
+        => Set<Entity>(nameof(WithRowsAffectedResultColumn));
+
+    public DbSet<Entity> WithRowsAffectedReturnValue
+        => Set<Entity>(nameof(WithRowsAffectedReturnValue));
+
+    public DbSet<Entity> WithStoreGeneratedConcurrencyTokenAsInoutParameter
+        => Set<Entity>(nameof(WithStoreGeneratedConcurrencyTokenAsInoutParameter));
+
+    public DbSet<Entity> WithStoreGeneratedConcurrencyTokenAsTwoParameters
+        => Set<Entity>(nameof(WithStoreGeneratedConcurrencyTokenAsTwoParameters));
+
+    public DbSet<EntityWithAdditionalProperty> WithUserManagedConcurrencyToken
+        => Set<EntityWithAdditionalProperty>(nameof(WithUserManagedConcurrencyToken));
+
+    public DbSet<Entity> WithOriginalAndCurrentValueOnNonConcurrencyToken
+        => Set<Entity>(nameof(WithOriginalAndCurrentValueOnNonConcurrencyToken));
+
+    public DbSet<Entity> WithInputOutputParameterOnNonConcurrencyToken
+        => Set<Entity>(nameof(WithInputOutputParameterOnNonConcurrencyToken));
+
+    public DbSet<TphParent> TphParent { get; set; }
+    public DbSet<TphChild> TphChild { get; set; }
+    public DbSet<TptParent> TptParent { get; set; }
+    public DbSet<TptChild> TptChild { get; set; }
+    public DbSet<TptMixedParent> TptMixedParent { get; set; }
+    public DbSet<TptMixedChild> TptMixedChild { get; set; }
+    public DbSet<TpcParent> TpcParent { get; set; }
+    public DbSet<TpcChild> TpcChild { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TpcChild.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TpcChild.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TpcChild : TpcParent
+{
+    public int ChildProperty { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TpcParent.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TpcParent.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TpcParent
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TphChild.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TphChild.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TphChild : TphParent
+{
+    public int ChildProperty { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TphParent.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TphParent.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TphParent
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TptChild.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TptChild.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TptChild : TptParent
+{
+    public int ChildProperty { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TptMixedChild.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TptMixedChild.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TptMixedChild : TptMixedParent
+{
+    public int ChildProperty { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TptMixedParent.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TptMixedParent.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TptMixedParent
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TptParent.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TptParent.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TptParent
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/Update/StoreValueGenerationFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoreValueGenerationFixtureBase.cs
@@ -72,20 +72,26 @@ public abstract class StoreValueGenerationFixtureBase : SharedStoreFixtureBase<S
         context.SaveChanges();
     }
 
-    protected override void Clean(DbContext context)
+    public void Seed()
     {
-        var storeValueGenerationContext = CreateContext();
+        using var context = CreateContext();
+        Seed(context);
+    }
 
-        storeValueGenerationContext.WithSomeDatabaseGenerated.RemoveRange(storeValueGenerationContext.WithSomeDatabaseGenerated);
-        storeValueGenerationContext.WithSomeDatabaseGenerated2.RemoveRange(storeValueGenerationContext.WithSomeDatabaseGenerated2);
+    public virtual void CleanData()
+    {
+        using var context = CreateContext();
 
-        storeValueGenerationContext.WithNoDatabaseGenerated.RemoveRange(storeValueGenerationContext.WithNoDatabaseGenerated);
-        storeValueGenerationContext.WithNoDatabaseGenerated2.RemoveRange(storeValueGenerationContext.WithNoDatabaseGenerated2);
+        context.WithSomeDatabaseGenerated.RemoveRange(context.WithSomeDatabaseGenerated);
+        context.WithSomeDatabaseGenerated2.RemoveRange(context.WithSomeDatabaseGenerated2);
 
-        storeValueGenerationContext.WithAllDatabaseGenerated.RemoveRange(storeValueGenerationContext.WithAllDatabaseGenerated);
-        storeValueGenerationContext.WithAllDatabaseGenerated2.RemoveRange(storeValueGenerationContext.WithAllDatabaseGenerated2);
+        context.WithNoDatabaseGenerated.RemoveRange(context.WithNoDatabaseGenerated);
+        context.WithNoDatabaseGenerated2.RemoveRange(context.WithNoDatabaseGenerated2);
 
-        storeValueGenerationContext.SaveChanges();
+        context.WithAllDatabaseGenerated.RemoveRange(context.WithAllDatabaseGenerated);
+        context.WithAllDatabaseGenerated2.RemoveRange(context.WithAllDatabaseGenerated2);
+
+        context.SaveChanges();
     }
 
     protected override bool ShouldLogCategory(string logCategory)

--- a/test/EFCore.Relational.Specification.Tests/Update/StoreValueGenerationTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoreValueGenerationTestBase.cs
@@ -14,7 +14,8 @@ public abstract class StoreValueGenerationTestBase<TFixture> : IClassFixture<TFi
     {
         Fixture = fixture;
 
-        fixture.Reseed();
+        fixture.CleanData();
+        fixture.Seed();
 
         ClearLog();
     }

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
@@ -1,0 +1,283 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+namespace Microsoft.EntityFrameworkCore.Update;
+
+#nullable enable
+
+public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<StoredProcedureUpdateContext>
+{
+    protected override string StoreName
+        => "StoredProcedureUpdateTest";
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        modelBuilder.SharedTypeEntity<Entity>(nameof(StoredProcedureUpdateContext.WithOutputParameter))
+            .InsertUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithOutputParameter) + "_Insert",
+                spb => spb
+                    .HasParameter(w => w.Name)
+                    .HasParameter(w => w.Id, pb => pb.IsOutput()))
+            .UpdateUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithOutputParameter) + "_Update",
+                spb => spb
+                    .HasParameter(w => w.Id)
+                    .HasParameter(w => w.Name))
+            .DeleteUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithOutputParameter) + "_Delete",
+                spb => spb.HasParameter(w => w.Id));
+
+        modelBuilder.SharedTypeEntity<Entity>(nameof(StoredProcedureUpdateContext.WithResultColumn))
+            .InsertUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithResultColumn) + "_Insert", spb => spb
+                    .HasParameter(w => w.Name)
+                    .HasResultColumn(w => w.Id));
+
+        modelBuilder.SharedTypeEntity<EntityWithAdditionalProperty>(
+            nameof(StoredProcedureUpdateContext.WithTwoResultColumns),
+            b =>
+            {
+                b.Property(w => w.AdditionalProperty).HasComputedColumnSql("8");
+
+                b.InsertUsingStoredProcedure(
+                    "WithTwoResultColumns_Insert", spb => spb
+                        .HasParameter(w => w.Name)
+                        .HasResultColumn(w => w.AdditionalProperty)
+                        .HasResultColumn(w => w.Id));
+            });
+
+        modelBuilder.SharedTypeEntity<EntityWithAdditionalProperty>(
+            nameof(StoredProcedureUpdateContext.WithOutputParameterAndResultColumn),
+            b =>
+            {
+                b.Property(w => w.AdditionalProperty).HasComputedColumnSql("8");
+
+                b.InsertUsingStoredProcedure(
+                    "WithOutputParameterAndResultColumn_Insert", spb => spb
+                        .HasParameter(w => w.Id, pb => pb.IsOutput())
+                        .HasParameter(w => w.Name)
+                        .HasResultColumn(w => w.AdditionalProperty));
+            });
+
+        modelBuilder.SharedTypeEntity<EntityWithAdditionalProperty>(nameof(StoredProcedureUpdateContext.WithTwoOutputParameters))
+            .UpdateUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithTwoOutputParameters) + "_Update", spb => spb
+                    .HasParameter(w => w.Id)
+                    .HasParameter(w => w.Name)
+                    .HasParameter(w => w.AdditionalProperty));
+
+        modelBuilder.SharedTypeEntity<Entity>(nameof(StoredProcedureUpdateContext.WithRowsAffectedParameter))
+            .UpdateUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithRowsAffectedParameter) + "_Update",
+                spb => spb
+                    .HasParameter(w => w.Id)
+                    .HasParameter(w => w.Name)
+                    .HasRowsAffectedParameter());
+
+        modelBuilder.SharedTypeEntity<Entity>(nameof(StoredProcedureUpdateContext.WithRowsAffectedResultColumn))
+            .UpdateUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithRowsAffectedResultColumn) + "_Update",
+                spb => spb
+                    .HasParameter(w => w.Id)
+                    .HasParameter(w => w.Name)
+                    .HasRowsAffectedResultColumn());
+
+        modelBuilder.SharedTypeEntity<Entity>(nameof(StoredProcedureUpdateContext.WithRowsAffectedReturnValue))
+            .UpdateUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithRowsAffectedReturnValue) + "_Update",
+                spb => spb
+                    .HasParameter(w => w.Id)
+                    .HasParameter(w => w.Name)
+                    .HasRowsAffectedReturnValue());
+
+        modelBuilder.SharedTypeEntity<Entity>(
+            nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsInoutParameter),
+            b =>
+            {
+                ConfigureStoreGeneratedConcurrencyToken(b, "ConcurrencyToken");
+
+                b.UpdateUsingStoredProcedure(
+                    nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsInoutParameter) + "_Update",
+                    spb => spb
+                        .HasParameter(w => w.Id)
+                        .HasOriginalValueParameter("ConcurrencyToken", pb => pb.IsInputOutput())
+                        .HasParameter(w => w.Name)
+                        .HasRowsAffectedParameter());
+            });
+
+        modelBuilder.SharedTypeEntity<Entity>(
+            nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsTwoParameters),
+            b =>
+            {
+                ConfigureStoreGeneratedConcurrencyToken(b, "ConcurrencyToken");
+
+                b.UpdateUsingStoredProcedure(
+                    nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsTwoParameters) + "_Update",
+                    spb => spb
+                        .HasParameter(w => w.Id)
+                        .HasOriginalValueParameter("ConcurrencyToken", pb => pb.HasName("ConcurrencyTokenIn"))
+                        .HasParameter(w => w.Name)
+                        .HasParameter(
+                            "ConcurrencyToken", pb => pb
+                                .HasName("ConcurrencyTokenOut")
+                                .IsOutput())
+                        .HasRowsAffectedParameter());
+            });
+
+        modelBuilder.SharedTypeEntity<EntityWithAdditionalProperty>(
+                nameof(StoredProcedureUpdateContext.WithUserManagedConcurrencyToken),
+                b =>
+                {
+                    b.Property(e => e.AdditionalProperty).IsConcurrencyToken();
+
+                    b.UpdateUsingStoredProcedure(
+                        nameof(StoredProcedureUpdateContext.WithUserManagedConcurrencyToken) + "_Update",
+                        spb => spb
+                            .HasParameter(w => w.Id)
+                            .HasOriginalValueParameter(w => w.AdditionalProperty, pb => pb.HasName("ConcurrencyTokenOriginal"))
+                            .HasParameter(w => w.Name)
+                            .HasParameter(w => w.AdditionalProperty, pb => pb.HasName("ConcurrencyTokenCurrent"))
+                            .HasRowsAffectedParameter());
+                });
+
+        modelBuilder.SharedTypeEntity<Entity>(nameof(StoredProcedureUpdateContext.WithOriginalAndCurrentValueOnNonConcurrencyToken))
+            .UpdateUsingStoredProcedure(
+                nameof(StoredProcedureUpdateContext.WithOriginalAndCurrentValueOnNonConcurrencyToken) + "_Update",
+                spb => spb
+                    .HasParameter(w => w.Id)
+                    .HasParameter(w => w.Name, pb => pb.HasName("NameCurrent"))
+                    .HasOriginalValueParameter(w => w.Name, pb => pb.HasName("NameOriginal")));
+
+        modelBuilder.SharedTypeEntity<Entity>(
+            nameof(StoredProcedureUpdateContext.WithInputOutputParameterOnNonConcurrencyToken),
+            b =>
+            {
+                b.Property(w => w.Name).ValueGeneratedOnAddOrUpdate();
+
+                b.UpdateUsingStoredProcedure(
+                    nameof(StoredProcedureUpdateContext.WithInputOutputParameterOnNonConcurrencyToken) + "_Update",
+                    spb => spb
+                        .HasParameter(w => w.Id)
+                        .HasParameter(w => w.Name, pb => pb.IsInputOutput()));
+            });
+
+        modelBuilder.SharedTypeEntity<EntityWithTwoAdditionalProperties>(
+            nameof(StoredProcedureUpdateContext.WithOutputParameterAndResultColumnAndResultValue),
+            b =>
+            {
+                b.Property(w => w.AdditionalProperty1).HasComputedColumnSql("8");
+                b.Property(w => w.AdditionalProperty2).HasComputedColumnSql("9");
+
+                b.UpdateUsingStoredProcedure(
+                    nameof(StoredProcedureUpdateContext.WithOutputParameterAndResultColumnAndResultValue) + "_Update",
+                    spb => spb
+                        .HasParameter(w => w.Id)
+                        .HasParameter(w => w.Name)
+                        .HasParameter(w => w.AdditionalProperty1, pb => pb.IsOutput())
+                        .HasResultColumn(w => w.AdditionalProperty2)
+                        .HasRowsAffectedReturnValue());
+            });
+
+        modelBuilder.Entity<TphParent>(
+            b =>
+            {
+                b.ToTable("Tph");
+
+                b.InsertUsingStoredProcedure(
+                    "Tph_Insert",
+                    spb => spb
+                        .HasParameter(w => w.Id, pb => pb.IsOutput())
+                        .HasParameter("Discriminator")
+                        .HasParameter(w => w.Name)
+                        .HasParameter(nameof(TphChild.ChildProperty)));
+            });
+
+        modelBuilder.Entity<TphChild>().ToTable("Tph");
+
+        modelBuilder.Entity<TptParent>(
+            b =>
+            {
+                b.UseTptMappingStrategy();
+
+                b.InsertUsingStoredProcedure(
+                    "TptParent_Insert",
+                    spb => spb
+                        .HasParameter(w => w.Id, pb => pb.IsOutput())
+                        .HasParameter(w => w.Name));
+            });
+
+        // TODO: The following fails validation:
+        // The entity type 'TptChild' is mapped to the stored procedure 'TptChild_Insert', however the store-generated properties {'Id'} are not mapped to any output parameter or result column.
+        modelBuilder.Entity<TptChild>()
+            .InsertUsingStoredProcedure(
+                "TptChild_Insert",
+                spb => spb
+                    .HasParameter(w => w.Id)
+                    .HasParameter(w => w.ChildProperty));
+
+        modelBuilder.Entity<TptMixedParent>(
+            b =>
+            {
+                b.UseTptMappingStrategy();
+
+                b.InsertUsingStoredProcedure(
+                    "TptMixedParent_Insert",
+                    spb => spb
+                        .HasParameter(w => w.Id, pb => pb.IsOutput())
+                        .HasParameter(w => w.Name));
+            });
+
+        // No sproc mapping for TptMixedChild, use regular SQL
+
+        modelBuilder.Entity<TpcParent>().UseTpcMappingStrategy();
+
+        modelBuilder.Entity<TpcChild>()
+            .UseTpcMappingStrategy()
+            .InsertUsingStoredProcedure(
+                "TpcChild_Insert",
+                spb => spb
+                    .HasParameter(w => w.Id, pb => pb.IsOutput())
+                    .HasParameter(w => w.Name)
+                    .HasParameter(w => w.ChildProperty));
+    }
+
+    /// <summary>
+    ///     A method to be implement by the provider, to set up a store-generated concurrency token shadow property with the given name.
+    /// </summary>
+    protected abstract void ConfigureStoreGeneratedConcurrencyToken(EntityTypeBuilder entityTypeBuilder, string propertyName);
+
+    public virtual void CleanData()
+    {
+        using var context = CreateContext();
+
+        context.WithOutputParameter.RemoveRange(context.WithOutputParameter);
+        context.WithResultColumn.RemoveRange(context.WithResultColumn);
+        context.WithTwoResultColumns.RemoveRange(context.WithTwoResultColumns);
+        context.WithOutputParameterAndResultColumn.RemoveRange(context.WithOutputParameterAndResultColumn);
+        context.WithOutputParameterAndResultColumnAndResultValue.RemoveRange(context.WithOutputParameterAndResultColumnAndResultValue);
+        context.WithTwoOutputParameters.RemoveRange(context.WithTwoOutputParameters);
+        context.WithRowsAffectedParameter.RemoveRange(context.WithRowsAffectedParameter);
+        context.WithRowsAffectedResultColumn.RemoveRange(context.WithRowsAffectedResultColumn);
+        context.WithRowsAffectedReturnValue.RemoveRange(context.WithRowsAffectedReturnValue);
+        context.WithStoreGeneratedConcurrencyTokenAsInoutParameter.RemoveRange(context.WithStoreGeneratedConcurrencyTokenAsInoutParameter);
+        context.WithStoreGeneratedConcurrencyTokenAsTwoParameters.RemoveRange(context.WithStoreGeneratedConcurrencyTokenAsTwoParameters);
+        context.WithUserManagedConcurrencyToken.RemoveRange(context.WithUserManagedConcurrencyToken);
+        context.WithOriginalAndCurrentValueOnNonConcurrencyToken.RemoveRange(context.WithOriginalAndCurrentValueOnNonConcurrencyToken);
+        context.WithInputOutputParameterOnNonConcurrencyToken.RemoveRange(context.WithInputOutputParameterOnNonConcurrencyToken);
+        context.TphParent.RemoveRange(context.TphParent);
+        context.TphChild.RemoveRange(context.TphChild);
+        context.TptParent.RemoveRange(context.TptParent);
+        context.TptChild.RemoveRange(context.TptChild);
+        context.TptMixedParent.RemoveRange(context.TptMixedParent);
+        context.TptMixedChild.RemoveRange(context.TptMixedChild);
+        context.TpcParent.RemoveRange(context.TpcParent);
+        context.TpcChild.RemoveRange(context.TpcChild);
+
+        context.SaveChanges();
+    }
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+}

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
@@ -1,0 +1,596 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+namespace Microsoft.EntityFrameworkCore.Update;
+
+#nullable enable
+
+public class StoredProcedureUpdateTestBase<TFixture> : IClassFixture<TFixture>
+    where TFixture : StoredProcedureUpdateFixtureBase
+{
+    protected StoredProcedureUpdateTestBase(TFixture fixture)
+    {
+        Fixture = fixture;
+
+        fixture.CleanData();
+
+        ClearLog();
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Insert_with_output_parameter(bool async)
+    {
+        await using var context = CreateContext();
+
+        var newEntity1 = new Entity { Name = "New" };
+        context.WithOutputParameter.Add(newEntity1);
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("New", context.WithOutputParameter.Single(b => b.Id == newEntity1.Id).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Insert_twice_with_output_parameter(bool async)
+    {
+        await using var context = CreateContext();
+
+        var (newEntity1, newEntity2) = (new Entity { Name = "New1" }, new Entity { Name = "New2" });
+
+        context.WithOutputParameter.AddRange(newEntity1, newEntity2);
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("New1", context.WithOutputParameter.Single(b => b.Id == newEntity1.Id).Name);
+            Assert.Equal("New2", context.WithOutputParameter.Single(b => b.Id == newEntity2.Id).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Insert_with_result_column(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new Entity { Name = "Foo" };
+        context.WithResultColumn.Add(entity);
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Foo", context.WithResultColumn.Single(b => b.Id == entity.Id).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Insert_with_two_result_columns(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new EntityWithAdditionalProperty { Name = "Foo" };
+        context.WithTwoResultColumns.Add(entity);
+        await SaveChanges(context, async);
+
+        Assert.Equal(1, entity.Id);
+        Assert.Equal(8, entity.AdditionalProperty);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Foo", context.WithTwoResultColumns.Single(b => b.Id == entity.Id).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Insert_with_output_parameter_and_result_column(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new EntityWithAdditionalProperty { Name = "Foo" };
+        context.WithOutputParameterAndResultColumn.Add(entity);
+        await SaveChanges(context, async);
+
+        Assert.Equal(8, entity.AdditionalProperty);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Foo", context.WithOutputParameterAndResultColumn.Single(b => b.Id == entity.Id).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Update(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new Entity { Name = "Initial" };
+        context.WithOutputParameter.Add(entity);
+        await SaveChanges(context, async);
+
+        ClearLog();
+
+        entity.Name = "Updated";
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Updated", (await context.WithOutputParameter.SingleAsync(w => w.Id == entity.Id)).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Update_partial(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new EntityWithAdditionalProperty { Name = "Foo", AdditionalProperty = 8 };
+        context.WithTwoOutputParameters.Add(entity);
+        await context.SaveChangesAsync();
+
+        entity.Name = "Updated";
+
+        ClearLog();
+
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            var actual = await context.WithTwoOutputParameters.SingleAsync(w => w.Id == entity.Id);
+
+            Assert.Equal("Updated", actual.Name);
+            Assert.Equal(8, actual.AdditionalProperty);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Delete(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new Entity { Name = "Initial" };
+        context.WithOutputParameter.Add(entity);
+        await context.SaveChangesAsync();
+
+        ClearLog();
+
+        context.WithOutputParameter.Remove(entity);
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal(0, await context.WithOutputParameter.CountAsync(b => b.Name == "Initial"));
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Rows_affected_parameter(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new Entity { Name = "Initial" };
+        context.WithRowsAffectedParameter.Add(entity);
+        await context.SaveChangesAsync();
+
+        ClearLog();
+
+        entity.Name = "Updated";
+
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Updated", (await context.WithRowsAffectedParameter.SingleAsync(w => w.Id == entity.Id)).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Rows_affected_parameter_and_concurrency_failure(bool async)
+    {
+        await using var context1 = CreateContext();
+
+        var entity1 = new Entity { Name = "Initial" };
+        context1.WithRowsAffectedParameter.Add(entity1);
+        await context1.SaveChangesAsync();
+
+        await using (var context2 = CreateContext())
+        {
+            var entity2 = await context2.WithRowsAffectedParameter.SingleAsync(w => w.Name == "Initial");
+            context2.WithRowsAffectedParameter.Remove(entity2);
+            await context2.SaveChangesAsync();
+        }
+
+        ClearLog();
+
+        entity1.Name = "Updated";
+
+        var exception = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await SaveChanges(context1, async));
+        var entry = exception.Entries.Single();
+        Assert.Same(entity1, entry.Entity);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Rows_affected_result_column(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new Entity { Name = "Initial" };
+        context.WithRowsAffectedResultColumn.Add(entity);
+        await context.SaveChangesAsync();
+
+        ClearLog();
+
+        entity.Name = "Updated";
+
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Updated", (await context.WithRowsAffectedResultColumn.SingleAsync(w => w.Id == entity.Id)).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Rows_affected_result_column_and_concurrency_failure(bool async)
+    {
+        await using var context1 = CreateContext();
+
+        var entity1 = new Entity { Name = "Initial" };
+        context1.WithRowsAffectedResultColumn.Add(entity1);
+        await context1.SaveChangesAsync();
+
+        await using (var context2 = CreateContext())
+        {
+            var entity2 = await context2.WithRowsAffectedResultColumn.SingleAsync(w => w.Name == "Initial");
+            context2.WithRowsAffectedResultColumn.Remove(entity2);
+            await context2.SaveChangesAsync();
+        }
+
+        ClearLog();
+
+        entity1.Name = "Updated";
+
+        var exception = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await SaveChanges(context1, async));
+        var entry = exception.Entries.Single();
+        Assert.Same(entity1, entry.Entity);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Rows_affected_return_value(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new Entity { Name = "Initial" };
+        context.WithRowsAffectedReturnValue.Add(entity);
+        await context.SaveChangesAsync();
+
+        ClearLog();
+
+        entity.Name = "Updated";
+
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Updated", (await context.WithRowsAffectedReturnValue.SingleAsync(w => w.Id == entity.Id)).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Rows_affected_return_value_and_concurrency_failure(bool async)
+    {
+        await using var context1 = CreateContext();
+
+        var entity1 = new Entity { Name = "Initial" };
+        context1.WithRowsAffectedReturnValue.Add(entity1);
+        await context1.SaveChangesAsync();
+
+        await using (var context2 = CreateContext())
+        {
+            var entity2 = await context2.WithRowsAffectedReturnValue.SingleAsync(w => w.Name == "Initial");
+            context2.WithRowsAffectedReturnValue.Remove(entity2);
+            await SaveChanges(context2, async);
+        }
+
+        ClearLog();
+
+        entity1.Name = "Updated";
+
+        var exception = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await SaveChanges(context1, async));
+        var entry = exception.Entries.Single();
+        Assert.Same(entity1, entry.Entity);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Store_generated_concurrency_token_as_inout_parameter(bool async)
+    {
+        await using var context1 = CreateContext();
+
+        var entity1 = new Entity { Name = "Initial" };
+        context1.WithStoreGeneratedConcurrencyTokenAsInoutParameter.Add(entity1);
+        await context1.SaveChangesAsync();
+
+        await using (var context2 = CreateContext())
+        {
+            var entity2 = await context2.WithStoreGeneratedConcurrencyTokenAsInoutParameter.SingleAsync(w => w.Name == "Initial");
+            entity2.Name = "Preempted";
+            await SaveChanges(context2, async);
+        }
+
+        ClearLog();
+
+        entity1.Name = "Updated";
+
+        var exception = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await SaveChanges(context1, async));
+        var entry = exception.Entries.Single();
+        Assert.Same(entity1, entry.Entity);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Store_generated_concurrency_token_as_two_parameters(bool async)
+    {
+        await using var context1 = CreateContext();
+
+        var entity1 = new Entity { Name = "Initial" };
+        context1.WithStoreGeneratedConcurrencyTokenAsTwoParameters.Add(entity1);
+        await context1.SaveChangesAsync();
+
+        await using (var context2 = CreateContext())
+        {
+            var entity2 = await context2.WithStoreGeneratedConcurrencyTokenAsTwoParameters.SingleAsync(w => w.Name == "Initial");
+            entity2.Name = "Preempted";
+            await SaveChanges(context2, async);
+        }
+
+        ClearLog();
+
+        entity1.Name = "Updated";
+
+        var exception = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await SaveChanges(context1, async));
+        var entry = exception.Entries.Single();
+        Assert.Same(entity1, entry.Entity);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task User_managed_concurrency_token(bool async)
+    {
+        await using var context1 = CreateContext();
+
+        var entity1 = new EntityWithAdditionalProperty
+        {
+            Name = "Initial",
+            AdditionalProperty = 8 // The concurrency token
+        };
+
+        context1.WithUserManagedConcurrencyToken.Add(entity1);
+        await context1.SaveChangesAsync();
+
+        entity1.Name = "Updated";
+        entity1.AdditionalProperty = 9;
+
+        await using (var context2 = CreateContext())
+        {
+            var entity2 = await context2.WithUserManagedConcurrencyToken.SingleAsync(w => w.Name == "Initial");
+            entity2.Name = "Preempted";
+            entity2.AdditionalProperty = 999;
+            await SaveChanges(context2, async);
+        }
+
+        ClearLog();
+
+        var exception = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await SaveChanges(context1, async));
+        Assert.Same(entity1, Assert.Single(exception.Entries).Entity);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Original_and_current_value_on_non_concurrency_token(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new Entity
+        {
+            Name = "Initial",
+        };
+
+        context.WithOriginalAndCurrentValueOnNonConcurrencyToken.Add(entity);
+        await context.SaveChangesAsync();
+
+        entity.Name = "Updated";
+
+        ClearLog();
+
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal(
+                "Updated",
+                (await context.WithOriginalAndCurrentValueOnNonConcurrencyToken.SingleAsync(w => w.Id == entity.Id)).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Input_output_parameter_on_non_concurrency_token(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new Entity { Name = "Initial", };
+        context.WithInputOutputParameterOnNonConcurrencyToken.Add(entity);
+        await context.SaveChangesAsync();
+
+        entity.Name = "Updated";
+
+        ClearLog();
+
+        await SaveChanges(context, async);
+
+        // TODO: This (and below) should be UpdatedWithSuffix. Reference issue tracking this.
+        Assert.Equal("Updated", entity.Name);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal(
+                "Updated", (await context.WithInputOutputParameterOnNonConcurrencyToken.SingleAsync(w => w.Id == entity.Id)).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Update_with_output_parameter_and_result_column_and_return_value(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity1 = new EntityWithTwoAdditionalProperties { Name = "Foo" };
+        context.WithOutputParameterAndResultColumnAndResultValue.Add(entity1);
+        await SaveChanges(context, async);
+
+        // Clear and attach a new instance to make sure we properly receive and populate the computed properties when updating below
+        context.ChangeTracker.Clear();
+
+        var entity2 = new EntityWithTwoAdditionalProperties { Id = entity1.Id };
+        context.WithOutputParameterAndResultColumnAndResultValue.Attach(entity2);
+        entity2.Name = "Updated";
+
+        ClearLog();
+
+        await SaveChanges(context, async);
+
+        Assert.Equal(8, entity2.AdditionalProperty1);
+        Assert.Equal(9, entity2.AdditionalProperty2);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Updated", context.WithOutputParameterAndResultColumnAndResultValue.Single(b => b.Id == entity1.Id).Name);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Tph(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity1 = new TphChild { Name = "Child", ChildProperty = 8 };
+        context.TphChild.Add(entity1);
+        await SaveChanges(context, async);
+
+        context.ChangeTracker.Clear();
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            var entity2 = context.TphChild.Single(b => b.Id == entity1.Id);
+
+            Assert.Equal("Child", entity2.Name);
+            Assert.Equal(8, entity2.ChildProperty);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Tpt(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity1 = new TptChild { Name = "Child", ChildProperty = 8 };
+        context.TptChild.Add(entity1);
+        await SaveChanges(context, async);
+
+        context.ChangeTracker.Clear();
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            var entity2 = context.TptChild.Single(b => b.Id == entity1.Id);
+
+            Assert.Equal("Child", entity2.Name);
+            Assert.Equal(8, entity2.ChildProperty);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Tpt_mixed_sproc_and_non_sproc(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity1 = new TptMixedChild { Name = "Child", ChildProperty = 8 };
+        context.TptMixedChild.Add(entity1);
+        await SaveChanges(context, async);
+
+        context.ChangeTracker.Clear();
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            var entity2 = context.TptMixedChild.Single(b => b.Id == entity1.Id);
+
+            Assert.Equal("Child", entity2.Name);
+            Assert.Equal(8, entity2.ChildProperty);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Tpc(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity1 = new TpcChild { Name = "Child", ChildProperty = 8 };
+        context.TpcChild.Add(entity1);
+        await SaveChanges(context, async);
+
+        context.ChangeTracker.Clear();
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            var entity2 = context.TpcChild.Single(b => b.Id == entity1.Id);
+
+            Assert.Equal("Child", entity2.Name);
+            Assert.Equal(8, entity2.ChildProperty);
+        }
+    }
+
+    private async Task SaveChanges(StoredProcedureUpdateContext context, bool async)
+    {
+        if (async)
+        {
+            await context.SaveChangesAsync();
+        }
+        else
+        {
+            context.SaveChanges();
+        }
+    }
+
+    protected StoredProcedureUpdateContext CreateContext()
+        => Fixture.CreateContext();
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { false }, new object[] { true } };
+
+    protected virtual void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    protected virtual void ClearLog()
+        => Fixture.TestSqlLoggerFactory.Clear();
+
+    protected TFixture Fixture { get; }
+}

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -1084,7 +1084,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Assert.Equal(
                 new[] { nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate) },
                 ordersInsertSproc.Parameters.Select(m => m.Name));
-            
+
             Assert.Equal(
                 new[] { 0, 1, 2 },
                 ordersInsertSproc.Parameters.Select(m => m.Position));
@@ -1139,7 +1139,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 RelationalStrings.TableNotMappedEntityType(nameof(SpecialCustomer), ordersInsertSproc.Name),
                 Assert.Throws<InvalidOperationException>(
                     () => ordersInsertSproc.IsOptional(specialCustomerType)).Message);
-            
+
             var tableMapping = orderInsertMapping.TableMapping;
             if (mappedToTables)
             {
@@ -1289,7 +1289,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     specialCustomerType.GetInsertStoredProcedureMappings().Single(m => m.IncludesDerivedTypes).StoreStoredProcedure.Name);
                 Assert.Null(baseInsertSproc.Schema);
                 Assert.Equal(
-                    new[] { nameof(AbstractBase), nameof(Customer), nameof(ExtraSpecialCustomer), nameof(SpecialCustomer) },
+                    new[] { nameof(AbstractBase), nameof(AbstractCustomer), nameof(Customer), nameof(ExtraSpecialCustomer), nameof(SpecialCustomer) },
                     baseInsertSproc.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
 
                 Assert.Equal(
@@ -1321,7 +1321,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
                 Assert.Null(baseUpdateSproc.Schema);
                 Assert.Equal(
-                    new[] { nameof(AbstractBase), nameof(Customer), nameof(ExtraSpecialCustomer), nameof(SpecialCustomer) },
+                    new[] { nameof(AbstractBase), nameof(AbstractCustomer), nameof(Customer), nameof(ExtraSpecialCustomer), nameof(SpecialCustomer) },
                     baseUpdateSproc.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
 
                 Assert.Equal(
@@ -1353,7 +1353,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
                 Assert.Null(baseDeleteSproc.Schema);
                 Assert.Equal(
-                    new[] { nameof(AbstractBase), nameof(Customer), nameof(ExtraSpecialCustomer), nameof(SpecialCustomer) },
+                    new[] { nameof(AbstractBase), nameof(AbstractCustomer), nameof(Customer), nameof(ExtraSpecialCustomer), nameof(SpecialCustomer) },
                     baseDeleteSproc.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
 
                 Assert.Equal(
@@ -1421,8 +1421,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 Assert.Same(idPropertyInsertParameter.StoredProcedure, idPropertyInsertParameter.Table);
                 Assert.Same(idPropertyInsertParameterMapping, idPropertyInsertParameter.FindParameterMapping(abstractBaseType));
 
-                Assert.Equal(3, idProperty.GetInsertStoredProcedureResultColumnMappings().Count());
-                Assert.Equal(7, idProperty.GetInsertStoredProcedureParameterMappings().Count());
+                Assert.Equal(2, idProperty.GetInsertStoredProcedureResultColumnMappings().Count());
+                Assert.Equal(10, idProperty.GetInsertStoredProcedureParameterMappings().Count());
                 Assert.Equal(
                     new[]
                     {
@@ -1451,7 +1451,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 Assert.Same(idPropertyUpdateParameterMapping, idPropertyUpdateParameter.FindParameterMapping(abstractBaseType));
 
                 Assert.Empty(idProperty.GetUpdateStoredProcedureResultColumnMappings());
-                Assert.Equal(10, idProperty.GetUpdateStoredProcedureParameterMappings().Count());
+                Assert.Equal(12, idProperty.GetUpdateStoredProcedureParameterMappings().Count());
                 Assert.Equal(
                     new[]
                     {
@@ -1479,7 +1479,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 Assert.Same(idPropertyDeleteParameter.StoredProcedure, idPropertyDeleteParameter.Table);
                 Assert.Same(idPropertyDeleteParameterMapping, idPropertyDeleteParameter.FindParameterMapping(abstractBaseType));
 
-                Assert.Equal(10, idProperty.GetDeleteStoredProcedureParameterMappings().Count());
+                Assert.Equal(12, idProperty.GetDeleteStoredProcedureParameterMappings().Count());
                 Assert.Equal(
                     new[]
                     {
@@ -1491,7 +1491,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     },
                     idProperty.GetMappedStoreObjects(StoreObjectType.DeleteStoredProcedure));
             }
-            else
+            else // Non-TPT
             {
                 var specialCustomerInsertMapping = specialCustomerType.GetInsertStoredProcedureMappings().Single();
                 Assert.Null(specialCustomerInsertMapping.IsSplitEntityTypePrincipal);
@@ -1721,7 +1721,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                         new[] { StoreObjectIdentifier.DeleteStoredProcedure(customerDeleteSproc.Name, customerDeleteSproc.Schema) },
                         idProperty.GetMappedStoreObjects(StoreObjectType.DeleteStoredProcedure));
                 }
-                else
+                else // TPC
                 {
                     Assert.Null(abstractBaseType.GetInsertStoredProcedure());
                     Assert.Null(abstractBaseType.GetUpdateStoredProcedure());
@@ -2012,11 +2012,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                             {
                                 cb.InsertUsingStoredProcedure(s => s.HasParameter("SpecialtyAk"));
                             }
-                            else
-                            {
-                                cb.InsertUsingStoredProcedure(
-                                    s => s.HasParameter(c => c.Id, p => p.IsOutput()));
-                            }
                         }
                     }
                 });
@@ -2196,7 +2191,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                             else if (mapping == Mapping.TPT)
                             {
                                 cb
-                                    .InsertUsingStoredProcedure(s => s.HasResultColumn(b => b.Id))
+                                    .InsertUsingStoredProcedure(s => s.HasParameter(b => b.Id))
                                     .UpdateUsingStoredProcedure(s => s.HasParameter(b => b.Id))
                                     .DeleteUsingStoredProcedure(s => s.HasParameter(b => b.Id));
                             }

--- a/test/EFCore.Relational.Tests/ModelBuilding/RelationalModelBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/ModelBuilding/RelationalModelBuilderTest.cs
@@ -236,7 +236,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
         public virtual void Duplicate_sproc_rows_affected_result_column_throws()
         {
             var modelBuilder = CreateModelBuilder();
-            
+
             var sproc = modelBuilder.Entity<BookLabel>()
                 .UpdateUsingStoredProcedure(
                     s => s.HasRowsAffectedResultColumn()).Metadata.GetUpdateStoredProcedure()!;
@@ -266,7 +266,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
         public virtual void Duplicate_sproc_rows_affected_parameter_throws()
         {
             var modelBuilder = CreateModelBuilder();
-            
+
             var sproc = modelBuilder.Entity<BookLabel>()
                 .UpdateUsingStoredProcedure(
                     s => s.HasRowsAffectedParameter()).Metadata.GetUpdateStoredProcedure()!;
@@ -394,7 +394,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             modelBuilder.Entity<BookLabel>()
                 .Ignore(s => s.SpecialBookLabel)
                 .InsertUsingStoredProcedure(
-                    s => s.SuppressTransactions().HasAnnotation("foo", "bar1")
+                    s => s.HasAnnotation("foo", "bar1")
                         .HasParameter(b => b.BookId)
                         .HasParameter("Discriminator")
                         .HasResultColumn(
@@ -407,7 +407,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
                         .HasResultColumn("RowVersion")
                         .HasRowsAffectedReturnValue())
                 .UpdateUsingStoredProcedure(
-                    s => s.SuppressTransactions().HasAnnotation("foo", "bar2")
+                    s => s.HasAnnotation("foo", "bar2")
                         .HasParameter(
                             b => b.Id, p =>
                             {
@@ -420,7 +420,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
                         .HasOriginalValueParameter("RowVersion", p => p.HasName("OriginalRowVersion"))
                         .HasParameter("RowVersion", p => p.IsOutput()))
                 .DeleteUsingStoredProcedure(
-                    s => s.SuppressTransactions().HasAnnotation("foo", "bar3")
+                    s => s.HasAnnotation("foo", "bar3")
                         .HasParameter(b => b.Id, p => p.HasName("DeleteId"))
                         .HasRowsAffectedResultColumn()
                         .HasOriginalValueParameter("RowVersion"));
@@ -446,7 +446,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Assert.Null(insertSproc.FindParameter("Id"));
             Assert.Null(insertSproc.FindResultColumn("Discriminator"));
             Assert.False(insertSproc.FindResultColumn("Id")!.ForRowsAffected);
-            Assert.True(insertSproc.AreTransactionsSuppressed);
             Assert.True(insertSproc.IsRowsAffectedReturned);
             Assert.Equal("bar1", insertSproc["foo"]);
             Assert.Same(bookLabel, insertSproc.EntityType);
@@ -456,7 +455,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Assert.Equal("dbo", updateSproc.Schema);
             Assert.Equal(new[] { "Id", "BookId", null, "RowVersion", "RowVersion" }, updateSproc.Parameters.Select(p => p.PropertyName));
             Assert.Empty(updateSproc.ResultColumns);
-            Assert.True(updateSproc.AreTransactionsSuppressed);
             Assert.Equal("bar2", updateSproc["foo"]);
             Assert.Same(bookLabel, updateSproc.EntityType);
             Assert.False(updateSproc.IsRowsAffectedReturned);
@@ -484,7 +482,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Assert.Equal("mySchema", deleteSproc.Schema);
             Assert.Equal(new[] { "Id", "RowVersion" }, deleteSproc.Parameters.Select(p => p.PropertyName));
             Assert.Equal(new[] { "RowsAffected" }, deleteSproc.ResultColumns.Select(p => p.Name));
-            Assert.True(deleteSproc.AreTransactionsSuppressed);
             Assert.Equal("bar3", deleteSproc["foo"]);
             Assert.Same(bookLabel, deleteSproc.EntityType);
             Assert.False(deleteSproc.IsRowsAffectedReturned);
@@ -719,11 +716,11 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
                     lb.Property(l => l.Id).ValueGeneratedOnUpdate();
 
                     lb.InsertUsingStoredProcedure(
-                            s => s.SuppressTransactions().HasAnnotation("foo", "bar1")
+                            s => s.HasAnnotation("foo", "bar1")
                                 .HasParameter(b => b.Id)
                                 .HasParameter(b => b.BookId, p => p.HasName("InsertId")))
                         .UpdateUsingStoredProcedure(
-                            s => s.SuppressTransactions().HasAnnotation("foo", "bar2")
+                            s => s.HasAnnotation("foo", "bar2")
                                 .HasParameter(b => b.Id)
                                 .HasParameter(b => b.BookId, p =>
                                 {
@@ -738,8 +735,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
                                         Assert.IsAssignableFrom<PropertyBuilder>(nonGenericBuilder.Instance.GetInfrastructure());
                                     }))
                         .DeleteUsingStoredProcedure(
-                            s => s.SuppressTransactions().HasAnnotation("foo", "bar3")
-                                .HasParameter(b => b.BookId, p => p.HasName("DeleteId")));
+                            s => s.HasAnnotation("foo", "bar3").HasParameter(b => b.BookId, p => p.HasName("DeleteId")));
                 });
             modelBuilder.Entity<Book>()
                 .OwnsOne(b => b.AlternateLabel);
@@ -767,7 +763,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Assert.Null(insertSproc.Schema);
             Assert.Equal(new[] { "Id", "BookId" }, insertSproc.Parameters.Select(p => p.PropertyName));
             Assert.Empty(insertSproc.ResultColumns);
-            Assert.True(insertSproc.AreTransactionsSuppressed);
             Assert.Equal("bar1", insertSproc["foo"]);
             Assert.Same(bookOwnership1.DeclaringEntityType, insertSproc.EntityType);
 
@@ -776,7 +771,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Assert.Equal("dbo", updateSproc.Schema);
             Assert.Equal(new[] { "Id", "BookId" }, updateSproc.Parameters.Select(p => p.PropertyName));
             Assert.Equal(new[] { "Id" }, updateSproc.ResultColumns.Select(p => p.Name));
-            Assert.True(updateSproc.AreTransactionsSuppressed);
             Assert.Equal("bar2", updateSproc["foo"]);
             Assert.Same(bookOwnership1.DeclaringEntityType, updateSproc.EntityType);
 
@@ -785,7 +779,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Assert.Null(deleteSproc.Schema);
             Assert.Equal(new[] { "BookId" }, deleteSproc.Parameters.Select(p => p.PropertyName));
             Assert.Empty(deleteSproc.ResultColumns);
-            Assert.True(deleteSproc.AreTransactionsSuppressed);
             Assert.Equal("bar3", deleteSproc["foo"]);
             Assert.Same(bookOwnership1.DeclaringEntityType, deleteSproc.EntityType);
 
@@ -800,7 +793,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Assert.Equal(
                 "BookId",
                 bookId.GetColumnName(StoreObjectIdentifier.Create(bookOwnership1.DeclaringEntityType, StoreObjectType.DeleteStoredProcedure)!.Value));
-            
+
             Assert.Null(bookOwnership2.DeclaringEntityType.GetInsertStoredProcedure());
             Assert.Null(bookOwnership2.DeclaringEntityType.GetUpdateStoredProcedure());
             Assert.Null(bookOwnership2.DeclaringEntityType.GetDeleteStoredProcedure());
@@ -918,7 +911,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public override TestCheckConstraintBuilder HasCheckConstraint(string name, string? sql)
             => new(TableBuilder.HasCheckConstraint(name, sql));
-        
+
         public override TestTriggerBuilder HasTrigger(string name)
             => new NonGenericTestTriggerBuilder(TableBuilder.HasTrigger(name));
 
@@ -976,11 +969,11 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
         public abstract string? Schema { get; }
 
         public abstract TestOwnedNavigationTableBuilder<TOwnerEntity, TDependentEntity> ExcludeFromMigrations(bool excluded = true);
-        
+
         public abstract TestCheckConstraintBuilder HasCheckConstraint(
             string name,
             string? sql);
-        
+
         public abstract TestColumnBuilder<TProperty> Property<TProperty>(string propertyName);
 
         public abstract TestColumnBuilder<TProperty> Property<TProperty>(Expression<Func<TDependentEntity, TProperty>> propertyExpression);
@@ -1253,7 +1246,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public override TestColumnBuilder<TProperty> Property<TProperty>(Expression<Func<TDependentEntity, TProperty>> propertyExpression)
             => new GenericTestColumnBuilder<TProperty>(TableBuilder.Property<TProperty>(propertyExpression.GetPropertyAccess().Name));
-        
+
         public override TestOwnedNavigationSplitTableBuilder<TOwnerEntity, TDependentEntity> HasAnnotation(string annotation, object? value)
             => Wrap(TableBuilder.HasAnnotation(annotation, value));
     }
@@ -1261,7 +1254,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
     public abstract class TestColumnBuilder<TProperty>
     {
         public abstract TestColumnBuilder<TProperty> HasColumnName(string? name);
-        
+
         public abstract TestColumnBuilder<TProperty> HasAnnotation(
             string annotation,
             object? value);
@@ -1284,7 +1277,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public override TestColumnBuilder<TProperty> HasColumnName(string? name)
             => Wrap(ColumnBuilder.HasColumnName(name));
-        
+
         public override TestColumnBuilder<TProperty> HasAnnotation(
             string annotation,
             object? value)
@@ -1559,7 +1552,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public abstract TestViewColumnBuilder<TProperty> Property<TProperty>(
             Expression<Func<TDependentEntity, TProperty>> propertyExpression);
-        
+
         public abstract TestOwnedNavigationSplitViewBuilder<TOwnerEntity, TDependentEntity> HasAnnotation(
             string annotation,
             object? value);
@@ -1723,7 +1716,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Expression<Func<TDerivedEntity, TProperty>> propertyExpression,
             Action<TestStoredProcedureParameterBuilder> buildAction)
             where TDerivedEntity : class, TEntity;
-        
+
         public abstract TestStoredProcedureBuilder<TEntity> HasOriginalValueParameter(
             string propertyName);
 
@@ -1782,8 +1775,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public abstract TestStoredProcedureBuilder<TEntity> HasRowsAffectedReturnValue(bool rowsAffectedReturned = true);
 
-        public abstract TestStoredProcedureBuilder<TEntity> SuppressTransactions(bool suppress = true);
-
         public abstract TestStoredProcedureBuilder<TEntity> HasAnnotation(string annotation, object? value);
     }
 
@@ -1830,7 +1821,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Expression<Func<TDerivedEntity, TProperty>> propertyExpression,
             Action<TestStoredProcedureParameterBuilder> buildAction)
             => Wrap(StoredProcedureBuilder.HasParameter(propertyExpression, s => buildAction(new(s))));
-        
+
         public override TestStoredProcedureBuilder<TEntity> HasOriginalValueParameter(
             string propertyName)
             => Wrap(StoredProcedureBuilder.HasOriginalValueParameter(propertyName));
@@ -1901,9 +1892,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public override TestStoredProcedureBuilder<TEntity> HasRowsAffectedReturnValue(bool rowsAffectedReturned)
             => Wrap(StoredProcedureBuilder.HasRowsAffectedReturnValue(rowsAffectedReturned));
-
-        public override TestStoredProcedureBuilder<TEntity> SuppressTransactions(bool suppress)
-            => Wrap(StoredProcedureBuilder.SuppressTransactions(suppress));
 
         public override TestStoredProcedureBuilder<TEntity> HasAnnotation(string annotation, object? value)
             => Wrap(StoredProcedureBuilder.HasAnnotation(annotation, value));
@@ -2036,9 +2024,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
         public override TestStoredProcedureBuilder<TEntity> HasRowsAffectedReturnValue(bool rowsAffectedReturned)
             => Wrap(StoredProcedureBuilder.HasRowsAffectedReturnValue(rowsAffectedReturned));
 
-        public override TestStoredProcedureBuilder<TEntity> SuppressTransactions(bool suppress)
-            => Wrap(StoredProcedureBuilder.SuppressTransactions(suppress));
-
         public override TestStoredProcedureBuilder<TEntity> HasAnnotation(string annotation, object? value)
             => Wrap(StoredProcedureBuilder.HasAnnotation(annotation, value));
     }
@@ -2060,7 +2045,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
         public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasParameter<TProperty>(
             Expression<Func<TDependentEntity, TProperty>> propertyExpression,
             Action<TestStoredProcedureParameterBuilder> buildAction);
-        
+
         public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasOriginalValueParameter(
             string propertyName);
 
@@ -2074,7 +2059,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
         public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasOriginalValueParameter<TProperty>(
             Expression<Func<TDependentEntity, TProperty>> propertyExpression,
             Action<TestStoredProcedureParameterBuilder> buildAction);
-        
+
         public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedParameter();
 
         public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedParameter(
@@ -2098,12 +2083,9 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedResultColumn(
             Action<TestStoredProcedureResultColumnBuilder> buildAction);
-        
+
         public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity>
             HasRowsAffectedReturnValue(bool rowsAffectedReturned = true);
-        
-        public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity>
-            SuppressTransactions(bool suppress = true);
 
         public abstract TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasAnnotation(
             string annotation,
@@ -2149,7 +2131,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Expression<Func<TDependentEntity, TProperty>> propertyExpression,
             Action<TestStoredProcedureParameterBuilder> buildAction)
             => Wrap(StoredProcedureBuilder.HasParameter<TProperty>(propertyExpression, s => buildAction(new(s))));
-        
+
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasOriginalValueParameter(
             string propertyName)
             => Wrap(StoredProcedureBuilder.HasOriginalValueParameter(propertyName));
@@ -2167,14 +2149,14 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Expression<Func<TDependentEntity, TProperty>> propertyExpression,
             Action<TestStoredProcedureParameterBuilder> buildAction)
             => Wrap(StoredProcedureBuilder.HasOriginalValueParameter<TProperty>(propertyExpression, s => buildAction(new(s))));
-        
+
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedParameter()
             => Wrap(StoredProcedureBuilder.HasRowsAffectedParameter());
 
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedParameter(
             Action<TestStoredProcedureParameterBuilder> buildAction)
             => Wrap(StoredProcedureBuilder.HasRowsAffectedParameter(s => buildAction(new(s))));
-        
+
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasResultColumn(
             string propertyName)
             => Wrap(StoredProcedureBuilder.HasResultColumn(propertyName));
@@ -2192,7 +2174,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             Expression<Func<TDependentEntity, TProperty>> propertyExpression,
             Action<TestStoredProcedureResultColumnBuilder> buildAction)
             => Wrap(StoredProcedureBuilder.HasResultColumn(propertyExpression, s => buildAction(new(s))));
-        
+
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedResultColumn()
             => Wrap(StoredProcedureBuilder.HasRowsAffectedResultColumn());
 
@@ -2202,9 +2184,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedReturnValue(bool rowsAffectedReturned)
             => Wrap(StoredProcedureBuilder.HasRowsAffectedReturnValue(rowsAffectedReturned));
-
-        public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> SuppressTransactions(bool suppress)
-            => Wrap(StoredProcedureBuilder.SuppressTransactions(suppress));
 
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasAnnotation(
             string annotation,
@@ -2251,7 +2230,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             => Wrap(
                 StoredProcedureBuilder.HasParameter(
                     propertyExpression.GetMemberAccess().Name, s => buildAction(new(s))));
-        
+
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasOriginalValueParameter(
             string propertyName)
             => Wrap(StoredProcedureBuilder.HasOriginalValueParameter(propertyName));
@@ -2271,7 +2250,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             => Wrap(
                 StoredProcedureBuilder.HasOriginalValueParameter(
                     propertyExpression.GetMemberAccess().Name, s => buildAction(new(s))));
-        
+
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedParameter()
             => Wrap(StoredProcedureBuilder.HasRowsAffectedParameter());
 
@@ -2298,7 +2277,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
             => Wrap(
                 StoredProcedureBuilder.HasResultColumn(
                     propertyExpression.GetMemberAccess().Name, s => buildAction(new(s))));
-        
+
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedResultColumn()
             => Wrap(StoredProcedureBuilder.HasRowsAffectedResultColumn());
 
@@ -2308,9 +2287,6 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasRowsAffectedReturnValue(bool rowsAffectedReturned)
             => Wrap(StoredProcedureBuilder.HasRowsAffectedReturnValue(rowsAffectedReturned));
-
-        public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> SuppressTransactions(bool suppress)
-            => Wrap(StoredProcedureBuilder.SuppressTransactions(suppress));
 
         public override TestOwnedNavigationStoredProcedureBuilder<TOwnerEntity, TDependentEntity> HasAnnotation(
             string annotation,
@@ -2341,7 +2317,7 @@ public partial class RelationalModelBuilderTest : ModelBuilderTest
 
         public virtual TestStoredProcedureParameterBuilder IsInputOutput()
             => Wrap(StoredProcedureParameterBuilder.IsInputOutput());
-        
+
         public virtual TestStoredProcedureParameterBuilder HasAnnotation(
             string annotation,
             object? value)

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -322,6 +322,8 @@ public abstract class RelationalTypeMappingTest
         Assert.True(parameter.IsNullable);
     }
 
+    // TODO: Add tests for parameter directions
+
     [ConditionalFact]
     public void Can_create_required_string_parameter()
     {

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerAdventureWorksTestStoreFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerAdventureWorksTestStoreFactory.cs
@@ -12,7 +12,7 @@ public class SqlServerAdventureWorksTestStoreFactory : SqlServerTestStoreFactory
     }
 
     public override TestStore GetOrCreate(string storeName)
-        => SqlServerTestStore.GetOrCreate(
+        => SqlServerTestStore.GetOrCreateWithScriptPath(
             "adventureworks",
             Path.Combine("SqlAzure", "adventureworks.sql"));
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerNorthwindTestStoreFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerNorthwindTestStoreFactory.cs
@@ -14,5 +14,5 @@ public class SqlServerNorthwindTestStoreFactory : SqlServerTestStoreFactory
     }
 
     public override TestStore GetOrCreate(string storeName)
-        => SqlServerTestStore.GetOrCreate(storeName, "Northwind.sql");
+        => SqlServerTestStore.GetOrCreateWithScriptPath(storeName, "Northwind.sql");
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -26,7 +26,10 @@ public class SqlServerTestStore : RelationalTestStore
     public static SqlServerTestStore GetOrCreateInitialized(string name)
         => new SqlServerTestStore(name).InitializeSqlServer(null, (Func<DbContext>)null, null);
 
-    public static SqlServerTestStore GetOrCreate(string name, string scriptPath, bool? multipleActiveResultSets = null)
+    public static SqlServerTestStore GetOrCreateWithInitScript(string name, string initScript)
+        => new(name, initScript: initScript);
+
+    public static SqlServerTestStore GetOrCreateWithScriptPath(string name, string scriptPath, bool? multipleActiveResultSets = null)
         => new(name, scriptPath: scriptPath, multipleActiveResultSets: multipleActiveResultSets);
 
     public static SqlServerTestStore Create(string name, bool useFileName = false)
@@ -37,12 +40,14 @@ public class SqlServerTestStore : RelationalTestStore
             .InitializeSqlServer(null, (Func<DbContext>)null, null);
 
     private readonly string _fileName;
+    private readonly string _initScript;
     private readonly string _scriptPath;
 
     private SqlServerTestStore(
         string name,
         bool useFileName = false,
         bool? multipleActiveResultSets = null,
+        string initScript = null,
         string scriptPath = null,
         bool shared = true)
         : base(name, shared)
@@ -50,6 +55,11 @@ public class SqlServerTestStore : RelationalTestStore
         if (useFileName)
         {
             _fileName = Path.Combine(CurrentDirectory, name + ".mdf");
+        }
+
+        if (initScript != null)
+        {
+            _initScript = initScript;
         }
 
         if (scriptPath != null)
@@ -79,12 +89,18 @@ public class SqlServerTestStore : RelationalTestStore
         {
             if (_scriptPath != null)
             {
-                ExecuteScript(_scriptPath);
+                ExecuteScript(File.ReadAllText(_scriptPath));
             }
             else
             {
                 using var context = createContext();
                 context.Database.EnsureCreatedResiliently();
+
+                if (_initScript != null)
+                {
+                    ExecuteScript(_initScript);
+                }
+
                 seed?.Invoke(context);
             }
         }
@@ -102,8 +118,7 @@ public class SqlServerTestStore : RelationalTestStore
             if (ExecuteScalar<int>(master, $"SELECT COUNT(*) FROM sys.databases WHERE name = N'{Name}'") > 0)
             {
                 // Only reseed scripted databases during CI runs
-                if (_scriptPath != null
-                    && !TestEnvironment.IsCI)
+                if (_scriptPath != null && !TestEnvironment.IsCI)
                 {
                     return false;
                 }
@@ -134,9 +149,8 @@ public class SqlServerTestStore : RelationalTestStore
     public override void Clean(DbContext context)
         => context.Database.EnsureClean();
 
-    public void ExecuteScript(string scriptPath)
+    public void ExecuteScript(string script)
     {
-        var script = File.ReadAllText(scriptPath);
         Execute(
             Connection, command =>
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Update/SqlServerUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/SqlServerUpdateSqlGeneratorTest.cs
@@ -92,7 +92,7 @@ VALUES (i.[Name], i.[Quacks], i.[ConcurrencyToken])
 OUTPUT INSERTED.[Id], INSERTED.[Computed], i._Position;
 ",
             stringBuilder.ToString());
-        Assert.Equal(ResultSetMapping.NotLastInResultSet, grouping);
+        Assert.Equal(ResultSetMapping.NotLastInResultSet | ResultSetMapping.IsPositionalResultMappingEnabled, grouping);
     }
 
     [ConditionalFact]
@@ -110,7 +110,7 @@ VALUES (@p0, @p1, @p2, @p3),
 (@p0, @p1, @p2, @p3);
 ",
             stringBuilder.ToString());
-        Assert.Equal(ResultSetMapping.NoResultSet, grouping);
+        Assert.Equal(ResultSetMapping.NoResults, grouping);
     }
 
     [ConditionalFact]
@@ -151,7 +151,7 @@ VALUES (DEFAULT),
 (DEFAULT);
 ";
         AssertBaseline(expectedText, stringBuilder.ToString());
-        Assert.Equal(ResultSetMapping.NoResultSet, grouping);
+        Assert.Equal(ResultSetMapping.NoResults, grouping);
     }
 
     protected override void AppendUpdateOperation_for_computed_property_verification(StringBuilder stringBuilder)

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentitySqlServerTest.cs
@@ -389,51 +389,12 @@ VALUES (@p1);");
         }
     }
 
-    public class StoreValueGenerationIdentitySqlServerFixture : StoreValueGenerationFixtureBase
+    public class StoreValueGenerationIdentitySqlServerFixture : StoreValueGenerationSqlServerFixtureBase
     {
-        private string? _identityResetCommand;
-
         protected override string StoreName
             => "StoreValueGenerationIdentityTest";
 
         protected override ITestStoreFactory TestStoreFactory
             => SqlServerTestStoreFactory.Instance;
-
-        public override void Reseed()
-        {
-            using var context = CreateContext();
-            Clean(context);
-            Seed(context);
-        }
-
-        protected override void Clean(DbContext context)
-        {
-            base.Clean(context);
-
-            // Reset the IDENTITY values since we assert on them
-            context.Database.ExecuteSqlRaw(GetIdentityResetCommand());
-        }
-
-        private string GetIdentityResetCommand()
-        {
-            if (_identityResetCommand is not null)
-            {
-                return _identityResetCommand;
-            }
-
-            var context = CreateContext();
-            var builder = new StringBuilder();
-
-            var tablesWithIdentity = context.Model.GetEntityTypes()
-                .Where(e => e.GetProperties().Any(p => p.GetValueGenerationStrategy() == SqlServerValueGenerationStrategy.IdentityColumn))
-                .Select(e => e.GetTableName());
-
-            foreach (var table in tablesWithIdentity)
-            {
-                builder.AppendLine($"DBCC CHECKIDENT ('{table}', RESEED, 0);");
-            }
-
-            return _identityResetCommand = builder.ToString();
-        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentityTriggerSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationIdentityTriggerSqlServerTest.cs
@@ -435,49 +435,10 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();");
 
     public class StoreValueGenerationIdentityWithTriggerSqlServerFixture : StoreValueGenerationTriggerSqlServerFixture
     {
-        private string? _identityResetCommand;
-
         protected override string StoreName
             => "StoreValueGenerationIdentityWithTriggerTest";
 
         protected override ITestStoreFactory TestStoreFactory
             => SqlServerTestStoreFactory.Instance;
-
-        public override void Reseed()
-        {
-            using var context = CreateContext();
-            Clean(context);
-            Seed(context);
-        }
-
-        protected override void Clean(DbContext context)
-        {
-            base.Clean(context);
-
-            // Reset the IDENTITY values since we assert on them
-            context.Database.ExecuteSqlRaw(GetIdentityResetCommand());
-        }
-
-        private string GetIdentityResetCommand()
-        {
-            if (_identityResetCommand is not null)
-            {
-                return _identityResetCommand;
-            }
-
-            var context = CreateContext();
-            var builder = new StringBuilder();
-
-            var tablesWithIdentity = context.Model.GetEntityTypes()
-                .Where(e => e.GetProperties().Any(p => p.GetValueGenerationStrategy() == SqlServerValueGenerationStrategy.IdentityColumn))
-                .Select(e => e.GetTableName());
-
-            foreach (var table in tablesWithIdentity)
-            {
-                builder.AppendLine($"DBCC CHECKIDENT ('{table}', RESEED, 0);");
-            }
-
-            return _identityResetCommand = builder.ToString();
-        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSequenceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSequenceSqlServerTest.cs
@@ -369,7 +369,7 @@ WHERE [Id] = @p1;");
         }
     }
 
-    public class StoreValueGenerationSequenceSqlServerFixture : StoreValueGenerationFixtureBase
+    public class StoreValueGenerationSequenceSqlServerFixture : StoreValueGenerationSqlServerFixtureBase
     {
         protected override string StoreName
             => "StoreValueGenerationSequenceTest";
@@ -396,21 +396,6 @@ WHERE [Id] = @p1;");
                     .Property(w => w.Id)
                     .HasDefaultValueSql("NEXT VALUE FOR [Ids]");
             }
-        }
-
-        public override void Reseed()
-        {
-            using var context = CreateContext();
-            Clean(context);
-            Seed(context);
-        }
-
-        protected override void Clean(DbContext context)
-        {
-            base.Clean(context);
-
-            // Reset the sequence values since we assert on them
-            context.Database.ExecuteSqlRaw("ALTER SEQUENCE [Ids] RESTART WITH 1");
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSequenceTriggerSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSequenceTriggerSqlServerTest.cs
@@ -473,20 +473,5 @@ ORDER BY [i].[_Position];");
                     .HasDefaultValueSql("NEXT VALUE FOR [Ids]");
             }
         }
-
-        public override void Reseed()
-        {
-            using var context = CreateContext();
-            Clean(context);
-            Seed(context);
-        }
-
-        protected override void Clean(DbContext context)
-        {
-            base.Clean(context);
-
-            // Reset the sequence values since we assert on them
-            context.Database.ExecuteSqlRaw("ALTER SEQUENCE [Ids] RESTART WITH 1");
-        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSqlServerFixtureBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationSqlServerFixtureBase.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Update;
+
+#nullable enable
+
+public abstract class StoreValueGenerationSqlServerFixtureBase : StoreValueGenerationFixtureBase
+{
+    private string? _cleanDataSql;
+
+    public override void CleanData()
+    {
+        using var context = CreateContext();
+        context.Database.ExecuteSqlRaw(_cleanDataSql ??= GetCleanDataSql());
+    }
+
+    private string GetCleanDataSql()
+    {
+        var context = CreateContext();
+        var builder = new StringBuilder();
+
+        var helper = context.GetService<ISqlGenerationHelper>();
+        var tables = context.Model.GetEntityTypes()
+            .SelectMany(e => e.GetTableMappings().Select(m => helper.DelimitIdentifier(m.Table.Name, m.Table.Schema)));
+
+        foreach (var table in tables)
+        {
+            builder.AppendLine($"TRUNCATE TABLE {table};");
+        }
+
+        foreach (var sequence in context.Model.GetSequences().Select(s => helper.DelimitIdentifier(s.Name, s.Schema)))
+        {
+            builder.AppendLine($"ALTER SEQUENCE {sequence} RESTART WITH 1;");
+        }
+
+        return builder.ToString();
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationTriggerSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoreValueGenerationTriggerSqlServerFixture.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.StoreValueGenerationModel;
 
 namespace Microsoft.EntityFrameworkCore.Update;
 
-public abstract class StoreValueGenerationTriggerSqlServerFixture : StoreValueGenerationFixtureBase
+public abstract class StoreValueGenerationTriggerSqlServerFixture : StoreValueGenerationSqlServerFixtureBase
 {
     protected override void Seed(StoreValueGenerationContext context)
     {

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
@@ -1,0 +1,564 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Update;
+
+#nullable enable
+
+public class StoredProcedureUpdateSqlServerTest
+    : StoredProcedureUpdateTestBase<StoredProcedureUpdateSqlServerTest.StoredProcedureUpdateSqlServerFixture>
+{
+    public StoredProcedureUpdateSqlServerTest(StoredProcedureUpdateSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Insert_with_output_parameter(bool async)
+    {
+        await base.Insert_with_output_parameter(async);
+
+        AssertSql(
+            @"@p0='New' (Size = 4000)
+@p1='1' (Direction = Output)
+
+SET NOCOUNT ON;
+EXEC [WithOutputParameter_Insert] @p0, @p1 OUTPUT;");
+    }
+
+    public override async Task Insert_twice_with_output_parameter(bool async)
+    {
+        await base.Insert_twice_with_output_parameter(async);
+
+        AssertSql(
+            @"@p0='New1' (Size = 4000)
+@p1='1' (Direction = Output)
+@p2='New2' (Size = 4000)
+@p3='2' (Direction = Output)
+
+SET NOCOUNT ON;
+EXEC [WithOutputParameter_Insert] @p0, @p1 OUTPUT;
+EXEC [WithOutputParameter_Insert] @p2, @p3 OUTPUT;");
+    }
+
+    public override async Task Insert_with_result_column(bool async)
+    {
+        await base.Insert_with_result_column(async);
+
+        AssertSql(
+            @"@p0='Foo' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [WithResultColumn_Insert] @p0;");
+    }
+
+    public override async Task Insert_with_two_result_columns(bool async)
+    {
+        await base.Insert_with_two_result_columns(async);
+
+        AssertSql(
+            @"@p0='Foo' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [WithTwoResultColumns_Insert] @p0;");
+    }
+
+    public override async Task Insert_with_output_parameter_and_result_column(bool async)
+    {
+        await base.Insert_with_output_parameter_and_result_column(async);
+
+        AssertSql(
+            @"@p0=NULL (Nullable = false) (Direction = Output) (DbType = Int32)
+@p1='Foo' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [WithOutputParameterAndResultColumn_Insert] @p0 OUTPUT, @p1;");
+    }
+
+    public override async Task Update_with_output_parameter_and_result_column_and_return_value(bool async)
+    {
+        await base.Update_with_output_parameter_and_result_column_and_return_value(async);
+
+        AssertSql(
+            @"@p0=NULL (Nullable = false) (Direction = Output) (DbType = Int32)
+@p1='1'
+@p2='Updated' (Size = 4000)
+@p3=NULL (Nullable = false) (Direction = Output) (DbType = Int32)
+
+SET NOCOUNT ON;
+EXEC @p0 = [WithOutputParameterAndResultColumnAndResultValue_Update] @p1, @p2, @p3 OUTPUT;");
+    }
+
+    public override async Task Update(bool async)
+    {
+        await base.Update(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='Updated' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [WithOutputParameter_Update] @p0, @p1;");
+    }
+
+    public override async Task Update_partial(bool async)
+    {
+        await base.Update_partial(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='Updated' (Size = 4000)
+@p2='8'
+
+SET NOCOUNT ON;
+EXEC [WithTwoOutputParameters_Update] @p0, @p1, @p2;");
+    }
+
+    public override async Task Delete(bool async)
+    {
+        await base.Delete(async);
+
+        AssertSql(
+            @"@p0='1'
+
+SET NOCOUNT ON;
+EXEC [WithOutputParameter_Delete] @p0;");
+    }
+
+    public override async Task Rows_affected_parameter(bool async)
+    {
+        await base.Rows_affected_parameter(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='Updated' (Size = 4000)
+@p2='1' (Direction = Output)
+
+SET NOCOUNT ON;
+EXEC [WithRowsAffectedParameter_Update] @p0, @p1, @p2 OUTPUT;");
+    }
+
+    public override async Task Rows_affected_parameter_and_concurrency_failure(bool async)
+    {
+        await base.Rows_affected_parameter_and_concurrency_failure(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='Updated' (Size = 4000)
+@p2='0' (Direction = Output)
+
+SET NOCOUNT ON;
+EXEC [WithRowsAffectedParameter_Update] @p0, @p1, @p2 OUTPUT;");
+    }
+
+    public override async Task Rows_affected_result_column(bool async)
+    {
+        await base.Rows_affected_result_column(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='Updated' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [WithRowsAffectedResultColumn_Update] @p0, @p1;");
+    }
+
+    public override async Task Rows_affected_result_column_and_concurrency_failure(bool async)
+    {
+        await base.Rows_affected_result_column_and_concurrency_failure(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='Updated' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [WithRowsAffectedResultColumn_Update] @p0, @p1;");
+    }
+
+    public override async Task Rows_affected_return_value(bool async)
+    {
+        await base.Rows_affected_return_value(async);
+
+        AssertSql(
+            @"@p0='1' (Direction = Output)
+@p1='1'
+@p2='Updated' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC @p0 = [WithRowsAffectedReturnValue_Update] @p1, @p2;");
+    }
+
+    public override async Task Rows_affected_return_value_and_concurrency_failure(bool async)
+    {
+        await base.Rows_affected_return_value_and_concurrency_failure(async);
+
+        AssertSql(
+            @"@p0='0' (Direction = Output)
+@p1='1'
+@p2='Updated' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC @p0 = [WithRowsAffectedReturnValue_Update] @p1, @p2;");
+    }
+
+    public override async Task Store_generated_concurrency_token_as_inout_parameter(bool async)
+    {
+        await base.Store_generated_concurrency_token_as_inout_parameter(async);
+
+        // Can't assert SQL baseline as usual because the concurrency token changes
+        Assert.Contains("(Size = 8) (Direction = InputOutput)", Fixture.TestSqlLoggerFactory.Sql);
+
+        Assert.Equal(
+            @"@p2='Updated' (Size = 4000)
+@p3='0' (Direction = Output)
+
+SET NOCOUNT ON;
+EXEC [WithStoreGeneratedConcurrencyTokenAsInoutParameter_Update] @p0, @p1 OUTPUT, @p2, @p3 OUTPUT;",
+            Fixture.TestSqlLoggerFactory.Sql.Substring(Fixture.TestSqlLoggerFactory.Sql.IndexOf("@p2", StringComparison.Ordinal)),
+            ignoreLineEndingDifferences: true);
+
+        Assert.Equal(
+            @"@p2='Updated' (Size = 4000)
+@p3='0' (Direction = Output)
+
+SET NOCOUNT ON;
+EXEC [WithStoreGeneratedConcurrencyTokenAsInoutParameter_Update] @p0, @p1 OUTPUT, @p2, @p3 OUTPUT;",
+            Fixture.TestSqlLoggerFactory.Sql.Substring(Fixture.TestSqlLoggerFactory.Sql.IndexOf("@p2", StringComparison.Ordinal)),
+            ignoreLineEndingDifferences: true);
+    }
+
+    public override async Task Store_generated_concurrency_token_as_two_parameters(bool async)
+    {
+        await base.Store_generated_concurrency_token_as_two_parameters(async);
+
+        // Can't assert SQL baseline as usual because the concurrency token changes
+        Assert.Equal(
+            @"@p2='Updated' (Size = 4000)
+@p3=NULL (Size = 8) (Direction = Output) (DbType = Binary)
+@p4='0' (Direction = Output)
+
+SET NOCOUNT ON;
+EXEC [WithStoreGeneratedConcurrencyTokenAsTwoParameters_Update] @p0, @p1, @p2, @p3 OUTPUT, @p4 OUTPUT;",
+            Fixture.TestSqlLoggerFactory.Sql.Substring(Fixture.TestSqlLoggerFactory.Sql.IndexOf("@p2", StringComparison.Ordinal)),
+            ignoreLineEndingDifferences: true);
+    }
+
+    public override async Task User_managed_concurrency_token(bool async)
+    {
+        await base.User_managed_concurrency_token(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='8'
+@p2='Updated' (Size = 4000)
+@p3='9'
+@p4='0' (Direction = Output)
+
+SET NOCOUNT ON;
+EXEC [WithUserManagedConcurrencyToken_Update] @p0, @p1, @p2, @p3, @p4 OUTPUT;");
+    }
+
+    public override async Task Original_and_current_value_on_non_concurrency_token(bool async)
+    {
+        await base.Original_and_current_value_on_non_concurrency_token(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='Updated' (Size = 4000)
+@p2='Initial' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [WithOriginalAndCurrentValueOnNonConcurrencyToken_Update] @p0, @p1, @p2;");
+    }
+
+    public override async Task Tph(bool async)
+    {
+        await base.Tph(async);
+
+        AssertSql(
+            @"@p0='1' (Direction = Output)
+@p1='TphChild' (Nullable = false) (Size = 4000)
+@p2='Child' (Size = 4000)
+@p3='8' (Nullable = true)
+
+SET NOCOUNT ON;
+EXEC [Tph_Insert] @p0 OUTPUT, @p1, @p2, @p3;");
+    }
+
+    public override async Task Tpt(bool async)
+    {
+        await base.Tpt(async);
+
+        AssertSql(
+            @"@p0='1' (Direction = Output)
+@p1='Child' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [TptParent_Insert] @p0 OUTPUT, @p1;",
+            //
+            @"@p2='1'
+@p3='8'
+
+SET NOCOUNT ON;
+EXEC [TptChild_Insert] @p2, @p3;");
+    }
+
+    public override async Task Tpt_mixed_sproc_and_non_sproc(bool async)
+    {
+        await base.Tpt_mixed_sproc_and_non_sproc(async);
+
+        AssertSql(
+            @"@p0='1' (Direction = Output)
+@p1='Child' (Size = 4000)
+
+SET NOCOUNT ON;
+EXEC [TptMixedParent_Insert] @p0 OUTPUT, @p1;",
+            //
+            @"@p2='1'
+@p3='8'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+INSERT INTO [TptMixedChild] ([Id], [ChildProperty])
+VALUES (@p2, @p3);");
+    }
+
+    public override async Task Tpc(bool async)
+    {
+        await base.Tpc(async);
+
+        AssertSql(
+            @"@p0='1' (Direction = Output)
+@p1='Child' (Size = 4000)
+@p2='8'
+
+SET NOCOUNT ON;
+EXEC [TpcChild_Insert] @p0 OUTPUT, @p1, @p2;");
+    }
+
+    public override async Task Input_output_parameter_on_non_concurrency_token(bool async)
+    {
+        await base.Input_output_parameter_on_non_concurrency_token(async);
+
+        AssertSql();
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    public class StoredProcedureUpdateSqlServerFixture : StoredProcedureUpdateFixtureBase
+    {
+        protected override ITestStoreFactory TestStoreFactory
+            => StoredProcedureTestStoryFactory.Instance;
+
+        protected override void ConfigureStoreGeneratedConcurrencyToken(EntityTypeBuilder entityTypeBuilder, string propertyName)
+            => entityTypeBuilder.Property<byte[]>(propertyName).IsRowVersion();
+
+        public override void CleanData()
+        {
+            using var context = CreateContext();
+            context.Database.ExecuteSqlRaw(CleanDataSql);
+        }
+
+        private const string CleanDataSql = @"
+-- Regular tables without foreign keys
+TRUNCATE TABLE [WithInputOutputParameterOnNonConcurrencyToken];
+TRUNCATE TABLE [WithOriginalAndCurrentValueOnNonConcurrencyToken];
+TRUNCATE TABLE [WithOutputParameter];
+TRUNCATE TABLE [WithOutputParameterAndResultColumn];
+TRUNCATE TABLE [WithOutputParameterAndResultColumnAndResultValue];
+TRUNCATE TABLE [WithResultColumn];
+TRUNCATE TABLE [WithTwoResultColumns];
+TRUNCATE TABLE [WithRowsAffectedParameter];
+TRUNCATE TABLE [WithRowsAffectedResultColumn];
+TRUNCATE TABLE [WithRowsAffectedReturnValue];
+TRUNCATE TABLE [WithStoreGeneratedConcurrencyTokenAsInoutParameter];
+TRUNCATE TABLE [WithStoreGeneratedConcurrencyTokenAsTwoParameters];
+TRUNCATE TABLE [WithTwoOutputParameters];
+TRUNCATE TABLE [WithUserManagedConcurrencyToken];
+TRUNCATE TABLE [Tph];
+TRUNCATE TABLE [TpcChild];
+TRUNCATE TABLE [TpcParent];
+
+ALTER SEQUENCE [TpcParentSequence] RESTART WITH 1;
+
+-- We can't use TRUNCATE on tables with foreign keys, so we DELETE and reset IDENTITY manually.
+-- DBCC CHECKIDENT resets IDENTITY, but behaves differently based on whether whether rows were ever inserted (seed+1) or not (seed).
+-- So we insert a dummy row before deleting everything to make sure we get the seed value 1.
+INSERT INTO [TptMixedParent] DEFAULT VALUES;
+DELETE FROM [TptMixedChild];
+DELETE FROM [TptMixedParent];
+DBCC CHECKIDENT ('[TptMixedParent]', RESEED, 0);
+
+INSERT INTO [TptParent] DEFAULT VALUES;
+DELETE FROM [TptChild];
+DELETE FROM [TptParent];
+DBCC CHECKIDENT ('[TptParent]', RESEED, 0);";
+
+        class StoredProcedureTestStoryFactory : SqlServerTestStoreFactory
+        {
+            public static new StoredProcedureTestStoryFactory Instance { get; } = new();
+
+            public override TestStore GetOrCreate(string storeName)
+                => SqlServerTestStore.GetOrCreateWithInitScript(storeName, InitScript);
+
+            private const string InitScript = @"
+CREATE PROCEDURE WithOutputParameter_Insert(@Name varchar(max), @Id int OUT)
+AS BEGIN
+    INSERT INTO [WithOutputParameter] ([Name]) VALUES (@Name);
+    SET @Id = SCOPE_IDENTITY();
+END;
+
+GO
+
+CREATE PROCEDURE WithOutputParameter_Update(@Id int, @Name varchar(max))
+AS UPDATE [WithOutputParameter] SET [Name] = @Name WHERE [Id] = @id;
+
+GO
+
+CREATE PROCEDURE WithOutputParameter_Delete(@Id int)
+AS DELETE FROM [WithOutputParameter] WHERE [Id] = @Id;
+
+GO
+
+CREATE PROCEDURE WithResultColumn_Insert(@Name varchar(max))
+AS INSERT INTO [WithResultColumn] ([Name]) OUTPUT [Inserted].[Id] VALUES (@Name);
+
+GO
+
+CREATE PROCEDURE WithTwoResultColumns_Insert(@Name varchar(max))
+AS INSERT INTO [WithTwoResultColumns] ([Name]) OUTPUT [Inserted].[AdditionalProperty], [Inserted].[Id] VALUES (@Name);
+
+GO
+
+CREATE PROCEDURE WithOutputParameterAndResultColumn_Insert(@Id int OUT, @Name varchar(max))
+AS BEGIN
+    INSERT INTO [WithOutputParameterAndResultColumn] ([Name]) VALUES (@Name);
+    SET @Id = SCOPE_IDENTITY();
+    SELECT [AdditionalProperty] FROM [WithOutputParameterAndResultColumn] WHERE [Id] = @Id
+END;
+
+GO
+
+CREATE PROCEDURE WithTwoOutputParameters_Update(@Id int, @Name varchar(max), @AdditionalProperty int)
+AS UPDATE [WithTwoOutputParameters] SET [Name] = @Name, [AdditionalProperty] = @AdditionalProperty WHERE [Id] = @id;
+
+GO
+CREATE PROCEDURE WithRowsAffectedParameter_Update(@Id int, @Name varchar(max), @RowsAffected int OUT)
+AS BEGIN
+    UPDATE [WithRowsAffectedParameter] SET [Name] = @Name WHERE [Id] = @Id;
+    SET @RowsAffected = @@ROWCOUNT;
+END;
+
+GO
+
+CREATE PROCEDURE WithRowsAffectedResultColumn_Update(@Id int, @Name varchar(max))
+AS BEGIN
+    UPDATE [WithRowsAffectedResultColumn] SET [Name] = @Name WHERE [Id] = @Id;
+    SELECT @@ROWCOUNT;
+END;
+
+GO
+
+CREATE PROCEDURE WithRowsAffectedReturnValue_Update(@Id int, @Name varchar(max))
+AS BEGIN
+    UPDATE [WithRowsAffectedReturnValue] SET [Name] = @Name WHERE [Id] = @Id;
+    RETURN @@ROWCOUNT;
+END;
+
+GO
+
+CREATE PROCEDURE WithStoreGeneratedConcurrencyTokenAsInoutParameter_Update(@Id int, @ConcurrencyToken rowversion OUT, @Name varchar(max), @RowsAffected int OUT)
+AS BEGIN
+    UPDATE [WithStoreGeneratedConcurrencyTokenAsInoutParameter] SET [Name] = @Name WHERE [Id] = @Id AND [ConcurrencyToken] = @ConcurrencyToken;
+    SET @RowsAffected = @@ROWCOUNT;
+END;
+
+GO
+
+CREATE PROCEDURE WithStoreGeneratedConcurrencyTokenAsTwoParameters_Update(@Id int, @ConcurrencyTokenIn rowversion, @Name varchar(max), @ConcurrencyTokenOut rowversion OUT, @RowsAffected int OUT)
+AS BEGIN
+    UPDATE [WithStoreGeneratedConcurrencyTokenAsTwoParameters] SET [Name] = @Name, @ConcurrencyTokenOut = [ConcurrencyToken] WHERE [Id] = @Id AND [ConcurrencyToken] = @ConcurrencyTokenIn;
+    SET @RowsAffected = @@ROWCOUNT;
+END;
+
+GO
+
+CREATE PROCEDURE WithUserManagedConcurrencyToken_Update(@Id int, @ConcurrencyTokenOriginal int, @Name varchar(max), @ConcurrencyTokenCurrent int, @RowsAffected int OUT)
+AS BEGIN
+    UPDATE [WithUserManagedConcurrencyToken] SET [Name] = @Name, [AdditionalProperty] = @ConcurrencyTokenCurrent WHERE [Id] = @Id AND [AdditionalProperty] = @ConcurrencyTokenOriginal;
+    SET @RowsAffected = @@ROWCOUNT;
+END;
+
+GO
+
+CREATE PROCEDURE WithOriginalAndCurrentValueOnNonConcurrencyToken_Update(@Id int, @NameCurrent varchar(max), @NameOriginal varchar(max))
+AS BEGIN
+    IF @NameCurrent <> @NameOriginal
+    BEGIN
+        UPDATE [WithOriginalAndCurrentValueOnNonConcurrencyToken] SET [Name] = @NameCurrent WHERE [Id] = @Id;
+    END
+END;
+
+GO
+
+CREATE PROCEDURE WithInputOutputParameterOnNonConcurrencyToken_Update(@Id int, @Name varchar(max) OUT)
+AS BEGIN
+    SET @Name = @Name + 'WithSuffix';
+    UPDATE [WithInputOutputParameterOnNonConcurrencyToken] SET [Name] = @Name WHERE [Id] = @Id;
+END;
+
+GO
+
+CREATE PROCEDURE WithOutputParameterAndResultColumnAndResultValue_Update(@Id int, @Name varchar(max), @AdditionalProperty1 int OUT)
+AS BEGIN
+    UPDATE [WithOutputParameterAndResultColumnAndResultValue] SET [Name] = @Name, @AdditionalProperty1 = [AdditionalProperty1] WHERE [Id] = @Id;
+    SELECT [AdditionalProperty2] FROM [WithOutputParameterAndResultColumnAndResultValue] WHERE [Id] = @Id
+    RETURN @@ROWCOUNT;
+END;
+
+GO
+
+CREATE PROCEDURE Tph_Insert(@Id int OUT, @Discriminator varchar(max), @Name varchar(max), @ChildProperty int)
+AS BEGIN
+    INSERT INTO [Tph] ([Discriminator], [Name], [ChildProperty]) VALUES (@Discriminator, @Name, @ChildProperty);
+    SET @Id = SCOPE_IDENTITY();
+END;
+
+GO
+
+CREATE PROCEDURE TptParent_Insert(@Id int OUT, @Name varchar(max))
+AS BEGIN
+    INSERT INTO [TptParent] ([Name]) VALUES (@Name);
+    SET @Id = SCOPE_IDENTITY();
+END;
+
+GO
+
+CREATE PROCEDURE TptChild_Insert(@Id int, @ChildProperty int)
+AS BEGIN
+    INSERT INTO [TptChild] ([Id], [ChildProperty]) VALUES (@Id, @ChildProperty);
+    SET @Id = SCOPE_IDENTITY();
+END;
+
+GO
+
+CREATE PROCEDURE TptMixedParent_Insert(@Id int OUT, @Name varchar(max))
+AS BEGIN
+    INSERT INTO [TptMixedParent] ([Name]) VALUES (@Name);
+    SET @Id = SCOPE_IDENTITY();
+END;
+
+GO
+
+CREATE PROCEDURE TpcChild_Insert(@Id int OUT, @Name varchar(max), @ChildProperty int)
+AS BEGIN
+    DECLARE @Table table ([Id] int);
+    INSERT INTO [TpcChild] ([Name], [ChildProperty]) OUTPUT [Inserted].[Id] INTO @Table VALUES (@Name, @ChildProperty);
+    SELECT @Id = [Id] FROM @Table;
+END;";
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
@@ -11,6 +11,7 @@ public class SqliteComplianceTest : RelationalComplianceTestBase
         typeof(SqlExecutorTestBase<>),
         typeof(UdfDbFunctionTestBase<>),
         typeof(TPCRelationshipsQueryTestBase<>), // internal class is added
+        typeof(StoredProcedureUpdateTestBase<>) // SQLite doesn't support stored procedures
     };
 
     protected override Assembly TargetAssembly { get; } = typeof(SqliteComplianceTest).Assembly;

--- a/test/EFCore.Sqlite.FunctionalTests/Update/StoreValueGenerationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/StoreValueGenerationSqliteTest.cs
@@ -334,7 +334,29 @@ RETURNING 1;");
 
     public class StoreValueGenerationSqliteFixture : StoreValueGenerationFixtureBase
     {
+        private string? _cleanDataSql;
+
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;
+
+        public override void CleanData()
+        {
+            using var context = CreateContext();
+            context.Database.ExecuteSqlRaw(_cleanDataSql ??= GenerateCleanDataSql());
+        }
+
+        private string GenerateCleanDataSql()
+        {
+            var context = CreateContext();
+            var builder = new StringBuilder();
+
+            foreach (var table in context.Model.GetEntityTypes().SelectMany(e => e.GetTableMappings().Select(m => m.Table.Name)))
+            {
+                builder.AppendLine($"DELETE FROM {table};");
+                builder.AppendLine($"DELETE FROM sqlite_sequence WHERE name='{table}';");
+            }
+
+            return builder.ToString();
+        }
     }
 }

--- a/test/EFCore.Sqlite.Tests/Infrastructure/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Infrastructure/SqliteModelValidatorTest.cs
@@ -72,6 +72,70 @@ public class SqliteModelValidatorTest : RelationalModelValidatorTest
             modelBuilder);
     }
 
+    [ConditionalFact]
+    public void Detects_insert_stored_procedures()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<Person>()
+            .InsertUsingStoredProcedure(
+                "Person_Insert",
+                spb => spb
+                    .HasParameter(w => w.Id, pb => pb.IsOutput())
+                    .HasParameter(w => w.Name)
+                    .HasParameter(w => w.FavoriteBreed));
+
+        VerifyError(SqliteStrings.StoredProceduresNotSupported(nameof(Person)), modelBuilder);
+    }
+
+    [ConditionalFact]
+    public void Detects_update_stored_procedures()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<Person>()
+            .UpdateUsingStoredProcedure(
+                "Person_Update",
+                spb => spb
+                    .HasParameter(w => w.Id)
+                    .HasParameter(w => w.Name)
+                    .HasParameter(w => w.FavoriteBreed));
+
+        VerifyError(SqliteStrings.StoredProceduresNotSupported(nameof(Person)), modelBuilder);
+    }
+
+    [ConditionalFact]
+    public void Detects_delete_stored_procedures()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<Person>()
+            .DeleteUsingStoredProcedure("Person_Delete", spb => spb.HasParameter(w => w.Id));
+
+        VerifyError(SqliteStrings.StoredProceduresNotSupported(nameof(Person)), modelBuilder);
+    }
+
+    public override void Passes_on_valid_UsingDeleteStoredProcedure_in_TPT()
+    {
+        var exception =
+            Assert.Throws<InvalidOperationException>(() => base.Passes_on_valid_UsingDeleteStoredProcedure_in_TPT());
+
+        Assert.Equal(SqliteStrings.StoredProceduresNotSupported(nameof(Animal)), exception.Message);
+    }
+
+    public override void Passes_on_derived_entity_type_mapped_to_a_stored_procedure_in_TPT()
+    {
+        var exception =
+            Assert.Throws<InvalidOperationException>(() => base.Passes_on_derived_entity_type_mapped_to_a_stored_procedure_in_TPT());
+
+        Assert.Equal(SqliteStrings.StoredProceduresNotSupported(nameof(Cat)), exception.Message);
+    }
+
+    public override void Passes_on_derived_entity_type_not_mapped_to_a_stored_procedure_in_TPT()
+    {
+        var exception =
+            Assert.Throws<InvalidOperationException>(() => base.Passes_on_derived_entity_type_not_mapped_to_a_stored_procedure_in_TPT());
+
+        Assert.Equal(SqliteStrings.StoredProceduresNotSupported(nameof(Animal)), exception.Message);
+    }
+
     public override void Store_generated_in_composite_key()
     {
         var modelBuilder = CreateConventionModelBuilder();


### PR DESCRIPTION
Here's a WIP for some early feedback to make sure I'm in the right direction.

Some comments:

* ResultSetMapping is now a flags enum, with a bit that specifies whether the command has output parameters (I've also redone the "positional mapping" optimization for SQL Server as another bit).
* Rows affected is unimplemented (waiting for metadata), same with fancier mapping scenarios (need to know which table is being updated by the sproc).
* Positional vs. named argument style
  * All databases support positional arguments to stored procedures, but not all support named (see comparison below); we should do positional by default.
  * Supporting named seems like it needs some metadata changes... StoredProcedureParameterBuilder has HasName (StoreStoredProcedureParameter extends IColumnBase which has Name). From a user perspective this looks like it should set the parameter name in the sproc call (e.g. `EXEC @id = 3, @name = 'foo'`). However, this is all non-nullable, so we have no way to make the named/positional distinction. Making IColumnBase.Name nullable seems like it would have a huge impact; another option would be to use some other property specific to StoreStoredProcedureParameter, but that would make Name dead for that type. We can also scope this out and say that named parameters aren't supported (and remove the HasName API for now).
* Some assumptions in this implementation:
  * We call sprocs from regular commands (CommandType.Text with EXEC), even with output parameters. The alterative is to use CommandType.StoredProcedure, but these can't be batched - one call per command (until the new ADO.NET batching API is implemented). This works well for SQL Server, but I'm not 100% sure of the portability here.
  * We consume output parameters as we're traversing the DbCommand's result set. If some database only populates output parameters at the end (e.g. when the reader is disposed), this will fail.
* No seeding support right now. I think this would require propagating the relational model through migrations - probably not trivial. Consider scoping out.
* Sprocs don't have to return rows affected (but they can). This means that the concurrency check is optional - not possible without sprocs at the moment (see #10443).

Some cross-database comparison:

Database   | Syntax                       | Named/Positional         | Docs
---------- | ---------------------------- | ------------------------ | ----
SQL Server | `EXEC MySproc 'foo', 'bar'`  | Both                     | [docs](https://www.postgresql.org/docs/11/sql-call.html)
PostgreSQL | `CALL MySproc('foo', 'bar')` | Both                     | [docs](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/execute-transact-sql?view=sql-server-ver16)
MySQL      | `CALL MySproc('foo', 'bar')`  | Positional only          | [docs](https://dev.mysql.com/doc/refman/8.0/en/call.html)
MariaDB    | `CALL MySproc('foo', 'bar')`  | Positional only          | [docs](https://mariadb.com/kb/en/call/)
Oracle     | `CALL MySproc('foo', 'bar')`  | Positional only (in SQL) | [docs](https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_4008.htm)
SQLite     | No sproc support             |                          |

Closes #245
Closes #28435
