### PR TITLE
Fall back to non-RETURNING updates with old Sqlite

### DIFF
--- a/benchmark/EFCore.Sqlite.Benchmarks/EFCore.Sqlite.Benchmarks.csproj
+++ b/benchmark/EFCore.Sqlite.Benchmarks/EFCore.Sqlite.Benchmarks.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,5 +30,6 @@
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
     <MicrosoftCodeAnalysisVersion>4.2.0</MicrosoftCodeAnalysisVersion>
+    <SqlitePCLRawVersion>2.1.1-pre20220822172036</SqlitePCLRawVersion>
   </PropertyGroup>
 </Project>

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteLegacyUpdateSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteLegacyUpdateSqlGenerator.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Update.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteLegacyUpdateSqlGenerator : UpdateAndSelectSqlGenerator
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqliteLegacyUpdateSqlGenerator(UpdateSqlGeneratorDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    /// <summary>
+    ///     Appends a <c>WHERE</c> condition for the identity (i.e. key value) of the given column.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="columnModification">The column for which the condition is being generated.</param>
+    protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, IColumnModification columnModification)
+    {
+        Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
+        Check.NotNull(columnModification, nameof(columnModification));
+
+        SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, "rowid");
+        commandStringBuilder.Append(" = ")
+            .Append("last_insert_rowid()");
+    }
+
+    /// <summary>
+    ///     Appends a SQL command for selecting the number of rows affected.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="name">The name of the table.</param>
+    /// <param name="schema">The table schema, or <see langword="null" /> to use the default schema.</param>
+    /// <param name="commandPosition">The ordinal of the command for which rows affected it being returned.</param>
+    /// <returns>The <see cref="ResultSetMapping" /> for this command.</returns>
+    protected override ResultSetMapping AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string? schema, int commandPosition)
+    {
+        Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
+        Check.NotEmpty(name, nameof(name));
+
+        commandStringBuilder
+            .Append("SELECT changes()")
+            .AppendLine(SqlGenerationHelper.StatementTerminator)
+            .AppendLine();
+
+        return ResultSetMapping.LastInResultSet;
+    }
+
+    /// <summary>
+    ///     Appends a <c>WHERE</c> condition checking rows affected.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="expectedRowsAffected">The expected number of rows affected.</param>
+    protected override void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
+    {
+        Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
+
+        commandStringBuilder.Append("changes() = ").Append(expectedRowsAffected);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override string GenerateNextSequenceValueOperation(string name, string? schema)
+        => throw new NotSupportedException(SqliteStrings.SequencesNotSupported);
+}

--- a/src/EFCore.Sqlite/EFCore.Sqlite.csproj
+++ b/src/EFCore.Sqlite/EFCore.Sqlite.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
+++ b/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
@@ -39,7 +39,7 @@ Microsoft.Data.Sqlite.SqliteTransaction</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.core" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.csproj
+++ b/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.csproj
@@ -24,7 +24,7 @@ Microsoft.Data.Sqlite.SqliteTransaction</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
+++ b/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/EFCore.Sqlite.FunctionalTests/EFCore.Sqlite.FunctionalTests.csproj
+++ b/test/EFCore.Sqlite.FunctionalTests/EFCore.Sqlite.FunctionalTests.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteVersionConditionAttribute.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteVersionConditionAttribute.cs
@@ -6,32 +6,34 @@ using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
+#nullable enable
+
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
 public sealed class SqliteVersionConditionAttribute : Attribute, ITestCondition
 {
-    private Version _min;
-    private Version _max;
-    private Version _skip;
+    private Version? _min;
+    private Version? _max;
+    private Version? _skip;
 
-    public string Min
+    public string? Min
     {
-        get => _min.ToString();
-        set => _min = new Version(value);
+        get => _min?.ToString();
+        set => _min = value is null ? null : new Version(value);
     }
 
-    public string Max
+    public string? Max
     {
-        get => _max.ToString();
-        set => _max = new Version(value);
+        get => _max?.ToString();
+        set => _max = value is null ? null : new Version(value);
     }
 
-    public string Skip
+    public string? Skip
     {
-        get => _skip.ToString();
-        set => _skip = new Version(value);
+        get => _skip?.ToString();
+        set => _skip = value is null ? null : new Version(value);
     }
 
-    private static Version Current
+    private static Version? Current
     {
         get
         {
@@ -61,7 +63,7 @@ public sealed class SqliteVersionConditionAttribute : Attribute, ITestCondition
         return new ValueTask<bool>(_max == null ? Current >= _min : Current <= _max && Current >= _min);
     }
 
-    private string _skipReason;
+    private string? _skipReason;
 
     public string SkipReason
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Update/StoreValueGenerationSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/StoreValueGenerationSqliteFixture.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Update;
+
+#nullable enable
+
+public class StoreValueGenerationSqliteFixture : StoreValueGenerationFixtureBase
+{
+    private string? _cleanDataSql;
+
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+
+    public override void CleanData()
+    {
+        using var context = CreateContext();
+        context.Database.ExecuteSqlRaw(_cleanDataSql ??= GenerateCleanDataSql());
+    }
+
+    private string GenerateCleanDataSql()
+    {
+        var context = CreateContext();
+        var builder = new StringBuilder();
+
+        foreach (var table in context.Model.GetEntityTypes().SelectMany(e => e.GetTableMappings().Select(m => m.Table.Name)))
+        {
+            builder.AppendLine($"DELETE FROM {table};");
+            builder.AppendLine($"DELETE FROM sqlite_sequence WHERE name='{table}';");
+        }
+
+        return builder.ToString();
+    }
+}

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.e_sqlcipher.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.e_sqlcipher.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.sqlite3.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.sqlite3.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.winsqlite3.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.winsqlite3.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_winsqlite3" Version="2.1.1-pre20220822172036" />
+    <PackageReference Include="SQLitePCLRaw.bundle_winsqlite3" Version="$(SqlitePCLRawVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@bricelam I ended up using SQLitePCL.raw.sqlite3_libversion_number() to find out which Sqlite version we're using, since the UpdateSqlGenerator is set up in a singleton context and it's a bit of a hassle to get a SqliteConnection etc. Are we aware of a situation where different versions of Sqlite could be used based on the connection string (seems unlikely)? If so and you think it's important, I can look into using SqliteConnection.ServerVersion instead.

Test-wise, I've verified manually that the old SQL gets properly generated on Windows (where the version is 3034001, using SQLitePCLRaw.bundle_winsqlite3); there's also a new legacy test suite which I've verified artifically by hard-coding an old version. But since all our tests pass in CI, I'm assuming we always run with the bundled version which is new; we could do the extra legwork to e.g. use the system Windows version for tests, but that seems low-value to me...

Fixes #28776
