### PR TITLE
Support sproc input/output parameters on non-concurrency-token properties

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1484,6 +1484,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, sproc, token);
 
         /// <summary>
+        ///     Current value parameter '{parameter}' is not allowed on delete stored procedure '{sproc}'. Use HasOriginalValueParameter() instead.
+        /// </summary>
+        public static string StoredProcedureCurrentValueParameterOnDelete(object? parameter, object? sproc)
+            => string.Format(
+                GetString("StoredProcedureCurrentValueParameterOnDelete", nameof(parameter), nameof(sproc)),
+                parameter, sproc);
+
+        /// <summary>
         ///     The property '{entityType}.{property}' is mapped to a parameter of the stored procedure '{sproc}', but only concurrency token and key properties are supported for Delete stored procedures.
         /// </summary>
         public static string StoredProcedureDeleteNonKeyProperty(object? entityType, object? property, object? sproc)
@@ -1556,6 +1564,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, sproc, properties);
 
         /// <summary>
+        ///     Input parameter '{parameter}' of insert stored procedure '{sproc}' is mapped to property '{property}' of entity type '{entityType}', but that property is configured with BeforeSaveBehavior '{behavior}', and so cannot be saved on insert.
+        /// </summary>
+        public static string StoredProcedureInputParameterForInsertNonSaveProperty(object? parameter, object? sproc, object? property, object? entityType, object? behavior)
+            => string.Format(
+                GetString("StoredProcedureInputParameterForInsertNonSaveProperty", nameof(parameter), nameof(sproc), nameof(property), nameof(entityType), nameof(behavior)),
+                parameter, sproc, property, entityType, behavior);
+
+        /// <summary>
+        ///     Input parameter '{parameter}' of update stored procedure '{sproc}' is mapped to property '{property}' of entity type '{entityType}', but that property is configured with AfterSaveBehavior '{behavior}', and so cannot be saved on update. You may need to use HasOriginalValueParameter() instead of HasParameter().
+        /// </summary>
+        public static string StoredProcedureInputParameterForUpdateNonSaveProperty(object? parameter, object? sproc, object? property, object? entityType, object? behavior)
+            => string.Format(
+                GetString("StoredProcedureInputParameterForUpdateNonSaveProperty", nameof(parameter), nameof(sproc), nameof(property), nameof(entityType), nameof(behavior)),
+                parameter, sproc, property, entityType, behavior);
+
+        /// <summary>
         ///     The keyless entity type '{entityType}' was configured to use '{sproc}'. An entity type requires a primary key to be able to be mapped to a stored procedure.
         /// </summary>
         public static string StoredProcedureKeyless(object? entityType, object? sproc)
@@ -1570,6 +1594,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("StoredProcedureNoName", nameof(entityType), nameof(sproc)),
                 entityType, sproc);
+
+        /// <summary>
+        ///     Original value parameter '{parameter}' is not allowed on insert stored procedure '{sproc}'. Use HasParameter() instead.
+        /// </summary>
+        public static string StoredProcedureOriginalValueParameterOnInsert(object? parameter, object? sproc)
+            => string.Format(
+                GetString("StoredProcedureOriginalValueParameterOnInsert", nameof(parameter), nameof(sproc)),
+                parameter, sproc);
 
         /// <summary>
         ///     The property '{entityType}.{property}' is mapped to an output parameter of the stored procedure '{sproc}', but it is also mapped to an output original value output parameter. A store-generated property can only be mapped to one output parameter.
@@ -1665,6 +1697,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static string StoredProcedureRowsAffectedNotPopulated(object? sproc)
             => string.Format(
                 GetString("StoredProcedureRowsAffectedNotPopulated", nameof(sproc)),
+                sproc);
+
+        /// <summary>
+        ///     A rows affected parameter, result column or return value cannot be configured on stored procedure '{sproc}' because it is used for insertion. Rows affected values are only allowed on stored procedures performing updating or deletion.
+        /// </summary>
+        public static string StoredProcedureRowsAffectedForInsert(object? sproc)
+            => string.Format(
+                GetString("StoredProcedureRowsAffectedForInsert", nameof(sproc)),
                 sproc);
 
         /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -979,6 +979,9 @@
   <data name="StoredProcedureConcurrencyTokenNotMapped" xml:space="preserve">
     <value>The entity type '{entityType}' is mapped to the stored procedure '{sproc}', but the concurrency token '{token}' is not mapped to any original value parameter.</value>
   </data>
+  <data name="StoredProcedureCurrentValueParameterOnDelete" xml:space="preserve">
+    <value>Current value parameter '{parameter}' is not allowed on delete stored procedure '{sproc}'. Use HasOriginalValueParameter() instead.</value>
+  </data>
   <data name="StoredProcedureDeleteNonKeyProperty" xml:space="preserve">
     <value>The property '{entityType}.{property}' is mapped to a parameter of the stored procedure '{sproc}', but only concurrency token and key properties are supported for Delete stored procedures.</value>
   </data>
@@ -1006,11 +1009,20 @@
   <data name="StoredProcedureGeneratedPropertiesNotMapped" xml:space="preserve">
     <value>The entity type '{entityType}' is mapped to the stored procedure '{sproc}', however the store-generated properties {properties} are not mapped to any output parameter or result column.</value>
   </data>
+  <data name="StoredProcedureInputParameterForInsertNonSaveProperty" xml:space="preserve">
+    <value>Input parameter '{parameter}' of insert stored procedure '{sproc}' is mapped to property '{property}' of entity type '{entityType}', but that property is configured with BeforeSaveBehavior '{behavior}', and so cannot be saved on insert.</value>
+  </data>
+  <data name="StoredProcedureInputParameterForUpdateNonSaveProperty" xml:space="preserve">
+    <value>Input parameter '{parameter}' of update stored procedure '{sproc}' is mapped to property '{property}' of entity type '{entityType}', but that property is configured with AfterSaveBehavior '{behavior}', and so cannot be saved on update. You may need to use HasOriginalValueParameter() instead of HasParameter().</value>
+  </data>
   <data name="StoredProcedureKeyless" xml:space="preserve">
     <value>The keyless entity type '{entityType}' was configured to use '{sproc}'. An entity type requires a primary key to be able to be mapped to a stored procedure.</value>
   </data>
   <data name="StoredProcedureNoName" xml:space="preserve">
     <value>The entity type '{entityType}' was configured to use '{sproc}', but the store name was not specified. Configure the stored procedure name explicitly.</value>
+  </data>
+  <data name="StoredProcedureOriginalValueParameterOnInsert" xml:space="preserve">
+    <value>Original value parameter '{parameter}' is not allowed on insert stored procedure '{sproc}'. Use HasParameter() instead.</value>
   </data>
   <data name="StoredProcedureOutputParameterConflict" xml:space="preserve">
     <value>The property '{entityType}.{property}' is mapped to an output parameter of the stored procedure '{sproc}', but it is also mapped to an output original value output parameter. A store-generated property can only be mapped to one output parameter.</value>
@@ -1047,6 +1059,9 @@
   </data>
   <data name="StoredProcedureRowsAffectedNotPopulated" xml:space="preserve">
     <value>Stored procedure '{sproc}' was configured with a rows affected output parameter or return value, but a valid value was not found when executing the procedure.</value>
+  </data>
+  <data name="StoredProcedureRowsAffectedForInsert" xml:space="preserve">
+    <value>A rows affected parameter, result column or return value cannot be configured on stored procedure '{sproc}' because it is used for insertion. Rows affected values are only allowed on stored procedures performing updating or deletion.</value>
   </data>
   <data name="StoredProcedureRowsAffectedReturnConflictingParameter" xml:space="preserve">
     <value>The stored procedure '{sproc}' cannot be configured to return the rows affected because a rows affected parameter or a rows affected result column for this stored procedure already exists.</value>

--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -44,7 +44,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
             bool? onResultSet = null;
             var hasOutputParameters = false;
 
-            for (; commandIndex < ResultSetMappings.Count; commandIndex++)
+            while (commandIndex < ResultSetMappings.Count)
             {
                 var resultSetMapping = ResultSetMappings[commandIndex];
 
@@ -63,9 +63,13 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                         ? lastHandledCommandIndex == commandIndex
                         : lastHandledCommandIndex > commandIndex, "Bad handling of ResultSetMapping and command indexing");
 
-                    commandIndex = lastHandledCommandIndex;
+                    commandIndex = lastHandledCommandIndex + 1;
 
                     onResultSet = reader.DbDataReader.NextResult();
+                }
+                else
+                {
+                    commandIndex++;
                 }
 
                 if (resultSetMapping.HasFlag(ResultSetMapping.HasOutputParameters))
@@ -158,7 +162,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
             bool? onResultSet = null;
             var hasOutputParameters = false;
 
-            for (; commandIndex < ResultSetMappings.Count; commandIndex++)
+            while (commandIndex < ResultSetMappings.Count)
             {
                 var resultSetMapping = ResultSetMappings[commandIndex];
 
@@ -177,9 +181,13 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                         ? lastHandledCommandIndex == commandIndex
                         : lastHandledCommandIndex > commandIndex, "Bad handling of ResultSetMapping and command indexing");
 
-                    commandIndex = lastHandledCommandIndex;
+                    commandIndex = lastHandledCommandIndex + 1;
 
                     onResultSet = await reader.DbDataReader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    commandIndex++;
                 }
 
                 if (resultSetMapping.HasFlag(ResultSetMapping.HasOutputParameters))

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -523,9 +523,12 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
                     && (isKey
                         || storedProcedureParameter is { ForOriginalValue: true }
                         || (property.IsConcurrencyToken && storedProcedureParameter is null));
+
+                // Store-generated properties generally need to be read back (unless we're deleting).
+                // One exception is if the property is mapped to a non-output parameter.
                 var readValue = state != EntityState.Deleted
                     && entry.IsStoreGenerated(property)
-                    && storedProcedureParameter is null or { ForOriginalValue: false };
+                    && (storedProcedureParameter is null || storedProcedureParameter.Direction.HasFlag(ParameterDirection.Output));
 
                 ColumnValuePropagator? columnPropagator = null;
                 sharedTableColumnMap?.TryGetValue(column.Name, out columnPropagator);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -2627,7 +2627,7 @@ namespace TestNamespace
                 true);
 
             var id0 = deleteSproc.AddParameter(
-                ""Id"", ParameterDirection.Input, false, ""Id"", false);
+                ""Id_Original"", ParameterDirection.Input, false, ""Id"", true);
             runtimeEntityType.AddAnnotation(""Relational:DeleteStoredProcedure"", deleteSproc);
 
             var updateSproc = new RuntimeStoredProcedure(
@@ -2641,7 +2641,7 @@ namespace TestNamespace
             var principalDerivedId0 = updateSproc.AddParameter(
                 ""PrincipalDerivedId"", ParameterDirection.Input, false, ""PrincipalDerivedId"", false);
             var id1 = updateSproc.AddParameter(
-                ""Id"", ParameterDirection.Input, false, ""Id"", false);
+                ""Id_Original"", ParameterDirection.Input, false, ""Id"", true);
             runtimeEntityType.AddAnnotation(""Relational:UpdateStoredProcedure"", updateSproc);
 
             runtimeEntityType.AddAnnotation(""Relational:FunctionName"", null);
@@ -2710,7 +2710,7 @@ namespace TestNamespace
                 false);
 
             var id = deleteSproc.AddParameter(
-                ""Id"", ParameterDirection.Input, false, ""Id"", false);
+                ""Id_Original"", ParameterDirection.Input, false, ""Id"", true);
             runtimeEntityType.AddAnnotation(""Relational:DeleteStoredProcedure"", deleteSproc);
 
             var updateSproc = new RuntimeStoredProcedure(
@@ -2724,7 +2724,7 @@ namespace TestNamespace
             var principalDerivedId0 = updateSproc.AddParameter(
                 ""PrincipalDerivedId"", ParameterDirection.Input, false, ""PrincipalDerivedId"", false);
             var id0 = updateSproc.AddParameter(
-                ""Id"", ParameterDirection.Input, false, ""Id"", false);
+                ""Id_Original"", ParameterDirection.Input, false, ""Id"", true);
             runtimeEntityType.AddAnnotation(""Relational:UpdateStoredProcedure"", updateSproc);
 
             runtimeEntityType.AddAnnotation(""Relational:FunctionName"", null);
@@ -2824,17 +2824,17 @@ namespace TestNamespace
                     Assert.False(updateSproc.IsRowsAffectedReturned);
                     Assert.Empty(updateSproc.GetAnnotations());
                     Assert.Same(principalBase, updateSproc.EntityType);
-                    Assert.Equal("Id", updateSproc.Parameters.Last().Name);
+                    Assert.Equal("Id_Original", updateSproc.Parameters.Last().Name);
                     Assert.Null(id.FindOverrides(StoreObjectIdentifier.Create(principalBase, StoreObjectType.UpdateStoredProcedure).Value));
 
                     var deleteSproc = principalBase.GetDeleteStoredProcedure()!;
                     Assert.Equal("PrincipalBase_Delete", deleteSproc.Name);
                     Assert.Equal("TPC", deleteSproc.Schema);
-                    Assert.Equal(new[] { "Id" }, deleteSproc.Parameters.Select(p => p.Name));
+                    Assert.Equal(new[] { "Id_Original" }, deleteSproc.Parameters.Select(p => p.Name));
                     Assert.Empty(deleteSproc.ResultColumns);
                     Assert.True(deleteSproc.IsRowsAffectedReturned);
                     Assert.Same(principalBase, deleteSproc.EntityType);
-                    Assert.Equal("Id", deleteSproc.Parameters.Last().Name);
+                    Assert.Equal("Id_Original", deleteSproc.Parameters.Last().Name);
                     Assert.Null(id.FindOverrides(StoreObjectIdentifier.Create(principalBase, StoreObjectType.DeleteStoredProcedure).Value));
 
                     Assert.Equal("PrincipalBase", principalBase.GetDiscriminatorValue());
@@ -2880,7 +2880,7 @@ namespace TestNamespace
                     Assert.Empty(updateSproc.ResultColumns);
                     Assert.Empty(updateSproc.GetAnnotations());
                     Assert.Same(principalDerived, updateSproc.EntityType);
-                    Assert.Equal("Id", updateSproc.Parameters.Last().Name);
+                    Assert.Equal("Id_Original", updateSproc.Parameters.Last().Name);
                     Assert.Null(
                         id.FindOverrides(StoreObjectIdentifier.Create(principalDerived, StoreObjectType.UpdateStoredProcedure).Value));
 
@@ -2890,7 +2890,7 @@ namespace TestNamespace
                     Assert.Equal(new[] { "Id" }, deleteSproc.Parameters.Select(p => p.PropertyName));
                     Assert.Empty(deleteSproc.ResultColumns);
                     Assert.Same(principalDerived, deleteSproc.EntityType);
-                    Assert.Equal("Id", deleteSproc.Parameters.Last().Name);
+                    Assert.Equal("Id_Original", deleteSproc.Parameters.Last().Name);
                     Assert.Null(
                         id.FindOverrides(StoreObjectIdentifier.Create(principalDerived, StoreObjectType.DeleteStoredProcedure).Value));
 
@@ -2972,10 +2972,10 @@ namespace TestNamespace
                         eb.UpdateUsingStoredProcedure(s => s
                             .HasParameter("PrincipalBaseId")
                             .HasParameter("PrincipalDerivedId")
-                            .HasParameter(p => p.Id));
+                            .HasOriginalValueParameter(p => p.Id));
                         eb.DeleteUsingStoredProcedure(s => s
                             .HasRowsAffectedReturnValue()
-                            .HasParameter(p => p.Id));
+                            .HasOriginalValueParameter(p => p.Id));
 
                         eb.HasIndex(new[] { "PrincipalBaseId" }, "PrincipalIndex")
                             .IsUnique()
@@ -3006,9 +3006,9 @@ namespace TestNamespace
                         eb.UpdateUsingStoredProcedure("Derived_Update", "Derived", s => s
                             .HasParameter("PrincipalBaseId")
                             .HasParameter("PrincipalDerivedId")
-                            .HasParameter(p => p.Id));
+                            .HasOriginalValueParameter(p => p.Id));
                         eb.DeleteUsingStoredProcedure("Derived_Delete", s => s
-                            .HasParameter(p => p.Id));
+                            .HasOriginalValueParameter(p => p.Id));
                     });
 
                 modelBuilder.Entity<DependentBase<byte?>>(

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/StoredProcedureUpdateContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/StoredProcedureUpdateContext.cs
@@ -25,8 +25,8 @@ public class StoredProcedureUpdateContext : PoolableDbContext
     public DbSet<EntityWithAdditionalProperty> WithOutputParameterAndRowsAffectedResultColumn
         => Set<EntityWithAdditionalProperty>(nameof(WithOutputParameterAndRowsAffectedResultColumn));
 
-    public DbSet<EntityWithAdditionalProperty> WithTwoOutputParameters
-        => Set<EntityWithAdditionalProperty>(nameof(WithTwoOutputParameters));
+    public DbSet<EntityWithAdditionalProperty> WithTwoInputParameters
+        => Set<EntityWithAdditionalProperty>(nameof(WithTwoInputParameters));
 
     public DbSet<Entity> WithRowsAffectedParameter
         => Set<Entity>(nameof(WithRowsAffectedParameter));
@@ -37,8 +37,8 @@ public class StoredProcedureUpdateContext : PoolableDbContext
     public DbSet<Entity> WithRowsAffectedReturnValue
         => Set<Entity>(nameof(WithRowsAffectedReturnValue));
 
-    public DbSet<Entity> WithStoreGeneratedConcurrencyTokenAsInoutParameter
-        => Set<Entity>(nameof(WithStoreGeneratedConcurrencyTokenAsInoutParameter));
+    public DbSet<Entity> WithStoreGeneratedConcurrencyTokenAsInOutParameter
+        => Set<Entity>(nameof(WithStoreGeneratedConcurrencyTokenAsInOutParameter));
 
     public DbSet<Entity> WithStoreGeneratedConcurrencyTokenAsTwoParameters
         => Set<Entity>(nameof(WithStoreGeneratedConcurrencyTokenAsTwoParameters));
@@ -49,8 +49,8 @@ public class StoredProcedureUpdateContext : PoolableDbContext
     public DbSet<Entity> WithOriginalAndCurrentValueOnNonConcurrencyToken
         => Set<Entity>(nameof(WithOriginalAndCurrentValueOnNonConcurrencyToken));
 
-    public DbSet<Entity> WithInputOutputParameterOnNonConcurrencyToken
-        => Set<Entity>(nameof(WithInputOutputParameterOnNonConcurrencyToken));
+    public DbSet<Entity> WithInputOrOutputParameter
+        => Set<Entity>(nameof(WithInputOrOutputParameter));
 
     public DbSet<TphParent> TphParent { get; set; }
     public DbSet<TphChild1> TphChild { get; set; }

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
@@ -23,11 +23,11 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
             .UpdateUsingStoredProcedure(
                 nameof(StoredProcedureUpdateContext.WithOutputParameter) + "_Update",
                 spb => spb
-                    .HasParameter(w => w.Id)
+                    .HasOriginalValueParameter(w => w.Id)
                     .HasParameter(w => w.Name))
             .DeleteUsingStoredProcedure(
                 nameof(StoredProcedureUpdateContext.WithOutputParameter) + "_Delete",
-                spb => spb.HasParameter(w => w.Id));
+                spb => spb.HasOriginalValueParameter(w => w.Id));
 
         modelBuilder.SharedTypeEntity<Entity>(nameof(StoredProcedureUpdateContext.WithResultColumn))
             .InsertUsingStoredProcedure(
@@ -70,16 +70,16 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
                 b.UpdateUsingStoredProcedure(
                     nameof(StoredProcedureUpdateContext.WithOutputParameterAndRowsAffectedResultColumn) + "_Update",
                     spb => spb
-                        .HasParameter(w => w.Id)
+                        .HasOriginalValueParameter(w => w.Id)
                         .HasParameter(w => w.Name)
                         .HasParameter(w => w.AdditionalProperty, pb => pb.IsOutput())
                         .HasRowsAffectedResultColumn());
             });
 
-        modelBuilder.SharedTypeEntity<EntityWithAdditionalProperty>(nameof(StoredProcedureUpdateContext.WithTwoOutputParameters))
+        modelBuilder.SharedTypeEntity<EntityWithAdditionalProperty>(nameof(StoredProcedureUpdateContext.WithTwoInputParameters))
             .UpdateUsingStoredProcedure(
-                nameof(StoredProcedureUpdateContext.WithTwoOutputParameters) + "_Update", spb => spb
-                    .HasParameter(w => w.Id)
+                nameof(StoredProcedureUpdateContext.WithTwoInputParameters) + "_Update", spb => spb
+                    .HasOriginalValueParameter(w => w.Id)
                     .HasParameter(w => w.Name)
                     .HasParameter(w => w.AdditionalProperty));
 
@@ -87,7 +87,7 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
             .UpdateUsingStoredProcedure(
                 nameof(StoredProcedureUpdateContext.WithRowsAffectedParameter) + "_Update",
                 spb => spb
-                    .HasParameter(w => w.Id)
+                    .HasOriginalValueParameter(w => w.Id)
                     .HasParameter(w => w.Name)
                     .HasRowsAffectedParameter());
 
@@ -95,7 +95,7 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
             .UpdateUsingStoredProcedure(
                 nameof(StoredProcedureUpdateContext.WithRowsAffectedResultColumn) + "_Update",
                 spb => spb
-                    .HasParameter(w => w.Id)
+                    .HasOriginalValueParameter(w => w.Id)
                     .HasParameter(w => w.Name)
                     .HasRowsAffectedResultColumn());
 
@@ -103,20 +103,20 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
             .UpdateUsingStoredProcedure(
                 nameof(StoredProcedureUpdateContext.WithRowsAffectedReturnValue) + "_Update",
                 spb => spb
-                    .HasParameter(w => w.Id)
+                    .HasOriginalValueParameter(w => w.Id)
                     .HasParameter(w => w.Name)
                     .HasRowsAffectedReturnValue());
 
         modelBuilder.SharedTypeEntity<Entity>(
-            nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsInoutParameter),
+            nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsInOutParameter),
             b =>
             {
                 ConfigureStoreGeneratedConcurrencyToken(b, "ConcurrencyToken");
 
                 b.UpdateUsingStoredProcedure(
-                    nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsInoutParameter) + "_Update",
+                    nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsInOutParameter) + "_Update",
                     spb => spb
-                        .HasParameter(w => w.Id)
+                        .HasOriginalValueParameter(w => w.Id)
                         .HasOriginalValueParameter("ConcurrencyToken", pb => pb.IsInputOutput())
                         .HasParameter(w => w.Name)
                         .HasRowsAffectedParameter());
@@ -131,7 +131,7 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
                 b.UpdateUsingStoredProcedure(
                     nameof(StoredProcedureUpdateContext.WithStoreGeneratedConcurrencyTokenAsTwoParameters) + "_Update",
                     spb => spb
-                        .HasParameter(w => w.Id)
+                        .HasOriginalValueParameter(w => w.Id)
                         .HasOriginalValueParameter("ConcurrencyToken", pb => pb.HasName("ConcurrencyTokenIn"))
                         .HasParameter(w => w.Name)
                         .HasParameter(
@@ -150,7 +150,7 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
                     b.UpdateUsingStoredProcedure(
                         nameof(StoredProcedureUpdateContext.WithUserManagedConcurrencyToken) + "_Update",
                         spb => spb
-                            .HasParameter(w => w.Id)
+                            .HasOriginalValueParameter(w => w.Id)
                             .HasOriginalValueParameter(w => w.AdditionalProperty, pb => pb.HasName("ConcurrencyTokenOriginal"))
                             .HasParameter(w => w.Name)
                             .HasParameter(w => w.AdditionalProperty, pb => pb.HasName("ConcurrencyTokenCurrent"))
@@ -161,20 +161,20 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
             .UpdateUsingStoredProcedure(
                 nameof(StoredProcedureUpdateContext.WithOriginalAndCurrentValueOnNonConcurrencyToken) + "_Update",
                 spb => spb
-                    .HasParameter(w => w.Id)
+                    .HasOriginalValueParameter(w => w.Id)
                     .HasParameter(w => w.Name, pb => pb.HasName("NameCurrent"))
                     .HasOriginalValueParameter(w => w.Name, pb => pb.HasName("NameOriginal")));
 
         modelBuilder.SharedTypeEntity<Entity>(
-            nameof(StoredProcedureUpdateContext.WithInputOutputParameterOnNonConcurrencyToken),
+            nameof(StoredProcedureUpdateContext.WithInputOrOutputParameter),
             b =>
             {
-                b.Property(w => w.Name).ValueGeneratedOnAddOrUpdate();
+                b.Property(w => w.Name).IsRequired().ValueGeneratedOnAdd();
 
-                b.UpdateUsingStoredProcedure(
-                    nameof(StoredProcedureUpdateContext.WithInputOutputParameterOnNonConcurrencyToken) + "_Update",
+                b.InsertUsingStoredProcedure(
+                    nameof(StoredProcedureUpdateContext.WithInputOrOutputParameter) + "_Insert",
                     spb => spb
-                        .HasParameter(w => w.Id)
+                        .HasParameter(w => w.Id, pb => pb.IsOutput())
                         .HasParameter(w => w.Name, pb => pb.IsInputOutput()));
             });
 
@@ -264,15 +264,15 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
         context.WithResultColumn.RemoveRange(context.WithResultColumn);
         context.WithTwoResultColumns.RemoveRange(context.WithTwoResultColumns);
         context.WithOutputParameterAndResultColumn.RemoveRange(context.WithOutputParameterAndResultColumn);
-        context.WithTwoOutputParameters.RemoveRange(context.WithTwoOutputParameters);
+        context.WithTwoInputParameters.RemoveRange(context.WithTwoInputParameters);
         context.WithRowsAffectedParameter.RemoveRange(context.WithRowsAffectedParameter);
         context.WithRowsAffectedResultColumn.RemoveRange(context.WithRowsAffectedResultColumn);
         context.WithRowsAffectedReturnValue.RemoveRange(context.WithRowsAffectedReturnValue);
-        context.WithStoreGeneratedConcurrencyTokenAsInoutParameter.RemoveRange(context.WithStoreGeneratedConcurrencyTokenAsInoutParameter);
+        context.WithStoreGeneratedConcurrencyTokenAsInOutParameter.RemoveRange(context.WithStoreGeneratedConcurrencyTokenAsInOutParameter);
         context.WithStoreGeneratedConcurrencyTokenAsTwoParameters.RemoveRange(context.WithStoreGeneratedConcurrencyTokenAsTwoParameters);
         context.WithUserManagedConcurrencyToken.RemoveRange(context.WithUserManagedConcurrencyToken);
         context.WithOriginalAndCurrentValueOnNonConcurrencyToken.RemoveRange(context.WithOriginalAndCurrentValueOnNonConcurrencyToken);
-        context.WithInputOutputParameterOnNonConcurrencyToken.RemoveRange(context.WithInputOutputParameterOnNonConcurrencyToken);
+        context.WithInputOrOutputParameter.RemoveRange(context.WithInputOrOutputParameter);
         context.TphParent.RemoveRange(context.TphParent);
         context.TphChild.RemoveRange(context.TphChild);
         context.TptParent.RemoveRange(context.TptParent);

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -1190,7 +1190,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 billingAddressUpdateSproc.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
 
             Assert.Equal(
-                new[] { nameof(Address.City), nameof(Address.Street), "OrderDetailsOrderId" },
+                new[] { nameof(Address.City), nameof(Address.Street), "OrderDetailsOrderId_Original" },
                 billingAddressUpdateSproc.Parameters.Select(m => m.Name));
 
             Assert.Empty(billingAddressUpdateSproc.ResultColumns.Select(m => m.Name));
@@ -1207,7 +1207,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 billingAddressDeleteSproc.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
 
             Assert.Equal(
-                new[] { "OrderDetailsOrderId" },
+                new[] { "OrderDetailsOrderId_Original" },
                 billingAddressDeleteSproc.Parameters.Select(m => m.Name));
 
             Assert.Empty(billingAddressDeleteSproc.ResultColumns.Select(m => m.Name));
@@ -1327,7 +1327,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     baseUpdateSproc.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
 
                 Assert.Equal(
-                    new[] { "UpdateId", "SpecialtyAk" },
+                    new[] { "UpdateId", "SpecialtyAk_Original" },
                     baseUpdateSproc.Parameters.Select(m => m.Name));
 
                 Assert.Empty(baseUpdateSproc.ResultColumns.Select(m => m.Name));
@@ -1935,7 +1935,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                             .HasParameter((Customer c) => c.SomeShort)
                                             .HasParameter((AbstractCustomer c) => c.AbstractString))
                                     .UpdateUsingStoredProcedure(
-                                        s => s.HasParameter(b => b.Id, p => p.HasName("UpdateId"))
+                                        s => s
+                                            .HasOriginalValueParameter(b => b.Id, p => p.HasName("UpdateId"))
                                             .HasParameter((SpecialCustomer c) => c.Specialty)
                                             .HasParameter((SpecialCustomer c) => c.RelatedCustomerSpecialty)
                                             .HasParameter("AnotherRelatedCustomerId")
@@ -1944,7 +1945,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                             .HasParameter((Customer c) => c.SomeShort)
                                             .HasParameter((AbstractCustomer c) => c.AbstractString))
                                     .DeleteUsingStoredProcedure(
-                                        s => s.HasParameter(b => b.Id, p => p.HasName("DeleteId")));
+                                        s => s.HasOriginalValueParameter(b => b.Id, p => p.HasName("DeleteId")));
                             }
                             else
                             {
@@ -1954,10 +1955,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                             .HasParameter(b => b.Id, p => p.IsOutput().HasName("InsertId"))
                                             .HasParameter("SpecialtyAk"))
                                     .UpdateUsingStoredProcedure(
-                                        s => s.HasParameter(b => b.Id, p => p.HasName("UpdateId"))
-                                            .HasParameter("SpecialtyAk"))
+                                        s => s
+                                            .HasOriginalValueParameter(b => b.Id, p => p.HasName("UpdateId"))
+                                            .HasOriginalValueParameter("SpecialtyAk"))
                                     .DeleteUsingStoredProcedure(
-                                        s => s.HasParameter(b => b.Id, p => p.HasName("DeleteId")));
+                                        s => s.HasOriginalValueParameter(b => b.Id, p => p.HasName("DeleteId")));
                             }
                         }
                     }
@@ -2003,12 +2005,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                         .HasParameter(c => c.SomeShort))
                                 .UpdateUsingStoredProcedure(
                                     s => s
-                                        .HasParameter(b => b.Id, p => p.HasName("UpdateId"))
+                                        .HasOriginalValueParameter(b => b.Id, p => p.HasName("UpdateId"))
                                         .HasParameter(c => c.EnumValue)
                                         .HasParameter(c => c.Name)
                                         .HasParameter(c => c.SomeShort))
                                 .DeleteUsingStoredProcedure(
-                                    s => s.HasParameter(b => b.Id, p => p.HasName("DeleteId")));
+                                    s => s.HasOriginalValueParameter(b => b.Id, p => p.HasName("DeleteId")));
 
                             if (mapping == Mapping.TPC)
                             {
@@ -2061,7 +2063,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                         .HasParameter(c => c.SomeShort)
                                         .HasParameter(c => c.AbstractString))
                                 .UpdateUsingStoredProcedure(
-                                    s => s.HasParameter(b => b.Id, p => p.HasName("UpdateId"))
+                                    s => s
+                                        .HasOriginalValueParameter(b => b.Id, p => p.HasName("UpdateId"))
                                         .HasParameter(c => c.Specialty)
                                         .HasParameter(c => c.RelatedCustomerSpecialty)
                                         .HasParameter("AnotherRelatedCustomerId")
@@ -2070,7 +2073,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                         .HasParameter(c => c.SomeShort)
                                         .HasParameter(c => c.AbstractString))
                                 .DeleteUsingStoredProcedure(
-                                    s => s.HasParameter(b => b.Id, p => p.HasName("DeleteId")));
+                                    s => s.HasOriginalValueParameter(b => b.Id, p => p.HasName("DeleteId")));
                         }
                         else if (mapping == Mapping.TPT)
                         {
@@ -2083,13 +2086,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                         .HasParameter("AnotherRelatedCustomerId")
                                         .HasParameter(c => c.AbstractString))
                                 .UpdateUsingStoredProcedure(
-                                    s => s.HasParameter(b => b.Id, p => p.HasName("UpdateId"))
+                                    s => s
+                                        .HasOriginalValueParameter(b => b.Id, p => p.HasName("UpdateId"))
                                         .HasParameter(c => c.Specialty)
                                         .HasParameter(c => c.RelatedCustomerSpecialty)
                                         .HasParameter("AnotherRelatedCustomerId")
                                         .HasParameter(c => c.AbstractString))
                                 .DeleteUsingStoredProcedure(
-                                    s => s.HasParameter(b => b.Id, p => p.HasName("DeleteId")));
+                                    s => s.HasOriginalValueParameter(b => b.Id, p => p.HasName("DeleteId")));
                         }
                     }
 
@@ -2134,15 +2138,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                             cb.OwnsOne(
                                 c => c.Details, cdb => cdb
                                     .InsertUsingStoredProcedure("CustomerDetailsInsert", s => s
-                                            .HasParameter("SpecialCustomerId")
-                                            .HasParameter(b => b.BirthDay)
-                                            .HasParameter(b => b.Address))
+                                        .HasParameter("SpecialCustomerId")
+                                        .HasParameter(b => b.BirthDay)
+                                        .HasParameter(b => b.Address))
                                     .UpdateUsingStoredProcedure("CustomerDetailsUpdate", s => s
-                                            .HasParameter("SpecialCustomerId")
-                                            .HasParameter(b => b.BirthDay)
-                                            .HasParameter(b => b.Address))
+                                        .HasOriginalValueParameter("SpecialCustomerId")
+                                        .HasParameter(b => b.BirthDay)
+                                        .HasParameter(b => b.Address))
                                     .DeleteUsingStoredProcedure("CustomerDetailsDelete", s => s
-                                        .HasParameter("SpecialCustomerId")));
+                                        .HasOriginalValueParameter("SpecialCustomerId")));
                         }
                     }
                 });
@@ -2179,7 +2183,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                             .HasParameter(c => c.SomeShort)
                                             .HasParameter(c => c.AbstractString))
                                     .UpdateUsingStoredProcedure(
-                                        s => s.HasParameter(b => b.Id, p => p.HasName("UpdateId"))
+                                        s => s
+                                            .HasOriginalValueParameter(b => b.Id, p => p.HasName("UpdateId"))
                                             .HasParameter(c => c.Specialty)
                                             .HasParameter(c => c.RelatedCustomerSpecialty)
                                             .HasParameter("AnotherRelatedCustomerId")
@@ -2188,14 +2193,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                             .HasParameter(c => c.SomeShort)
                                             .HasParameter(c => c.AbstractString))
                                     .DeleteUsingStoredProcedure(
-                                        s => s.HasParameter(b => b.Id, p => p.HasName("DeleteId")));
+                                        s => s.HasOriginalValueParameter(b => b.Id, p => p.HasName("DeleteId")));
                             }
                             else if (mapping == Mapping.TPT)
                             {
                                 cb
                                     .InsertUsingStoredProcedure(s => s.HasParameter(b => b.Id))
-                                    .UpdateUsingStoredProcedure(s => s.HasParameter(b => b.Id))
-                                    .DeleteUsingStoredProcedure(s => s.HasParameter(b => b.Id));
+                                    .UpdateUsingStoredProcedure(s => s.HasOriginalValueParameter(b => b.Id))
+                                    .DeleteUsingStoredProcedure(s => s.HasOriginalValueParameter(b => b.Id));
                             }
                         }
                     }
@@ -2226,12 +2231,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                             .HasParameter(b => b.Address))
                                     .UpdateUsingStoredProcedure(
                                         "CustomerDetailsUpdate", s => s
-                                            .HasParameter("ExtraSpecialCustomerId")
+                                            .HasOriginalValueParameter("ExtraSpecialCustomerId")
                                             .HasParameter(b => b.BirthDay)
                                             .HasParameter(b => b.Address))
                                     .DeleteUsingStoredProcedure(
                                         "CustomerDetailsDelete", s => s
-                                            .HasParameter("ExtraSpecialCustomerId")));
+                                            .HasOriginalValueParameter("ExtraSpecialCustomerId")));
                         }
                     }
                 });
@@ -2260,10 +2265,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                     .HasParameter(c => c.OrderDate))
                             .UpdateUsingStoredProcedure(
                                 s => s
-                                    .HasParameter(c => c.Id)
+                                    .HasOriginalValueParameter(c => c.Id)
                                     .HasParameter(c => c.CustomerId)
                                     .HasParameter(c => c.OrderDate))
-                            .DeleteUsingStoredProcedure(s => s.HasParameter(b => b.Id));
+                            .DeleteUsingStoredProcedure(s => s.HasOriginalValueParameter(b => b.Id));
                     }
 
                     ob.OwnsOne(
@@ -2289,12 +2294,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                             .HasParameter(c => c.OrderDate))
                                     .UpdateUsingStoredProcedure(
                                         "OrderDetails_Update", s => s
-                                            .HasParameter(c => c.OrderId)
+                                            .HasOriginalValueParameter(c => c.OrderId)
                                             .HasParameter(c => c.Active)
                                             .HasParameter(c => c.OrderDate))
                                     .DeleteUsingStoredProcedure(
                                         "OrderDetails_Delete", s => s
-                                            .HasParameter(b => b.OrderId));
+                                            .HasOriginalValueParameter(b => b.OrderId));
 
                                 odb.OwnsOne(
                                     od => od.BillingAddress, bab => bab
@@ -2307,10 +2312,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                             "BillingAddress_Update", s => s
                                                 .HasParameter(c => c.City)
                                                 .HasParameter(c => c.Street)
-                                                .HasParameter("OrderDetailsOrderId"))
+                                                .HasOriginalValueParameter("OrderDetailsOrderId"))
                                         .DeleteUsingStoredProcedure(
                                             "BillingAddress_Delete", s => s
-                                                .HasParameter("OrderDetailsOrderId")));
+                                                .HasOriginalValueParameter("OrderDetailsOrderId")));
 
                                 odb.OwnsOne(
                                     od => od.ShippingAddress, sab => sab
@@ -2321,12 +2326,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                                 .HasParameter(c => c.Street))
                                         .UpdateUsingStoredProcedure(
                                             "ShippingAddress_Update", s => s
-                                                .HasParameter("OrderDetailsOrderId")
+                                                .HasOriginalValueParameter("OrderDetailsOrderId")
                                                 .HasParameter(c => c.City)
                                                 .HasParameter(c => c.Street))
                                         .DeleteUsingStoredProcedure(
                                             "ShippingAddress_Delete", s => s
-                                                .HasParameter("OrderDetailsOrderId")));
+                                                .HasOriginalValueParameter("OrderDetailsOrderId")));
                             }
                             else
                             {

--- a/test/EFCore.Sqlite.Tests/Infrastructure/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Infrastructure/SqliteModelValidatorTest.cs
@@ -68,7 +68,7 @@ public class SqliteModelValidatorTest : RelationalModelValidatorTest
             .UpdateUsingStoredProcedure(
                 "Person_Update",
                 spb => spb
-                    .HasParameter(w => w.Id)
+                    .HasOriginalValueParameter(w => w.Id)
                     .HasParameter(w => w.Name)
                     .HasParameter(w => w.FavoriteBreed));
 
@@ -80,9 +80,27 @@ public class SqliteModelValidatorTest : RelationalModelValidatorTest
     {
         var modelBuilder = CreateConventionModelBuilder();
         modelBuilder.Entity<Person>()
-            .DeleteUsingStoredProcedure("Person_Delete", spb => spb.HasParameter(w => w.Id));
+            .DeleteUsingStoredProcedure("Person_Delete", spb => spb.HasOriginalValueParameter(w => w.Id));
 
         VerifyError(SqliteStrings.StoredProceduresNotSupported(nameof(Person)), modelBuilder);
+    }
+
+    public override void Passes_for_stored_procedure_without_parameter_for_insert_non_save_property()
+    {
+        var exception =
+            Assert.Throws<InvalidOperationException>(
+                () => base.Passes_for_stored_procedure_without_parameter_for_insert_non_save_property());
+
+        Assert.Equal(SqliteStrings.StoredProceduresNotSupported(nameof(Animal)), exception.Message);
+    }
+
+    public override void Passes_for_stored_procedure_without_parameter_for_update_non_save_property()
+    {
+        var exception =
+            Assert.Throws<InvalidOperationException>(
+                () => base.Passes_for_stored_procedure_without_parameter_for_update_non_save_property());
+
+        Assert.Equal(SqliteStrings.StoredProceduresNotSupported(nameof(Animal)), exception.Message);
     }
 
     public override void Passes_on_valid_UsingDeleteStoredProcedure_in_TPT()


### PR DESCRIPTION
@AndriySvyryd @ajcvickers one last design thought on this... This PR makes in/out parameters means "always both send and receive", as discussed. If, in the future, we implement optional sproc parameters with sentinel values, it would be a breaking change to change the meaning of in/out to "write only if the user set the property, read only if they didn't" (which is our regular SQL behavior). In other words, in order to allow the user to *sometimes* provide a value and sometimes not (in different commands) - today, without optional params/sentinels - we're making it so that their value is *always* sent and read back (in the same command).

I'm a bit concerned that we're painting ourselves into a corner; ideally, the write-and-read within the same command would be triggered by a separate opt-in, since it's probably really rare. Not merging this PR would mean users currently must choose either input or output, but not both, which doesn't seem too bad. If/when we have optional/sentinel parameters, they'd be able to do input/output without reading back values when they provide them.

But we've already discussed this too much... If you're guys this we should do this, I'm OK with it.

Closes #28704

