### PR TITLE
Query: Fix for query fails with JSON columns and Include collection

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryFixtureBase.cs
@@ -25,6 +25,8 @@ public abstract class JsonQueryFixtureBase : SharedStoreFixtureBase<JsonQueryCon
     public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
     {
         { typeof(JsonEntityBasic), e => ((JsonEntityBasic)e)?.Id },
+        { typeof(JsonEntityBasicForReference), e => ((JsonEntityBasicForReference)e)?.Id },
+        { typeof(JsonEntityBasicForCollection), e => ((JsonEntityBasicForCollection)e)?.Id },
         { typeof(JsonEntityCustomNaming), e => ((JsonEntityCustomNaming)e)?.Id },
         { typeof(JsonEntitySingleOwned), e => ((JsonEntitySingleOwned)e)?.Id },
         { typeof(JsonEntityInheritanceBase), e => ((JsonEntityInheritanceBase)e)?.Id },
@@ -52,6 +54,36 @@ public abstract class JsonQueryFixtureBase : SharedStoreFixtureBase<JsonQueryCon
                     {
                         AssertOwnedRoot(ee.OwnedCollectionRoot[i], aa.OwnedCollectionRoot[i]);
                     }
+                }
+            }
+        },
+        {
+            typeof(JsonEntityBasicForReference), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+                if (a != null)
+                {
+                    var ee = (JsonEntityBasicForReference)e;
+                    var aa = (JsonEntityBasicForReference)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentId, aa.ParentId);
+                }
+            }
+        },
+        {
+            typeof(JsonEntityBasicForCollection), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+                if (a != null)
+                {
+                    var ee = (JsonEntityBasicForCollection)e;
+                    var aa = (JsonEntityBasicForCollection)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.ParentId, aa.ParentId);
                 }
             }
         },
@@ -282,6 +314,8 @@ public abstract class JsonQueryFixtureBase : SharedStoreFixtureBase<JsonQueryCon
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
         modelBuilder.Entity<JsonEntityBasic>().Property(x => x.Id).ValueGeneratedNever();
+        modelBuilder.Entity<JsonEntityBasicForReference>().Property(x => x.Id).ValueGeneratedNever();
+        modelBuilder.Entity<JsonEntityBasicForCollection>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<JsonEntityBasic>().OwnsOne(x => x.OwnedReferenceRoot, b =>
         {
             b.ToJson();

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -634,5 +634,45 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
             ss => ss.Set<JsonEntityBasic>()
             .GroupBy(x => x.OwnedReferenceRoot.Name).Select(x => new { x.Key, Count = x.Count() }));
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_with_include_on_json_entity(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Include(x => x.OwnedReferenceRoot),
+            entryCount: 40);
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_with_include_on_entity_reference(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Include(x => x.EntityReference),
+            elementAsserter: (e, a) => AssertInclude(
+                e, a,
+                new ExpectedInclude<JsonEntityBasic>(x => x.EntityReference)),
+            entryCount: 41);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_with_include_on_entity_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Include(x => x.EntityCollection),
+            elementAsserter: (e, a) => AssertInclude(
+                e, a,
+                new ExpectedInclude<JsonEntityBasic>(x => x.EntityCollection)),
+            entryCount: 43);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_with_include_on_entity_collection_and_reference(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Include(x => x.EntityReference).Include(x => x.EntityCollection),
+            elementAsserter: (e, a) => AssertInclude(
+                e, a,
+                new ExpectedInclude<JsonEntityBasic>(x => x.EntityReference),
+                new ExpectedInclude<JsonEntityBasic>(x => x.EntityCollection)),
+            entryCount: 44);
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonEntityBasic.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonEntityBasic.cs
@@ -10,5 +10,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery
 
         public JsonOwnedRoot OwnedReferenceRoot { get; set; }
         public List<JsonOwnedRoot> OwnedCollectionRoot { get; set; }
+
+        public JsonEntityBasicForReference EntityReference { get; set; }
+        public List<JsonEntityBasicForCollection> EntityCollection { get; set; }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonEntityBasicForCollection.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonEntityBasicForCollection.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery
+{
+    public class JsonEntityBasicForCollection
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public int? ParentId { get; set; }
+        public JsonEntityBasic Parent { get; set; }
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonEntityBasicForReference.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonEntityBasicForReference.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery
+{
+    public class JsonEntityBasicForReference
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public int? ParentId { get; set; }
+        public JsonEntityBasic Parent { get; set; }
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
@@ -11,6 +11,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery
         }
 
         public DbSet<JsonEntityBasic> JsonEntitiesBasic { get; set; }
+        public DbSet<JsonEntityBasicForReference> JsonEntitiesBasicForReference { get; set; }
+        public DbSet<JsonEntityBasicForCollection> JsonEntitiesBasicForCollection { get; set; }
         public DbSet<JsonEntityCustomNaming> JsonEntitiesCustomNaming { get; set; }
         public DbSet<JsonEntitySingleOwned> JsonEntitiesSingleOwned { get; set; }
         public DbSet<JsonEntityInheritanceBase> JsonEntitiesInheritance { get; set; }
@@ -18,11 +20,17 @@ namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery
         public static void Seed(JsonQueryContext context)
         {
             var jsonEntitiesBasic = JsonQueryData.CreateJsonEntitiesBasic();
+            var jsonEntitiesBasicForReference = JsonQueryData.CreateJsonEntitiesBasicForReference();
+            var jsonEntitiesBasicForCollection = JsonQueryData.CreateJsonEntitiesBasicForCollection();
+            JsonQueryData.WireUp(jsonEntitiesBasic, jsonEntitiesBasicForReference, jsonEntitiesBasicForCollection);
+
             var jsonEntitiesCustomNaming = JsonQueryData.CreateJsonEntitiesCustomNaming();
             var jsonEntitiesSingleOwned = JsonQueryData.CreateJsonEntitiesSingleOwned();
             var jsonEntitiesInheritance = JsonQueryData.CreateJsonEntitiesInheritance();
 
             context.JsonEntitiesBasic.AddRange(jsonEntitiesBasic);
+            context.JsonEntitiesBasicForReference.AddRange(jsonEntitiesBasicForReference);
+            context.JsonEntitiesBasicForCollection.AddRange(jsonEntitiesBasicForCollection);
             context.JsonEntitiesCustomNaming.AddRange(jsonEntitiesCustomNaming);
             context.JsonEntitiesSingleOwned.AddRange(jsonEntitiesSingleOwned);
             context.JsonEntitiesInheritance.AddRange(jsonEntitiesInheritance);

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
@@ -8,12 +8,18 @@ public class JsonQueryData : ISetSource
     public JsonQueryData()
     {
         JsonEntitiesBasic = CreateJsonEntitiesBasic();
+        JsonEntitiesBasicForReference = CreateJsonEntitiesBasicForReference();
+        JsonEntitiesBasicForCollection = CreateJsonEntitiesBasicForCollection();
+        WireUp(JsonEntitiesBasic, JsonEntitiesBasicForReference, JsonEntitiesBasicForCollection);
+
         JsonEntitiesCustomNaming = CreateJsonEntitiesCustomNaming();
         JsonEntitiesSingleOwned = CreateJsonEntitiesSingleOwned();
         JsonEntitiesInheritance = CreateJsonEntitiesInheritance();
     }
 
     public IReadOnlyList<JsonEntityBasic> JsonEntitiesBasic { get; }
+    public IReadOnlyList<JsonEntityBasicForReference> JsonEntitiesBasicForReference { get; }
+    public IReadOnlyList<JsonEntityBasicForCollection> JsonEntitiesBasicForCollection { get; }
     public IReadOnlyList<JsonEntityCustomNaming> JsonEntitiesCustomNaming { get; set; }
     public IReadOnlyList<JsonEntitySingleOwned> JsonEntitiesSingleOwned { get; set; }
     public IReadOnlyList<JsonEntityInheritanceBase> JsonEntitiesInheritance { get; set; }
@@ -275,6 +281,46 @@ public class JsonQueryData : ISetSource
         e1_c2.Owner = entity1;
 
         return new List<JsonEntityBasic> { entity1 };
+    }
+
+
+    public static IReadOnlyList<JsonEntityBasicForReference> CreateJsonEntitiesBasicForReference()
+    {
+        var entity1 = new JsonEntityBasicForReference { Id = 1, Name = "EntityReference1" };
+
+        return new List<JsonEntityBasicForReference> { entity1 };
+    }
+
+    public static IReadOnlyList<JsonEntityBasicForCollection> CreateJsonEntitiesBasicForCollection()
+    {
+        var entity1 = new JsonEntityBasicForCollection { Id = 1, Name = "EntityCollection1" };
+        var entity2 = new JsonEntityBasicForCollection { Id = 2, Name = "EntityCollection2" };
+        var entity3 = new JsonEntityBasicForCollection { Id = 3, Name = "EntityCollection3" };
+
+        return new List<JsonEntityBasicForCollection> { entity1, entity2, entity3 };
+    }
+
+    public static void WireUp(
+        IReadOnlyList<JsonEntityBasic> entitiesBasic,
+        IReadOnlyList<JsonEntityBasicForReference> entitiesBasicForReference,
+        IReadOnlyList<JsonEntityBasicForCollection> entitiesBasicForCollection)
+    {
+        entitiesBasic[0].EntityReference = entitiesBasicForReference[0];
+        entitiesBasicForReference[0].Parent = entitiesBasic[0];
+        entitiesBasicForReference[0].ParentId = entitiesBasic[0].Id;
+
+        entitiesBasic[0].EntityCollection = new List<JsonEntityBasicForCollection> {
+            entitiesBasicForCollection[0],
+            entitiesBasicForCollection[1],
+            entitiesBasicForCollection[2]
+        };
+
+        entitiesBasicForCollection[0].Parent = entitiesBasic[0];
+        entitiesBasicForCollection[0].ParentId = entitiesBasic[0].Id;
+        entitiesBasicForCollection[1].Parent = entitiesBasic[0];
+        entitiesBasicForCollection[1].ParentId = entitiesBasic[0].Id;
+        entitiesBasicForCollection[2].Parent = entitiesBasic[0];
+        entitiesBasicForCollection[2].ParentId = entitiesBasic[0].Id;
     }
 
     public static IReadOnlyList<JsonEntityCustomNaming> CreateJsonEntitiesCustomNaming()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -553,6 +553,48 @@ FROM (
 GROUP BY [t].[Key]");
     }
 
+    public override async Task Json_with_include_on_json_entity(bool async)
+    {
+        await base.Json_with_include_on_json_entity(async);
+
+        AssertSql(
+            @"SELECT [j].[Id], [j].[Name], JSON_QUERY([j].[OwnedCollectionRoot],'$'), JSON_QUERY([j].[OwnedReferenceRoot],'$')
+FROM [JsonEntitiesBasic] AS [j]");
+    }
+
+    public override async Task Json_with_include_on_entity_reference(bool async)
+    {
+        await base.Json_with_include_on_entity_reference(async);
+
+        AssertSql(
+            @"SELECT [j].[Id], [j].[Name], JSON_QUERY([j].[OwnedCollectionRoot],'$'), JSON_QUERY([j].[OwnedReferenceRoot],'$'), [j0].[Id], [j0].[Name], [j0].[ParentId]
+FROM [JsonEntitiesBasic] AS [j]
+LEFT JOIN [JsonEntitiesBasicForReference] AS [j0] ON [j].[Id] = [j0].[ParentId]");
+    }
+
+    public override async Task Json_with_include_on_entity_collection(bool async)
+    {
+        await base.Json_with_include_on_entity_collection(async);
+
+        AssertSql(
+            @"SELECT [j].[Id], [j].[Name], JSON_QUERY([j].[OwnedCollectionRoot],'$'), JSON_QUERY([j].[OwnedReferenceRoot],'$'), [j0].[Id], [j0].[Name], [j0].[ParentId]
+FROM [JsonEntitiesBasic] AS [j]
+LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
+ORDER BY [j].[Id]");
+    }
+
+    public override async Task Json_with_include_on_entity_collection_and_reference(bool async)
+    {
+        await base.Json_with_include_on_entity_collection_and_reference(async);
+
+        AssertSql(
+            @"SELECT [j].[Id], [j].[Name], JSON_QUERY([j].[OwnedCollectionRoot],'$'), JSON_QUERY([j].[OwnedReferenceRoot],'$'), [j0].[Id], [j0].[Name], [j0].[ParentId], [j1].[Id], [j1].[Name], [j1].[ParentId]
+FROM [JsonEntitiesBasic] AS [j]
+LEFT JOIN [JsonEntitiesBasicForReference] AS [j0] ON [j].[Id] = [j0].[ParentId]
+LEFT JOIN [JsonEntitiesBasicForCollection] AS [j1] ON [j].[Id] = [j1].[ParentId]
+ORDER BY [j].[Id], [j0].[Id]");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }


### PR DESCRIPTION
Resolves #28808

The entity instance is in resultContext.Values. We were trying to use it before creating resultContext.Values.
Fix is to materialize the includes for JSON after resultContext.Values has been created.

The collection include introduces the resultContext.
