### PR TITLE
Fix bugs in SQL Server bulk insert management

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -320,6 +320,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sqlite/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subqueries/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subquery/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=transactionality/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unconfigured/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unignore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fixup/@EntryIndexedValue">True</s:Boolean>

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
@@ -12,7 +12,7 @@ public class StoredProcedureUpdateSqlServerTest
         : base(fixture)
     {
         Fixture.TestSqlLoggerFactory.Clear();
-        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        // Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
     public override async Task Insert_with_output_parameter(bool async)

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -11,20 +11,33 @@ namespace Microsoft.EntityFrameworkCore.Update;
 
 public class SqlServerModificationCommandBatchTest
 {
-    [ConditionalFact]
-    public void AddCommand_returns_false_when_max_batch_size_is_reached()
+    [ConditionalTheory]
+    [InlineData(EntityState.Added)]
+    [InlineData(EntityState.Deleted)]
+    [InlineData(EntityState.Modified)]
+    public void AddCommand_returns_false_when_max_batch_size_is_reached(EntityState entityState)
     {
         var batch = CreateBatch(maxBatchSize: 1);
 
         var firstCommand = CreateModificationCommand("T1", null, false);
+        firstCommand.EntityState = entityState;
+        var secondCommand = CreateModificationCommand("T1", null, false);
+        secondCommand.EntityState = entityState;
+
         Assert.True(batch.TryAddCommand(firstCommand));
-        Assert.False(batch.TryAddCommand(CreateModificationCommand("T1", null, false)));
+        Assert.False(batch.TryAddCommand(secondCommand));
 
         Assert.Same(firstCommand, Assert.Single(batch.ModificationCommands));
     }
 
-    [ConditionalFact]
-    public void AddCommand_returns_false_when_max_parameters_are_reached()
+    [ConditionalTheory]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
+    [InlineData(EntityState.Deleted, true)]
+    [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Modified, true)]
+    [InlineData(EntityState.Modified, false)]
+    public void AddCommand_returns_false_when_max_parameters_are_reached(EntityState entityState, bool withSameTable)
     {
         var typeMapper = CreateTypeMappingSource();
         var intMapping = typeMapper.FindMapping(typeof(int));
@@ -33,6 +46,7 @@ public class SqlServerModificationCommandBatchTest
         var batch = CreateBatch();
 
         var command = CreateModificationCommand("T1", null, false);
+        command.EntityState = entityState;
         for (var i = 0; i < 2098; i++)
         {
             command.AddColumnModification(CreateModificationParameters("col" + i));
@@ -40,6 +54,7 @@ public class SqlServerModificationCommandBatchTest
         Assert.True(batch.TryAddCommand(command));
 
         var secondCommand = CreateModificationCommand("T2", null, false);
+        secondCommand.EntityState = entityState;
         secondCommand.AddColumnModification(CreateModificationParameters("col"));
         Assert.False(batch.TryAddCommand(secondCommand));
         Assert.Same(command, Assert.Single(batch.ModificationCommands));


### PR DESCRIPTION
For the parameter check, we previously added the parameters only when the pending bulk insert commands were applied; this is why they weren't being taken into account for the parameter limit check. The fix here is to move parameter adding to when the bulk insert command is added, just like any normal command; only the SQL addition is deferred.

Note that this won't support fancy bulk strategies, such as a single array parameter for multiple rows in PostgreSQL. But other things have to be done for that anyway, and this seems like an acceptable fix for now.

Fixes #27840
Fixes #28712
