### PR TITLE
Avoid cascade cycles on SQL Server for derived-type referencing many-to-many

### DIFF
--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -61,7 +61,7 @@ public class SqlServerOnDeleteConvention : CascadeDeleteConvention, ISkipNavigat
         }
 
         var selfReferencingSkipNavigation = foreignKey.GetReferencingSkipNavigations()
-            .FirstOrDefault(s => s.Inverse != null && s.TargetEntityType == s.DeclaringEntityType);
+            .FirstOrDefault(s => s.Inverse != null && s.TargetEntityType.IsAssignableFrom(s.DeclaringEntityType));
         if (selfReferencingSkipNavigation == null)
         {
             return deleteBehavior;

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -86,7 +86,9 @@ public class SqlServerOnDeleteConvention : CascadeDeleteConvention,
             var inverseDeleteBehavior = DefaultDeleteBehavior(inverseSkipNavigation);
 
             if (deleteBehavior == DeleteBehavior.Cascade
-                && inverseDeleteBehavior == DeleteBehavior.Cascade)
+                && inverseDeleteBehavior == DeleteBehavior.Cascade
+                && !(inverseSkipNavigation.ForeignKey!.GetDeleteBehaviorConfigurationSource() == ConfigurationSource.Explicit
+                    && inverseSkipNavigation.ForeignKey!.DeleteBehavior != DeleteBehavior.Cascade))
             {
                 deleteBehavior = DeleteBehavior.ClientCascade;
             }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -1555,7 +1555,7 @@ namespace TestNamespace
             var runtimeForeignKey = declaringEntityType.AddForeignKey(new[] { declaringEntityType.FindProperty(""DerivedsId"")!, declaringEntityType.FindProperty(""DerivedsAlternateId"")! },
                 principalEntityType.FindKey(new[] { principalEntityType.FindProperty(""Id"")!, principalEntityType.FindProperty(""AlternateId"")! })!,
                 principalEntityType,
-                deleteBehavior: DeleteBehavior.Cascade,
+                deleteBehavior: DeleteBehavior.ClientCascade,
                 required: true);
 
             return runtimeForeignKey;

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -1555,7 +1555,7 @@ namespace TestNamespace
             var runtimeForeignKey = declaringEntityType.AddForeignKey(new[] { declaringEntityType.FindProperty(""DerivedsId"")!, declaringEntityType.FindProperty(""DerivedsAlternateId"")! },
                 principalEntityType.FindKey(new[] { principalEntityType.FindProperty(""Id"")!, principalEntityType.FindProperty(""AlternateId"")! })!,
                 principalEntityType,
-                deleteBehavior: DeleteBehavior.ClientCascade,
+                deleteBehavior: DeleteBehavior.Cascade,
                 required: true);
 
             return runtimeForeignKey;
@@ -1566,7 +1566,7 @@ namespace TestNamespace
             var runtimeForeignKey = declaringEntityType.AddForeignKey(new[] { declaringEntityType.FindProperty(""PrincipalsId"")!, declaringEntityType.FindProperty(""PrincipalsAlternateId"")! },
                 principalEntityType.FindKey(new[] { principalEntityType.FindProperty(""Id"")!, principalEntityType.FindProperty(""AlternateId"")! })!,
                 principalEntityType,
-                deleteBehavior: DeleteBehavior.Cascade,
+                deleteBehavior: DeleteBehavior.ClientCascade,
                 required: true);
 
             return runtimeForeignKey;

--- a/test/EFCore.Relational.Specification.Tests/ManyToManyTrackingRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ManyToManyTrackingRelationalTestBase.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public abstract class ManyToManyTrackingRelationalTestBase<TFixture> : ManyToManyTrackingTestBase<TFixture>
+    where TFixture : ManyToManyTrackingRelationalTestBase<TFixture>.ManyToManyTrackingRelationalFixture
+{
+    protected ManyToManyTrackingRelationalTestBase(TFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [ConditionalFact]
+    public void Many_to_many_delete_behaviors_are_set()
+    {
+        using var context = CreateContext();
+        var model = context.Model;
+
+        var navigations = model.GetEntityTypes().SelectMany(e => e.GetDeclaredSkipNavigations())
+            .Where(e => e.ForeignKey.DeleteBehavior != DeleteBehavior.Cascade).ToList();
+
+        var builder = new StringBuilder();
+        foreach (var navigation in navigations)
+        {
+            builder.AppendLine($"{{ \"{navigation.DeclaringEntityType.ShortName()}.{navigation.Name}\", DeleteBehavior.ClientCascade }},");
+        }
+
+        var x = builder.ToString();
+
+        foreach (var skipNavigation in model.GetEntityTypes().SelectMany(e => e.GetSkipNavigations()))
+        {
+            Assert.Equal(
+                CustomDeleteBehaviors.TryGetValue(
+                    $"{skipNavigation.DeclaringEntityType.ShortName()}.{skipNavigation.Name}", out var deleteBehavior)
+                    ? deleteBehavior
+                    : DeleteBehavior.Cascade,
+                skipNavigation.ForeignKey.DeleteBehavior);
+        }
+    }
+
+    protected virtual Dictionary<string, DeleteBehavior> CustomDeleteBehaviors { get; } = new();
+
+    protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+        => facade.UseTransaction(transaction.GetDbTransaction());
+
+    public abstract class ManyToManyTrackingRelationalFixture : ManyToManyTrackingFixtureBase
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder.Entity<EntityTableSharing1>().ToTable("TableSharing");
+            modelBuilder.Entity<EntityTableSharing2>(
+                b =>
+                {
+                    b.HasOne<EntityTableSharing1>().WithOne().HasForeignKey<EntityTableSharing2>(e => e.Id);
+                    b.ToTable("TableSharing");
+                });
+        }
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/ManyToManyQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ManyToManyQueryRelationalFixture.cs
@@ -1,10 +1,25 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class ManyToManyQueryRelationalFixture : ManyToManyQueryFixtureBase
 {
     public TestSqlLoggerFactory TestSqlLoggerFactory
         => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<EntityTableSharing1>().ToTable("TableSharing");
+        modelBuilder.Entity<EntityTableSharing2>(
+            b =>
+            {
+                b.HasOne<EntityTableSharing1>().WithOne().HasForeignKey<EntityTableSharing2>(e => e.Id);
+                b.ToTable("TableSharing");
+            });
+    }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/TPCManyToManyQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPCManyToManyQueryRelationalFixture.cs
@@ -23,6 +23,8 @@ public abstract class TPCManyToManyQueryRelationalFixture : ManyToManyQueryRelat
         modelBuilder.Entity<EntityRoot>().ToTable("Roots");
         modelBuilder.Entity<EntityBranch>().ToTable("Branches");
         modelBuilder.Entity<EntityLeaf>().ToTable("Leaves");
+        modelBuilder.Entity<EntityBranch2>().ToTable("Branch2s");
+        modelBuilder.Entity<EntityLeaf2>().ToTable("Leaf2s");
 
         modelBuilder.Entity<UnidirectionalEntityRoot>().UseTpcMappingStrategy();
         modelBuilder.Entity<UnidirectionalEntityRoot>().ToTable("UnidirectionalRoots");

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTManyToManyQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTManyToManyQueryRelationalFixture.cs
@@ -17,6 +17,8 @@ public abstract class TPTManyToManyQueryRelationalFixture : ManyToManyQueryRelat
         modelBuilder.Entity<EntityRoot>().ToTable("Roots");
         modelBuilder.Entity<EntityBranch>().ToTable("Branches");
         modelBuilder.Entity<EntityLeaf>().ToTable("Leaves");
+        modelBuilder.Entity<EntityBranch2>().ToTable("Branch2s");
+        modelBuilder.Entity<EntityLeaf2>().ToTable("Leaf2s");
 
         modelBuilder.Entity<UnidirectionalEntityRoot>().ToTable("UnidirectionalRoots");
         modelBuilder.Entity<UnidirectionalEntityBranch>().ToTable("UnidirectionalBranches");

--- a/test/EFCore.Specification.Tests/Query/ManyToManyFieldsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyFieldsQueryFixtureBase.cs
@@ -269,6 +269,10 @@ public abstract class ManyToManyFieldsQueryFixtureBase : SharedStoreFixtureBase<
             .HasMany(e => e.TwoSkipShared)
             .WithMany(e => e.OneSkipShared);
 
+        modelBuilder.Entity<EntityRoot>()
+            .HasMany(e => e.BranchSkipShared)
+            .WithMany(e => e.RootSkipShared);
+
         // Nav:2 Payload:No Join:Concrete Extra:None
         modelBuilder.Entity<EntityOne>()
             .HasMany(e => e.TwoSkip)

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
@@ -40,6 +40,10 @@ public abstract class ManyToManyQueryFixtureBase : SharedStoreFixtureBase<ManyTo
         { typeof(EntityRoot), e => ((EntityRoot)e)?.Id },
         { typeof(EntityBranch), e => ((EntityBranch)e)?.Id },
         { typeof(EntityLeaf), e => ((EntityLeaf)e)?.Id },
+        { typeof(EntityBranch2), e => ((EntityBranch2)e)?.Id },
+        { typeof(EntityLeaf2), e => ((EntityLeaf2)e)?.Id },
+        { typeof(EntityTableSharing1), e => ((EntityTableSharing1)e)?.Id },
+        { typeof(EntityTableSharing2), e => ((EntityTableSharing2)e)?.Id },
         { typeof(UnidirectionalEntityOne), e => ((UnidirectionalEntityOne)e)?.Id },
         { typeof(UnidirectionalEntityTwo), e => ((UnidirectionalEntityTwo)e)?.Id },
         { typeof(UnidirectionalEntityThree), e => ((UnidirectionalEntityThree)e)?.Id },
@@ -162,6 +166,69 @@ public abstract class ManyToManyQueryFixtureBase : SharedStoreFixtureBase<ManyTo
                     Assert.Equal(ee.Name, aa.Name);
                     Assert.Equal(ee.Number, aa.Number);
                     Assert.Equal(ee.IsGreen, aa.IsGreen);
+                }
+            }
+        },
+        {
+            typeof(EntityBranch2), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (EntityBranch2)e;
+                    var aa = (EntityBranch2)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Slumber, aa.Slumber);
+                }
+            }
+        },
+        {
+            typeof(EntityLeaf2), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (EntityLeaf2)e;
+                    var aa = (EntityLeaf2)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                    Assert.Equal(ee.Slumber, aa.Slumber);
+                    Assert.Equal(ee.IsBrown, aa.IsBrown);
+                }
+            }
+        },
+        {
+            typeof(EntityTableSharing1), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (EntityTableSharing1)e;
+                    var aa = (EntityTableSharing1)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Name, aa.Name);
+                }
+            }
+        },
+        {
+            typeof(EntityTableSharing2), (e, a) =>
+            {
+                Assert.Equal(e == null, a == null);
+
+                if (a != null)
+                {
+                    var ee = (EntityTableSharing2)e;
+                    var aa = (EntityTableSharing2)a;
+
+                    Assert.Equal(ee.Id, aa.Id);
+                    Assert.Equal(ee.Cucumber, aa.Cucumber);
                 }
             }
         },
@@ -292,6 +359,10 @@ public abstract class ManyToManyQueryFixtureBase : SharedStoreFixtureBase<ManyTo
         modelBuilder.Entity<EntityRoot>().Property(e => e.Id).ValueGeneratedNever();
         modelBuilder.Entity<EntityBranch>().HasBaseType<EntityRoot>();
         modelBuilder.Entity<EntityLeaf>().HasBaseType<EntityBranch>();
+        modelBuilder.Entity<EntityBranch2>().HasBaseType<EntityRoot>();
+        modelBuilder.Entity<EntityLeaf2>().HasBaseType<EntityBranch2>();
+        modelBuilder.Entity<EntityTableSharing1>().Property(e => e.Id).ValueGeneratedNever();
+        modelBuilder.Entity<EntityTableSharing2>().Property(e => e.Id).ValueGeneratedNever();
 
         modelBuilder.Entity<UnidirectionalEntityOne>().Property(e => e.Id).ValueGeneratedNever();
         modelBuilder.Entity<UnidirectionalEntityTwo>().Property(e => e.Id).ValueGeneratedNever();
@@ -324,6 +395,18 @@ public abstract class ManyToManyQueryFixtureBase : SharedStoreFixtureBase<ManyTo
         modelBuilder.Entity<EntityRoot>()
             .HasMany(e => e.BranchSkipShared)
             .WithMany(e => e.RootSkipShared);
+
+        modelBuilder.Entity<EntityBranch2>()
+            .HasMany(e => e.SelfSkipSharedLeft)
+            .WithMany(e => e.SelfSkipSharedRight);
+
+        modelBuilder.Entity<EntityBranch2>()
+            .HasMany(e => e.Leaf2SkipShared)
+            .WithMany(e => e.Branch2SkipShared);
+
+        modelBuilder.Entity<EntityTableSharing1>()
+            .HasMany(e => e.TableSharing2Shared)
+            .WithMany(e => e.TableSharing1Shared);
 
         // Nav:2 Payload:No Join:Concrete Extra:None
         modelBuilder.Entity<EntityOne>()

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
@@ -321,6 +321,10 @@ public abstract class ManyToManyQueryFixtureBase : SharedStoreFixtureBase<ManyTo
             .HasMany(e => e.TwoSkipShared)
             .WithMany(e => e.OneSkipShared);
 
+        modelBuilder.Entity<EntityRoot>()
+            .HasMany(e => e.BranchSkipShared)
+            .WithMany(e => e.RootSkipShared);
+
         // Nav:2 Payload:No Join:Concrete Extra:None
         modelBuilder.Entity<EntityOne>()
             .HasMany(e => e.TwoSkip)
@@ -438,6 +442,10 @@ public abstract class ManyToManyQueryFixtureBase : SharedStoreFixtureBase<ManyTo
         modelBuilder.Entity<UnidirectionalEntityOne>()
             .HasMany(e => e.TwoSkipShared)
             .WithMany();
+
+        modelBuilder.Entity<UnidirectionalEntityBranch>()
+            .HasMany<UnidirectionalEntityRoot>()
+            .WithMany(e => e.BranchSkipShared);
 
         // Nav:2 Payload:No Join:Concrete Extra:None
         modelBuilder.Entity<UnidirectionalEntityOne>()

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityBranch.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityBranch.cs
@@ -7,4 +7,5 @@ public class EntityBranch : EntityRoot
 {
     public long Number;
     public ICollection<EntityOne> OneSkip;
+    public ICollection<EntityRoot> RootSkipShared;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityRoot.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityRoot.cs
@@ -9,4 +9,5 @@ public class EntityRoot
     public string Name;
     public ICollection<EntityThree> ThreeSkipShared;
     public ICollection<EntityCompositeKey> CompositeKeySkipShared;
+    public ICollection<EntityBranch> BranchSkipShared;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ManyToManyData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ManyToManyData.cs
@@ -43,6 +43,7 @@ public class ManyToManyData : ISetSource
         context.Set<Dictionary<string, object>>("EntityCompositeKeyEntityTwo").AddRange(CreateEntityCompositeKeyEntityTwos(context));
         context.Set<Dictionary<string, object>>("EntityRootEntityThree").AddRange(CreateEntityRootEntityThrees(context));
         context.Set<Dictionary<string, object>>("EntityCompositeKeyEntityRoot").AddRange(CreateEntityCompositeKeyEntityRoots(context));
+        context.Set<Dictionary<string, object>>("EntityBranchEntityRoot").AddRange(CreateEntityRootEntityBranches(context));
     }
 
     public IQueryable<TEntity> Set<TEntity>()
@@ -1160,6 +1161,39 @@ public class ManyToManyData : ISetSource
             context?.Set<Dictionary<string, object>>("EntityRootEntityThree"), (e, p) =>
             {
                 e["ThreeSkipSharedId"] = context?.Entry(three).Property(e => e.Id).CurrentValue ?? three.Id;
+                e["RootSkipSharedId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
+            });
+
+    private Dictionary<string, object>[] CreateEntityRootEntityBranches(ManyToManyContext context)
+    {
+        var branches = _roots.OfType<EntityBranch>().ToList();
+        return new[]
+        {
+            CreateEntityRootEntityBranch(context, branches[0], _roots[6]),
+            CreateEntityRootEntityBranch(context, branches[0], _roots[7]),
+            CreateEntityRootEntityBranch(context, branches[0], _roots[14]),
+            CreateEntityRootEntityBranch(context, branches[1], _roots[3]),
+            CreateEntityRootEntityBranch(context, branches[1], _roots[15]),
+            CreateEntityRootEntityBranch(context, branches[2], _roots[11]),
+            CreateEntityRootEntityBranch(context, branches[2], _roots[13]),
+            CreateEntityRootEntityBranch(context, branches[2], _roots[19]),
+            CreateEntityRootEntityBranch(context, branches[4], _roots[13]),
+            CreateEntityRootEntityBranch(context, branches[4], _roots[14]),
+            CreateEntityRootEntityBranch(context, branches[4], _roots[15]),
+            CreateEntityRootEntityBranch(context, branches[5], _roots[16]),
+            CreateEntityRootEntityBranch(context, branches[6], _roots[0]),
+            CreateEntityRootEntityBranch(context, branches[6], _roots[5]),
+        };
+    }
+
+    private static Dictionary<string, object> CreateEntityRootEntityBranch(
+        ManyToManyContext context,
+        EntityBranch branch,
+        EntityRoot root)
+        => CreateInstance(
+            context?.Set<Dictionary<string, object>>("EntityRootEntityBranch"), (e, p) =>
+            {
+                e["BranchSkipSharedId"] = context?.Entry(branch).Property(e => e.Id).CurrentValue ?? branch.Id;
                 e["RootSkipSharedId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
             });
 

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityBranch.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityBranch.cs
@@ -7,4 +7,5 @@ public class EntityBranch : EntityRoot
 {
     public virtual long Number { get; set; }
     public virtual ICollection<EntityOne> OneSkip { get; set; }
+    public virtual ICollection<EntityRoot> RootSkipShared { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityBranch2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityBranch2.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
+public abstract class EntityBranch2 : EntityRoot
+{
+    public virtual long Slumber { get; set; }
+    public virtual ICollection<EntityLeaf2> Leaf2SkipShared { get; set; }
+
+    public virtual ICollection<EntityBranch2> SelfSkipSharedLeft { get; set; }
+    public virtual ICollection<EntityBranch2> SelfSkipSharedRight { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityLeaf2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityLeaf2.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
+public class EntityLeaf2 : EntityBranch2
+{
+    public virtual bool? IsBrown { get; set; }
+    public virtual ICollection<EntityBranch2> Branch2SkipShared { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityRoot.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityRoot.cs
@@ -9,4 +9,5 @@ public class EntityRoot
     public virtual string Name { get; set; }
     public virtual ICollection<EntityThree> ThreeSkipShared { get; set; }
     public virtual ICollection<EntityCompositeKey> CompositeKeySkipShared { get; set; }
+    public virtual ICollection<EntityBranch> BranchSkipShared { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTableSharing1.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTableSharing1.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
+public class EntityTableSharing1
+{
+    public virtual int Id { get; set; }
+    public virtual string Name { get; set; }
+    public virtual ICollection<EntityTableSharing2> TableSharing2Shared { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTableSharing2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTableSharing2.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
+public class EntityTableSharing2
+{
+    public virtual int Id { get; set; }
+    public virtual long Cucumber { get; set; }
+    public virtual ICollection<EntityTableSharing1> TableSharing1Shared { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyContext.cs
@@ -17,6 +17,8 @@ public class ManyToManyContext : PoolableDbContext
     public DbSet<EntityThree> EntityThrees { get; set; }
     public DbSet<EntityCompositeKey> EntityCompositeKeys { get; set; }
     public DbSet<EntityRoot> EntityRoots { get; set; }
+    public DbSet<EntityTableSharing1> EntityTableSharing1s { get; set; }
+    public DbSet<EntityTableSharing2> EntityTableSharing2s { get; set; }
     public DbSet<ImplicitManyToManyA> ImplicitManyToManyAs { get; set; }
     public DbSet<ImplicitManyToManyB> ImplicitManyToManyBs { get; set; }
     public DbSet<GeneratedKeysLeft> GeneratedKeysLefts { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyData.cs
@@ -48,6 +48,7 @@ public class ManyToManyData : ISetSource
         context.Set<Dictionary<string, object>>("EntityCompositeKeyEntityTwo").AddRange(CreateJoinTwoToCompositeKeyShareds(context));
         context.Set<Dictionary<string, object>>("EntityRootEntityThree").AddRange(CreateEntityRootEntityThrees(context));
         context.Set<Dictionary<string, object>>("EntityCompositeKeyEntityRoot").AddRange(CreateJoinCompositeKeyToRootShareds(context));
+        context.Set<Dictionary<string, object>>("EntityBranchEntityRoot").AddRange(CreateEntityRootEntityBranches(context));
 
         _unidirectionalOnes = CreateUnidirectionalOnes(context);
         context.Set<UnidirectionalEntityOne>().AddRange(_unidirectionalOnes);
@@ -80,8 +81,8 @@ public class ManyToManyData : ISetSource
             .AddRange(CreateUnidirectionalEntityRootEntityThrees(context));
         context.Set<Dictionary<string, object>>("UnidirectionalEntityCompositeKeyUnidirectionalEntityRoot")
             .AddRange(CreateUnidirectionalJoinCompositeKeyToRootShareds(context));
-
-        var entries = context.ChangeTracker.Entries<UnidirectionalEntityCompositeKey>().ToList();
+        context.Set<Dictionary<string, object>>("UnidirectionalEntityBranchUnidirectionalEntityRoot")
+            .AddRange(CreateUnidirectionalEntityRootUnidirectionalEntityBranches(context));
     }
 
     public IQueryable<TEntity> Set<TEntity>()
@@ -1183,6 +1184,40 @@ public class ManyToManyData : ISetSource
             context?.Set<Dictionary<string, object>>("EntityRootEntityThree"), (e, p) =>
             {
                 e["ThreeSkipSharedId"] = context?.Entry(three).Property(e => e.Id).CurrentValue ?? three.Id;
+                e["RootSkipSharedId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
+            });
+
+
+    private Dictionary<string, object>[] CreateEntityRootEntityBranches(ManyToManyContext context)
+    {
+        var branches = _roots.OfType<EntityBranch>().ToList();
+        return new[]
+        {
+            CreateEntityRootEntityBranch(context, branches[0], _roots[6]),
+            CreateEntityRootEntityBranch(context, branches[0], _roots[7]),
+            CreateEntityRootEntityBranch(context, branches[0], _roots[14]),
+            CreateEntityRootEntityBranch(context, branches[1], _roots[3]),
+            CreateEntityRootEntityBranch(context, branches[1], _roots[15]),
+            CreateEntityRootEntityBranch(context, branches[2], _roots[11]),
+            CreateEntityRootEntityBranch(context, branches[2], _roots[13]),
+            CreateEntityRootEntityBranch(context, branches[2], _roots[19]),
+            CreateEntityRootEntityBranch(context, branches[4], _roots[13]),
+            CreateEntityRootEntityBranch(context, branches[4], _roots[14]),
+            CreateEntityRootEntityBranch(context, branches[4], _roots[15]),
+            CreateEntityRootEntityBranch(context, branches[5], _roots[16]),
+            CreateEntityRootEntityBranch(context, branches[6], _roots[0]),
+            CreateEntityRootEntityBranch(context, branches[6], _roots[5]),
+        };
+    }
+
+    private static Dictionary<string, object> CreateEntityRootEntityBranch(
+        ManyToManyContext context,
+        EntityBranch branch,
+        EntityRoot root)
+        => CreateInstance(
+            context?.Set<Dictionary<string, object>>("EntityBranchEntityRoot"), (e, p) =>
+            {
+                e["BranchSkipSharedId"] = context?.Entry(branch).Property(e => e.Id).CurrentValue ?? branch.Id;
                 e["RootSkipSharedId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
             });
 
@@ -2300,6 +2335,40 @@ public class ManyToManyData : ISetSource
             context?.Set<Dictionary<string, object>>("UnidirectionalEntityRootUnidirectionalEntityThree"), (e, p) =>
             {
                 e["ThreeSkipSharedId"] = context?.Entry(three).Property(e => e.Id).CurrentValue ?? three.Id;
+                e["UnidirectionalEntityRootId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
+            });
+
+
+    private Dictionary<string, object>[] CreateUnidirectionalEntityRootUnidirectionalEntityBranches(ManyToManyContext context)
+    {
+        var branches = _unidirectionalRoots.OfType<UnidirectionalEntityBranch>().ToList();
+        return new[]
+        {
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[0], _unidirectionalRoots[6]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[0], _unidirectionalRoots[7]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[0], _unidirectionalRoots[14]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[1], _unidirectionalRoots[3]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[1], _unidirectionalRoots[15]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[2], _unidirectionalRoots[11]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[2], _unidirectionalRoots[13]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[2], _unidirectionalRoots[19]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[4], _unidirectionalRoots[13]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[4], _unidirectionalRoots[14]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[4], _unidirectionalRoots[15]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[5], _unidirectionalRoots[16]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[6], _unidirectionalRoots[0]),
+            CreateUnidirectionalEntityRootUnidirectionalEntityBranch(context, branches[6], _unidirectionalRoots[5]),
+        };
+    }
+
+    private static Dictionary<string, object> CreateUnidirectionalEntityRootUnidirectionalEntityBranch(
+        ManyToManyContext context,
+        UnidirectionalEntityBranch branch,
+        UnidirectionalEntityRoot root)
+        => CreateInstance(
+            context?.Set<Dictionary<string, object>>("UnidirectionalEntityBranchUnidirectionalEntityRoot"), (e, p) =>
+            {
+                e["BranchSkipSharedId"] = context?.Entry(branch).Property(e => e.Id).CurrentValue ?? branch.Id;
                 e["UnidirectionalEntityRootId"] = context?.Entry(root).Property(e => e.Id).CurrentValue ?? root.Id;
             });
 

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityRoot.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityRoot.cs
@@ -8,4 +8,5 @@ public class UnidirectionalEntityRoot
     public virtual int Id { get; set; }
     public virtual string Name { get; set; }
     public virtual ICollection<UnidirectionalEntityThree> ThreeSkipShared { get; set; }
+    public virtual ICollection<UnidirectionalEntityBranch> BranchSkipShared { get; set; }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingGeneratedKeysSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingGeneratedKeysSqlServerTest.cs
@@ -30,6 +30,8 @@ public class ManyToManyTrackingGeneratedKeysSqlServerTest
             modelBuilder.Entity<EntityThree>().Property(e => e.Id).ValueGeneratedOnAdd();
             modelBuilder.Entity<EntityCompositeKey>().Property(e => e.Key1).ValueGeneratedOnAdd();
             modelBuilder.Entity<EntityRoot>().Property(e => e.Id).ValueGeneratedOnAdd();
+            modelBuilder.Entity<EntityTableSharing1>().Property(e => e.Id).ValueGeneratedOnAdd();
+            modelBuilder.Entity<EntityTableSharing2>().Property(e => e.Id).ValueGeneratedOnAdd();
             modelBuilder.SharedTypeEntity<ProxyableSharedType>("PST").IndexerProperty<int>("Id").ValueGeneratedOnAdd();
             modelBuilder.Entity<ImplicitManyToManyA>().Property(e => e.Id).ValueGeneratedOnAdd();
             modelBuilder.Entity<ImplicitManyToManyB>().Property(e => e.Id).ValueGeneratedOnAdd();

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingProxyGeneratedKeysSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingProxyGeneratedKeysSqlServerTest.cs
@@ -71,6 +71,8 @@ public class ManyToManyTrackingProxyGeneratedKeysSqlServerTest
             modelBuilder.Entity<EntityThree>().Property(e => e.Id).ValueGeneratedOnAdd();
             modelBuilder.Entity<EntityCompositeKey>().Property(e => e.Key1).ValueGeneratedOnAdd();
             modelBuilder.Entity<EntityRoot>().Property(e => e.Id).ValueGeneratedOnAdd();
+            modelBuilder.Entity<EntityTableSharing1>().Property(e => e.Id).ValueGeneratedOnAdd();
+            modelBuilder.Entity<EntityTableSharing2>().Property(e => e.Id).ValueGeneratedOnAdd();
             modelBuilder.SharedTypeEntity<ProxyableSharedType>("PST").IndexerProperty<int>("Id").ValueGeneratedOnAdd();
             modelBuilder.Entity<ImplicitManyToManyA>().Property(e => e.Id).ValueGeneratedOnAdd();
             modelBuilder.Entity<ImplicitManyToManyB>().Property(e => e.Id).ValueGeneratedOnAdd();

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingProxySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingProxySqlServerTest.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
 namespace Microsoft.EntityFrameworkCore;
 
 public class ManyToManyTrackingProxySqlServerTest
@@ -10,6 +12,20 @@ public class ManyToManyTrackingProxySqlServerTest
         : base(fixture)
     {
     }
+
+    protected override Dictionary<string, DeleteBehavior> CustomDeleteBehaviors { get; } = new()
+    {
+        { "EntityBranch.RootSkipShared", DeleteBehavior.ClientCascade },
+        { "EntityBranch2.Leaf2SkipShared", DeleteBehavior.ClientCascade },
+        { "EntityBranch2.SelfSkipSharedLeft", DeleteBehavior.Restrict },
+        { "EntityBranch2.SelfSkipSharedRight", DeleteBehavior.Restrict },
+        { "EntityOne.SelfSkipPayloadLeft", DeleteBehavior.ClientCascade },
+        { "EntityTwo.SelfSkipSharedLeft", DeleteBehavior.ClientCascade },
+        { "EntityTableSharing1.TableSharing2Shared", DeleteBehavior.ClientCascade },
+        { "UnidirectionalEntityBranch.UnidirectionalEntityRoot", DeleteBehavior.ClientCascade },
+        { "UnidirectionalEntityOne.SelfSkipPayloadLeft", DeleteBehavior.ClientCascade },
+        { "UnidirectionalEntityTwo.SelfSkipSharedRight", DeleteBehavior.ClientCascade }
+    };
 
     public override Task Can_insert_many_to_many_shared_with_payload(bool async)
         // Mutable properties aren't proxyable on Dictionary
@@ -51,6 +67,14 @@ public class ManyToManyTrackingProxySqlServerTest
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {
             base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder.Entity<EntityBranch2>()
+                .HasMany(e => e.SelfSkipSharedLeft)
+                .WithMany(e => e.SelfSkipSharedRight)
+                .UsingEntity<Dictionary<string, object>>(
+                    "EntityBranch2EntityBranch2",
+                    r => r.HasOne<EntityBranch2>().WithMany().HasForeignKey("SelfSkipSharedRightId").OnDelete(DeleteBehavior.Restrict),
+                    l => l.HasOne<EntityBranch2>().WithMany().HasForeignKey("SelfSkipSharedLeftId").OnDelete(DeleteBehavior.Restrict));
 
             modelBuilder
                 .SharedTypeEntity<Dictionary<string, object>>("JoinOneToThreePayloadFullShared")

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTest.cs
@@ -13,5 +13,7 @@ public class ManyToManyTrackingSqlServerTest
 
     public class ManyToManyTrackingSqlServerFixture : ManyToManyTrackingSqlServerFixtureBase
     {
+        protected override string StoreName
+            => "ManyToManyTrackingSqlServerTest";
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTestBase.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public abstract class ManyToManyTrackingSqlServerTestBase<TFixture> : ManyToManyTrackingTestBase<TFixture>
+public abstract class ManyToManyTrackingSqlServerTestBase<TFixture> : ManyToManyTrackingRelationalTestBase<TFixture>
     where TFixture : ManyToManyTrackingSqlServerTestBase<TFixture>.ManyToManyTrackingSqlServerFixtureBase
 {
     protected ManyToManyTrackingSqlServerTestBase(TFixture fixture)
@@ -13,10 +13,20 @@ public abstract class ManyToManyTrackingSqlServerTestBase<TFixture> : ManyToMany
     {
     }
 
-    protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
-        => facade.UseTransaction(transaction.GetDbTransaction());
+    protected override Dictionary<string, DeleteBehavior> CustomDeleteBehaviors { get; } = new()
+    {
+        { "EntityBranch.RootSkipShared", DeleteBehavior.ClientCascade },
+        { "EntityBranch2.Leaf2SkipShared", DeleteBehavior.ClientCascade },
+        { "EntityBranch2.SelfSkipSharedLeft", DeleteBehavior.ClientCascade },
+        { "EntityOne.SelfSkipPayloadLeft", DeleteBehavior.ClientCascade },
+        { "EntityTableSharing1.TableSharing2Shared", DeleteBehavior.ClientCascade },
+        { "EntityTwo.SelfSkipSharedLeft", DeleteBehavior.ClientCascade },
+        { "UnidirectionalEntityBranch.UnidirectionalEntityRoot", DeleteBehavior.ClientCascade },
+        { "UnidirectionalEntityOne.SelfSkipPayloadLeft", DeleteBehavior.ClientCascade },
+        { "UnidirectionalEntityTwo.SelfSkipSharedRight", DeleteBehavior.ClientCascade },
+    };
 
-    public class ManyToManyTrackingSqlServerFixtureBase : ManyToManyTrackingFixtureBase
+    public class ManyToManyTrackingSqlServerFixtureBase : ManyToManyTrackingRelationalFixture
     {
         protected override ITestStoreFactory TestStoreFactory
             => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
@@ -566,10 +566,10 @@ ORDER BY [e].[Id]");
         await base.Include_skip_navigation(async);
 
         AssertSql(
-            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
+            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[Slumber], [e1].[IsGreen], [e1].[IsBrown], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
 ) AS [t] ON [e].[Key1] = [t].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t].[CompositeKeySkipSharedKey3]
@@ -746,7 +746,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
     SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId], [t].[Id] AS [Id0], [t].[Name] AS [Name0], [t].[OneId], [t].[ThreeId]
@@ -767,7 +767,7 @@ ORDER BY [e].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id],
         await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
     SELECT [e1].[Key1], [e1].[Key2], [e1].[Key3], [e1].[Name], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[Id0], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
@@ -978,10 +978,10 @@ ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
             //
-            @"SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [e].[Key1], [e].[Key2], [e].[Key3]
+            @"SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[Slumber], [e1].[IsGreen], [e1].[IsBrown], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
 ) AS [t] ON [e].[Key1] = [t].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t].[CompositeKeySkipSharedKey3]
@@ -1218,7 +1218,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where_split(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown]
 FROM [EntityRoots] AS [e]
 ORDER BY [e].[Id]",
             //
@@ -1252,7 +1252,7 @@ ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]");
         await base.Filtered_then_include_skip_navigation_order_by_skip_take_split(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown]
 FROM [EntityRoots] AS [e]
 ORDER BY [e].[Id]",
             //

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -565,10 +565,10 @@ ORDER BY [e].[Id]");
         await base.Include_skip_navigation(async);
 
         AssertSql(
-            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen]
+            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[Slumber], [e1].[IsGreen], [e1].[IsBrown]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
 ) AS [t] ON [e].[Key1] = [t].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t].[CompositeKeySkipSharedKey3]
@@ -745,7 +745,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
     SELECT [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [t].[OneId], [t].[ThreeId], [t].[Payload], [t].[Id] AS [Id0], [t].[Name] AS [Name0]
@@ -766,7 +766,7 @@ ORDER BY [e].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id],
         await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
 FROM [EntityRoots] AS [e]
 LEFT JOIN (
     SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Key1], [e1].[Key2], [e1].[Key3], [e1].[Name], [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId]
@@ -977,10 +977,10 @@ ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
             //
-            @"SELECT [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [e].[Key1], [e].[Key2], [e].[Key3]
+            @"SELECT [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[Slumber], [e1].[IsGreen], [e1].[IsBrown]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN [EntityRoots] AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
 ) AS [t] ON [e].[Key1] = [t].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t].[CompositeKeySkipSharedKey3]
@@ -1217,7 +1217,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where_split(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown]
 FROM [EntityRoots] AS [e]
 ORDER BY [e].[Id]",
             //
@@ -1251,7 +1251,7 @@ ORDER BY [e].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]");
         await base.Filtered_then_include_skip_navigation_order_by_skip_take_split(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown]
 FROM [EntityRoots] AS [e]
 ORDER BY [e].[Id]",
             //

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyNoTrackingQuerySqlServerTest.cs
@@ -184,6 +184,9 @@ INNER JOIN (
         UNION ALL
         SELECT [l].[Id]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
     }
@@ -203,6 +206,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e0].[Key1], [e].[RootSkipSharedId]
@@ -377,6 +383,9 @@ LEFT JOIN (
         UNION ALL
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id], [l0].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityLeaf2' AS [Discriminator]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] = N'EntityLeaf'
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
@@ -434,6 +443,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId]
@@ -529,6 +541,9 @@ INNER JOIN (
         UNION ALL
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id], [l0].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityLeaf2' AS [Discriminator]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
 ) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
@@ -618,20 +633,23 @@ ORDER BY [e].[Id]");
         await base.Include_skip_navigation(async);
 
         AssertSql(
-            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
+            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[Slumber], [t0].[IsGreen], [t0].[IsBrown], [t0].[Discriminator], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
-        SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+        SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
         FROM [Roots] AS [r]
         UNION ALL
-        SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+        SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
         FROM [Branches] AS [b]
         UNION ALL
-        SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+        SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
@@ -803,16 +821,19 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where(async);
 
         AssertSql(
-            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
+            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
 FROM (
-    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
     UNION ALL
-    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
-    SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+    SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 LEFT JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [t1].[Id] AS [Id0], [t1].[Name] AS [Name0], [t1].[OneId], [t1].[ThreeId]
@@ -833,16 +854,19 @@ ORDER BY [t].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id],
         await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
         AssertSql(
-            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
+            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
 FROM (
-    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
     UNION ALL
-    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
-    SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+    SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 LEFT JOIN (
     SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[Id0], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
@@ -1054,20 +1078,23 @@ ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
             //
-            @"SELECT [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
+            @"SELECT [t0].[Id], [t0].[Name], [t0].[Number], [t0].[Slumber], [t0].[IsGreen], [t0].[IsBrown], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
-        SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+        SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
         FROM [Roots] AS [r]
         UNION ALL
-        SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+        SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
         FROM [Branches] AS [b]
         UNION ALL
-        SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+        SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
@@ -1295,16 +1322,19 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where_split(async);
 
         AssertSql(
-            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
 FROM (
-    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
     UNION ALL
-    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
-    SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+    SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 ORDER BY [t].[Id]",
             //
@@ -1318,6 +1348,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId]
@@ -1336,6 +1369,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e0].[Id], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId]
@@ -1356,16 +1392,19 @@ ORDER BY [t].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id]"
         await base.Filtered_then_include_skip_navigation_order_by_skip_take_split(async);
 
         AssertSql(
-            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
 FROM (
-    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
     UNION ALL
-    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
-    SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+    SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 ORDER BY [t].[Id]",
             //
@@ -1379,6 +1418,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3]
@@ -1397,6 +1439,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3]
@@ -1764,7 +1809,7 @@ WHERE EXISTS (
         await base.GetType_in_hierarchy_in_base_type(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+            @"SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
 FROM [Roots] AS [r]");
     }
 
@@ -1773,7 +1818,7 @@ FROM [Roots] AS [r]");
         await base.GetType_in_hierarchy_in_intermediate_type(async);
 
         AssertSql(
-            @"SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+            @"SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
 FROM [Branches] AS [b]");
     }
 
@@ -1782,7 +1827,7 @@ FROM [Branches] AS [b]");
         await base.GetType_in_hierarchy_in_leaf_type(async);
 
         AssertSql(
-            @"SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+            @"SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
 FROM [Leaves] AS [l]");
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyQuerySqlServerTest.cs
@@ -184,6 +184,9 @@ INNER JOIN (
         UNION ALL
         SELECT [l].[Id]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
     }
@@ -203,6 +206,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e0].[Key1], [e].[RootSkipSharedId]
@@ -377,6 +383,9 @@ LEFT JOIN (
         UNION ALL
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id], [l0].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityLeaf2' AS [Discriminator]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] = N'EntityLeaf'
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
@@ -434,6 +443,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId]
@@ -529,6 +541,9 @@ INNER JOIN (
         UNION ALL
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id], [l0].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityLeaf2' AS [Discriminator]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
 ) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
@@ -618,20 +633,23 @@ ORDER BY [e].[Id]");
         await base.Include_skip_navigation(async);
 
         AssertSql(
-            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator]
+            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[Slumber], [t0].[IsGreen], [t0].[IsBrown], [t0].[Discriminator]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
-        SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+        SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
         FROM [Roots] AS [r]
         UNION ALL
-        SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+        SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
         FROM [Branches] AS [b]
         UNION ALL
-        SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+        SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
@@ -803,16 +821,19 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where(async);
 
         AssertSql(
-            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
+            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
 FROM (
-    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
     UNION ALL
-    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
-    SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+    SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 LEFT JOIN (
     SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [t1].[OneId], [t1].[ThreeId], [t1].[Payload], [t1].[Id] AS [Id0], [t1].[Name] AS [Name0]
@@ -833,16 +854,19 @@ ORDER BY [t].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id],
         await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
         AssertSql(
-            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
+            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
 FROM (
-    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
     UNION ALL
-    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
-    SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+    SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 LEFT JOIN (
     SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId]
@@ -1054,20 +1078,23 @@ ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
             //
-            @"SELECT [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
+            @"SELECT [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[Slumber], [t0].[IsGreen], [t0].[IsBrown], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
-        SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+        SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
         FROM [Roots] AS [r]
         UNION ALL
-        SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+        SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
         FROM [Branches] AS [b]
         UNION ALL
-        SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+        SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
+        UNION ALL
+        SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+        FROM [Leaf2s] AS [l0]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
@@ -1295,16 +1322,19 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where_split(async);
 
         AssertSql(
-            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
 FROM (
-    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
     UNION ALL
-    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
-    SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+    SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 ORDER BY [t].[Id]",
             //
@@ -1318,6 +1348,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
@@ -1336,6 +1369,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id]
@@ -1356,16 +1392,19 @@ ORDER BY [t].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id]"
         await base.Filtered_then_include_skip_navigation_order_by_skip_take_split(async);
 
         AssertSql(
-            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+            @"SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
 FROM (
-    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+    SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
     FROM [Roots] AS [r]
     UNION ALL
-    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+    SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
     FROM [Branches] AS [b]
     UNION ALL
-    SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+    SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id], [l0].[Name], NULL AS [Number], [l0].[Slumber], NULL AS [IsGreen], [l0].[IsBrown], N'EntityLeaf2' AS [Discriminator]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 ORDER BY [t].[Id]",
             //
@@ -1379,6 +1418,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
@@ -1397,6 +1439,9 @@ FROM (
     UNION ALL
     SELECT [l].[Id]
     FROM [Leaves] AS [l]
+    UNION ALL
+    SELECT [l0].[Id]
+    FROM [Leaf2s] AS [l0]
 ) AS [t]
 INNER JOIN (
     SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3]
@@ -1770,7 +1815,7 @@ WHERE EXISTS (
         await base.GetType_in_hierarchy_in_base_type(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [IsGreen], N'EntityRoot' AS [Discriminator]
+            @"SELECT [r].[Id], [r].[Name], NULL AS [Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityRoot' AS [Discriminator]
 FROM [Roots] AS [r]");
     }
 
@@ -1779,7 +1824,7 @@ FROM [Roots] AS [r]");
         await base.GetType_in_hierarchy_in_intermediate_type(async);
 
         AssertSql(
-            @"SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [IsGreen], N'EntityBranch' AS [Discriminator]
+            @"SELECT [b].[Id], [b].[Name], [b].[Number], NULL AS [Slumber], NULL AS [IsGreen], NULL AS [IsBrown], N'EntityBranch' AS [Discriminator]
 FROM [Branches] AS [b]");
     }
 
@@ -1788,7 +1833,7 @@ FROM [Branches] AS [b]");
         await base.GetType_in_hierarchy_in_leaf_type(async);
 
         AssertSql(
-            @"SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
+            @"SELECT [l].[Id], [l].[Name], [l].[Number], NULL AS [Slumber], [l].[IsGreen], NULL AS [IsBrown], N'EntityLeaf' AS [Discriminator]
 FROM [Leaves] AS [l]");
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
@@ -359,12 +359,14 @@ LEFT JOIN (
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
             WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
         END AS [Discriminator]
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+        LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] = N'EntityLeaf'
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
@@ -501,12 +503,14 @@ INNER JOIN (
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
             WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
         END AS [Discriminator]
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+        LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
 ) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
@@ -597,19 +601,22 @@ ORDER BY [e].[Id]");
         await base.Include_skip_navigation(async);
 
         AssertSql(
-            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
+            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[Slumber], [t0].[IsGreen], [t0].[IsBrown], [t0].[Discriminator], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
-        SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+        SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+            WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
             WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
         END AS [Discriminator]
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+        LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+        LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
@@ -786,13 +793,16 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 LEFT JOIN (
     SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [t].[Id] AS [Id0], [t].[Name] AS [Name0], [t].[OneId], [t].[ThreeId]
     FROM [EntityRootEntityThree] AS [e]
@@ -812,13 +822,16 @@ ORDER BY [r].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id],
         await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[Id0]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 LEFT JOIN (
     SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[Id0], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
@@ -1032,19 +1045,22 @@ ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
             //
-            @"SELECT [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
+            @"SELECT [t0].[Id], [t0].[Name], [t0].[Number], [t0].[Slumber], [t0].[IsGreen], [t0].[IsBrown], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
+    SELECT [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
-        SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+        SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+            WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
             WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
         END AS [Discriminator]
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+        LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+        LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
@@ -1282,13 +1298,16 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where_split(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 ORDER BY [r].[Id]",
             //
             @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId]
@@ -1321,13 +1340,16 @@ ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]");
         await base.Filtered_then_include_skip_navigation_order_by_skip_take_split(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 ORDER BY [r].[Id]",
             //
             @"SELECT [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [r].[Id], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3]
@@ -1714,14 +1736,17 @@ WHERE EXISTS (
         await base.GetType_in_hierarchy_in_base_type(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-WHERE [l].[Id] IS NULL AND [b].[Id] IS NULL");
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
+WHERE [l0].[Id] IS NULL AND [l].[Id] IS NULL AND [b].[Id] IS NULL");
     }
 
     public override async Task GetType_in_hierarchy_in_intermediate_type(bool async)
@@ -1729,13 +1754,16 @@ WHERE [l].[Id] IS NULL AND [b].[Id] IS NULL");
         await base.GetType_in_hierarchy_in_intermediate_type(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 WHERE [l].[Id] IS NULL AND [b].[Id] IS NOT NULL");
     }
 
@@ -1744,13 +1772,16 @@ WHERE [l].[Id] IS NULL AND [b].[Id] IS NOT NULL");
         await base.GetType_in_hierarchy_in_leaf_type(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 WHERE [l].[Id] IS NOT NULL");
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
@@ -358,12 +358,14 @@ LEFT JOIN (
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
             WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
         END AS [Discriminator]
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+        LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] = N'EntityLeaf'
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
@@ -500,12 +502,14 @@ INNER JOIN (
     FROM [EntityRootEntityThree] AS [e0]
     INNER JOIN (
         SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
             WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
         END AS [Discriminator]
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+        LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
     WHERE [t].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
 ) AS [t0] ON [e].[Id] = [t0].[ThreeSkipSharedId]");
@@ -596,19 +600,22 @@ ORDER BY [e].[Id]");
         await base.Include_skip_navigation(async);
 
         AssertSql(
-            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator]
+            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[Slumber], [t0].[IsGreen], [t0].[IsBrown], [t0].[Discriminator]
 FROM [EntityCompositeKeys] AS [e]
 LEFT JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
-        SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+        SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+            WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
             WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
         END AS [Discriminator]
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+        LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+        LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3]");
@@ -785,13 +792,16 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[Id0], [t0].[Name0]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 LEFT JOIN (
     SELECT [e].[RootSkipSharedId], [e].[ThreeSkipSharedId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [t].[OneId], [t].[ThreeId], [t].[Payload], [t].[Id] AS [Id0], [t].[Name] AS [Name0]
     FROM [EntityRootEntityThree] AS [e]
@@ -811,13 +821,16 @@ ORDER BY [r].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id],
         await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 LEFT JOIN (
     SELECT [e].[RootSkipSharedId], [e].[CompositeKeySkipSharedKey1], [e].[CompositeKeySkipSharedKey2], [e].[CompositeKeySkipSharedKey3], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId]
     FROM [EntityCompositeKeyEntityRoot] AS [e]
@@ -1031,19 +1044,22 @@ ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
 FROM [EntityCompositeKeys] AS [e]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
             //
-            @"SELECT [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
+            @"SELECT [t0].[RootSkipSharedId], [t0].[CompositeKeySkipSharedKey1], [t0].[CompositeKeySkipSharedKey2], [t0].[CompositeKeySkipSharedKey3], [t0].[Id], [t0].[Name], [t0].[Number], [t0].[Slumber], [t0].[IsGreen], [t0].[IsBrown], [t0].[Discriminator], [e].[Key1], [e].[Key2], [e].[Key3]
 FROM [EntityCompositeKeys] AS [e]
 INNER JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[IsGreen], [t].[Discriminator]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [t].[Id], [t].[Name], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown], [t].[Discriminator]
     FROM [EntityCompositeKeyEntityRoot] AS [e0]
     INNER JOIN (
-        SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+        SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+            WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
             WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
             WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
         END AS [Discriminator]
         FROM [Roots] AS [r]
         LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+        LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+        LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
     ) AS [t] ON [e0].[RootSkipSharedId] = [t].[Id]
 ) AS [t0] ON [e].[Key1] = [t0].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t0].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t0].[CompositeKeySkipSharedKey3]
 ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
@@ -1281,13 +1297,16 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where_split(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 ORDER BY [r].[Id]",
             //
             @"SELECT [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [r].[Id]
@@ -1320,13 +1339,16 @@ ORDER BY [r].[Id], [t].[RootSkipSharedId], [t].[ThreeSkipSharedId], [t].[Id]");
         await base.Filtered_then_include_skip_navigation_order_by_skip_take_split(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 ORDER BY [r].[Id]",
             //
             @"SELECT [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [r].[Id]
@@ -1719,14 +1741,17 @@ WHERE EXISTS (
         await base.GetType_in_hierarchy_in_base_type(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
-WHERE [l].[Id] IS NULL AND [b].[Id] IS NULL");
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
+WHERE [l0].[Id] IS NULL AND [l].[Id] IS NULL AND [b].[Id] IS NULL");
     }
 
     public override async Task GetType_in_hierarchy_in_intermediate_type(bool async)
@@ -1734,13 +1759,16 @@ WHERE [l].[Id] IS NULL AND [b].[Id] IS NULL");
         await base.GetType_in_hierarchy_in_intermediate_type(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 WHERE [l].[Id] IS NULL AND [b].[Id] IS NOT NULL");
     }
 
@@ -1749,13 +1777,16 @@ WHERE [l].[Id] IS NULL AND [b].[Id] IS NOT NULL");
         await base.GetType_in_hierarchy_in_leaf_type(async);
 
         AssertSql(
-            @"SELECT [r].[Id], [r].[Name], [b].[Number], [l].[IsGreen], CASE
+            @"SELECT [r].[Id], [r].[Name], [b].[Number], [b0].[Slumber], [l].[IsGreen], [l0].[IsBrown], CASE
+    WHEN [l0].[Id] IS NOT NULL THEN N'EntityLeaf2'
     WHEN [l].[Id] IS NOT NULL THEN N'EntityLeaf'
     WHEN [b].[Id] IS NOT NULL THEN N'EntityBranch'
 END AS [Discriminator]
 FROM [Roots] AS [r]
 LEFT JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
+LEFT JOIN [Branch2s] AS [b0] ON [r].[Id] = [b0].[Id]
 LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
+LEFT JOIN [Leaf2s] AS [l0] ON [r].[Id] = [l0].[Id]
 WHERE [l].[Id] IS NOT NULL");
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerFixture.cs
@@ -20,6 +20,14 @@ public class TemporalManyToManyQuerySqlServerFixture : ManyToManyQueryFixtureBas
 
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
+        modelBuilder.Entity<EntityTableSharing1>().ToTable("TableSharing");
+        modelBuilder.Entity<EntityTableSharing2>(
+            b =>
+            {
+                b.HasOne<EntityTableSharing1>().WithOne().HasForeignKey<EntityTableSharing2>(e => e.Id);
+                b.ToTable("TableSharing");
+            });
+
         modelBuilder.Entity<EntityOne>().ToTable(tb => tb.IsTemporal());
         modelBuilder.Entity<EntityTwo>().ToTable(tb => tb.IsTemporal());
         modelBuilder.Entity<EntityThree>().ToTable(tb => tb.IsTemporal());
@@ -44,6 +52,11 @@ public class TemporalManyToManyQuerySqlServerFixture : ManyToManyQueryFixtureBas
         modelBuilder.Entity<EntityRoot>().Property(e => e.Id).ValueGeneratedNever();
         modelBuilder.Entity<EntityBranch>().HasBaseType<EntityRoot>();
         modelBuilder.Entity<EntityLeaf>().HasBaseType<EntityBranch>();
+        modelBuilder.Entity<EntityLeaf>().HasBaseType<EntityBranch>();
+        modelBuilder.Entity<EntityBranch2>().HasBaseType<EntityRoot>();
+        modelBuilder.Entity<EntityLeaf2>().HasBaseType<EntityBranch2>();
+        modelBuilder.Entity<EntityTableSharing1>().Property(e => e.Id).ValueGeneratedNever();
+        modelBuilder.Entity<EntityTableSharing2>().Property(e => e.Id).ValueGeneratedNever();
 
         modelBuilder.Entity<UnidirectionalEntityOne>().Property(e => e.Id).ValueGeneratedNever();
         modelBuilder.Entity<UnidirectionalEntityTwo>().Property(e => e.Id).ValueGeneratedNever();
@@ -78,6 +91,18 @@ public class TemporalManyToManyQuerySqlServerFixture : ManyToManyQueryFixtureBas
             .HasMany(e => e.BranchSkipShared)
             .WithMany(e => e.RootSkipShared)
             .UsingEntity(t => t.ToTable(tb => tb.IsTemporal()));
+
+        modelBuilder.Entity<EntityBranch2>()
+            .HasMany(e => e.SelfSkipSharedLeft)
+            .WithMany(e => e.SelfSkipSharedRight);
+
+        modelBuilder.Entity<EntityBranch2>()
+            .HasMany(e => e.Leaf2SkipShared)
+            .WithMany(e => e.Branch2SkipShared);
+
+        modelBuilder.Entity<EntityTableSharing1>()
+            .HasMany(e => e.TableSharing2Shared)
+            .WithMany(e => e.TableSharing1Shared);
 
         // Nav:2 Payload:No Join:Concrete Extra:None
         modelBuilder.Entity<EntityOne>()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerFixture.cs
@@ -74,6 +74,11 @@ public class TemporalManyToManyQuerySqlServerFixture : ManyToManyQueryFixtureBas
             .WithMany(e => e.OneSkipShared)
             .UsingEntity(t => t.ToTable(tb => tb.IsTemporal()));
 
+        modelBuilder.Entity<EntityRoot>()
+            .HasMany(e => e.BranchSkipShared)
+            .WithMany(e => e.RootSkipShared)
+            .UsingEntity(t => t.ToTable(tb => tb.IsTemporal()));
+
         // Nav:2 Payload:No Join:Concrete Extra:None
         modelBuilder.Entity<EntityOne>()
             .HasMany(e => e.TwoSkip)
@@ -201,6 +206,11 @@ public class TemporalManyToManyQuerySqlServerFixture : ManyToManyQueryFixtureBas
         modelBuilder.Entity<UnidirectionalEntityOne>()
             .HasMany(e => e.TwoSkipShared)
             .WithMany()
+            .UsingEntity(t => t.ToTable(tb => tb.IsTemporal()));
+
+        modelBuilder.Entity<UnidirectionalEntityBranch>()
+            .HasMany<UnidirectionalEntityRoot>()
+            .WithMany(e => e.BranchSkipShared)
             .UsingEntity(t => t.ToTable(tb => tb.IsTemporal()));
 
         // Nav:2 Payload:No Join:Concrete Extra:None

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerTest.cs
@@ -28,6 +28,10 @@ public class TemporalManyToManyQuerySqlServerTest : ManyToManyQueryRelationalTes
             typeof(EntityRoot),
             typeof(EntityBranch),
             typeof(EntityLeaf),
+            typeof(EntityBranch2),
+            typeof(EntityLeaf2),
+            typeof(EntityTableSharing1),
+            typeof(EntityTableSharing2),
             typeof(UnidirectionalEntityOne),
             typeof(UnidirectionalEntityTwo),
             typeof(UnidirectionalEntityThree),
@@ -592,10 +596,10 @@ ORDER BY [e].[Id]");
         await base.Include_skip_navigation(async);
 
         AssertSql(
-            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [e].[PeriodEnd], [e].[PeriodStart], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[PeriodEnd], [t].[PeriodStart], [t].[Id], [t].[Discriminator], [t].[Name], [t].[PeriodEnd0], [t].[PeriodStart0], [t].[Number], [t].[IsGreen]
+            @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [e].[PeriodEnd], [e].[PeriodStart], [t].[RootSkipSharedId], [t].[CompositeKeySkipSharedKey1], [t].[CompositeKeySkipSharedKey2], [t].[CompositeKeySkipSharedKey3], [t].[PeriodEnd], [t].[PeriodStart], [t].[Id], [t].[Discriminator], [t].[Name], [t].[PeriodEnd0], [t].[PeriodStart0], [t].[Number], [t].[Slumber], [t].[IsGreen], [t].[IsBrown]
 FROM [EntityCompositeKeys] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e]
 LEFT JOIN (
-    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e0].[PeriodEnd], [e0].[PeriodStart], [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[PeriodEnd] AS [PeriodEnd0], [e1].[PeriodStart] AS [PeriodStart0], [e1].[Number], [e1].[IsGreen]
+    SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e0].[PeriodEnd], [e0].[PeriodStart], [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[PeriodEnd] AS [PeriodEnd0], [e1].[PeriodStart] AS [PeriodStart0], [e1].[Number], [e1].[Slumber], [e1].[IsGreen], [e1].[IsBrown]
     FROM [EntityCompositeKeyEntityRoot] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0]
     INNER JOIN [EntityRoots] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e1] ON [e0].[RootSkipSharedId] = [e1].[Id]
 ) AS [t] ON [e].[Key1] = [t].[CompositeKeySkipSharedKey1] AND [e].[Key2] = [t].[CompositeKeySkipSharedKey2] AND [e].[Key3] = [t].[CompositeKeySkipSharedKey3]
@@ -792,7 +796,7 @@ ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[Composit
         await base.Filtered_then_include_skip_navigation_where(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[PeriodEnd], [e].[PeriodStart], [e].[Number], [e].[IsGreen], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[PeriodEnd], [t0].[PeriodStart], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[PeriodEnd0], [t0].[PeriodStart0], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[PeriodEnd1], [t0].[PeriodStart1], [t0].[Id0], [t0].[Name0], [t0].[PeriodEnd00], [t0].[PeriodStart00]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[PeriodEnd], [e].[PeriodStart], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[PeriodEnd], [t0].[PeriodStart], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[PeriodEnd0], [t0].[PeriodStart0], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Payload], [t0].[PeriodEnd1], [t0].[PeriodStart1], [t0].[Id0], [t0].[Name0], [t0].[PeriodEnd00], [t0].[PeriodStart00]
 FROM [EntityRoots] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e]
 LEFT JOIN (
     SELECT [e0].[RootSkipSharedId], [e0].[ThreeSkipSharedId], [e0].[PeriodEnd], [e0].[PeriodStart], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[PeriodEnd] AS [PeriodEnd0], [e1].[PeriodStart] AS [PeriodStart0], [e1].[ReferenceInverseId], [t].[OneId], [t].[ThreeId], [t].[Payload], [t].[PeriodEnd] AS [PeriodEnd1], [t].[PeriodStart] AS [PeriodStart1], [t].[Id] AS [Id0], [t].[Name] AS [Name0], [t].[PeriodEnd0] AS [PeriodEnd00], [t].[PeriodStart0] AS [PeriodStart00]
@@ -813,7 +817,7 @@ ORDER BY [e].[Id], [t0].[RootSkipSharedId], [t0].[ThreeSkipSharedId], [t0].[Id],
         await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
 
         AssertSql(
-            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[PeriodEnd], [e].[PeriodStart], [e].[Number], [e].[IsGreen], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[PeriodEnd], [t1].[PeriodStart], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[PeriodEnd0], [t1].[PeriodStart0], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[PeriodEnd1], [t1].[PeriodStart1], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[PeriodEnd00], [t1].[PeriodStart00], [t1].[ReferenceInverseId]
+            @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[PeriodEnd], [e].[PeriodStart], [e].[Number], [e].[Slumber], [e].[IsGreen], [e].[IsBrown], [t1].[RootSkipSharedId], [t1].[CompositeKeySkipSharedKey1], [t1].[CompositeKeySkipSharedKey2], [t1].[CompositeKeySkipSharedKey3], [t1].[PeriodEnd], [t1].[PeriodStart], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[PeriodEnd0], [t1].[PeriodStart0], [t1].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[PeriodEnd1], [t1].[PeriodStart1], [t1].[ThreeId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[PeriodEnd00], [t1].[PeriodStart00], [t1].[ReferenceInverseId]
 FROM [EntityRoots] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e]
 LEFT JOIN (
     SELECT [e0].[RootSkipSharedId], [e0].[CompositeKeySkipSharedKey1], [e0].[CompositeKeySkipSharedKey2], [e0].[CompositeKeySkipSharedKey3], [e0].[PeriodEnd], [e0].[PeriodStart], [e1].[Key1], [e1].[Key2], [e1].[Key3], [e1].[Name], [e1].[PeriodEnd] AS [PeriodEnd0], [e1].[PeriodStart] AS [PeriodStart0], [t0].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[PeriodEnd] AS [PeriodEnd1], [t0].[PeriodStart] AS [PeriodStart1], [t0].[ThreeId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[PeriodEnd0] AS [PeriodEnd00], [t0].[PeriodStart0] AS [PeriodStart00], [t0].[ReferenceInverseId]

--- a/test/EFCore.SqlServer.FunctionalTests/TpcManyToManyTrackingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TpcManyToManyTrackingSqlServerTest.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class TpcManyToManyTrackingSqlServerTest
+    : ManyToManyTrackingSqlServerTestBase<TpcManyToManyTrackingSqlServerTest.TpcManyToManyTrackingSqlServerFixture>
+{
+    public TpcManyToManyTrackingSqlServerTest(TpcManyToManyTrackingSqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    public class TpcManyToManyTrackingSqlServerFixture : ManyToManyTrackingSqlServerFixtureBase
+    {
+        protected override string StoreName
+            => "TpcManyToManyTrackingSqlServerTest";
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder).ConfigureWarnings(
+                w => w.Log(RelationalEventId.ForeignKeyTpcPrincipalWarning));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder.Entity<EntityRoot>().UseTpcMappingStrategy();
+            modelBuilder.Entity<EntityRoot>().ToTable("Roots");
+            modelBuilder.Entity<EntityBranch>().ToTable("Branches");
+            modelBuilder.Entity<EntityLeaf>().ToTable("Leaves");
+            modelBuilder.Entity<EntityBranch2>().ToTable("Branch2s");
+            modelBuilder.Entity<EntityLeaf2>().ToTable("Leaf2s");
+
+            modelBuilder.Entity<UnidirectionalEntityRoot>().UseTpcMappingStrategy();
+            modelBuilder.Entity<UnidirectionalEntityRoot>().ToTable("UnidirectionalRoots");
+            modelBuilder.Entity<UnidirectionalEntityBranch>().ToTable("UnidirectionalBranches");
+            modelBuilder.Entity<UnidirectionalEntityLeaf>().ToTable("UnidirectionalLeaves");
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/TptManyToManyTrackingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TptManyToManyTrackingSqlServerTest.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class TptManyToManyTrackingSqlServerTest
+    : ManyToManyTrackingSqlServerTestBase<TptManyToManyTrackingSqlServerTest.TptManyToManyTrackingSqlServerFixture>
+{
+    public TptManyToManyTrackingSqlServerTest(TptManyToManyTrackingSqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    public class TptManyToManyTrackingSqlServerFixture : ManyToManyTrackingSqlServerFixtureBase
+    {
+        protected override string StoreName
+            => "TptManyToManyTrackingSqlServerTest";
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder.Entity<EntityRoot>().ToTable("Roots");
+            modelBuilder.Entity<EntityBranch>().ToTable("Branches");
+            modelBuilder.Entity<EntityLeaf>().ToTable("Leaves");
+            modelBuilder.Entity<EntityBranch2>().ToTable("Branch2s");
+            modelBuilder.Entity<EntityLeaf2>().ToTable("Leaf2s");
+
+            modelBuilder.Entity<UnidirectionalEntityRoot>().ToTable("UnidirectionalRoots");
+            modelBuilder.Entity<UnidirectionalEntityBranch>().ToTable("UnidirectionalBranches");
+            modelBuilder.Entity<UnidirectionalEntityLeaf>().ToTable("UnidirectionalLeaves");
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/ManyToManyTrackingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ManyToManyTrackingSqliteTest.cs
@@ -5,17 +5,15 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-public class ManyToManyTrackingSqliteTest : ManyToManyTrackingTestBase<ManyToManyTrackingSqliteTest.ManyToManyTrackingSqliteFixture>
+public class ManyToManyTrackingSqliteTest
+    : ManyToManyTrackingRelationalTestBase<ManyToManyTrackingSqliteTest.ManyToManyTrackingSqliteFixture>
 {
     public ManyToManyTrackingSqliteTest(ManyToManyTrackingSqliteFixture fixture)
         : base(fixture)
     {
     }
 
-    protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
-        => facade.UseTransaction(transaction.GetDbTransaction());
-
-    public class ManyToManyTrackingSqliteFixture : ManyToManyTrackingFixtureBase
+    public class ManyToManyTrackingSqliteFixture : ManyToManyTrackingRelationalFixture
     {
         protected override ITestStoreFactory TestStoreFactory
             => SqliteTestStoreFactory.Instance;


### PR DESCRIPTION
Fixes #28633
