### PR TITLE
Add immutable annotation support to TableExpressionBase

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -1321,11 +1321,6 @@ public class InMemoryQueryableMethodTranslatingExpressionVisitor : QueryableMeth
 
             return innerShaper;
         }
-
-        private static Expression AddConvertToObject(Expression expression)
-            => expression.Type.IsValueType
-                ? Expression.Convert(expression, typeof(object))
-                : expression;
     }
 
     private ShapedQueryExpression TranslateTwoParameterSelector(ShapedQueryExpression source, LambdaExpression resultSelector)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1655,11 +1655,11 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                             : foreignKey.PrincipalKey.Properties[0]);
 
                 var sourceTable = FindRootTableExpressionForColumn(sourceColumn);
-                var ownedTable = new TableExpression(targetTable);
+                TableExpressionBase ownedTable = new TableExpression(targetTable);
 
                 foreach (var annotation in sourceTable.GetAnnotations())
                 {
-                    ownedTable.SetAnnotation(annotation.Name, annotation.Value);
+                    ownedTable = ownedTable.AddAnnotation(annotation.Name, annotation.Value);
                 }
 
                 return _sqlExpressionFactory.Select(targetEntityType, ownedTable);
@@ -1687,11 +1687,6 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                 return table;
             }
         }
-
-        private static Expression AddConvertToObject(Expression expression)
-            => expression.Type.IsValueType
-                ? Expression.Convert(expression, typeof(object))
-                : expression;
 
         private EntityProjectionExpression GetEntityProjectionExpression(EntityShaperExpression entityShaperExpression)
             => entityShaperExpression.ValueBufferExpression switch

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
@@ -44,6 +44,10 @@ public class CrossApplyExpression : JoinExpressionBase
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new CrossApplyExpression(Table, GetAnnotations());
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Append("CROSS APPLY ");

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
@@ -44,6 +44,10 @@ public class CrossJoinExpression : JoinExpressionBase
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new CrossJoinExpression(Table, annotations);
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Append("CROSS JOIN ");

--- a/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
@@ -62,6 +62,10 @@ public class ExceptExpression : SetOperationBase
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new ExceptExpression(Alias, Source1, Source2, IsDistinct, annotations);
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Append("(");

--- a/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
@@ -84,6 +84,10 @@ public class FromSqlExpression : TableExpressionBase, IClonableTableExpressionBa
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new FromSqlExpression(Alias, _table, Sql, Arguments, annotations);
+
+    /// <inheritdoc />
     ITableBase ITableBasedExpression.Table => _table;
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
@@ -54,6 +54,10 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new InnerJoinExpression(Table, JoinPredicate, annotations);
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Append("INNER JOIN ");

--- a/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
@@ -62,6 +62,10 @@ public class IntersectExpression : SetOperationBase
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new IntersectExpression(Alias, Source1, Source2, IsDistinct, annotations);
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Append("(");

--- a/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
@@ -54,6 +54,10 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new LeftJoinExpression(Table, JoinPredicate, annotations);
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Append("LEFT JOIN ");

--- a/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
@@ -44,6 +44,10 @@ public class OuterApplyExpression : JoinExpressionBase
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new OuterApplyExpression(Table, annotations);
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Append("OUTER APPLY ");

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -513,6 +513,9 @@ public sealed partial class SelectExpression
         // This is implementation detail hence visitors are not supposed to see inside unless they really need to.
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
 
+        protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+            => new TpcTablesExpression(Alias, EntityType, SelectExpressions, annotations);
+
         protected override void Print(ExpressionPrinter expressionPrinter)
         {
             expressionPrinter.AppendLine("(");

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
@@ -28,23 +28,6 @@ public sealed class TableExpression : TableExpressionBase, IClonableTableExpress
         Table = table;
     }
 
-    /// <inheritdoc />
-    ITableBase ITableBasedExpression.Table => Table;
-
-    /// <inheritdoc />
-    protected override void Print(ExpressionPrinter expressionPrinter)
-    {
-        if (!string.IsNullOrEmpty(Schema))
-        {
-            expressionPrinter.Append(Schema).Append(".");
-        }
-
-        expressionPrinter.Append(Name);
-        PrintAnnotations(expressionPrinter);
-
-        expressionPrinter.Append(" AS ").Append(Alias);
-    }
-
     /// <summary>
     ///     The alias assigned to this table source.
     /// </summary>
@@ -71,8 +54,28 @@ public sealed class TableExpression : TableExpressionBase, IClonableTableExpress
     public ITableBase Table { get; }
 
     /// <inheritdoc />
-    public TableExpressionBase Clone()
-        => new TableExpression(Table, GetAnnotations()) { Alias = Alias };
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new TableExpression(Table, annotations) { Alias = Alias };
+
+    /// <inheritdoc />
+    ITableBase ITableBasedExpression.Table => Table;
+
+    /// <inheritdoc />
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        if (!string.IsNullOrEmpty(Schema))
+        {
+            expressionPrinter.Append(Schema).Append(".");
+        }
+
+        expressionPrinter.Append(Name);
+        PrintAnnotations(expressionPrinter);
+
+        expressionPrinter.Append(" AS ").Append(Alias);
+    }
+
+    /// <inheritdoc />
+    public TableExpressionBase Clone() => CreateWithAnnotations(GetAnnotations());
 
     /// <inheritdoc />
     public override bool Equals(object? obj)

--- a/src/EFCore.Relational/Query/SqlExpressions/TableValuedFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableValuedFunctionExpression.cs
@@ -92,6 +92,10 @@ public class TableValuedFunctionExpression : TableExpressionBase, ITableBasedExp
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new TableValuedFunctionExpression(Alias, StoreFunction, Arguments, annotations);
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         if (!string.IsNullOrEmpty(StoreFunction.Schema))

--- a/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
@@ -62,6 +62,10 @@ public class UnionExpression : SetOperationBase
             : this;
 
     /// <inheritdoc />
+    protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
+        => new UnionExpression(Alias, Source1, Source2, IsDistinct, annotations);
+
+    /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Append("(");

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
@@ -227,7 +227,8 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
                 Sql.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(tableExpression.Name, tableExpression.Schema))
                     .Append(" FOR SYSTEM_TIME ");
 
-                var temporalOperationType = (TemporalOperationType)tableExpression[SqlServerAnnotationNames.TemporalOperationType]!;
+                var temporalOperationType = (TemporalOperationType)tableExpression
+                    .FindAnnotation(SqlServerAnnotationNames.TemporalOperationType)!.Value!;
 
                 switch (temporalOperationType)
                 {
@@ -236,7 +237,7 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
                         break;
 
                     case TemporalOperationType.AsOf:
-                        var pointInTime = (DateTime)tableExpression[SqlServerAnnotationNames.TemporalAsOfPointInTime]!;
+                        var pointInTime = (DateTime)tableExpression.FindAnnotation(SqlServerAnnotationNames.TemporalAsOfPointInTime)!.Value!;
 
                         Sql.Append("AS OF ")
                             .Append(_typeMappingSource.GetMapping(typeof(DateTime)).GenerateSqlLiteral(pointInTime));
@@ -246,10 +247,10 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
                     case TemporalOperationType.ContainedIn:
                     case TemporalOperationType.FromTo:
                         var from = _typeMappingSource.GetMapping(typeof(DateTime)).GenerateSqlLiteral(
-                            (DateTime)tableExpression[SqlServerAnnotationNames.TemporalRangeOperationFrom]!);
+                            (DateTime)tableExpression.FindAnnotation(SqlServerAnnotationNames.TemporalRangeOperationFrom)!.Value!);
 
                         var to = _typeMappingSource.GetMapping(typeof(DateTime)).GenerateSqlLiteral(
-                            (DateTime)tableExpression[SqlServerAnnotationNames.TemporalRangeOperationTo]!);
+                            (DateTime)tableExpression.FindAnnotation(SqlServerAnnotationNames.TemporalRangeOperationTo)!.Value!);
 
                         switch (temporalOperationType)
                         {


### PR DESCRIPTION
Resolves #28120

Only SelectExpression does mutable way, all other expressions will recreate with new annotations.
