### PR TITLE
Query: Split databases for filter/non-filter cases for bulk updates

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqlServerFixture.cs
@@ -5,6 +5,8 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 public class FiltersInheritanceBulkUpdatesSqlServerFixture : InheritanceBulkUpdatesSqlServerFixture
 {
+    protected override string StoreName => "FiltersInheritanceBulkUpdatesTest";
+
     protected override bool EnableFilters
         => true;
 }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqlServerFixture.cs
@@ -5,5 +5,7 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 public class TPCFiltersInheritanceBulkUpdatesSqlServerFixture : TPCInheritanceBulkUpdatesSqlServerFixture
 {
+    protected override string StoreName => "TPCFiltersInheritanceBulkUpdatesTest";
+
     protected override bool EnableFilters => true;
 }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqlServerFixture.cs
@@ -5,5 +5,7 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 public class TPTFiltersInheritanceBulkUpdatesSqlServerFixture : TPTInheritanceBulkUpdatesSqlServerFixture
 {
+    protected override string StoreName => "TPTFiltersInheritanceBulkUpdatesTest";
+
     protected override bool EnableFilters => true;
 }


### PR DESCRIPTION
Using same database concurrently (from 2 different test classes) was causing time outs when running bulk command due to locking of tables
