### PR TITLE
Fully-qualify ExpressionPrinter in DebuggerDisplay

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlExpression.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///     </para>
 /// </summary>
 #if DEBUG
-[DebuggerDisplay("{new ExpressionPrinter().Print(this), nq}")]
+[DebuggerDisplay("{new Microsoft.EntityFrameworkCore.Query.ExpressionPrinter().Print(this), nq}")]
 #endif
 public abstract class SqlExpression : Expression, IPrintableExpression
 {


### PR DESCRIPTION
This causes an issue in Jetbrains IDEs which don't properly resolve partially-qualified ExpressionPrinter