### PR TITLE
Fix to #27228 - EF Core 6.0 temporal tables - Support specifying precision for PeriodEnd and PeriodStart columns

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerModelValidator.cs
@@ -286,7 +286,14 @@ public class SqlServerModelValidator : RelationalModelValidator
                     temporalEntityType.DisplayName(), periodProperty.Name, nameof(DateTime)));
         }
 
-        const string expectedPeriodColumnName = "datetime2";
+        const string expectedPeriodColumnNameWithoutPrecision = "datetime2";
+        const string expectedPeriodColumnNameWithPrecision = "datetime2({0})";
+
+        var precision = periodProperty.GetPrecision();
+        var expectedPeriodColumnName = precision != null
+            ? string.Format(expectedPeriodColumnNameWithPrecision, precision.Value)
+            : expectedPeriodColumnNameWithoutPrecision;
+
         if (periodProperty.GetColumnType() != expectedPeriodColumnName)
         {
             throw new InvalidOperationException(

--- a/src/EFCore.SqlServer/Metadata/Builders/OwnedNavigationTemporalPeriodPropertyBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Builders/OwnedNavigationTemporalPeriodPropertyBuilder.cs
@@ -42,6 +42,22 @@ public class OwnedNavigationTemporalPeriodPropertyBuilder
         return this;
     }
 
+    /// <summary>
+    ///     Configures the precision of the period property.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///     for more information.
+    /// </remarks>
+    /// <param name="precision">The precision of the period property.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual OwnedNavigationTemporalPeriodPropertyBuilder HasPrecision(int precision)
+    {
+        _propertyBuilder.HasPrecision(precision);
+
+        return this;
+    }
+
     #region Hidden System.Object members
 
     /// <summary>

--- a/src/EFCore.SqlServer/Metadata/Builders/TemporalPeriodPropertyBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Builders/TemporalPeriodPropertyBuilder.cs
@@ -43,6 +43,22 @@ public class TemporalPeriodPropertyBuilder
         return this;
     }
 
+    /// <summary>
+    ///     Configures the precision of the period property.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-temporal">Using SQL Server temporal tables with EF Core</see>
+    ///     for more information.
+    /// </remarks>
+    /// <param name="precision">The precision of the period property.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual TemporalPeriodPropertyBuilder HasPrecision(int precision)
+    {
+        _propertyBuilder.HasPrecision(precision);
+
+        return this;
+    }
+
     #region Hidden System.Object members
 
     /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerFixture.cs
@@ -15,7 +15,11 @@ public class TemporalGearsOfWarQuerySqlServerFixture : GearsOfWarQuerySqlServerF
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
         modelBuilder.Entity<City>().ToTable(tb => tb.IsTemporal());
-        modelBuilder.Entity<CogTag>().ToTable(tb => tb.IsTemporal());
+        modelBuilder.Entity<CogTag>().ToTable(tb => tb.IsTemporal(ttb =>
+        {
+            ttb.HasPeriodStart("PeriodStart").HasPrecision(0);
+            ttb.HasPeriodEnd("PeriodEnd").HasPrecision(0);
+        }));
         modelBuilder.Entity<Faction>().ToTable(tb => tb.IsTemporal());
         modelBuilder.Entity<Gear>().ToTable(tb => tb.IsTemporal());
         modelBuilder.Entity<LocustLeader>().ToTable(tb => tb.IsTemporal());


### PR DESCRIPTION
Added HasPrecision builder methods for temporal period columns and fixed validation so that it can recognize custom precision.

Fixes #27228