### PR TITLE
Query: Don't simplify Case block when ElseResult exists

### DIFF
--- a/src/EFCore.Relational/Query/Internal/SqlExpressionSimplifyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/SqlExpressionSimplifyingExpressionVisitor.cs
@@ -231,7 +231,8 @@ public class SqlExpressionSimplifyingExpressionVisitor : ExpressionVisitor
             && sqlConstantComponent != null
             && sqlConstantComponent.Value != null
             && caseComponent != null
-            && caseComponent.Operand == null)
+            && caseComponent.Operand == null
+            && caseComponent.ElseResult == null)
         {
             var matchingCaseBlock = caseComponent.WhenClauses.FirstOrDefault(wc => sqlConstantComponent.Equals(wc.Result));
             if (matchingCaseBlock != null)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -2259,6 +2259,16 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
     }
 
+    public override async Task Case_block_simplification_works_correctly(bool async)
+    {
+        await base.Case_block_simplification_works_correctly(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""Region""] = null) ? ""OR"" : c[""Region""]) = ""OR""))");
+    }
+
     public override async Task Where_compare_null_with_cast_to_object(bool async)
     {
         await base.Where_compare_null_with_cast_to_object(async);

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -2433,4 +2433,14 @@ public abstract class NorthwindWhereQueryTestBase<TFixture> : QueryTestBase<TFix
             async,
             ss => ss.Set<Customer>().Where(c => c.GetType() != typeof(Order)),
             entryCount: 91);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Case_block_simplification_works_correctly(bool async)
+#pragma warning disable IDE0029 // Use coalesce expression
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => (c.Region == null ? "OR" : c.Region) == "OR"),
+            entryCount: 64);
+#pragma warning restore IDE0029 // Use coalesce expression
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -2521,6 +2521,19 @@ WHERE 0 = 1");
 FROM [Customers] AS [c]");
     }
 
+    public override async Task Case_block_simplification_works_correctly(bool async)
+    {
+        await base.Case_block_simplification_works_correctly(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE CASE
+    WHEN [c].[Region] IS NULL THEN N'OR'
+    ELSE [c].[Region]
+END = N'OR'");
+    }
+
     public override async Task Where_poco_closure(bool async)
     {
         await base.Where_poco_closure(async);


### PR DESCRIPTION
Resolves #27609
