### PR TITLE
Query: Use object.Equals rather than Expression.Equal when constructi…

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -533,6 +533,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
             updatedMemberExpression = ConvertToNullable(updatedMemberExpression);
 
             return Expression.Condition(
+                // Since inner is nullable type this is fine.
                 Expression.Equal(innerExpression, Expression.Default(innerExpression.Type)),
                 Expression.Default(updatedMemberExpression.Type),
                 updatedMemberExpression);
@@ -1502,7 +1503,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
                         l = l.Type.IsNullableType() ? l : Expression.Convert(l, r.Type);
                     }
 
-                    return Expression.Equal(l, r);
+                    return ExpressionExtensions.BuildEqualsExpression(l, r);
                 })
             .Aggregate((a, b) => Expression.AndAlso(a, b));
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -535,7 +535,7 @@ public class InMemoryQueryableMethodTranslatingExpressionVisitor : QueryableMeth
         var left = RemapLambdaBody(outer, outerKeySelector);
         var right = RemapLambdaBody(inner, innerKeySelector);
 
-        var joinCondition = TranslateExpression(Expression.Equal(left, right));
+        var joinCondition = TranslateExpression(EntityFrameworkCore.Infrastructure.ExpressionExtensions.BuildEqualsExpression(left, right));
 
         var (outerKeyBody, innerKeyBody) = DecomposeJoinCondition(joinCondition);
 
@@ -1145,9 +1145,6 @@ public class InMemoryQueryableMethodTranslatingExpressionVisitor : QueryableMeth
 
     private sealed class SharedTypeEntityExpandingExpressionVisitor : ExpressionVisitor
     {
-        private static readonly MethodInfo ObjectEqualsMethodInfo
-            = typeof(object).GetRuntimeMethod(nameof(object.Equals), new[] { typeof(object), typeof(object) })!;
-
         private readonly InMemoryExpressionTranslatingExpressionVisitor _expressionTranslator;
 
         private InMemoryQueryExpression _queryExpression;
@@ -1254,8 +1251,7 @@ public class InMemoryQueryableMethodTranslatingExpressionVisitor : QueryableMeth
                         : foreignKey.Properties,
                     makeNullable);
 
-                var keyComparison = Expression.Call(
-                    ObjectEqualsMethodInfo, AddConvertToObject(outerKey), AddConvertToObject(innerKey));
+                var keyComparison = EntityFrameworkCore.Infrastructure.ExpressionExtensions.BuildEqualsExpression(outerKey, innerKey);
 
                 var predicate = makeNullable
                     ? Expression.AndAlso(

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -40,9 +40,6 @@ public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<objec
     internal static readonly MethodInfo EqualityComparerEqualsMethod
         = typeof(IEqualityComparer).GetRuntimeMethod(nameof(IEqualityComparer.Equals), new[] { typeof(object), typeof(object) })!;
 
-    internal static readonly MethodInfo ObjectEqualsMethod
-        = typeof(object).GetRuntimeMethod(nameof(object.Equals), new[] { typeof(object), typeof(object) })!;
-
     internal static readonly MethodInfo ObjectGetHashCodeMethod
         = typeof(object).GetRuntimeMethod(nameof(object.GetHashCode), Type.EmptyTypes)!;
 

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -159,10 +159,7 @@ public class ValueComparer<T> : ValueComparer, IEqualityComparer<T>
 
         return Expression.Lambda<Func<T?, T?, bool>>(
             typedEquals == null
-                ? Expression.Call(
-                    ObjectEqualsMethod,
-                    Expression.Convert(param1, typeof(object)),
-                    Expression.Convert(param2, typeof(object)))
+                ? Infrastructure.ExpressionExtensions.BuildEqualsExpression(param1, param2)
                 : Expression.Call(typedEquals, param1, param2),
             param1, param2);
     }

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -193,9 +193,6 @@ public static class ExpressionExtensions
         return expression;
     }
 
-    private static readonly MethodInfo ObjectEqualsMethodInfo
-        = typeof(object).GetRuntimeMethod(nameof(object.Equals), new[] { typeof(object), typeof(object) })!;
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -226,18 +223,15 @@ public static class ExpressionExtensions
             => property.ClrType.IsValueType
                 && property.ClrType.UnwrapNullableType() is Type nonNullableType
                 && !(nonNullableType == typeof(bool) || nonNullableType.IsNumeric() || nonNullableType.IsEnum)
-                    ? Expression.Call(
-                        ObjectEqualsMethodInfo,
+                    ? Infrastructure.ExpressionExtensions.BuildEqualsExpression(
                         Expression.Call(
                             EF.PropertyMethod.MakeGenericMethod(typeof(object)),
                             entityParameterExpression,
                             Expression.Constant(property.Name, typeof(string))),
-                        Expression.Convert(
-                            Expression.Call(
-                                keyValuesConstantExpression,
-                                ValueBuffer.GetValueMethod,
-                                Expression.Constant(i)),
-                            typeof(object)))
+                        Expression.Call(
+                            keyValuesConstantExpression,
+                            ValueBuffer.GetValueMethod,
+                            Expression.Constant(i)))
                     : Expression.Equal(
                         Expression.Call(
                             EF.PropertyMethod.MakeGenericMethod(property.ClrType),

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -376,4 +376,38 @@ public static class ExpressionExtensions
             target,
             Expression.Constant(propertyName));
     }
+
+    private static readonly MethodInfo ObjectEqualsMethodInfo
+            = typeof(object).GetRuntimeMethod(nameof(object.Equals), new[] { typeof(object), typeof(object) })!;
+
+    /// <summary>
+    ///     <para>
+    ///         Creates an <see cref="Expression" /> tree representing equality comparison between 2 expressions using
+    ///         <see cref="object.Equals(object?, object?)"/> method.
+    ///     </para>
+    ///     <para>
+    ///         This method is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    /// <param name="left">The left expression in equality comparison.</param>
+    /// <param name="right">The right expression in equality comparison.</param>
+    /// <param name="negated">If the comparison is non-equality.</param>
+    /// <returns>An expression to compare left and right expressions.</returns>
+    public static Expression BuildEqualsExpression(
+        Expression left,
+        Expression right,
+        bool negated = false)
+    {
+        var result = Expression.Call(ObjectEqualsMethodInfo, AddConvertToObject(left), AddConvertToObject(right));
+
+        return negated
+            ? Expression.Not(result)
+            : result;
+
+        static Expression AddConvertToObject(Expression expression)
+            => expression.Type.IsValueType
+                ? Expression.Convert(expression, typeof(object))
+                : expression;
+    }
 }

--- a/src/EFCore/Query/Internal/NullCheckRemovingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NullCheckRemovingExpressionVisitor.cs
@@ -87,6 +87,7 @@ public class NullCheckRemovingExpressionVisitor : ExpressionVisitor
     {
         // Simplify (a ? b : null) == null => !a || b == null
         // Simplify (a ? null : b) == null => a || b == null
+        // Expression.Equal is fine here since we match the binary expression of same kind.
         if (expression is BinaryExpression binaryExpression
             && binaryExpression.NodeType == ExpressionType.Equal
             && (binaryExpression.Left is ConditionalExpression

--- a/src/EFCore/Query/Internal/QueryOptimizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizingExpressionVisitor.cs
@@ -243,9 +243,7 @@ public class QueryOptimizingExpressionVisitor : ExpressionVisitor
 
             var anyLambdaParameter = Expression.Parameter(typeArgument, "p");
             var anyLambda = Expression.Lambda(
-                Expression.Equal(
-                    anyLambdaParameter,
-                    methodCallExpression.Arguments[1]),
+                Infrastructure.ExpressionExtensions.BuildEqualsExpression(anyLambdaParameter, methodCallExpression.Arguments[1]),
                 anyLambdaParameter);
 
             return Expression.Call(null, anyMethod, new[] { Visit(methodCallExpression.Arguments[0]), anyLambda });

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
@@ -27,7 +27,7 @@ public abstract class NorthwindAggregateOperatorsQueryRelationalTestBase<TFixtur
 
     public override async Task Contains_over_keyless_entity_throws(bool async)
         => Assert.Equal(
-            CoreStrings.EntityEqualityOnKeylessEntityNotSupported("==", nameof(CustomerQuery)),
+            CoreStrings.EntityEqualityOnKeylessEntityNotSupported("Equals", nameof(CustomerQuery)),
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Contains_over_keyless_entity_throws(async))).Message);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
@@ -784,7 +784,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture> : QueryTestBas
     public virtual async Task Where_subquery_on_navigation(bool async)
         // Complex entity equality. Issue #15260.
         => Assert.Equal(
-            CoreStrings.EntityEqualityOnCompositeKeyEntitySubqueryNotSupported("==", nameof(OrderDetail)),
+            CoreStrings.EntityEqualityOnCompositeKeyEntitySubqueryNotSupported("Equals", nameof(OrderDetail)),
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => AssertQuery(
                     async,
@@ -800,7 +800,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture> : QueryTestBas
     public virtual async Task Where_subquery_on_navigation2(bool async)
         // Complex entity equality. Issue #15260.
         => Assert.Equal(
-            CoreStrings.EntityEqualityOnCompositeKeyEntitySubqueryNotSupported("==", nameof(OrderDetail)),
+            CoreStrings.EntityEqualityOnCompositeKeyEntitySubqueryNotSupported("Equals", nameof(OrderDetail)),
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => AssertQuery(
                     async,


### PR DESCRIPTION
…ng comparison in query

Not all types implement equality operator, so it can throw exception.
Reference types, Nullable<T> & known types are ok to be used with Expression.Equal

Originally reported in https://github.com/npgsql/efcore.pg/issues/2458
