### PR TITLE
Stop setting JSON array entities' state to Modified in SaveChanges

### DIFF
--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -259,25 +259,7 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
         public object? PropertyValue { get; set; }
     }
 
-    private record struct JsonPartialUpdatePathEntry
-    {
-        public JsonPartialUpdatePathEntry(
-            string propertyName,
-            int? ordinal,
-            IUpdateEntry parentEntry,
-            INavigation navigation)
-        {
-            PropertyName = propertyName;
-            Ordinal = ordinal;
-            ParentEntry = parentEntry;
-            Navigation = navigation;
-        }
-
-        public string PropertyName { get; }
-        public int? Ordinal { get; }
-        public IUpdateEntry ParentEntry { get; }
-        public INavigation Navigation { get; }
-    }
+    private record struct JsonPartialUpdatePathEntry(string PropertyName, int? Ordinal, IUpdateEntry ParentEntry, INavigation Navigation);
 
     private List<IColumnModification> GenerateColumnModifications()
     {
@@ -334,7 +316,6 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
             var processedEntries = new List<IUpdateEntry>();
             foreach (var entry in _entries.Where(e => e.EntityType.IsMappedToJson()))
             {
-                var modifiedMembers = entry.ToEntityEntry().Properties.Where(m => m.IsModified).ToList();
                 var jsonColumn = entry.EntityType.GetContainerColumnName()!;
                 var jsonPartialUpdateInfo = FindJsonPartialUpdateInfo(entry, processedEntries);
 
@@ -423,7 +404,6 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
             }
         }
 
-        var processedJsonNavigations = new List<INavigation>();
         foreach (var entry in _entries.Where(x => !x.EntityType.IsMappedToJson()))
         {
             var nonMainEntry = !_mainEntryAdded || entry != _entries[0];
@@ -757,7 +737,7 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
             {
                 if (property.IsOrdinalKeyProperty() && ordinal != null)
                 {
-                    entry.SetStoreGeneratedValue(property, ordinal.Value);
+                    entry.SetStoreGeneratedValue(property, ordinal.Value, setModified: false);
                 }
 
                 continue;

--- a/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityReferenceMap.cs
@@ -228,29 +228,11 @@ public class EntityReferenceMap
     {
         // Perf sensitive
 
-        var returnAdded
-            = added
-            && _addedReferenceMap != null
-            && _addedReferenceMap.Count > 0;
-
-        var returnModified
-            = modified
-            && _modifiedReferenceMap != null
-            && _modifiedReferenceMap.Count > 0;
-
-        var returnDeleted
-            = deleted
-            && _deletedReferenceMap != null
-            && _deletedReferenceMap.Count > 0;
-
-        var returnUnchanged
-            = unchanged
-            && _unchangedReferenceMap != null
-            && _unchangedReferenceMap.Count > 0;
-
-        var hasSharedTypes
-            = _sharedTypeReferenceMap != null
-            && _sharedTypeReferenceMap.Count > 0;
+        var returnAdded = added && _addedReferenceMap is { Count: > 0 };
+        var returnModified = modified && _modifiedReferenceMap is { Count: > 0 };
+        var returnDeleted = deleted && _deletedReferenceMap is { Count: > 0 };
+        var returnUnchanged = unchanged && _unchangedReferenceMap is { Count: > 0 };
+        var hasSharedTypes = _sharedTypeReferenceMap is { Count: > 0 };
 
         if (!hasSharedTypes)
         {

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -523,8 +523,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
 
         var currentState = _stateData.EntityState;
 
-        if (currentState == EntityState.Added
-            || currentState == EntityState.Detached
+        if (currentState is EntityState.Added or EntityState.Detached
             || !changeState)
         {
             var index = property.GetOriginalValueIndex();
@@ -573,8 +572,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
         }
 
         if (isModified
-            && (currentState == EntityState.Unchanged
-                || currentState == EntityState.Detached))
+            && currentState is EntityState.Unchanged or EntityState.Detached)
         {
             if (changeState)
             {
@@ -746,7 +744,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public void SetStoreGeneratedValue(IProperty property, object? value)
+    public void SetStoreGeneratedValue(IProperty property, object? value, bool setModified = true)
     {
         if (property.GetStoreGeneratedIndex() == -1)
         {
@@ -758,7 +756,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
             property,
             value,
             isMaterialization: false,
-            setModified: true,
+            setModified,
             isCascadeDelete: false,
             CurrentValueType.StoreGenerated);
     }

--- a/src/EFCore/Update/IUpdateEntry.cs
+++ b/src/EFCore/Update/IUpdateEntry.cs
@@ -108,7 +108,8 @@ public interface IUpdateEntry
     /// </summary>
     /// <param name="property">The property to set the value for.</param>
     /// <param name="value">The value to set.</param>
-    void SetStoreGeneratedValue(IProperty property, object? value);
+    /// <param name="setModified">Whether to set the store-generated property's state to Modified.</param>
+    void SetStoreGeneratedValue(IProperty property, object? value, bool setModified = true);
 
     /// <summary>
     ///     Gets an <see cref="EntityEntry" /> for the entity being saved. <see cref="EntityEntry" /> is an API optimized for

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -362,7 +362,7 @@ public class CosmosTestStore : TestStore
         public void SetPropertyModified(IProperty property)
             => throw new NotImplementedException();
 
-        public void SetStoreGeneratedValue(IProperty property, object value)
+        public void SetStoreGeneratedValue(IProperty property, object value, bool setModified = true)
             => throw new NotImplementedException();
 
         public EntityEntry ToEntityEntry()

--- a/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateTestBase.cs
@@ -270,6 +270,9 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
                 entity.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf.Add(newLeaf);
                 ClearLog();
                 await context.SaveChangesAsync();
+
+                // Do SaveChanges again, see #28813
+                await context.SaveChangesAsync();
             },
             async context =>
             {

--- a/test/EFCore.Tests/ExceptionTest.cs
+++ b/test/EFCore.Tests/ExceptionTest.cs
@@ -199,7 +199,7 @@ public class ExceptionTest
         public TProperty GetOriginalValue<TProperty>(IProperty property)
             => throw new NotImplementedException();
 
-        public void SetStoreGeneratedValue(IProperty property, object value)
+        public void SetStoreGeneratedValue(IProperty property, object value, bool setModified = true)
             => throw new NotImplementedException();
 
         public EntityEntry ToEntityEntry()


### PR DESCRIPTION
The issue is when saving entities within JSON arrays. When generating column modifications in SaveChanges, we rebuild the entire JSON document in CreateJson; any entities which are contained in a JSON array get their "ordinal key property" recalculated and assigned ([see this line](https://github.com/dotnet/efcore/blob/release/7.0/src/EFCore.Relational/Update/ModificationCommand.cs#L760)); this changes the entity's state to Modified. Since these entities are unrelated to the original change, we don't accept changes on them (not in entriesToSave in StateManager.SaveChanges), and so they remain Modified after SaveChanges completes.

Note that something similar actually happens when we save a regular entity with a computed property: propagating the computed property marks the entry as Modified. But in that case it's already Modified anyway, and accepting the changes reverts it back to Unchanged.

I tried changing SetStoreGeneratedValue to pass setModified=false to SetStoreGeneratedValue, with the thought that propagating a value back from the database shouldn't change the entity's state; that could even be a slight optimization for  regular non-JSON propagation. But that caused test failures in       TableSplittingTestBase.Can_use_optional_dependents_with_shared_concurrency_tokens, OptimisticConcurrencySqlServerTestBase.Database_concurrency_token_value_is_updated_for_all_sharing_entities, OptimisticConcurrencySqlServerTestBase.Database_concurrency_token_value_is_updated_for_all_sharing_entities.

So for now I've simply exposed setModified on SetStoreGeneratedValue, which seems minimally-invasive and low risk (but a small public API change. Let me know what you think.

Fixes #28813
