### PR TITLE
Fix to #27155 - Average_Grouped_from_LINQ_101 is non-deterministic

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/Query/Ef6GroupByInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/Ef6GroupByInMemoryTest.cs
@@ -10,15 +10,6 @@ public class Ef6GroupByInMemoryTest : Ef6GroupByTestBase<Ef6GroupByInMemoryTest.
     {
     }
 
-    public override Task Average_Grouped_from_LINQ_101(bool async)
-        => AssertQuery(
-            async,
-            ss => from p in ss.Set<ProductForLinq>()
-                  group p by p.Category
-                  into g
-                  select new { Category = g.Key, AveragePrice = g.Average(p => p.UnitPrice) },
-            elementSorter: e => (e.Category, e.AveragePrice));
-
     public class Ef6GroupByInMemoryFixture : Ef6GroupByFixtureBase
     {
         protected override ITestStoreFactory TestStoreFactory

--- a/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
@@ -410,11 +410,12 @@ public abstract class Ef6GroupByTestBase<TFixture> : QueryTestBase<TFixture>
                   group p by p.Category
                   into g
                   select new { Category = g.Key, AveragePrice = g.Average(p => p.UnitPrice) },
-            ss => from p in ss.Set<ProductForLinq>()
-                  group p by p.Category
-                  into g
-                  select new { Category = g.Key, AveragePrice = Math.Round(g.Average(p => p.UnitPrice) - 0.0000005m, 6) },
-            elementSorter: e => (e.Category, e.AveragePrice));
+            elementSorter: e => (e.Category, e.AveragePrice),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Category, a.Category);
+                Assert.Equal(e.AveragePrice, a.AveragePrice, 5);
+            });
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -644,7 +645,7 @@ public abstract class Ef6GroupByTestBase<TFixture> : QueryTestBase<TFixture>
                 Assert.Equal(l.Id, r.Id);
                 Assert.Equal(l.Age, r.Age);
                 Assert.Equal(l.Style, r.Style);
-                Assert.Equal(l.Values, r.Values);
+                AssertCollection(l.Values, r.Values, elementSorter: e => (e.Id, e.Style, e.Age));
             });
 
     [ConditionalTheory] // From #19506


### PR DESCRIPTION
Added custom asserter that checks results within range, rather than adding sql server specific expected query.
For the second test, added proper collection asserter so we can impose the order within nested collection.

Fixes #27155