### PR TITLE
Translate non-aggregate string.Join to CONCAT_WS on SQL Server

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitorFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
+
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 
 /// <summary>
@@ -11,6 +13,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerSqlTranslatingExpressionVisitorFactory : IRelationalSqlTranslatingExpressionVisitorFactory
 {
+    private readonly ISqlServerSingletonOptions _sqlServerSingletonOptions;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -18,9 +22,11 @@ public class SqlServerSqlTranslatingExpressionVisitorFactory : IRelationalSqlTra
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public SqlServerSqlTranslatingExpressionVisitorFactory(
-        RelationalSqlTranslatingExpressionVisitorDependencies dependencies)
+        RelationalSqlTranslatingExpressionVisitorDependencies dependencies,
+        ISqlServerSingletonOptions sqlServerSingletonOptions)
     {
         Dependencies = dependencies;
+        _sqlServerSingletonOptions = sqlServerSingletonOptions;
     }
 
     /// <summary>
@@ -40,5 +46,6 @@ public class SqlServerSqlTranslatingExpressionVisitorFactory : IRelationalSqlTra
         => new SqlServerSqlTranslatingExpressionVisitor(
             Dependencies,
             (SqlServerQueryCompilationContext)queryCompilationContext,
-            queryableMethodTranslatingExpressionVisitor);
+            queryableMethodTranslatingExpressionVisitor,
+            _sqlServerSingletonOptions);
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1940,6 +1940,9 @@ WHERE (c["Discriminator"] = "Customer")
     public override Task String_Join_over_nullable_column(bool async)
         => AssertTranslationFailed(() => base.String_Join_over_nullable_column(async));
 
+    public override Task String_Join_non_aggregate(bool async)
+        => AssertTranslationFailed(() => base.String_Join_non_aggregate(async));
+
     public override Task String_Concat(bool async)
         => AssertTranslationFailed(() => base.String_Concat(async));
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -273,6 +273,17 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_Join_non_aggregate(bool async)
+    {
+        var foo = "foo";
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => string.Join("|", new[] { c.CompanyName, foo, null, "bar" }) == "Around the Horn|foo||bar"));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task String_Concat(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -360,6 +360,21 @@ GROUP BY [c].[City]
     }
 
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2017)]
+    public override async Task String_Join_non_aggregate(bool async)
+    {
+        await base.String_Join_non_aggregate(async);
+
+        AssertSql(
+            """
+@__foo_0='foo' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE CONCAT_WS(N'|', [c].[CompanyName], COALESCE(@__foo_0, N''), N'', N'bar') = N'Around the Horn|foo||bar'
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2017)]
     public override async Task String_Concat(bool async)
     {
         await base.String_Concat(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -989,6 +989,9 @@ ORDER BY "c1"."City", "c0"."CustomerID" DESC
 """);
     }
 
+    public override Task String_Join_non_aggregate(bool async)
+        => AssertTranslationFailed(() => base.String_Join_non_aggregate(async));
+
     public override async Task String_Concat(bool async)
     {
         await base.String_Concat(async);


### PR DESCRIPTION
As usual, this was a bit more tricky than it looks.

* The translation is in SqlServerSqlTranslatingExpressionVisitor because there's an array parameter.
* CONCAT_WS is interesting in that the type it returns has a length based on its inputs, so concatenating 3 4-letter words with a 1-char delimiter returns a `varchar(14)`. We don't have column/parameter values, so I'm setting the return mapping to be varchar(max) or nvarchar(max) (based on whether we've seen nvarchar or not). See below for 
* There's also CONCAT which is similar to CONCAT_WS. We already have a relational translation for string.Concat in [StringMethodTranslator](https://github.com/dotnet/efcore/blob/release/7.0/src/EFCore.Relational/Query/Internal/StringMethodTranslator.cs#L19), but that works only for the overloads with 2-4 arguments, and not for 5+ (which has an array parameter). We could translate to CONCAT instead just like for CONCAT_WS, but then we should override the relational and do it regardless of number of args (shouldn't use different translations for different arg numbers). If you agree I can do this.

Closes #28899

<details>
<summary>Interesting experiments for CONCAT_WS result type</summary>

```sql
SELECT CONCAT_WS(', ', CAST('foo' AS varchar(max)), CAST('bar' AS varchar(max)));

SELECT CONCAT_WS(', ', 'foo', 'bar'); -- varchar(8), adds lengths of arguments + delimiter as necessary
SELECT CONCAT_WS(', ', CAST('f' AS varchar(1)), CAST('b' AS varchar(1))); -- varchar(4)
SELECT CONCAT_WS(', ', CAST('f' AS varchar(1)), 'bar'); -- varchar(6)
SELECT CONCAT_WS(', ', CAST('f' AS varchar(3)), 'bar'); -- varchar(8)
SELECT CONCAT_WS(', ', 'f', CAST('bar' AS varchar(max))); -- varchar(max)

SELECT CONCAT_WS(', ', 'foo', CAST('bar' AS char(3))); -- varchar(8), char expanded to varchar
SELECT CONCAT_WS(CAST(', ' AS char(2)), CAST('foo' AS char(3)), CAST('bar' AS char(3))); -- varchar(8), even though all arguments are char

SELECT CONCAT_WS(', ', N'foo', 'bar'); -- nvarchar(16), varchar treated as nvarchar

-- Look at this thing (one for the book):
SELECT CONCAT_WS('|', REPLICATE('x', 7999), 'bar'); -- returns ...xxxxxb ('ar' is truncated)

-- To find out an expression's type:
DECLARE @what sql_variant;
SELECT @what = 'some expression';
SELECT
    SQL_VARIANT_PROPERTY(@what, 'BaseType'),
    SQL_VARIANT_PROPERTY(@what, 'Precision'),
    SQL_VARIANT_PROPERTY(@what, 'Scale'),
    SQL_VARIANT_PROPERTY(@what, 'MaxLength');
```

</details>