### PR TITLE
Avoid nullability warnings w/ new XUnit.Assert

### DIFF
--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Data.Sqlite
                 CommandText = null
             };
 
+            Assert.NotNull(command.CommandText);
             Assert.Empty(command.CommandText);
         }
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Data.Sqlite
                 ConnectionString = null
             };
 
+            Assert.NotNull(builder.ConnectionString);
             Assert.Empty(builder.ConnectionString);
         }
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Data.Sqlite
                 ConnectionString = null
             };
 
+            Assert.NotNull(connection.ConnectionString);
             Assert.Empty(connection.ConnectionString);
         }
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Data.Sqlite
                 ParameterName = null
             };
 
+            Assert.NotNull(parameter.ParameterName);
             Assert.Empty(parameter.ParameterName);
         }
 
@@ -68,6 +69,7 @@ namespace Microsoft.Data.Sqlite
                 SourceColumn = null
             };
 
+            Assert.NotNull(parameter.SourceColumn);
             Assert.Empty(parameter.SourceColumn);
         }
 


### PR DESCRIPTION
- don't pass what looks like `null` to `Assert.Empty(...)`