### PR TITLE
Make filtered unique index update dependencies soft so they can be broken if there's a cycle, since they might not be enforced in the database.

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
@@ -108,9 +108,7 @@ public static class RelationalIndexExtensions
     /// <param name="index">The index.</param>
     /// <returns>The index filter expression.</returns>
     public static string? GetFilter(this IReadOnlyIndex index)
-        => (index is RuntimeIndex)
-            ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
-            : (string?)index.FindAnnotation(RelationalAnnotationNames.Filter)?.Value;
+        => (string?)index.FindAnnotation(RelationalAnnotationNames.Filter)?.Value;
 
     /// <summary>
     ///     Returns the index filter expression.
@@ -120,11 +118,6 @@ public static class RelationalIndexExtensions
     /// <returns>The index filter expression.</returns>
     public static string? GetFilter(this IReadOnlyIndex index, in StoreObjectIdentifier storeObject)
     {
-        if (index is RuntimeIndex)
-        {
-            throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData);
-        }
-
         var annotation = index.FindAnnotation(RelationalAnnotationNames.Filter);
         if (annotation != null)
         {

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
@@ -433,7 +433,10 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
     {
         base.ProcessIndexAnnotations(annotations, index, runtimeIndex, runtime);
 
-        annotations.Remove(runtime ? RelationalAnnotationNames.TableIndexMappings : RelationalAnnotationNames.Filter);
+        if (runtime)
+        {
+            annotations.Remove(RelationalAnnotationNames.TableIndexMappings);
+        }
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -306,7 +306,11 @@ public class CommandBatchPreparer : ICommandBatchPreparer
 
         AddSameTableEdges(_modificationCommandGraph);
 
-        return _modificationCommandGraph.BatchingTopologicalSort(static (_, _, edges) => edges.All(e => e is ITable), FormatCycle);
+        return _modificationCommandGraph.BatchingTopologicalSort(
+            static (_, _, edges) => edges.All(e =>
+                e is ITable
+                || (e is ITableIndex index && index.Filter != null)),
+            FormatCycle);
     }
 
     private string FormatCycle(

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -1870,9 +1870,7 @@ namespace TestNamespace
                     Assert.Equal("AlternateIndex", alternateIndex.Name);
                     Assert.Equal("AIX", alternateIndex.GetDatabaseName());
                     Assert.Null(alternateIndex[RelationalAnnotationNames.Filter]);
-                    Assert.Equal(
-                        CoreStrings.RuntimeModelMissingData,
-                        Assert.Throws<InvalidOperationException>(() => alternateIndex.GetFilter()).Message);
+                    Assert.Null(alternateIndex.GetFilter());
 
                     Assert.Equal(new[] { compositeIndex, alternateIndex }, principalAlternateId.GetContainingIndexes());
 


### PR DESCRIPTION
So they can be broken if there's a cycle, since they might not be enforced in the database.

Fixes #28065
