### PR TITLE
Allow users to always use transactions with SaveChanges

### DIFF
--- a/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
+++ b/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
@@ -66,12 +66,14 @@ public class BatchExecutor : IBatchExecutor
         try
         {
             var transactionEnlistManager = connection as ITransactionEnlistmentManager;
+            var autoTransactionBehavior = CurrentContext.Context.Database.AutoTransactionBehavior;
             if (transaction == null
                 && transactionEnlistManager?.EnlistedTransaction is null
                 && transactionEnlistManager?.CurrentAmbientTransaction is null
-                && CurrentContext.Context.Database.AutoTransactionsEnabled
                 // Don't start a transaction if we have a single batch which doesn't require a transaction (single command), for perf.
-                && (batch.AreMoreBatchesExpected || batch.RequiresTransaction))
+                && ((autoTransactionBehavior == AutoTransactionBehavior.WhenNeeded
+                        && (batch.AreMoreBatchesExpected || batch.RequiresTransaction))
+                    || autoTransactionBehavior == AutoTransactionBehavior.Always))
             {
                 transaction = connection.BeginTransaction();
                 beganTransaction = true;
@@ -174,12 +176,14 @@ public class BatchExecutor : IBatchExecutor
         try
         {
             var transactionEnlistManager = connection as ITransactionEnlistmentManager;
+            var autoTransactionBehavior = CurrentContext.Context.Database.AutoTransactionBehavior;
             if (transaction == null
                 && transactionEnlistManager?.EnlistedTransaction is null
                 && transactionEnlistManager?.CurrentAmbientTransaction is null
-                && CurrentContext.Context.Database.AutoTransactionsEnabled
                 // Don't start a transaction if we have a single batch which doesn't require a transaction (single command), for perf.
-                && (batch.AreMoreBatchesExpected || batch.RequiresTransaction))
+                && ((autoTransactionBehavior == AutoTransactionBehavior.WhenNeeded
+                        && (batch.AreMoreBatchesExpected || batch.RequiresTransaction))
+                    || autoTransactionBehavior == AutoTransactionBehavior.Always))
             {
                 transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
                 beganTransaction = true;

--- a/src/EFCore/AutoTransactionBehavior.cs
+++ b/src/EFCore/AutoTransactionBehavior.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Indicates whether or not a transaction will be created automatically by <see cref="DbContext.SaveChanges()" /> if a user transaction
+///     wasn't created via 'BeginTransaction' or provided via 'UseTransaction'.
+/// </summary>
+public enum AutoTransactionBehavior
+{
+    /// <summary>
+    ///     Transactions are automatically created as needed. For example, most single SQL statements are implicitly executed within a
+    ///     transaction, and so do not require an explicit one to be created, reducing database round trips. This is the default setting.
+    /// </summary>
+    WhenNeeded,
+
+    /// <summary>
+    ///     Transactions are always created automatically, as long there's no user transaction. This setting may create transactions even
+    ///     when they're not needed, adding additional database round trips which may degrade performance.
+    /// </summary>
+    Always,
+
+    /// <summary>
+    ///     Transactions are never created automatically. Use this options with caution, since the database could be left in an inconsistent
+    ///     state if a failure occurs.
+    /// </summary>
+    Never
+}

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -1235,7 +1235,7 @@ public class StateManager : IStateManager
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual int SaveChanges(bool acceptAllChangesOnSuccess)
-        => !Context.Database.AutoTransactionsEnabled
+        => Context.Database.AutoTransactionBehavior == AutoTransactionBehavior.Never
             ? SaveChanges(this, acceptAllChangesOnSuccess)
             : Dependencies.ExecutionStrategy.Execute(
                 (StateManager: this, AcceptAllChangesOnSuccess: acceptAllChangesOnSuccess),
@@ -1291,7 +1291,7 @@ public class StateManager : IStateManager
     public virtual Task<int> SaveChangesAsync(
         bool acceptAllChangesOnSuccess,
         CancellationToken cancellationToken = default)
-        => !Context.Database.AutoTransactionsEnabled
+        => Context.Database.AutoTransactionBehavior == AutoTransactionBehavior.Never
             ? SaveChangesAsync(this, acceptAllChangesOnSuccess, cancellationToken)
             : Dependencies.ExecutionStrategy.ExecuteAsync(
                 (StateManager: this, AcceptAllChangesOnSuccess: acceptAllChangesOnSuccess),

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -869,7 +869,7 @@ public class DbContext :
             || _configurationSnapshot.HasDatabaseConfiguration)
         {
             var database = Database;
-            database.AutoTransactionsEnabled = _configurationSnapshot.AutoTransactionsEnabled;
+            database.AutoTransactionBehavior = _configurationSnapshot.AutoTransactionBehavior;
             database.AutoSavepointsEnabled = _configurationSnapshot.AutoSavepointsEnabled;
         }
 
@@ -917,7 +917,7 @@ public class DbContext :
             changeDetectorEvents != null,
             _changeTracker?.AutoDetectChangesEnabled ?? true,
             _changeTracker?.QueryTrackingBehavior ?? QueryTrackingBehavior.TrackAll,
-            _database?.AutoTransactionsEnabled ?? true,
+            _database?.AutoTransactionBehavior ?? AutoTransactionBehavior.WhenNeeded,
             _database?.AutoSavepointsEnabled ?? true,
             _changeTracker?.LazyLoadingEnabled ?? true,
             _changeTracker?.CascadeDeleteTiming ?? CascadeTiming.Immediate,

--- a/src/EFCore/Infrastructure/DatabaseFacade.cs
+++ b/src/EFCore/Infrastructure/DatabaseFacade.cs
@@ -376,28 +376,63 @@ public class DatabaseFacade : IInfrastructure<IServiceProvider>, IDatabaseFacade
         => Dependencies.TransactionManager.CurrentTransaction;
 
     /// <summary>
-    ///     Gets or sets a value indicating whether or not a transaction will be created
-    ///     automatically by <see cref="DbContext.SaveChanges()" /> if none of the
-    ///     'BeginTransaction' or 'UseTransaction' methods have been called.
+    ///     Gets or sets a value indicating whether or not a transaction will be created automatically by
+    ///     <see cref="DbContext.SaveChanges()" /> if none of the 'BeginTransaction' or 'UseTransaction' methods have been called.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Setting this value to <see langword="false" /> will also disable the <see cref="IExecutionStrategy" />
-    ///         for <see cref="DbContext.SaveChanges()" />
+    ///         Setting this value to <see langword="false" /> will also disable the <see cref="IExecutionStrategy" /> for
+    ///         <see cref="DbContext.SaveChanges()" />
     ///     </para>
     ///     <para>
     ///         The default value is <see langword="true" />, meaning that <see cref="DbContext.SaveChanges()" /> will always use a
     ///         transaction when saving changes.
     ///     </para>
     ///     <para>
-    ///         Setting this value to <see langword="false" /> should only be done with caution since the database
-    ///         could be left in a corrupted state if <see cref="DbContext.SaveChanges()" /> fails.
+    ///         Setting this value to <see langword="false" /> should only be done with caution, since the database could be left in an
+    ///         inconsistent state if failure occurs.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-transactions">Transactions in EF Core</see> for more information and examples.
     ///     </para>
     /// </remarks>
-    public virtual bool AutoTransactionsEnabled { get; set; } = true;
+    [Obsolete("Use EnableAutoTransactions instead")]
+    public virtual bool AutoTransactionsEnabled
+    {
+        get => AutoTransactionBehavior is AutoTransactionBehavior.Always or AutoTransactionBehavior.WhenNeeded;
+        set
+        {
+            if (value)
+            {
+                if (AutoTransactionBehavior == AutoTransactionBehavior.Never)
+                {
+                    AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
+                }
+            }
+            else
+            {
+                AutoTransactionBehavior = AutoTransactionBehavior.Never;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether or not a transaction will be created automatically by
+    ///     <see cref="DbContext.SaveChanges()" /> if neither 'BeginTransaction' nor 'UseTransaction' has been called.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The default setting is <see cref="AutoTransactionBehavior.WhenNeeded" />.
+    ///     </para>
+    ///     <para>
+    ///         Setting this to <see cref="AutoTransactionBehavior.Never" /> with caution, since the database could be left in
+    ///         an inconsistent state if failure occurs.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-transactions">Transactions in EF Core</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    public virtual AutoTransactionBehavior AutoTransactionBehavior { get; set; } = AutoTransactionBehavior.WhenNeeded;
 
     /// <summary>
     ///     Whether a transaction savepoint will be created automatically by <see cref="DbContext.SaveChanges()" /> if it is called
@@ -483,7 +518,7 @@ public class DatabaseFacade : IInfrastructure<IServiceProvider>, IDatabaseFacade
     /// <inheritdoc />
     void IResettableService.ResetState()
     {
-        AutoTransactionsEnabled = true;
+        AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
         AutoSavepointsEnabled = true;
     }
 

--- a/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
+++ b/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
@@ -24,7 +24,7 @@ public sealed class DbContextPoolConfigurationSnapshot
         bool hasChangeDetectorConfiguration,
         bool autoDetectChangesEnabled,
         QueryTrackingBehavior queryTrackingBehavior,
-        bool autoTransactionsEnabled,
+        AutoTransactionBehavior autoTransactionBehavior,
         bool autoSavepointsEnabled,
         bool lazyLoadingEnabled,
         CascadeTiming cascadeDeleteTiming,
@@ -47,8 +47,8 @@ public sealed class DbContextPoolConfigurationSnapshot
         HasChangeDetectorConfiguration = hasChangeDetectorConfiguration;
         AutoDetectChangesEnabled = autoDetectChangesEnabled;
         QueryTrackingBehavior = queryTrackingBehavior;
-        AutoTransactionsEnabled = autoTransactionsEnabled;
         AutoSavepointsEnabled = autoSavepointsEnabled;
+        AutoTransactionBehavior = autoTransactionBehavior;
         LazyLoadingEnabled = lazyLoadingEnabled;
         CascadeDeleteTiming = cascadeDeleteTiming;
         DeleteOrphansTiming = deleteOrphansTiming;
@@ -143,7 +143,7 @@ public sealed class DbContextPoolConfigurationSnapshot
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public bool AutoTransactionsEnabled { get; }
+    public AutoTransactionBehavior AutoTransactionBehavior { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -109,7 +109,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
 
             ChangeTracker.AutoDetectChangesEnabled = false;
             ChangeTracker.LazyLoadingEnabled = false;
-            Database.AutoTransactionsEnabled = false;
+            Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
             Database.AutoSavepointsEnabled = false;
             ChangeTracker.CascadeDeleteTiming = CascadeTiming.Never;
             ChangeTracker.DeleteOrphansTiming = CascadeTiming.Never;
@@ -728,7 +728,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         context1.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
         context1.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Immediate;
-        context1.Database.AutoTransactionsEnabled = true;
+        context1.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
         context1.Database.AutoSavepointsEnabled = true;
         context1.Database.SetCommandTimeout(1);
         context1.ChangeTracker.Tracking += ChangeTracker_OnTracking;
@@ -759,7 +759,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
         Assert.Equal(CascadeTiming.Never, context2.ChangeTracker.CascadeDeleteTiming);
         Assert.Equal(CascadeTiming.Never, context2.ChangeTracker.DeleteOrphansTiming);
-        Assert.False(context2.Database.AutoTransactionsEnabled);
+        Assert.Equal(AutoTransactionBehavior.Never, context2.Database.AutoTransactionBehavior);
         Assert.False(context2.Database.AutoSavepointsEnabled);
         Assert.Null(context1.Database.GetCommandTimeout());
 
@@ -826,7 +826,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         context1.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
         context1.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Immediate;
-        context1.Database.AutoTransactionsEnabled = true;
+        context1.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
         context1.Database.AutoSavepointsEnabled = true;
         context1.ChangeTracker.Tracking += ChangeTracker_OnTracking;
         context1.ChangeTracker.Tracked += ChangeTracker_OnTracked;
@@ -878,7 +878,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         context.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
         context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Immediate;
-        context.Database.AutoTransactionsEnabled = true;
+        context.Database.AutoTransactionBehavior = AutoTransactionBehavior.WhenNeeded;
         context.Database.AutoSavepointsEnabled = true;
         context.ChangeTracker.Tracking += ChangeTracker_OnTracking;
         context.ChangeTracker.Tracked += ChangeTracker_OnTracked;
@@ -899,7 +899,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         Assert.Equal(QueryTrackingBehavior.NoTracking, context.ChangeTracker.QueryTrackingBehavior);
         Assert.Equal(CascadeTiming.Immediate, context.ChangeTracker.CascadeDeleteTiming);
         Assert.Equal(CascadeTiming.Immediate, context.ChangeTracker.DeleteOrphansTiming);
-        Assert.True(context.Database.AutoTransactionsEnabled);
+        Assert.Equal(AutoTransactionBehavior.WhenNeeded, context.Database.AutoTransactionBehavior);
         Assert.True(context.Database.AutoSavepointsEnabled);
 
         Assert.False(_changeTracker_OnTracking);
@@ -1005,7 +1005,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         context1!.ChangeTracker.AutoDetectChangesEnabled = false;
         context1.ChangeTracker.LazyLoadingEnabled = false;
         context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
-        context1.Database.AutoTransactionsEnabled = false;
+        context1.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
         context1.Database.AutoSavepointsEnabled = false;
         context1.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
         context1.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Immediate;
@@ -1024,7 +1024,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
         Assert.Equal(CascadeTiming.Immediate, context2.ChangeTracker.CascadeDeleteTiming);
         Assert.Equal(CascadeTiming.Immediate, context2.ChangeTracker.DeleteOrphansTiming);
-        Assert.True(context2.Database.AutoTransactionsEnabled);
+        Assert.Equal(AutoTransactionBehavior.WhenNeeded, context2.Database.AutoTransactionBehavior);
         Assert.True(context2.Database.AutoSavepointsEnabled);
     }
 
@@ -1042,7 +1042,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         context1.ChangeTracker.AutoDetectChangesEnabled = false;
         context1.ChangeTracker.LazyLoadingEnabled = false;
         context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
-        context1.Database.AutoTransactionsEnabled = false;
+        context1.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
         context1.Database.AutoSavepointsEnabled = false;
         context1.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
         context1.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Immediate;
@@ -1058,7 +1058,7 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
         Assert.Equal(CascadeTiming.Immediate, context2.ChangeTracker.CascadeDeleteTiming);
         Assert.Equal(CascadeTiming.Immediate, context2.ChangeTracker.DeleteOrphansTiming);
-        Assert.True(context2.Database.AutoTransactionsEnabled);
+        Assert.Equal(AutoTransactionBehavior.WhenNeeded, context2.Database.AutoTransactionBehavior);
         Assert.True(context2.Database.AutoSavepointsEnabled);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
@@ -26,10 +26,11 @@ public class TransactionSqlServerTest : TransactionTestBase<TransactionSqlServer
         => Task.CompletedTask;
 
     // Test relies on savepoints, which are disabled when MARS is enabled
-    public override Task SaveChanges_uses_explicit_transaction_with_failure_behavior(bool async, bool autoTransaction)
+    public override Task SaveChanges_uses_explicit_transaction_with_failure_behavior(
+        bool async, AutoTransactionBehavior autoTransactionBehavior)
         => new SqlConnectionStringBuilder(TestStore.ConnectionString).MultipleActiveResultSets
             ? Task.CompletedTask
-            : base.SaveChanges_uses_explicit_transaction_with_failure_behavior(async, autoTransaction);
+            : base.SaveChanges_uses_explicit_transaction_with_failure_behavior(async, autoTransactionBehavior);
 
     [ConditionalTheory]
     [InlineData(true)]


### PR DESCRIPTION
To avoid a new flag which would be weird with the existing AutoTransactionsEnabled (e.g. AutoTransactionsEnabled=false, newflag=true), I went with the controversial choice of obsoleting AutoTransactionsEnabled and replacing it with an AutoTransactionBehavior enum that has WhenNeeded (default), Never, Always. Before you start hating, remember we almost decided to remove AutoTransactionsEnabled because it's obscure and nobody uses it (or should)...

Closes #27574

