### PR TITLE
API review items 

### DIFF
--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Data;
-
 namespace Microsoft.EntityFrameworkCore.Update;
 
 /// <summary>
@@ -23,8 +21,9 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
     ///     Creates a new <see cref="AffectedCountModificationCommandBatch" /> instance.
     /// </summary>
     /// <param name="dependencies">Service dependencies.</param>
-    protected AffectedCountModificationCommandBatch(ModificationCommandBatchFactoryDependencies dependencies)
-        : base(dependencies)
+    /// <param name="maxBatchSize">The maximum batch size. Defaults to 1000.</param>
+    protected AffectedCountModificationCommandBatch(ModificationCommandBatchFactoryDependencies dependencies, int? maxBatchSize = null)
+        : base(dependencies, maxBatchSize)
     {
     }
 

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -33,7 +33,8 @@ public abstract class ReaderModificationCommandBatch : ModificationCommandBatch
     ///     Creates a new <see cref="ReaderModificationCommandBatch" /> instance.
     /// </summary>
     /// <param name="dependencies">Service dependencies.</param>
-    protected ReaderModificationCommandBatch(ModificationCommandBatchFactoryDependencies dependencies)
+    /// <param name="maxBatchSize">The maximum batch size. Defaults to 1000.</param>
+    protected ReaderModificationCommandBatch(ModificationCommandBatchFactoryDependencies dependencies, int? maxBatchSize = null)
     {
         Dependencies = dependencies;
 
@@ -42,6 +43,8 @@ public abstract class ReaderModificationCommandBatch : ModificationCommandBatch
         UpdateSqlGenerator = dependencies.UpdateSqlGenerator;
         UpdateSqlGenerator.AppendBatchHeader(SqlBuilder);
         _batchHeaderLength = SqlBuilder.Length;
+
+        MaxBatchSize = maxBatchSize ?? 1000;
     }
 
     /// <summary>
@@ -62,8 +65,7 @@ public abstract class ReaderModificationCommandBatch : ModificationCommandBatch
     /// <summary>
     ///     The maximum number of <see cref="ModificationCommand"/> instances that can be added to a single batch.
     /// </summary>
-    protected virtual int MaxBatchSize
-        => 1000;
+    protected virtual int MaxBatchSize { get; }
 
     /// <summary>
     ///     Gets the command text builder for the commands in the batch.

--- a/src/EFCore.Relational/Update/SingularModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/SingularModificationCommandBatch.cs
@@ -23,13 +23,7 @@ public class SingularModificationCommandBatch : AffectedCountModificationCommand
     /// </summary>
     /// <param name="dependencies">Service dependencies.</param>
     public SingularModificationCommandBatch(ModificationCommandBatchFactoryDependencies dependencies)
-        : base(dependencies)
+        : base(dependencies, maxBatchSize: 1)
     {
     }
-
-    /// <summary>
-    ///     The maximum number of <see cref="ModificationCommand"/> instances that can be added to a single batch; always returns 1.
-    /// </summary>
-    protected override int MaxBatchSize
-        => 1;
 }

--- a/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
@@ -134,7 +134,7 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
 
         AppendUpdateCommand(
             commandStringBuilder, name, schema, writeOperations, readOperations, conditionOperations,
-            additionalReadValues: readOperations.Count == 0 ? "1" : null);
+            appendReturningOneClause: readOperations.Count == 0);
 
         return ResultSetMapping.LastInResultSet;
     }
@@ -175,7 +175,7 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
         requiresTransaction = false;
 
         AppendDeleteCommand(
-            commandStringBuilder, name, schema, Array.Empty<IColumnModification>(), conditionOperations, additionalReadValues: "1");
+            commandStringBuilder, name, schema, Array.Empty<IColumnModification>(), conditionOperations, appendReturningOneClause: true);
 
         return ResultSetMapping.LastInResultSet;
     }
@@ -211,7 +211,7 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
     /// <param name="writeOperations">The operations for each column.</param>
     /// <param name="readOperations">The operations for column values to be read back.</param>
     /// <param name="conditionOperations">The operations used to generate the <c>WHERE</c> clause for the update.</param>
-    /// <param name="additionalReadValues">Additional values to be read back.</param>
+    /// <param name="appendReturningOneClause">Whether to append an additional constant of 1 to be read back.</param>
     protected virtual void AppendUpdateCommand(
         StringBuilder commandStringBuilder,
         string name,
@@ -219,11 +219,11 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
         IReadOnlyList<IColumnModification> writeOperations,
         IReadOnlyList<IColumnModification> readOperations,
         IReadOnlyList<IColumnModification> conditionOperations,
-        string? additionalReadValues = null)
+        bool appendReturningOneClause = false)
     {
         AppendUpdateCommandHeader(commandStringBuilder, name, schema, writeOperations);
         AppendWhereClause(commandStringBuilder, conditionOperations);
-        AppendReturningClause(commandStringBuilder, readOperations, additionalReadValues);
+        AppendReturningClause(commandStringBuilder, readOperations, appendReturningOneClause ? "1" : null);
         commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator);
     }
 
@@ -235,18 +235,18 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
     /// <param name="schema">The table schema, or <see langword="null" /> to use the default schema.</param>
     /// <param name="readOperations">The operations for column values to be read back.</param>
     /// <param name="conditionOperations">The operations used to generate the <c>WHERE</c> clause for the delete.</param>
-    /// <param name="additionalReadValues">Additional values to be read back.</param>
+    /// <param name="appendReturningOneClause">Whether to append an additional constant of 1 to be read back.</param>
     protected virtual void AppendDeleteCommand(
         StringBuilder commandStringBuilder,
         string name,
         string? schema,
         IReadOnlyList<IColumnModification> readOperations,
         IReadOnlyList<IColumnModification> conditionOperations,
-        string? additionalReadValues = null)
+        bool appendReturningOneClause = false)
     {
         AppendDeleteCommandHeader(commandStringBuilder, name, schema);
         AppendWhereClause(commandStringBuilder, conditionOperations);
-        AppendReturningClause(commandStringBuilder, readOperations, additionalReadValues);
+        AppendReturningClause(commandStringBuilder, readOperations, appendReturningOneClause ? "1" : null);
         commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator);
     }
 
@@ -478,7 +478,7 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
                     commandStringBuilder.Append(", ");
                 }
 
-                commandStringBuilder.Append(additionalValues);
+                commandStringBuilder.Append("1");
             }
         }
     }

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
@@ -29,8 +29,9 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
     public SqlServerModificationCommandBatch(
         ModificationCommandBatchFactoryDependencies dependencies,
         int maxBatchSize)
-        : base(dependencies)
-        => MaxBatchSize = maxBatchSize;
+        : base(dependencies, maxBatchSize)
+    {
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -40,14 +41,6 @@ public class SqlServerModificationCommandBatch : AffectedCountModificationComman
     /// </summary>
     protected new virtual ISqlServerUpdateSqlGenerator UpdateSqlGenerator
         => (ISqlServerUpdateSqlGenerator)base.UpdateSqlGenerator;
-
-    /// <summary>
-    ///     The maximum number of <see cref="ModificationCommand"/> instances that can be added to a single batch.
-    /// </summary>
-    /// <remarks>
-    ///     For SQL Server, this is 42 by default, and cannot exceed 1000.
-    /// </remarks>
-    protected override int MaxBatchSize { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -126,11 +126,11 @@ public class SqlServerUpdateSqlGenerator : UpdateAndSelectSqlGenerator, ISqlServ
         IReadOnlyList<IColumnModification> writeOperations,
         IReadOnlyList<IColumnModification> readOperations,
         IReadOnlyList<IColumnModification> conditionOperations,
-        string? additionalReadValues = null)
+        bool appendReturningOneClause = false)
     {
         // In SQL Server the OUTPUT clause is placed differently (before the WHERE instead of at the end)
         AppendUpdateCommandHeader(commandStringBuilder, name, schema, writeOperations);
-        AppendOutputClause(commandStringBuilder, readOperations, additionalReadValues);
+        AppendOutputClause(commandStringBuilder, readOperations, appendReturningOneClause ? "1" : null);
         AppendWhereClause(commandStringBuilder, conditionOperations);
         commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator);
     }
@@ -166,11 +166,11 @@ public class SqlServerUpdateSqlGenerator : UpdateAndSelectSqlGenerator, ISqlServ
         string? schema,
         IReadOnlyList<IColumnModification> readOperations,
         IReadOnlyList<IColumnModification> conditionOperations,
-        string? additionalReadValues = null)
+        bool appendReturningOneClause = false)
     {
         // In SQL Server the OUTPUT clause is placed differently (before the WHERE instead of at the end)
         AppendDeleteCommandHeader(commandStringBuilder, name, schema);
-        AppendOutputClause(commandStringBuilder, readOperations, additionalReadValues);
+        AppendOutputClause(commandStringBuilder, readOperations, appendReturningOneClause ? "1" : null);
         AppendWhereClause(commandStringBuilder, conditionOperations);
         commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator);
     }


### PR DESCRIPTION
* Append{Update,Delete}Command now accept a higher-level flag for adding a 1 constant to the RETURNING clause.
  * Note that AppendReturningClause still accepts a lower-level string; that's actually being used in SQL Server for the synthetic position value we project out (and could be useful elsewhere).
* Accept MaxBatchSize in the ReadModificationCommandBatch constructor

Part of https://github.com/dotnet/efcore/issues/27588