### PR TITLE
ExecuteDelete: Always generate Any form

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -83,7 +83,7 @@ public class QuerySqlGenerator : SqlExpressionVisitor
         switch (queryExpression)
         {
             case SelectExpression selectExpression:
-                GenerateTagsHeaderComment(selectExpression);
+                GenerateTagsHeaderComment(selectExpression.Tags);
 
                 if (selectExpression.IsNonComposedFromSql())
                 {
@@ -93,6 +93,16 @@ public class QuerySqlGenerator : SqlExpressionVisitor
                 {
                     VisitSelect(selectExpression);
                 }
+                break;
+
+            case UpdateExpression updateExpression:
+                GenerateTagsHeaderComment(updateExpression.Tags);
+                VisitUpdate(updateExpression);
+                break;
+
+            case DeleteExpression deleteExpression:
+                GenerateTagsHeaderComment(deleteExpression.Tags);
+                VisitDelete(deleteExpression);
                 break;
 
             default:
@@ -117,11 +127,29 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     ///     Generates the head comment for tags.
     /// </summary>
     /// <param name="selectExpression">A select expression to generate tags for.</param>
+    [Obsolete("Use the method which takes tags instead.")]
     protected virtual void GenerateTagsHeaderComment(SelectExpression selectExpression)
     {
         if (selectExpression.Tags.Count > 0)
         {
             foreach (var tag in selectExpression.Tags)
+            {
+                _relationalCommandBuilder.AppendLines(_sqlGenerationHelper.GenerateComment(tag));
+            }
+
+            _relationalCommandBuilder.AppendLine();
+        }
+    }
+
+    /// <summary>
+    ///     Generates the head comment for tags.
+    /// </summary>
+    /// <param name="tags">A set of tags to print as comment.</param>
+    protected virtual void GenerateTagsHeaderComment(ISet<string> tags)
+    {
+        if (tags.Count > 0)
+        {
+            foreach (var tag in tags)
             {
                 _relationalCommandBuilder.AppendLines(_sqlGenerationHelper.GenerateComment(tag));
             }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1079,13 +1079,6 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
         var clrType = entityType.ClrType;
         var entityParameter = Expression.Parameter(clrType);
         Expression predicateBody;
-        //if (pk.Properties.Count == 1)
-        //{
-        //    predicateBody = Expression.Call(
-        //        EnumerableMethods.Contains.MakeGenericMethod(clrType), source, entityParameter);
-        //}
-        //else
-        //{
         var innerParameter = Expression.Parameter(clrType);
         predicateBody = Expression.Call(
             QueryableMethods.AnyWithPredicate.MakeGenericMethod(clrType),
@@ -1093,7 +1086,6 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             Expression.Quote(Expression.Lambda(
                 Infrastructure.ExpressionExtensions.CreateEqualsExpression(innerParameter, entityParameter),
                 innerParameter)));
-        //}
 
         var newSource = Expression.Call(
             QueryableMethods.Where.MakeGenericMethod(clrType),

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -56,11 +56,24 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
     /// <returns>An expression which executes a non-query operation.</returns>
     protected virtual Expression VisitNonQuery(NonQueryExpression nonQueryExpression)
     {
+        // Apply tags
+        var innerExpression = nonQueryExpression.Expression;
+        switch (innerExpression)
+        {
+            case UpdateExpression updateExpression:
+                innerExpression = updateExpression.ApplyTags(_tags);
+                break;
+
+            case DeleteExpression deleteExpression:
+                innerExpression = deleteExpression.ApplyTags(_tags);
+                break;
+        }
+
         var relationalCommandCache = new RelationalCommandCache(
             Dependencies.MemoryCache,
             RelationalDependencies.QuerySqlGeneratorFactory,
             RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-            nonQueryExpression.Expression,
+            innerExpression,
             _useRelationalNulls);
 
         return Expression.Call(

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -735,6 +735,12 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             }
         }
 
+        // EF.Default
+        if (methodCallExpression.Method.IsEFDefaultMethod())
+        {
+            return new SqlFragmentExpression("DEFAULT");
+        }
+
         var method = methodCallExpression.Method;
         var arguments = methodCallExpression.Arguments;
         EnumerableExpression? enumerableExpression = null;

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
@@ -606,8 +605,82 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                 return new EntityReferenceExpression(entityShaperExpression);
 
             case ProjectionBindingExpression projectionBindingExpression:
-                return ((SelectExpression)projectionBindingExpression.QueryExpression)
-                    .GetProjection(projectionBindingExpression);
+                return Visit(((SelectExpression)projectionBindingExpression.QueryExpression)
+                    .GetProjection(projectionBindingExpression));
+
+            case ShapedQueryExpression shapedQueryExpression:
+                if (shapedQueryExpression.ResultCardinality == ResultCardinality.Enumerable)
+                {
+                    return QueryCompilationContext.NotTranslatedExpression;
+                }
+
+                var shaperExpression = shapedQueryExpression.ShaperExpression;
+                ProjectionBindingExpression? mappedProjectionBindingExpression = null;
+
+                var innerExpression = shaperExpression;
+                Type? convertedType = null;
+                if (shaperExpression is UnaryExpression unaryExpression
+                    && unaryExpression.NodeType == ExpressionType.Convert)
+                {
+                    convertedType = unaryExpression.Type;
+                    innerExpression = unaryExpression.Operand;
+                }
+
+                if (innerExpression is EntityShaperExpression ese
+                    && (convertedType == null
+                        || convertedType.IsAssignableFrom(ese.Type)))
+                {
+                    return new EntityReferenceExpression(shapedQueryExpression.UpdateShaperExpression(innerExpression));
+                }
+
+                if (innerExpression is ProjectionBindingExpression pbe
+                    && (convertedType == null
+                        || convertedType.MakeNullable() == innerExpression.Type))
+                {
+                    mappedProjectionBindingExpression = pbe;
+                }
+
+                if (mappedProjectionBindingExpression == null
+                    && shaperExpression is BlockExpression blockExpression
+                    && blockExpression.Expressions.Count == 2
+                    && blockExpression.Expressions[0] is BinaryExpression binaryExpression
+                    && binaryExpression.NodeType == ExpressionType.Assign
+                    && binaryExpression.Right is ProjectionBindingExpression pbe2)
+                {
+                    mappedProjectionBindingExpression = pbe2;
+                }
+
+                if (mappedProjectionBindingExpression == null)
+                {
+                    return QueryCompilationContext.NotTranslatedExpression;
+                }
+
+                var subquery = (SelectExpression)shapedQueryExpression.QueryExpression;
+                var projection = subquery.GetProjection(mappedProjectionBindingExpression);
+                if (projection is not SqlExpression sqlExpression)
+                {
+                    return QueryCompilationContext.NotTranslatedExpression;
+                }
+
+                if (subquery.Tables.Count == 0)
+                {
+                    return sqlExpression;
+                }
+
+                subquery.ReplaceProjection(new List<Expression> { sqlExpression });
+                subquery.ApplyProjection();
+
+                SqlExpression scalarSubqueryExpression = new ScalarSubqueryExpression(subquery);
+
+                if (shapedQueryExpression.ResultCardinality == ResultCardinality.SingleOrDefault
+                    && !shaperExpression.Type.IsNullableType())
+                {
+                    scalarSubqueryExpression = _sqlExpressionFactory.Coalesce(
+                        scalarSubqueryExpression,
+                        (SqlExpression)Visit(shaperExpression.Type.GetDefaultValueConstant()));
+                }
+
+                return scalarSubqueryExpression;
 
             default:
                 return QueryCompilationContext.NotTranslatedExpression;
@@ -632,7 +705,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         var innerExpression = Visit(memberExpression.Expression);
 
         return TryBindMember(innerExpression, MemberIdentity.Create(memberExpression.Member))
-            ?? (TranslationFailed(memberExpression.Expression, Visit(memberExpression.Expression), out var sqlInnerExpression)
+            ?? (TranslationFailed(memberExpression.Expression, innerExpression, out var sqlInnerExpression)
                 ? QueryCompilationContext.NotTranslatedExpression
                 : Dependencies.MemberTranslatorProvider.Translate(
                     sqlInnerExpression, memberExpression.Member, memberExpression.Type, _queryCompilationContext.Logger))
@@ -792,9 +865,9 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     : method;
 
                 var enumerableSource = Visit(arguments[0]);
-                if (enumerableSource is EnumerableExpression)
+                if (enumerableSource is EnumerableExpression ee)
                 {
-                    enumerableExpression = (EnumerableExpression)enumerableSource;
+                    enumerableExpression = ee;
                     switch (method.Name)
                     {
                         case nameof(Queryable.AsQueryable)
@@ -928,10 +1001,10 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                 && !skipVisitChildren)
             {
                 var @object = Visit(methodCallExpression.Object);
-                if (@object is EnumerableExpression)
+                if (@object is EnumerableExpression eeo)
                 {
                     // This is safe since if enumerableExpression is non-null then it was static method
-                    enumerableExpression = (EnumerableExpression)@object;
+                    enumerableExpression = eeo;
                 }
                 else if (TranslationFailed(methodCallExpression.Object, @object, out sqlObject))
                 {
@@ -944,7 +1017,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     {
                         var argument = arguments[i];
                         var visitedArgument = Visit(argument);
-                        if (visitedArgument is EnumerableExpression)
+                        if (visitedArgument is EnumerableExpression eea)
                         {
                             if (enumerableExpression != null)
                             {
@@ -952,7 +1025,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                                 break;
                             }
 
-                            enumerableExpression = (EnumerableExpression)visitedArgument;
+                            enumerableExpression = eea;
                             continue;
                         }
 
@@ -1009,83 +1082,10 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
         // Subquery case
         var subqueryTranslation = _queryableMethodTranslatingExpressionVisitor.TranslateSubquery(methodCallExpression);
-        if (subqueryTranslation != null)
-        {
-            if (subqueryTranslation.ResultCardinality == ResultCardinality.Enumerable)
-            {
-                return QueryCompilationContext.NotTranslatedExpression;
-            }
 
-            var shaperExpression = subqueryTranslation.ShaperExpression;
-            ProjectionBindingExpression? mappedProjectionBindingExpression = null;
-
-            var innerExpression = shaperExpression;
-            Type? convertedType = null;
-            if (shaperExpression is UnaryExpression unaryExpression
-                && unaryExpression.NodeType == ExpressionType.Convert)
-            {
-                convertedType = unaryExpression.Type;
-                innerExpression = unaryExpression.Operand;
-            }
-
-            if (innerExpression is EntityShaperExpression ese
-                && (convertedType == null
-                    || convertedType.IsAssignableFrom(ese.Type)))
-            {
-                return new EntityReferenceExpression(subqueryTranslation.UpdateShaperExpression(innerExpression));
-            }
-
-            if (innerExpression is ProjectionBindingExpression pbe
-                && (convertedType == null
-                    || convertedType.MakeNullable() == innerExpression.Type))
-            {
-                mappedProjectionBindingExpression = pbe;
-            }
-
-            if (mappedProjectionBindingExpression == null
-                && shaperExpression is BlockExpression blockExpression
-                && blockExpression.Expressions.Count == 2
-                && blockExpression.Expressions[0] is BinaryExpression binaryExpression
-                && binaryExpression.NodeType == ExpressionType.Assign
-                && binaryExpression.Right is ProjectionBindingExpression pbe2)
-            {
-                mappedProjectionBindingExpression = pbe2;
-            }
-
-            if (mappedProjectionBindingExpression == null)
-            {
-                return QueryCompilationContext.NotTranslatedExpression;
-            }
-
-            var subquery = (SelectExpression)subqueryTranslation.QueryExpression;
-            var projection = subquery.GetProjection(mappedProjectionBindingExpression);
-            if (projection is not SqlExpression sqlExpression)
-            {
-                return QueryCompilationContext.NotTranslatedExpression;
-            }
-
-            if (subquery.Tables.Count == 0)
-            {
-                return sqlExpression;
-            }
-
-            subquery.ReplaceProjection(new List<Expression> { sqlExpression });
-            subquery.ApplyProjection();
-
-            SqlExpression scalarSubqueryExpression = new ScalarSubqueryExpression(subquery);
-
-            if (subqueryTranslation.ResultCardinality == ResultCardinality.SingleOrDefault
-                && !shaperExpression.Type.IsNullableType())
-            {
-                scalarSubqueryExpression = _sqlExpressionFactory.Coalesce(
-                    scalarSubqueryExpression,
-                    (SqlExpression)Visit(shaperExpression.Type.GetDefaultValueConstant()));
-            }
-
-            return scalarSubqueryExpression;
-        }
-
-        return QueryCompilationContext.NotTranslatedExpression;
+        return subqueryTranslation == null
+            ? QueryCompilationContext.NotTranslatedExpression
+            : Visit(subqueryTranslation);
     }
 
     /// <inheritdoc />
@@ -1394,12 +1394,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
     {
         var lambdaBody = RemapLambda(enumerableExpression, lambdaExpression);
         var predicate = TranslateInternal(lambdaBody);
-        if (predicate == null)
-        {
-            return null;
-        }
-
-        return enumerableExpression.ApplyPredicate(predicate);
+        return predicate == null ? null : enumerableExpression.ApplyPredicate(predicate);
     }
 
     private static Expression TryRemoveImplicitConvert(Expression expression)

--- a/src/EFCore.Relational/Query/SqlExpressions/DeleteExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/DeleteExpression.cs
@@ -19,10 +19,21 @@ public sealed class DeleteExpression : Expression, IPrintableExpression
     /// <param name="table">A table on which the delete operation is being applied.</param>
     /// <param name="selectExpression">A select expression which is used to determine which rows to delete.</param>
     public DeleteExpression(TableExpression table, SelectExpression selectExpression)
+        : this(table, selectExpression, new HashSet<string>())
+    {
+    }
+
+    private DeleteExpression(TableExpression table, SelectExpression selectExpression, ISet<string> tags)
     {
         Table = table;
         SelectExpression = selectExpression;
+        Tags = tags;
     }
+
+    /// <summary>
+    ///     The list of tags applied to this <see cref="DeleteExpression" />.
+    /// </summary>
+    public ISet<string> Tags { get; }
 
     /// <summary>
     ///     The table on which the delete operation is being applied.
@@ -33,6 +44,13 @@ public sealed class DeleteExpression : Expression, IPrintableExpression
     ///     The select expression which is used to determine which rows to delete.
     /// </summary>
     public SelectExpression SelectExpression { get; }
+
+    /// <summary>
+    ///     Applies a given set of tags.
+    /// </summary>
+    /// <param name="tags">A list of tags to apply.</param>
+    public DeleteExpression ApplyTags(ISet<string> tags)
+        => new(Table, SelectExpression, tags);
 
     /// <inheritdoc />
     public override Type Type
@@ -58,12 +76,17 @@ public sealed class DeleteExpression : Expression, IPrintableExpression
     /// <returns>This expression if no children changed, or an expression with the updated children.</returns>
     public DeleteExpression Update(SelectExpression selectExpression)
         => selectExpression != SelectExpression
-            ? new DeleteExpression(Table, selectExpression)
+            ? new DeleteExpression(Table, selectExpression, Tags)
             : this;
 
     /// <inheritdoc />
     public void Print(ExpressionPrinter expressionPrinter)
     {
+        foreach (var tag in Tags)
+        {
+            expressionPrinter.Append($"-- {tag}");
+        }
+        expressionPrinter.AppendLine();
         expressionPrinter.AppendLine($"DELETE FROM {Table.Name} AS {Table.Alias}");
         expressionPrinter.Visit(SelectExpression);
     }

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -112,7 +112,7 @@ public class SqlNullabilityProcessor
 
         return selectExpression != updateExpression.SelectExpression
             || setColumnValues != null
-            ? new UpdateExpression(updateExpression.Table, selectExpression, setColumnValues ?? updateExpression.SetColumnValues)
+            ? updateExpression.Update(selectExpression, setColumnValues ?? updateExpression.SetColumnValues)
             : updateExpression;
     }
 

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -38,6 +38,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             => GetString("ApplyNotSupported");
 
         /// <summary>
+        ///     Translating this operation requires the 'DEFAULT', which is not supported on SQLite.
+        /// </summary>
+        public static string DefaultNotSupported
+            => GetString("DefaultNotSupported");
+
+        /// <summary>
         ///     '{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}', but are configured with different SRIDs.
         /// </summary>
         public static string DuplicateColumnNameSridMismatch(object? entityType1, object? property1, object? entityType2, object? property2, object? columnName, object? table)
@@ -74,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             => GetString("SequencesNotSupported");
 
         /// <summary>
-        ///     SQLite does not support stored procedures. See http://go.microsoft.com/fwlink/?LinkId=723262 for more information and examples.
+        ///     SQLite does not support stored procedures, but one has been configured on entity type '{entityType}'. See http://go.microsoft.com/fwlink/?LinkId=723262 for more information and examples.
         /// </summary>
         public static string StoredProceduresNotSupported(object? entityType)
             => string.Format(

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
@@ -123,6 +123,9 @@
   <data name="ApplyNotSupported" xml:space="preserve">
     <value>Translating this query requires the SQL APPLY operation, which is not supported on SQLite.</value>
   </data>
+  <data name="DefaultNotSupported" xml:space="preserve">
+    <value>Translating this operation requires the 'DEFAULT', which is not supported on SQLite.</value>
+  </data>
   <data name="DuplicateColumnNameSridMismatch" xml:space="preserve">
     <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}', but are configured with different SRIDs.</value>
   </data>

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 
@@ -209,6 +210,24 @@ public class SqliteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
         }
 
         return visitedExpression;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        // EF.Default
+        if (methodCallExpression.Method.IsEFDefaultMethod())
+        {
+            AddTranslationErrorDetails(SqliteStrings.DefaultNotSupported);
+            return QueryCompilationContext.NotTranslatedExpression;
+        }
+
+        return base.VisitMethodCall(methodCallExpression);
     }
 
     private static Type? GetProviderType(SqlExpression? expression)

--- a/src/EFCore/EF.cs
+++ b/src/EFCore/EF.cs
@@ -17,6 +17,9 @@ public static partial class EF
     internal static readonly MethodInfo PropertyMethod
         = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(Property))!;
 
+    internal static readonly MethodInfo DefaultMethod
+        = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(Default))!;
+
     /// <summary>
     ///     This flag is set to <see langword="true" /> when code is being run from a design-time tool, such
     ///     as "dotnet ef" or one of the Package Manager Console PowerShell commands "Add-Migration", "Update-Database", etc.
@@ -54,6 +57,20 @@ public static partial class EF
         object entity,
         [NotParameterized] string propertyName)
         => throw new InvalidOperationException(CoreStrings.PropertyMethodInvoked);
+
+    /// <summary>
+    ///     Used set a property to its default value within <see cref="M:RelationalQueryableExtensions.ExecuteUpdate" /> or
+    ///     <see cref="M:RelationalQueryableExtensions.ExecuteUpdateAsync" />.
+    /// </summary>
+    /// <remarks>
+    ///     Depending on how the property is configured, this may be <see langword="null" />, or another value defined via
+    ///     <see cref="M:RelationalPropertyBuilderExtensions.HasDefaultValue" /> or similar.
+    /// </remarks>
+    /// <typeparam name="T">The type of the property being set.</typeparam>
+    /// <returns>The default value of the property.</returns>
+    public static T Default<T>()
+        // TODO: Update exception message
+        => throw new InvalidOperationException(CoreStrings.DefaultMethodInvoked);
 
     /// <summary>
     ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.

--- a/src/EFCore/Infrastructure/MethodInfoExtensions.cs
+++ b/src/EFCore/Infrastructure/MethodInfoExtensions.cs
@@ -25,11 +25,24 @@ public static class MethodInfoExtensions
     /// </summary>
     /// <param name="methodInfo">The method.</param>
     /// <returns><see langword="true" /> if the method is <see cref="EF.Property{TProperty}" />; <see langword="false" /> otherwise.</returns>
-    public static bool IsEFPropertyMethod(this MethodInfo? methodInfo)
-        => Equals(methodInfo, EF.PropertyMethod)
-            // fallback to string comparison because MethodInfo.Equals is not
-            // always true in .NET Native even if methods are the same
-            || methodInfo?.IsGenericMethod == true
-            && methodInfo.Name == nameof(EF.Property)
-            && methodInfo.DeclaringType?.FullName == EFTypeName;
+    public static bool IsEFPropertyMethod(this MethodInfo methodInfo)
+        => methodInfo.IsGenericMethod
+            && (Equals(methodInfo.GetGenericMethodDefinition(), EF.PropertyMethod)
+                // fallback to string comparison because MethodInfo.Equals is not
+                // always true in .NET Native even if methods are the same
+                || (methodInfo.Name == nameof(EF.Property)
+                    && methodInfo.DeclaringType?.FullName == EFTypeName));
+
+    /// <summary>
+    ///     Returns <see langword="true" /> if the given method is <see cref="EF.Default{T}" />.
+    /// </summary>
+    /// <param name="methodInfo">The method.</param>
+    /// <returns><see langword="true" /> if the method is <see cref="EF.Default{T}" />; <see langword="false" /> otherwise.</returns>
+    public static bool IsEFDefaultMethod(this MethodInfo methodInfo)
+        => methodInfo.IsGenericMethod
+            && (Equals(methodInfo.GetGenericMethodDefinition(), EF.DefaultMethod)
+                // fallback to string comparison because MethodInfo.Equals is not
+                // always true in .NET Native even if methods are the same
+                || (methodInfo.Name == nameof(EF.DefaultMethod)
+                    && methodInfo.DeclaringType?.FullName == EFTypeName));
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -599,6 +599,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 message);
 
         /// <summary>
+        ///     The EF.Default&lt;T&gt; property may only be used within Entity Framework ExecuteUpdate method.
+        /// </summary>
+        public static string DefaultMethodInvoked
+            => GetString("DefaultMethodInvoked");
+
+        /// <summary>
         ///     The [DeleteBehavior] attribute may only be specified on navigation properties, and is not supported not on properties making up the foreign key.
         /// </summary>
         public static string DeleteBehaviorAttributeNotOnNavigationProperty

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -336,6 +336,9 @@
   <data name="DebugViewQueryStringError" xml:space="preserve">
     <value>Error creating query string: {message}.</value>
   </data>
+  <data name="DefaultMethodInvoked" xml:space="preserve">
+    <value>The EF.Default&lt;T&gt; property may only be used within Entity Framework ExecuteUpdate method.</value>
+  </data>
   <data name="DeleteBehaviorAttributeNotOnNavigationProperty" xml:space="preserve">
     <value>The [DeleteBehavior] attribute may only be specified on navigation properties, and is not supported not on properties making up the foreign key.</value>
   </data>

--- a/src/EFCore/Query/EvaluatableExpressionFilter.cs
+++ b/src/EFCore/Query/EvaluatableExpressionFilter.cs
@@ -81,7 +81,8 @@ public class EvaluatableExpressionFilter : IEvaluatableExpressionFilter
                     || Equals(method, RandomNextNoArgs)
                     || Equals(method, RandomNextOneArg)
                     || Equals(method, RandomNextTwoArgs)
-                    || method.DeclaringType == typeof(DbFunctionsExtensions))
+                    || method.DeclaringType == typeof(DbFunctionsExtensions)
+                    || method.IsEFDefaultMethod())
                 {
                     return false;
                 }

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -153,10 +153,7 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
                         var source2 = Visit(methodCallExpression.Arguments[1]);
                         if (source2 is ShapedQueryExpression innerShapedQueryExpression)
                         {
-                            return CheckTranslated(
-                                TranslateConcat(
-                                    shapedQueryExpression,
-                                    innerShapedQueryExpression));
+                            return CheckTranslated(TranslateConcat(shapedQueryExpression, innerShapedQueryExpression));
                         }
 
                         break;
@@ -207,10 +204,7 @@ public abstract class QueryableMethodTranslatingExpressionVisitor : ExpressionVi
                         var source2 = Visit(methodCallExpression.Arguments[1]);
                         if (source2 is ShapedQueryExpression innerShapedQueryExpression)
                         {
-                            return CheckTranslated(
-                                TranslateExcept(
-                                    shapedQueryExpression,
-                                    innerShapedQueryExpression));
+                            return CheckTranslated(TranslateExcept(shapedQueryExpression, innerShapedQueryExpression));
                         }
 
                         break;

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/FiltersInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/FiltersInheritanceBulkUpdatesTestBase.cs
@@ -21,7 +21,7 @@ public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpda
             ss => ss.Set<Animal>().Where(e => e.Name == "Great spotted kiwi"),
             rowsAffectedCount: 1);
 
-    [ConditionalTheory(Skip = "Issue#28524")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Delete_where_hierarchy_subquery(bool async)
         => AssertDelete(
@@ -51,6 +51,35 @@ public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpda
         => AssertDelete(
             async,
             ss => ss.Set<Country>().Where(e => e.Animals.OfType<Kiwi>().Where(a => a.CountryId > 0).Count() > 0),
+            rowsAffectedCount: 1);
+
+    [ConditionalTheory(Skip = "Issue#28525")]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Delete_GroupBy_Where_Select_First(bool async)
+        => AssertDelete(
+            async,
+            ss => ss.Set<Animal>()
+                    .GroupBy(e => e.CountryId)
+                    .Where(g => g.Count() < 3)
+                    .Select(g => g.First()),
+            rowsAffectedCount: 1);
+
+    [ConditionalTheory(Skip = "Issue#26753")]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Delete_GroupBy_Where_Select_First_2(bool async)
+        => AssertDelete(
+            async,
+            ss => ss.Set<Animal>().Where(e => e == ss.Set<Animal>().GroupBy(e => e.CountryId)
+                                                .Where(g => g.Count() < 3).Select(g => g.First()).FirstOrDefault()),
+            rowsAffectedCount: 1);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Delete_GroupBy_Where_Select_First_3(bool async)
+        => AssertDelete(
+            async,
+            ss => ss.Set<Animal>().Where(e => ss.Set<Animal>().GroupBy(e => e.CountryId)
+                                                .Where(g => g.Count() < 3).Select(g => g.First()).Any(i => i == e)),
             rowsAffectedCount: 1);
 
     [ConditionalTheory]

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesFixtureBase.cs
@@ -7,6 +7,9 @@ public abstract class InheritanceBulkUpdatesFixtureBase : InheritanceQueryFixtur
 {
     protected override string StoreName => "InheritanceBulkUpdatesTest";
 
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder).ConfigureWarnings(w => w.Log(CoreEventId.FirstWithoutOrderByAndFilterWarning));
+
     public void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
         => facade.UseTransaction(transaction.GetDbTransaction());
 }

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesTestBase.cs
@@ -21,7 +21,7 @@ public abstract class InheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTest
             ss => ss.Set<Animal>().Where(e => e.Name == "Great spotted kiwi"),
             rowsAffectedCount: 1);
 
-    [ConditionalTheory(Skip = "Issue#28524")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Delete_where_hierarchy_subquery(bool async)
         => AssertDelete(
@@ -52,6 +52,35 @@ public abstract class InheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTest
             async,
             ss => ss.Set<Country>().Where(e => e.Animals.OfType<Kiwi>().Where(a => a.CountryId > 0).Count() > 0),
             rowsAffectedCount: 1);
+
+    [ConditionalTheory(Skip = "Issue#28525")]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Delete_GroupBy_Where_Select_First(bool async)
+        => AssertDelete(
+            async,
+            ss => ss.Set<Animal>()
+                    .GroupBy(e => e.CountryId)
+                    .Where( g=> g.Count() < 3)
+                    .Select(g => g.First()),
+            rowsAffectedCount: 2);
+
+    [ConditionalTheory(Skip = "Issue#26753")]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Delete_GroupBy_Where_Select_First_2(bool async)
+        => AssertDelete(
+            async,
+            ss => ss.Set<Animal>().Where(e => e == ss.Set<Animal>().GroupBy(e => e.CountryId)
+                                                .Where(g => g.Count() < 3).Select(g => g.First()).FirstOrDefault()),
+            rowsAffectedCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Delete_GroupBy_Where_Select_First_3(bool async)
+        => AssertDelete(
+            async,
+            ss => ss.Set<Animal>().Where(e => ss.Set<Animal>().GroupBy(e => e.CountryId)
+                                                .Where(g => g.Count() < 3).Select(g => g.First()).Any(i => i == e)),
+            rowsAffectedCount: 2);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
@@ -16,6 +16,14 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture> : BulkUpdatesTestBa
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Delete_Where_TagWith(bool async)
+        => AssertDelete(
+            async,
+            ss => ss.Set<OrderDetail>().Where(e => e.OrderID < 10300).TagWith("MyDelete"),
+            rowsAffectedCount: 140);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Delete_Where(bool async)
         => AssertDelete(
             async,
@@ -349,6 +357,17 @@ WHERE [OrderID] < 10300"))
                   from o in ss.Set<Order>().Where(o => o.OrderID < od.OrderID).OrderBy(e => e.OrderID).Skip(0).Take(100).DefaultIfEmpty()
                   select od,
             rowsAffectedCount: 74);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_Where_set_constant_TagWith(bool async)
+        => AssertUpdate(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).TagWith("MyUpdate"),
+            e => e,
+            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            rowsAffectedCount: 8,
+            (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
@@ -382,6 +382,17 @@ WHERE [OrderID] < 10300"))
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_Where_set_default(bool async)
+        => AssertUpdate(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
+            e => e,
+            s => s.SetProperty(c => c.ContactName, c => EF.Default<string>()),
+            rowsAffectedCount: 8,
+            (b, a) => Assert.All(a, c => Assert.Null(c.ContactName)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual async Task Update_Where_parameter_set_constant(bool async)
     {
         var customer = "ALFKI";

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesTestBase.cs
@@ -19,6 +19,16 @@ public abstract class TPCFiltersInheritanceBulkUpdatesTestBase<TFixture> : Filte
             RelationalStrings.ExecuteOperationOnTPC("ExecuteDelete", "Animal"),
             () => base.Delete_where_hierarchy(async));
 
+    public override Task Delete_where_hierarchy_subquery(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.ExecuteOperationOnTPC("ExecuteDelete", "Animal"),
+            () => base.Delete_where_hierarchy_subquery(async));
+
+    public override Task Delete_GroupBy_Where_Select_First_3(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.ExecuteOperationOnTPC("ExecuteDelete", "Animal"),
+            () => base.Delete_GroupBy_Where_Select_First_3(async));
+
     // Keyless entities are mapped as TPH only
     public override Task Update_where_keyless_entity_mapped_to_sql_query(bool async) => Task.CompletedTask;
 

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPCInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPCInheritanceBulkUpdatesTestBase.cs
@@ -19,6 +19,16 @@ public abstract class TPCInheritanceBulkUpdatesTestBase<TFixture> : InheritanceB
             RelationalStrings.ExecuteOperationOnTPC("ExecuteDelete", "Animal"),
             () => base.Delete_where_hierarchy(async));
 
+    public override Task Delete_where_hierarchy_subquery(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.ExecuteOperationOnTPC("ExecuteDelete", "Animal"),
+            () => base.Delete_where_hierarchy_subquery(async));
+
+    public override Task Delete_GroupBy_Where_Select_First_3(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.ExecuteOperationOnTPC("ExecuteDelete", "Animal"),
+            () => base.Delete_GroupBy_Where_Select_First_3(async));
+
     // Keyless entities are mapped as TPH only
     public override Task Update_where_keyless_entity_mapped_to_sql_query(bool async) => Task.CompletedTask;
 

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesTestBase.cs
@@ -19,10 +19,20 @@ public abstract class TPTFiltersInheritanceBulkUpdatesTestBase<TFixture> : Filte
             RelationalStrings.ExecuteOperationOnTPT("ExecuteDelete", "Animal"),
             () => base.Delete_where_hierarchy(async));
 
+    public override Task Delete_where_hierarchy_subquery(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.ExecuteOperationOnTPT("ExecuteDelete", "Animal"),
+            () => base.Delete_where_hierarchy_subquery(async));
+
     public override Task Delete_where_hierarchy_derived(bool async)
         => AssertTranslationFailed(
             RelationalStrings.ExecuteOperationOnTPT("ExecuteDelete", "Kiwi"),
             () => base.Delete_where_hierarchy_derived(async));
+
+    public override Task Delete_GroupBy_Where_Select_First_3(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.ExecuteOperationOnTPT("ExecuteDelete", "Animal"),
+            () => base.Delete_GroupBy_Where_Select_First_3(async));
 
     [ConditionalTheory(Skip = "Issue#28532")]
     public override Task Delete_where_using_hierarchy(bool async)

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/TPTInheritanceBulkUpdatesTestBase.cs
@@ -19,10 +19,20 @@ public abstract class TPTInheritanceBulkUpdatesTestBase<TFixture> : InheritanceB
             RelationalStrings.ExecuteOperationOnTPT("ExecuteDelete", "Animal"),
             () => base.Delete_where_hierarchy(async));
 
+    public override Task Delete_where_hierarchy_subquery(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.ExecuteOperationOnTPT("ExecuteDelete", "Animal"),
+            () => base.Delete_where_hierarchy_subquery(async));
+
     public override Task Delete_where_hierarchy_derived(bool async)
         => AssertTranslationFailed(
             RelationalStrings.ExecuteOperationOnTPT("ExecuteDelete", "Kiwi"),
             () => base.Delete_where_hierarchy_derived(async));
+
+    public override Task Delete_GroupBy_Where_Select_First_3(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.ExecuteOperationOnTPT("ExecuteDelete", "Animal"),
+            () => base.Delete_GroupBy_Where_Select_First_3(async));
 
     [ConditionalTheory(Skip = "FK constraint issue")]
     public override Task Delete_where_using_hierarchy(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -61,6 +61,38 @@ WHERE (
     WHERE [a].[CountryId] = 1 AND [c].[Id] = [a].[CountryId] AND [a].[Discriminator] = N'Kiwi' AND [a].[CountryId] > 0) > 0");
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql(
+            @"DELETE FROM [a]
+FROM [Animals] AS [a]
+WHERE [a].[CountryId] = 1 AND EXISTS (
+    SELECT 1
+    FROM [Animals] AS [a0]
+    WHERE [a0].[CountryId] = 1
+    GROUP BY [a0].[CountryId]
+    HAVING COUNT(*) < 3 AND (
+        SELECT TOP(1) [a1].[Id]
+        FROM [Animals] AS [a1]
+        WHERE [a1].[CountryId] = 1 AND [a0].[CountryId] = [a1].[CountryId]) = [a].[Id])");
+    }
+
     public override async Task Delete_where_keyless_entity_mapped_to_sql_query(bool async)
     {
         await base.Delete_where_keyless_entity_mapped_to_sql_query(async);
@@ -72,7 +104,22 @@ WHERE (
     {
         await base.Delete_where_hierarchy_subquery(async);
 
-        AssertSql();
+        AssertSql(
+            @"@__p_0='0'
+@__p_1='3'
+
+DELETE FROM [a]
+FROM [Animals] AS [a]
+WHERE EXISTS (
+    SELECT 1
+    FROM (
+        SELECT [a0].[Id], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[Species], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
+        FROM [Animals] AS [a0]
+        WHERE [a0].[CountryId] = 1 AND [a0].[Name] = N'Great spotted kiwi'
+        ORDER BY [a0].[Name]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    ) AS [t]
+    WHERE [t].[Id] = [a].[Id])");
     }
 
     public override async Task Update_where_hierarchy(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqlServerTest.cs
@@ -61,6 +61,37 @@ WHERE (
     WHERE [c].[Id] = [a].[CountryId] AND [a].[Discriminator] = N'Kiwi' AND [a].[CountryId] > 0) > 0");
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql(
+            @"DELETE FROM [a]
+FROM [Animals] AS [a]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Animals] AS [a0]
+    GROUP BY [a0].[CountryId]
+    HAVING COUNT(*) < 3 AND (
+        SELECT TOP(1) [a1].[Id]
+        FROM [Animals] AS [a1]
+        WHERE [a0].[CountryId] = [a1].[CountryId]) = [a].[Id])");
+    }
+
     public override async Task Delete_where_keyless_entity_mapped_to_sql_query(bool async)
     {
         await base.Delete_where_keyless_entity_mapped_to_sql_query(async);
@@ -72,7 +103,22 @@ WHERE (
     {
         await base.Delete_where_hierarchy_subquery(async);
 
-        AssertSql();
+        AssertSql(
+            @"@__p_0='0'
+@__p_1='3'
+
+DELETE FROM [a]
+FROM [Animals] AS [a]
+WHERE EXISTS (
+    SELECT 1
+    FROM (
+        SELECT [a0].[Id], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[Species], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
+        FROM [Animals] AS [a0]
+        WHERE [a0].[Name] = N'Great spotted kiwi'
+        ORDER BY [a0].[Name]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    ) AS [t]
+    WHERE [t].[Id] = [a].[Id])");
     }
 
     public override async Task Update_where_hierarchy(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -568,6 +568,17 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'");
     }
 
+    public override async Task Update_Where_set_default(bool async)
+    {
+        await base.Update_Where_set_default(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE [c]
+    SET [c].[ContactName] = DEFAULT
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'");
+    }
+
     public override async Task Update_Where_parameter_set_constant(bool async)
     {
         await base.Update_Where_parameter_set_constant(async);

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -14,6 +14,18 @@ public class NorthwindBulkUpdatesSqlServerTest : NorthwindBulkUpdatesTestBase<No
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
+    public override async Task Delete_Where_TagWith(bool async)
+    {
+        await base.Delete_Where_TagWith(async);
+
+        AssertSql(
+            @"-- MyDelete
+
+DELETE FROM [o]
+FROM [Order Details] AS [o]
+WHERE [o].[OrderID] < 10300");
+    }
+
     public override async Task Delete_Where(bool async)
     {
         await base.Delete_Where(async);
@@ -530,6 +542,19 @@ OUTER APPLY (
     OFFSET 0 ROWS FETCH NEXT 100 ROWS ONLY
 ) AS [t]
 WHERE [o].[OrderID] < 10276");
+    }
+
+    public override async Task Update_Where_set_constant_TagWith(bool async)
+    {
+        await base.Update_Where_set_constant_TagWith(async);
+
+        AssertExecuteUpdateSql(
+            @"-- MyUpdate
+
+UPDATE [c]
+    SET [c].[ContactName] = N'Updated'
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'");
     }
 
     public override async Task Update_Where_set_constant(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -81,6 +81,27 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql();
+    }
+
     public override async Task Update_where_hierarchy(bool async)
     {
         await base.Update_where_hierarchy(async);

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqlServerTest.cs
@@ -81,6 +81,27 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql();
+    }
+
     public override async Task Update_where_hierarchy(bool async)
     {
         await base.Update_where_hierarchy(async);

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -69,6 +69,27 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql();
+    }
+
     public override async Task Update_where_hierarchy(bool async)
     {
         await base.Update_where_hierarchy(async);

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesSqlServerTest.cs
@@ -57,6 +57,27 @@ public class TPTInheritanceBulkUpdatesSqlServerTest : TPTInheritanceBulkUpdatesT
         AssertSql();
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql();
+    }
+
     public override async Task Update_where_hierarchy(bool async)
     {
         await base.Update_where_hierarchy(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -28,7 +28,21 @@ WHERE ""a"".""CountryId"" = 1 AND ""a"".""Name"" = 'Great spotted kiwi'");
     {
         await base.Delete_where_hierarchy_subquery(async);
 
-        AssertSql();
+        AssertSql(
+            @"@__p_1='3'
+@__p_0='0'
+
+DELETE FROM ""Animals"" AS ""a""
+WHERE EXISTS (
+    SELECT 1
+    FROM (
+        SELECT ""a0"".""Id"", ""a0"".""CountryId"", ""a0"".""Discriminator"", ""a0"".""Name"", ""a0"".""Species"", ""a0"".""EagleId"", ""a0"".""IsFlightless"", ""a0"".""Group"", ""a0"".""FoundOn""
+        FROM ""Animals"" AS ""a0""
+        WHERE ""a0"".""CountryId"" = 1 AND ""a0"".""Name"" = 'Great spotted kiwi'
+        ORDER BY ""a0"".""Name""
+        LIMIT @__p_1 OFFSET @__p_0
+    ) AS ""t""
+    WHERE ""t"".""Id"" = ""a"".""Id"")");
     }
 
     public override async Task Delete_where_hierarchy_derived(bool async)
@@ -69,6 +83,38 @@ WHERE (
         await base.Delete_where_keyless_entity_mapped_to_sql_query(async);
 
         AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql(
+            @"DELETE FROM ""Animals"" AS ""a""
+WHERE ""a"".""CountryId"" = 1 AND EXISTS (
+    SELECT 1
+    FROM ""Animals"" AS ""a0""
+    WHERE ""a0"".""CountryId"" = 1
+    GROUP BY ""a0"".""CountryId""
+    HAVING COUNT(*) < 3 AND (
+        SELECT ""a1"".""Id""
+        FROM ""Animals"" AS ""a1""
+        WHERE ""a1"".""CountryId"" = 1 AND ""a0"".""CountryId"" = ""a1"".""CountryId""
+        LIMIT 1) = ""a"".""Id"")");
     }
 
     public override async Task Update_where_hierarchy(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqliteTest.cs
@@ -28,7 +28,21 @@ WHERE ""a"".""Name"" = 'Great spotted kiwi'");
     {
         await base.Delete_where_hierarchy_subquery(async);
 
-        AssertSql();
+        AssertSql(
+            @"@__p_1='3'
+@__p_0='0'
+
+DELETE FROM ""Animals"" AS ""a""
+WHERE EXISTS (
+    SELECT 1
+    FROM (
+        SELECT ""a0"".""Id"", ""a0"".""CountryId"", ""a0"".""Discriminator"", ""a0"".""Name"", ""a0"".""Species"", ""a0"".""EagleId"", ""a0"".""IsFlightless"", ""a0"".""Group"", ""a0"".""FoundOn""
+        FROM ""Animals"" AS ""a0""
+        WHERE ""a0"".""Name"" = 'Great spotted kiwi'
+        ORDER BY ""a0"".""Name""
+        LIMIT @__p_1 OFFSET @__p_0
+    ) AS ""t""
+    WHERE ""t"".""Id"" = ""a"".""Id"")");
     }
 
     public override async Task Delete_where_hierarchy_derived(bool async)
@@ -69,6 +83,37 @@ WHERE (
         await base.Delete_where_keyless_entity_mapped_to_sql_query(async);
 
         AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql(
+            @"DELETE FROM ""Animals"" AS ""a""
+WHERE EXISTS (
+    SELECT 1
+    FROM ""Animals"" AS ""a0""
+    GROUP BY ""a0"".""CountryId""
+    HAVING COUNT(*) < 3 AND (
+        SELECT ""a1"".""Id""
+        FROM ""Animals"" AS ""a1""
+        WHERE ""a0"".""CountryId"" = ""a1"".""CountryId""
+        LIMIT 1) = ""a"".""Id"")");
     }
 
     public override async Task Update_where_hierarchy(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -16,6 +16,17 @@ public class NorthwindBulkUpdatesSqliteTest : NorthwindBulkUpdatesTestBase<North
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
+    public override async Task Delete_Where_TagWith(bool async)
+    {
+        await base.Delete_Where_TagWith(async);
+
+        AssertSql(
+            @"-- MyDelete
+
+DELETE FROM ""Order Details"" AS ""o""
+WHERE ""o"".""OrderID"" < 10300");
+    }
+
     public override async Task Delete_Where(bool async)
     {
         await base.Delete_Where(async);
@@ -515,6 +526,18 @@ WHERE EXISTS (
         => Assert.Equal(
             SqliteStrings.ApplyNotSupported,
             (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Delete_with_outer_apply(async))).Message);
+
+    public override async Task Update_Where_set_constant_TagWith(bool async)
+    {
+        await base.Update_Where_set_constant_TagWith(async);
+
+        AssertExecuteUpdateSql(
+            @"-- MyUpdate
+
+UPDATE ""Customers"" AS ""c""
+    SET ""ContactName"" = 'Updated'
+WHERE ""c"".""CustomerID"" LIKE 'F%'");
+    }
 
     public override async Task Update_Where_set_constant(bool async)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
@@ -548,6 +549,12 @@ WHERE ""c"".""CustomerID"" LIKE 'F%'");
     SET ""ContactName"" = 'Updated'
 WHERE ""c"".""CustomerID"" LIKE 'F%'");
     }
+
+    public override Task Update_Where_set_default(bool async)
+        => AssertTranslationFailed(
+            RelationalStrings.UnableToTranslateSetProperty(
+                "c => c.ContactName", "c => EF.Default<string>()", SqliteStrings.DefaultNotSupported),
+            () => base.Update_Where_set_default(async));
 
     public override async Task Update_Where_parameter_set_constant(bool async)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -78,6 +78,27 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql();
+    }
+
     public override async Task Update_where_hierarchy(bool async)
     {
         await base.Update_where_hierarchy(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesSqliteTest.cs
@@ -78,6 +78,27 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql();
+    }
+
     public override async Task Update_where_hierarchy(bool async)
     {
         await base.Update_where_hierarchy(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -69,6 +69,27 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql();
+    }
+
     public override async Task Update_where_hierarchy(bool async)
     {
         await base.Update_where_hierarchy(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesSqliteTest.cs
@@ -43,6 +43,27 @@ public class TPTInheritanceBulkUpdatesSqliteTest : TPTInheritanceBulkUpdatesTest
         AssertSql();
     }
 
+    public override async Task Delete_GroupBy_Where_Select_First(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_2(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Delete_GroupBy_Where_Select_First_3(bool async)
+    {
+        await base.Delete_GroupBy_Where_Select_First_3(async);
+
+        AssertSql();
+    }
+
     public override async Task Delete_where_keyless_entity_mapped_to_sql_query(bool async)
     {
         await base.Delete_where_keyless_entity_mapped_to_sql_query(async);


### PR DESCRIPTION
Visit retrived ProjectionBinding from select expression as projection binding can bind to non-SqlExpression too.

Resolves #28524
Resolves #28745
Resolves #28752
