### PR TITLE
Fix sproc TPH mapping

### DIFF
--- a/src/EFCore.Relational/Update/ColumnModificationParameters.cs
+++ b/src/EFCore.Relational/Update/ColumnModificationParameters.cs
@@ -198,7 +198,7 @@ public readonly record struct ColumnModificationParameters
     /// <param name="columnIsCondition">Indicates whether the column is used in the <c>WHERE</c> clause when updating.</param>
     /// <param name="sensitiveLoggingEnabled">Indicates whether potentially sensitive data (e.g. database values) can be logged.</param>
     public ColumnModificationParameters(
-        IUpdateEntry entry,
+        IUpdateEntry? entry,
         IProperty? property,
         IColumnBase column,
         Func<string> generateParameterName,

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -266,25 +266,10 @@ public abstract class ReaderModificationCommandBatch : ModificationCommandBatch
     /// <param name="modificationCommand">The modification command for which to add parameters.</param>
     protected virtual void AddParameters(IReadOnlyModificationCommand modificationCommand)
     {
-        IEnumerable<IColumnModification> columnModifications;
-
-        if (modificationCommand.StoreStoredProcedure is null)
-        {
-            columnModifications = modificationCommand.ColumnModifications;
-        }
-        else
-        {
-            if (modificationCommand.StoreStoredProcedure.ReturnValue is not null)
-            {
-                AddParameter(modificationCommand.ColumnModifications.First(c => c.Column is IStoreStoredProcedureReturnValue));
-            }
-
-            columnModifications = modificationCommand.ColumnModifications
-                .Where(c => c.Column is IStoreStoredProcedureParameter)
-                .OrderBy(c => ((IStoreStoredProcedureParameter)c.Column!).Position);
-        }
-
-        foreach (var columnModification in columnModifications)
+        Check.DebugAssert(!modificationCommand.ColumnModifications.Any(m => m.Column is IStoreStoredProcedureReturnValue)
+            || modificationCommand.ColumnModifications[0].Column is IStoreStoredProcedureReturnValue,
+            "ResultValue column modification in non-first position");
+        foreach (var columnModification in modificationCommand.ColumnModifications)
         {
             AddParameter(columnModification);
         }

--- a/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
@@ -355,13 +355,16 @@ public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
 
         // Only positional parameter style supported for now, see #28439
 
-        var orderedParameterModifications = command.ColumnModifications
-            .Where(c => c.Column is IStoreStoredProcedureParameter)
-            .OrderBy(c => ((IStoreStoredProcedureParameter)c.Column!).Position);
-
-        foreach (var columnModification in orderedParameterModifications)
+        // Note: the column modifications are already ordered according to the sproc parameter ordering
+        // (see ModificationCommand.GenerateColumnModifications)
+        for (var i = 0; i < command.ColumnModifications.Count; i++)
         {
-            var parameter = (IStoreStoredProcedureParameter)columnModification.Column!;
+            var columnModification = command.ColumnModifications[i];
+
+            if (columnModification.Column is not IStoreStoredProcedureParameter parameter)
+            {
+                continue;
+            }
 
             if (first)
             {

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -591,13 +591,16 @@ public class SqlServerUpdateSqlGenerator : UpdateAndSelectSqlGenerator, ISqlServ
 
             // Only positional parameter style supported for now, see #28439
 
-            var orderedParameterModifications = command.ColumnModifications
-                .Where(c => c.Column is IStoreStoredProcedureParameter)
-                .OrderBy(c => ((IStoreStoredProcedureParameter)c.Column!).Position);
-
-            foreach (var columnModification in orderedParameterModifications)
+            // Note: the column modifications are already ordered according to the sproc parameter ordering
+            // (see ModificationCommand.GenerateColumnModifications)
+            for (var i = 0; i < command.ColumnModifications.Count; i++)
             {
-                var parameter = (IStoreStoredProcedureParameter)columnModification.Column!;
+                var columnModification = command.ColumnModifications[i];
+
+                if (columnModification.Column is not IStoreStoredProcedureParameter parameter)
+                {
+                    continue;
+                }
 
                 if (first)
                 {

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/StoredProcedureUpdateContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/StoredProcedureUpdateContext.cs
@@ -53,7 +53,7 @@ public class StoredProcedureUpdateContext : PoolableDbContext
         => Set<Entity>(nameof(WithInputOutputParameterOnNonConcurrencyToken));
 
     public DbSet<TphParent> TphParent { get; set; }
-    public DbSet<TphChild> TphChild { get; set; }
+    public DbSet<TphChild1> TphChild { get; set; }
     public DbSet<TptParent> TptParent { get; set; }
     public DbSet<TptChild> TptChild { get; set; }
     public DbSet<TptMixedParent> TptMixedParent { get; set; }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TphChild1.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TphChild1.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
 
-public class TphChild : TphParent
+public class TphChild1 : TphParent
 {
-    public int ChildProperty { get; set; }
+    public int Child1Property { get; set; }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TphChild2.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/TphChild2.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.StoredProcedureUpdateModel;
+
+public class TphChild2 : TphParent
+{
+    public int Child2InputProperty { get; set; }
+    public int Child2OutputParameterProperty { get; set; }
+    public int Child2ResultColumnProperty { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
@@ -180,6 +180,15 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
                         .HasRowsAffectedReturnValue());
             });
 
+        modelBuilder.Entity<TphChild1>();
+
+        modelBuilder.Entity<TphChild2>(
+            b =>
+            {
+                b.Property(w => w.Child2OutputParameterProperty).HasDefaultValue(8);
+                b.Property(w => w.Child2ResultColumnProperty).HasDefaultValue(9);
+            });
+
         modelBuilder.Entity<TphParent>(
             b =>
             {
@@ -191,10 +200,11 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
                         .HasParameter(w => w.Id, pb => pb.IsOutput())
                         .HasParameter("Discriminator")
                         .HasParameter(w => w.Name)
-                        .HasParameter(nameof(TphChild.ChildProperty)));
+                        .HasParameter(nameof(TphChild1.Child1Property))
+                        .HasParameter(nameof(TphChild2.Child2InputProperty))
+                        .HasParameter(nameof(TphChild2.Child2OutputParameterProperty), o => o.IsOutput())
+                        .HasResultColumn(nameof(TphChild2.Child2ResultColumnProperty)));
             });
-
-        modelBuilder.Entity<TphChild>().ToTable("Tph");
 
         modelBuilder.Entity<TptParent>(
             b =>

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
@@ -514,7 +514,7 @@ public class StoredProcedureUpdateTestBase<TFixture> : IClassFixture<TFixture>
     {
         await using var context = CreateContext();
 
-        var entity1 = new TphChild { Name = "Child", ChildProperty = 8 };
+        var entity1 = new TphChild1 { Name = "Child", Child1Property = 8 };
         context.TphChild.Add(entity1);
         await SaveChanges(context, async);
 
@@ -525,7 +525,7 @@ public class StoredProcedureUpdateTestBase<TFixture> : IClassFixture<TFixture>
             var entity2 = context.TphChild.Single(b => b.Id == entity1.Id);
 
             Assert.Equal("Child", entity2.Name);
-            Assert.Equal(8, entity2.ChildProperty);
+            Assert.Equal(8, entity2.Child1Property);
         }
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
@@ -291,13 +291,15 @@ EXEC [WithOriginalAndCurrentValueOnNonConcurrencyToken_Update] @p0, @p1, @p2;");
         await base.Tph(async);
 
         AssertSql(
-            @"@p0='1' (Direction = Output)
-@p1='TphChild' (Nullable = false) (Size = 4000)
+            @"@p0=NULL (Nullable = false) (Direction = Output) (DbType = Int32)
+@p1='TphChild1' (Nullable = false) (Size = 4000)
 @p2='Child' (Size = 4000)
 @p3='8' (Nullable = true)
+@p4=NULL (DbType = Int32)
+@p5=NULL (Direction = Output) (DbType = Int32)
 
 SET NOCOUNT ON;
-EXEC [Tph_Insert] @p0 OUTPUT, @p1, @p2, @p3;");
+EXEC [Tph_Insert] @p0 OUTPUT, @p1, @p2, @p3, @p4, @p5 OUTPUT;");
     }
 
     public override async Task Tpt(bool async)
@@ -535,10 +537,13 @@ END;
 
 GO
 
-CREATE PROCEDURE Tph_Insert(@Id int OUT, @Discriminator varchar(max), @Name varchar(max), @ChildProperty int)
+CREATE PROCEDURE Tph_Insert(@Id int OUT, @Discriminator varchar(max), @Name varchar(max), @Child1Property int, @Child2InputProperty int, @Child2OutputParameterProperty int OUT)
 AS BEGIN
-    INSERT INTO [Tph] ([Discriminator], [Name], [ChildProperty]) VALUES (@Discriminator, @Name, @ChildProperty);
+    DECLARE @Table table ([Child2OutputParameterProperty] int);
+    INSERT INTO [Tph] ([Discriminator], [Name], [Child1Property], [Child2InputProperty]) OUTPUT [Inserted].[Child2OutputParameterProperty] INTO @Table VALUES (@Discriminator, @Name, @Child1Property, @Child2InputProperty);
     SET @Id = SCOPE_IDENTITY();
+    SELECT @Child2OutputParameterProperty = [Child2OutputParameterProperty] FROM @Table;
+    SELECT [Child2ResultColumnProperty] FROM [Tph] WHERE [Id] = @Id
 END;
 
 GO


### PR DESCRIPTION
This creates column modifications for all parameters of a sproc, regardless if they're mapped to the entity or not. It also changes the design to lay out column modifications for sproc parameters according to their sproc param order; we can then rely on that in SQL generation, parameter generation, etc.

Fixes #28805

