### PR TITLE
Uniquify FK and Key constraint names across tables

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
@@ -47,16 +47,24 @@ public class SharedTableConvention : IModelFinalizingConvention
         TryUniquifyTableNames(modelBuilder.Metadata, tables, maxLength);
 
         var columns = new Dictionary<string, IConventionProperty>();
-        var keys = new Dictionary<string, IConventionKey>();
-        var foreignKeys = new Dictionary<string, IConventionForeignKey>();
-        var indexes = new Dictionary<string, IConventionIndex>();
-        var checkConstraints = new Dictionary<(string, string?), IConventionCheckConstraint>();
-        var triggers = new Dictionary<string, IConventionTrigger>();
+        var keys = new Dictionary<string, (IConventionKey, StoreObjectIdentifier)>();
+        var foreignKeys = new Dictionary<string, (IConventionForeignKey, StoreObjectIdentifier)>();
+        var indexes = new Dictionary<string, (IConventionIndex, StoreObjectIdentifier)>();
+        var checkConstraints = new Dictionary<(string, string?), (IConventionCheckConstraint, StoreObjectIdentifier)>();
+        var triggers = new Dictionary<string, (IConventionTrigger, StoreObjectIdentifier)>();
         foreach (var ((tableName, schema), conventionEntityTypes) in tables)
         {
             columns.Clear();
-            keys.Clear();
-            foreignKeys.Clear();
+
+            if (!KeysUniqueAcrossTables)
+            {
+                keys.Clear();
+            }
+
+            if (!ForeignKeysUniqueAcrossTables)
+            {
+                foreignKeys.Clear();
+            }
 
             if (!IndexesUniqueAcrossTables)
             {
@@ -85,6 +93,18 @@ public class SharedTableConvention : IModelFinalizingConvention
             }
         }
     }
+
+    /// <summary>
+    ///     Gets a value indicating whether key names should be unique across tables.
+    /// </summary>
+    protected virtual bool KeysUniqueAcrossTables
+        => false;
+
+    /// <summary>
+    ///     Gets a value indicating whether foreign key names should be unique across tables.
+    /// </summary>
+    protected virtual bool ForeignKeysUniqueAcrossTables
+        => false;
 
     /// <summary>
     ///     Gets a value indicating whether index names should be unique across tables.
@@ -297,7 +317,7 @@ public class SharedTableConvention : IModelFinalizingConvention
 
     private void TryUniquifyKeyNames(
         IConventionEntityType entityType,
-        Dictionary<string, IConventionKey> keys,
+        Dictionary<string, (IConventionKey, StoreObjectIdentifier)> keys,
         in StoreObjectIdentifier storeObject,
         int maxLength)
     {
@@ -309,15 +329,17 @@ public class SharedTableConvention : IModelFinalizingConvention
                 continue;
             }
 
-            if (!keys.TryGetValue(keyName, out var otherKey))
+            if (!keys.TryGetValue(keyName, out var otherKeyPair))
             {
-                keys[keyName] = key;
+                keys[keyName] = (key, storeObject);
                 continue;
             }
 
-            if ((key.IsPrimaryKey()
-                    && otherKey.IsPrimaryKey())
-                || AreCompatible(key, otherKey, storeObject))
+            var (otherKey, otherStoreObject) = otherKeyPair;
+            if (storeObject == otherStoreObject
+                && ((key.IsPrimaryKey()
+                        && otherKey.IsPrimaryKey())
+                    || AreCompatible(key, otherKey, storeObject)))
             {
                 continue;
             }
@@ -325,15 +347,15 @@ public class SharedTableConvention : IModelFinalizingConvention
             var newKeyName = TryUniquify(key, keyName, keys, maxLength);
             if (newKeyName != null)
             {
-                keys[newKeyName] = key;
+                keys[newKeyName] = (key, storeObject);
                 continue;
             }
 
             var newOtherKeyName = TryUniquify(otherKey, keyName, keys, maxLength);
             if (newOtherKeyName != null)
             {
-                keys[keyName] = key;
-                keys[newOtherKeyName] = otherKey;
+                keys[keyName] = (key, storeObject);
+                keys[newOtherKeyName] = otherKeyPair;
             }
         }
     }
@@ -351,10 +373,10 @@ public class SharedTableConvention : IModelFinalizingConvention
         in StoreObjectIdentifier storeObject)
         => key.AreCompatible(duplicateKey, storeObject, shouldThrow: false);
 
-    private static string? TryUniquify<T>(
+    private static string? TryUniquify(
         IConventionKey key,
         string keyName,
-        Dictionary<string, T> keys,
+        Dictionary<string, (IConventionKey, StoreObjectIdentifier)> keys,
         int maxLength)
     {
         if (key.Builder.CanSetName(null))
@@ -369,7 +391,7 @@ public class SharedTableConvention : IModelFinalizingConvention
 
     private void TryUniquifyIndexNames(
         IConventionEntityType entityType,
-        Dictionary<string, IConventionIndex> indexes,
+        Dictionary<string, (IConventionIndex, StoreObjectIdentifier)> indexes,
         in StoreObjectIdentifier storeObject,
         int maxLength)
     {
@@ -381,13 +403,15 @@ public class SharedTableConvention : IModelFinalizingConvention
                 continue;
             }
 
-            if (!indexes.TryGetValue(indexName, out var otherIndex))
+            if (!indexes.TryGetValue(indexName, out var otherIndexPair))
             {
-                indexes[indexName] = index;
+                indexes[indexName] = (index, storeObject);
                 continue;
             }
 
-            if (AreCompatible(index, otherIndex, storeObject))
+            var (otherIndex, otherStoreObject) = otherIndexPair;
+            if (storeObject == otherStoreObject
+                && AreCompatible(index, otherIndex, storeObject))
             {
                 continue;
             }
@@ -395,15 +419,15 @@ public class SharedTableConvention : IModelFinalizingConvention
             var newIndexName = TryUniquify(index, indexName, indexes, maxLength);
             if (newIndexName != null)
             {
-                indexes[newIndexName] = index;
+                indexes[newIndexName] = (index, storeObject);
                 continue;
             }
 
             var newOtherIndexName = TryUniquify(otherIndex, indexName, indexes, maxLength);
             if (newOtherIndexName != null)
             {
-                indexes[indexName] = index;
-                indexes[newOtherIndexName] = otherIndex;
+                indexes[indexName] = (index, storeObject);
+                indexes[newOtherIndexName] = otherIndexPair;
             }
         }
     }
@@ -421,10 +445,10 @@ public class SharedTableConvention : IModelFinalizingConvention
         in StoreObjectIdentifier storeObject)
         => index.AreCompatible(duplicateIndex, storeObject, shouldThrow: false);
 
-    private static string? TryUniquify<T>(
+    private static string? TryUniquify(
         IConventionIndex index,
         string indexName,
-        Dictionary<string, T> indexes,
+        Dictionary<string, (IConventionIndex, StoreObjectIdentifier)> indexes,
         int maxLength)
     {
         if (index.Builder.CanSetDatabaseName(null))
@@ -439,7 +463,7 @@ public class SharedTableConvention : IModelFinalizingConvention
 
     private void TryUniquifyForeignKeyNames(
         IConventionEntityType entityType,
-        Dictionary<string, IConventionForeignKey> foreignKeys,
+        Dictionary<string, (IConventionForeignKey, StoreObjectIdentifier)> foreignKeys,
         in StoreObjectIdentifier storeObject,
         int maxLength)
     {
@@ -466,13 +490,15 @@ public class SharedTableConvention : IModelFinalizingConvention
                 continue;
             }
 
-            if (!foreignKeys.TryGetValue(foreignKeyName, out var otherForeignKey))
+            if (!foreignKeys.TryGetValue(foreignKeyName, out var otherForeignKeyPair))
             {
-                foreignKeys[foreignKeyName] = foreignKey;
+                foreignKeys[foreignKeyName] = (foreignKey, storeObject);
                 continue;
             }
 
-            if (AreCompatible(foreignKey, otherForeignKey, storeObject))
+            var (otherForeignKey, otherStoreObject) = otherForeignKeyPair;
+            if (storeObject == otherStoreObject
+                && AreCompatible(foreignKey, otherForeignKey, storeObject))
             {
                 continue;
             }
@@ -480,7 +506,7 @@ public class SharedTableConvention : IModelFinalizingConvention
             var newForeignKeyName = TryUniquify(foreignKey, foreignKeyName, foreignKeys, maxLength);
             if (newForeignKeyName != null)
             {
-                foreignKeys[newForeignKeyName] = foreignKey;
+                foreignKeys[newForeignKeyName] = (foreignKey, storeObject);
                 continue;
             }
 
@@ -493,8 +519,8 @@ public class SharedTableConvention : IModelFinalizingConvention
             var newOtherForeignKeyName = TryUniquify(otherForeignKey, foreignKeyName, foreignKeys, maxLength);
             if (newOtherForeignKeyName != null)
             {
-                foreignKeys[foreignKeyName] = foreignKey;
-                foreignKeys[newOtherForeignKeyName] = otherForeignKey;
+                foreignKeys[foreignKeyName] = (foreignKey, storeObject);
+                foreignKeys[newOtherForeignKeyName] = otherForeignKeyPair;
             }
         }
     }
@@ -512,10 +538,10 @@ public class SharedTableConvention : IModelFinalizingConvention
         in StoreObjectIdentifier storeObject)
         => foreignKey.AreCompatible(duplicateForeignKey, storeObject, shouldThrow: false);
 
-    private static string? TryUniquify<T>(
+    private static string? TryUniquify(
         IConventionForeignKey foreignKey,
         string foreignKeyName,
-        Dictionary<string, T> foreignKeys,
+        Dictionary<string, (IConventionForeignKey, StoreObjectIdentifier)> foreignKeys,
         int maxLength)
     {
         if (foreignKey.Builder.CanSetConstraintName(null))
@@ -530,7 +556,7 @@ public class SharedTableConvention : IModelFinalizingConvention
 
     private void TryUniquifyCheckConstraintNames(
         IConventionEntityType entityType,
-        Dictionary<(string, string?), IConventionCheckConstraint> checkConstraints,
+        Dictionary<(string, string?), (IConventionCheckConstraint, StoreObjectIdentifier)> checkConstraints,
         in StoreObjectIdentifier storeObject,
         int maxLength)
     {
@@ -542,13 +568,15 @@ public class SharedTableConvention : IModelFinalizingConvention
                 continue;
             }
 
-            if (!checkConstraints.TryGetValue((constraintName, storeObject.Schema), out var otherCheckConstraint))
+            if (!checkConstraints.TryGetValue((constraintName, storeObject.Schema), out var otherCheckConstraintPair))
             {
-                checkConstraints[(constraintName, storeObject.Schema)] = checkConstraint;
+                checkConstraints[(constraintName, storeObject.Schema)] = (checkConstraint, storeObject);
                 continue;
             }
 
-            if (AreCompatible(checkConstraint, otherCheckConstraint, storeObject))
+            var (otherCheckConstraint, otherStoreObject) = otherCheckConstraintPair;
+            if (storeObject == otherStoreObject
+                && AreCompatible(checkConstraint, otherCheckConstraint, storeObject))
             {
                 continue;
             }
@@ -556,15 +584,15 @@ public class SharedTableConvention : IModelFinalizingConvention
             var newConstraintName = TryUniquify(checkConstraint, constraintName, storeObject.Schema, checkConstraints, maxLength);
             if (newConstraintName != null)
             {
-                checkConstraints[(newConstraintName, storeObject.Schema)] = checkConstraint;
+                checkConstraints[(newConstraintName, storeObject.Schema)] = (checkConstraint, storeObject);
                 continue;
             }
 
             var newOtherConstraintName = TryUniquify(otherCheckConstraint, constraintName, storeObject.Schema, checkConstraints, maxLength);
             if (newOtherConstraintName != null)
             {
-                checkConstraints[(constraintName, storeObject.Schema)] = checkConstraint;
-                checkConstraints[(newOtherConstraintName, storeObject.Schema)] = otherCheckConstraint;
+                checkConstraints[(constraintName, storeObject.Schema)] = (checkConstraint, storeObject);
+                checkConstraints[(newOtherConstraintName, otherStoreObject.Schema)] = otherCheckConstraintPair;
             }
         }
     }
@@ -582,11 +610,11 @@ public class SharedTableConvention : IModelFinalizingConvention
         in StoreObjectIdentifier storeObject)
         => CheckConstraint.AreCompatible(checkConstraint, duplicateCheckConstraint, storeObject, shouldThrow: false);
 
-    private static string? TryUniquify<T>(
+    private static string? TryUniquify(
         IConventionCheckConstraint checkConstraint,
         string checkConstraintName,
         string? schema,
-        Dictionary<(string, string?), T> checkConstraints,
+        Dictionary<(string, string?), (IConventionCheckConstraint, StoreObjectIdentifier)> checkConstraints,
         int maxLength)
     {
         if (checkConstraint.Builder.CanSetName(null))
@@ -601,7 +629,7 @@ public class SharedTableConvention : IModelFinalizingConvention
 
     private void TryUniquifyTriggerNames(
         IConventionEntityType entityType,
-        Dictionary<string, IConventionTrigger> triggers,
+        Dictionary<string, (IConventionTrigger, StoreObjectIdentifier)> triggers,
         in StoreObjectIdentifier storeObject,
         int maxLength)
     {
@@ -613,13 +641,15 @@ public class SharedTableConvention : IModelFinalizingConvention
                 continue;
             }
 
-            if (!triggers.TryGetValue(triggerName, out var otherTrigger))
+            if (!triggers.TryGetValue(triggerName, out var otherTriggerPair))
             {
-                triggers[triggerName] = trigger;
+                triggers[triggerName] = (trigger, storeObject);
                 continue;
             }
 
-            if (AreCompatible(trigger, otherTrigger, storeObject))
+            var (otherTrigger, otherStoreObject) = otherTriggerPair;
+            if (otherStoreObject == storeObject
+                && AreCompatible(trigger, otherTrigger, storeObject))
             {
                 continue;
             }
@@ -627,15 +657,15 @@ public class SharedTableConvention : IModelFinalizingConvention
             var newTriggerName = TryUniquify(trigger, triggerName, triggers, maxLength);
             if (newTriggerName != null)
             {
-                triggers[newTriggerName] = trigger;
+                triggers[newTriggerName] = (trigger, storeObject);
                 continue;
             }
 
             var newOtherTrigger = TryUniquify(otherTrigger, triggerName, triggers, maxLength);
             if (newOtherTrigger != null)
             {
-                triggers[triggerName] = trigger;
-                triggers[newOtherTrigger] = otherTrigger;
+                triggers[triggerName] = (trigger, storeObject);
+                triggers[newOtherTrigger] = otherTriggerPair;
             }
         }
     }
@@ -653,10 +683,10 @@ public class SharedTableConvention : IModelFinalizingConvention
         in StoreObjectIdentifier storeObject)
         => true;
 
-    private static string? TryUniquify<T>(
+    private static string? TryUniquify(
         IConventionTrigger trigger,
         string triggerName,
-        Dictionary<string, T> triggers,
+        Dictionary<string, (IConventionTrigger, StoreObjectIdentifier)> triggers,
         int maxLength)
     {
         if (trigger.Builder.CanSetName(null))

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -61,6 +61,8 @@ public class SqlServerConventionSetBuilder : RelationalConventionSetBuilder
         conventionSet.Replace<ValueGenerationConvention>(
             new SqlServerValueGenerationConvention(Dependencies, RelationalDependencies));
         conventionSet.Replace<RuntimeModelConvention>(new SqlServerRuntimeModelConvention(Dependencies, RelationalDependencies));
+        conventionSet.Replace<SharedTableConvention>(
+            new SqlServerSharedTableConvention(Dependencies, RelationalDependencies));
 
         var sqlServerTemporalConvention = new SqlServerTemporalConvention(Dependencies, RelationalDependencies);
         ConventionSet.AddBefore(

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerSharedTableConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerSharedTableConvention.cs
@@ -29,6 +29,9 @@ public class SqlServerSharedTableConvention : SharedTableConvention
     }
 
     /// <inheritdoc />
+    protected override bool IndexesUniqueAcrossTables => false;
+
+    /// <inheritdoc />
     protected override bool AreCompatible(IReadOnlyKey key, IReadOnlyKey duplicateKey, in StoreObjectIdentifier storeObject)
         => base.AreCompatible(key, duplicateKey, storeObject)
             && key.AreCompatibleForSqlServer(duplicateKey, storeObject, shouldThrow: false);

--- a/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteSharedTableConvention.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteSharedTableConvention.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
@@ -178,7 +178,7 @@ WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_Princ
             "ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingC~1",
             entityType2.GetProperties().ElementAt(2).GetColumnName(StoreObjectIdentifier.Table(entityType2.GetTableName())));
         Assert.Equal(
-            "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWor~1",
+            "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWork~",
             entityType2.GetIndexes().Single().GetDatabaseName());
     }
 


### PR DESCRIPTION
Don't uniquify index constraint names across tables in SQL Server

Fixes #23144
Fixes #27651