### PR TITLE
Sproc fixes

### DIFF
--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -107,7 +107,8 @@ public static class RelationalEventId
         BatchSmallerThanMinBatchSize,
         BatchExecutorFailedToRollbackToSavepoint,
         BatchExecutorFailedToReleaseSavepoint,
-        OptionalDependentWithAllNullPropertiesWarning
+        OptionalDependentWithAllNullPropertiesWarning,
+        UnexpectedTrailingResultSetWhenSaving,
     }
 
     private static readonly string _connectionPrefix = DbLoggerCategory.Database.Connection.Name + ".";
@@ -1001,4 +1002,16 @@ public static class RelationalEventId
     /// </remarks>
     public static readonly EventId OptionalDependentWithAllNullPropertiesWarning
         = MakeUpdateId(Id.OptionalDependentWithAllNullPropertiesWarning);
+
+    /// <summary>
+    ///     An unexpected trailing result set was found when reading the results of a SaveChanges operation; this may indicate that a stored
+    ///     procedure returned a result set without being configured for it in the EF model. Check your stored procedure definitions.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Update" /> category.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId UnexpectedTrailingResultSetWhenSaving =
+        MakeUpdateId(Id.UnexpectedTrailingResultSetWhenSaving);
 }

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -3327,4 +3327,31 @@ public static class RelationalLoggerExtensions
         var p = (MigrationColumnOperationEventData)payload;
         return d.GenerateMessage((p.ColumnOperation.Table, p.ColumnOperation.Schema).FormatTable(), p.ColumnOperation.Name);
     }
+
+    /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.UnexpectedTrailingResultSetWhenSaving" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    public static void UnexpectedTrailingResultSetWhenSaving(this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics)
+    {
+        var definition = RelationalResources.LogUnexpectedTrailingResultSetWhenSaving(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new EventData(
+                definition,
+                static (definition, _) =>
+                {
+                    var d = (EventDefinition)definition;
+                    return d.GenerateMessage();
+                });
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
 }

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -663,4 +663,13 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     /// </summary>
     [EntityFrameworkInternal]
     public EventDefinitionBase? LogExceptionDuringExecuteUpdate;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? LogUnexpectedTrailingResultSetWhenSaving;
 }

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1198,6 +1198,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 parameter);
 
         /// <summary>
+        ///     A result set was was missing when reading the results of a SaveChanges operation; this may indicate that a stored procedure was configured to return results in the EF model, but did not. Check your stored procedure definitions.
+        /// </summary>
+        public static string MissingResultSetWhenSaving
+            => GetString("MissingResultSetWhenSaving");
+
+        /// <summary>
         ///     Cannot add commands to a completed ModificationCommandBatch.
         /// </summary>
         public static string ModificationCommandBatchAlreadyComplete
@@ -3658,6 +3664,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                             level,
                             RelationalEventId.TransactionError,
                             _resourceManager.GetString("LogTransactionError")!)));
+            }
+
+            return (EventDefinition)definition;
+        }
+
+        /// <summary>
+        ///     An unexpected trailing result set was found when reading the results of a SaveChanges operation; this may indicate that a stored procedure returned a result set without being configured for it in the EF model. Check your stored procedure definitions.
+        /// </summary>
+        public static EventDefinition LogUnexpectedTrailingResultSetWhenSaving(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogUnexpectedTrailingResultSetWhenSaving;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogUnexpectedTrailingResultSetWhenSaving,
+                    logger,
+                    static logger => new EventDefinition(
+                        logger.Options,
+                        RelationalEventId.UnexpectedTrailingResultSetWhenSaving,
+                        LogLevel.Warning,
+                        "CoreEventId.UnexpectedTrailingResultSetWhenSaving",
+                        level => LoggerMessage.Define(
+                            level,
+                            RelationalEventId.UnexpectedTrailingResultSetWhenSaving,
+                            _resourceManager.GetString("LogUnexpectedTrailingResultSetWhenSaving")!)));
             }
 
             return (EventDefinition)definition;

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -809,6 +809,10 @@
     <value>An error occurred using a transaction.</value>
     <comment>Error RelationalEventId.TransactionError</comment>
   </data>
+  <data name="LogUnexpectedTrailingResultSetWhenSaving" xml:space="preserve">
+    <value>An unexpected trailing result set was found when reading the results of a SaveChanges operation; this may indicate that a stored procedure returned a result set without being configured for it in the EF model. Check your stored procedure definitions.</value>
+    <comment>Warning CoreEventId.UnexpectedTrailingResultSetWhenSaving</comment>
+  </data>
   <data name="LogUnnamedIndexAllPropertiesNotToMappedToAnyTable" xml:space="preserve">
     <value>The unnamed index on the entity type '{entityType}' specifies properties {indexProperties}, but none of these properties are mapped to a column in any table. This index will not be created in the database.</value>
     <comment>Warning RelationalEventId.AllIndexPropertiesNotToMappedToAnyTable string string</comment>
@@ -854,6 +858,9 @@
   </data>
   <data name="MissingParameterValue" xml:space="preserve">
     <value>No value was provided for the required parameter '{parameter}'.</value>
+  </data>
+  <data name="MissingResultSetWhenSaving" xml:space="preserve">
+    <value>A result set was was missing when reading the results of a SaveChanges operation; this may indicate that a stored procedure was configured to return results in the EF model, but did not. Check your stored procedure definitions.</value>
   </data>
   <data name="ModificationCommandBatchAlreadyComplete" xml:space="preserve">
     <value>Cannot add commands to a completed ModificationCommandBatch.</value>

--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Data.Common;
-
 namespace Microsoft.EntityFrameworkCore.Storage;
 
 /// <summary>
@@ -30,6 +28,7 @@ public class RelationalDataReader : IDisposable, IAsyncDisposable
 
     private int _readCount;
 
+    private bool _closed;
     private bool _disposed;
 
     /// <summary>
@@ -53,6 +52,7 @@ public class RelationalDataReader : IDisposable, IAsyncDisposable
         _commandId = commandId;
         _logger = logger;
         _readCount = 0;
+        _closed = false;
         _disposed = false;
         _startTime = DateTimeOffset.UtcNow;
         _stopwatch.Restart();
@@ -106,62 +106,115 @@ public class RelationalDataReader : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    ///     Closes the reader.
+    /// </summary>
+    public virtual void Close()
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        var closeInterceptionResult = default(InterceptionResult);
+        try
+        {
+            if (_logger?.ShouldLogDataReaderClose(DateTimeOffset.UtcNow) == true)
+            {
+                closeInterceptionResult = _logger.DataReaderClosing(
+                    _relationalConnection,
+                    _command,
+                    _reader,
+                    _commandId,
+                    _reader.RecordsAffected,
+                    _readCount,
+                    _startTime); // can throw
+            }
+        }
+        finally
+        {
+            _closed = true;
+
+            if (!closeInterceptionResult.IsSuppressed)
+            {
+                _reader.Close(); // can throw
+            }
+        }
+    }
+
+    /// <summary>
     ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
     /// </summary>
     public virtual void Dispose()
     {
-        if (!_disposed)
+        if (_disposed)
         {
-            var interceptionResult = default(InterceptionResult);
-            try
-            {
-                var closeInterceptionResult = default(InterceptionResult);
-                try
-                {
-                    if (_logger?.ShouldLogDataReaderClose(DateTimeOffset.UtcNow) == true)
-                    {
-                        closeInterceptionResult = _logger.DataReaderClosing(
-                            _relationalConnection,
-                            _command,
-                            _reader,
-                            _commandId,
-                            _reader.RecordsAffected,
-                            _readCount,
-                            _startTime); // can throw
-                    }
-                }
-                finally
-                {
-                    if (!closeInterceptionResult.IsSuppressed)
-                    {
-                        _reader.Close(); // can throw
-                    }
-                }
+            return;
+        }
 
-                if (_logger?.ShouldLogDataReaderDispose(DateTimeOffset.UtcNow) == true)
-                {
-                    interceptionResult = _logger.DataReaderDisposing(
-                        _relationalConnection,
-                        _command,
-                        _reader,
-                        _commandId,
-                        _reader.RecordsAffected,
-                        _readCount,
-                        _startTime,
-                        _stopwatch.Elapsed); // can throw
-                }
+        var interceptionResult = default(InterceptionResult);
+        try
+        {
+            Close();
+
+            if (_logger?.ShouldLogDataReaderDispose(DateTimeOffset.UtcNow) == true)
+            {
+                interceptionResult = _logger.DataReaderDisposing(
+                    _relationalConnection,
+                    _command,
+                    _reader,
+                    _commandId,
+                    _reader.RecordsAffected,
+                    _readCount,
+                    _startTime,
+                    _stopwatch.Elapsed); // can throw
             }
-            finally
-            {
-                _disposed = true;
+        }
+        finally
+        {
+            _disposed = true;
 
-                if (!interceptionResult.IsSuppressed)
-                {
-                    _reader.Dispose();
-                    _command.Parameters.Clear();
-                    _command.Dispose();
-                    _relationalConnection.Close();
-                }
+            if (!interceptionResult.IsSuppressed)
+            {
+                _reader.Dispose();
+                _command.Parameters.Clear();
+                _command.Dispose();
+                _relationalConnection.Close();
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Closes the reader.
+    /// </summary>
+    public virtual async ValueTask CloseAsync()
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        var closeInterceptionResult = default(InterceptionResult);
+        try
+        {
+            if (_logger?.ShouldLogDataReaderClose(DateTimeOffset.UtcNow) == true)
+            {
+                closeInterceptionResult = await _logger.DataReaderClosingAsync(
+                    _relationalConnection,
+                    _command,
+                    _reader,
+                    _commandId,
+                    _reader.RecordsAffected,
+                    _readCount,
+                    _startTime).ConfigureAwait(false); // can throw
+            }
+        }
+        finally
+        {
+            _closed = true;
+
+            if (!closeInterceptionResult.IsSuppressed)
+            {
+                await _reader.CloseAsync().ConfigureAwait(false); // can throw
             }
         }
     }
@@ -171,58 +224,47 @@ public class RelationalDataReader : IDisposable, IAsyncDisposable
     /// </summary>
     public virtual async ValueTask DisposeAsync()
     {
-        if (!_disposed)
+        if (_disposed)
         {
-            var interceptionResult = default(InterceptionResult);
-            try
-            {
-                var closeInterceptionResult = default(InterceptionResult);
-                try
-                {
-                    if (_logger?.ShouldLogDataReaderClose(DateTimeOffset.UtcNow) == true)
-                    {
-                        closeInterceptionResult = await _logger.DataReaderClosingAsync(
-                            _relationalConnection,
-                            _command,
-                            _reader,
-                            _commandId,
-                            _reader.RecordsAffected,
-                            _readCount,
-                            _startTime).ConfigureAwait(false); // can throw
-                    }
-                }
-                finally
-                {
-                    if (!closeInterceptionResult.IsSuppressed)
-                    {
-                        await _reader.CloseAsync().ConfigureAwait(false); // can throw
-                    }
-                }
+            return;
+        }
 
-                if (_logger?.ShouldLogDataReaderDispose(DateTimeOffset.UtcNow) == true)
-                {
-                    interceptionResult = _logger.DataReaderDisposing(
-                        _relationalConnection,
-                        _command,
-                        _reader,
-                        _commandId,
-                        _reader.RecordsAffected,
-                        _readCount,
-                        _startTime,
-                        _stopwatch.Elapsed); // can throw
-                }
+        var interceptionResult = default(InterceptionResult);
+        try
+        {
+            // Skip extra async call for most cases
+            if (_logger?.ShouldLogDataReaderClose(DateTimeOffset.UtcNow) == true)
+            {
+                await CloseAsync().ConfigureAwait(false);
             }
-            finally
+            else
             {
-                _disposed = true;
+                await _reader.CloseAsync().ConfigureAwait(false); // can throw
+            }
 
-                if (!interceptionResult.IsSuppressed)
-                {
-                    await _reader.DisposeAsync().ConfigureAwait(false);
-                    _command.Parameters.Clear();
-                    await _command.DisposeAsync().ConfigureAwait(false);
-                    await _relationalConnection.CloseAsync().ConfigureAwait(false);
-                }
+            if (_logger?.ShouldLogDataReaderDispose(DateTimeOffset.UtcNow) == true)
+            {
+                interceptionResult = _logger.DataReaderDisposing(
+                    _relationalConnection,
+                    _command,
+                    _reader,
+                    _commandId,
+                    _reader.RecordsAffected,
+                    _readCount,
+                    _startTime,
+                    _stopwatch.Elapsed); // can throw
+            }
+        }
+        finally
+        {
+            _disposed = true;
+
+            if (!interceptionResult.IsSuppressed)
+            {
+                await _reader.DisposeAsync().ConfigureAwait(false);
+                _command.Parameters.Clear();
+                await _command.DisposeAsync().ConfigureAwait(false);
+                await _relationalConnection.CloseAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -80,7 +80,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 Dependencies.UpdateLogger.UnexpectedTrailingResultSetWhenSaving();
             }
 
-            reader.DbDataReader.Close();
+            reader.Close();
 
             if (hasOutputParameters)
             {
@@ -198,7 +198,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 Dependencies.UpdateLogger.UnexpectedTrailingResultSetWhenSaving();
             }
 
-            await reader.DbDataReader.CloseAsync().ConfigureAwait(false);
+            await reader.CloseAsync().ConfigureAwait(false);
 
             if (hasOutputParameters)
             {

--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -53,7 +53,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 {
                     if (onResultSet == false)
                     {
-                        Check.DebugFail("Missing a result set");
+                        throw new InvalidOperationException(RelationalStrings.MissingResultSetWhenSaving);
                     }
 
                     var lastHandledCommandIndex = command.RequiresResultPropagation
@@ -75,12 +75,15 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 }
             }
 
-            Debug.Assert(onResultSet != true, "Unexpected result set found at end");
+            if (onResultSet == true)
+            {
+                Dependencies.UpdateLogger.UnexpectedTrailingResultSetWhenSaving();
+            }
+
+            reader.DbDataReader.Close();
 
             if (hasOutputParameters)
             {
-                reader.DbDataReader.Close();
-
                 var parameterCounter = 0;
                 IReadOnlyModificationCommand command;
 
@@ -133,7 +136,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
             throw new DbUpdateException(
                 RelationalStrings.UpdateStoreException,
                 ex,
-                ModificationCommands[commandIndex].Entries);
+                ModificationCommands[commandIndex < ModificationCommands.Count ? commandIndex : ModificationCommands.Count - 1].Entries);
         }
     }
 
@@ -168,7 +171,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 {
                     if (onResultSet == false)
                     {
-                        Check.DebugFail("Missing a result set");
+                        throw new InvalidOperationException(RelationalStrings.MissingResultSetWhenSaving);
                     }
 
                     var lastHandledCommandIndex = command.RequiresResultPropagation
@@ -190,12 +193,15 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 }
             }
 
-            Debug.Assert(onResultSet != true, "Unexpected result set found at end");
+            if (onResultSet == true)
+            {
+                Dependencies.UpdateLogger.UnexpectedTrailingResultSetWhenSaving();
+            }
+
+            await reader.DbDataReader.CloseAsync().ConfigureAwait(false);
 
             if (hasOutputParameters)
             {
-                await reader.DbDataReader.CloseAsync().ConfigureAwait(false);
-
                 var parameterCounter = 0;
                 IReadOnlyModificationCommand command;
 
@@ -249,7 +255,7 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
             throw new DbUpdateException(
                 RelationalStrings.UpdateStoreException,
                 ex,
-                ModificationCommands[commandIndex].Entries);
+                ModificationCommands[commandIndex < ModificationCommands.Count ? commandIndex : ModificationCommands.Count - 1].Entries);
         }
     }
 

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -866,6 +866,11 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
                     break;
 
                 case IStoreStoredProcedureResultColumn resultColumn:
+                    if (ReferenceEquals(RowsAffectedColumn, resultColumn))
+                    {
+                        continue;
+                    }
+
                     // For stored procedure result sets, we need to get the column ordering from metadata.
                     readerIndex = resultColumn.Position;
 #if DEBUG

--- a/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/StoredProcedureUpdateContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/StoredProcedureUpdateModel/StoredProcedureUpdateContext.cs
@@ -22,6 +22,9 @@ public class StoredProcedureUpdateContext : PoolableDbContext
     public DbSet<EntityWithAdditionalProperty> WithOutputParameterAndResultColumn
         => Set<EntityWithAdditionalProperty>(nameof(WithOutputParameterAndResultColumn));
 
+    public DbSet<EntityWithAdditionalProperty> WithOutputParameterAndRowsAffectedResultColumn
+        => Set<EntityWithAdditionalProperty>(nameof(WithOutputParameterAndRowsAffectedResultColumn));
+
     public DbSet<EntityWithTwoAdditionalProperties> WithOutputParameterAndResultColumnAndResultValue
         => Set<EntityWithTwoAdditionalProperties>(nameof(WithOutputParameterAndResultColumnAndResultValue));
 

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
@@ -61,6 +61,21 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
                         .HasResultColumn(w => w.AdditionalProperty));
             });
 
+        modelBuilder.SharedTypeEntity<EntityWithAdditionalProperty>(
+            nameof(StoredProcedureUpdateContext.WithOutputParameterAndRowsAffectedResultColumn),
+            b =>
+            {
+                b.Property(w => w.AdditionalProperty).HasComputedColumnSql("8");
+
+                b.UpdateUsingStoredProcedure(
+                    nameof(StoredProcedureUpdateContext.WithOutputParameterAndRowsAffectedResultColumn) + "_Update",
+                    spb => spb
+                        .HasParameter(w => w.Id)
+                        .HasParameter(w => w.Name)
+                        .HasParameter(w => w.AdditionalProperty, pb => pb.IsOutput())
+                        .HasRowsAffectedResultColumn());
+            });
+
         modelBuilder.SharedTypeEntity<EntityWithAdditionalProperty>(nameof(StoredProcedureUpdateContext.WithTwoOutputParameters))
             .UpdateUsingStoredProcedure(
                 nameof(StoredProcedureUpdateContext.WithTwoOutputParameters) + "_Update", spb => spb

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
@@ -154,6 +154,31 @@ public class StoredProcedureUpdateTestBase<TFixture> : IClassFixture<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Update_with_output_parameter_and_rows_affected_result_column(bool async)
+    {
+        await using var context = CreateContext();
+
+        var entity = new EntityWithAdditionalProperty { Name = "Foo" };
+        context.WithOutputParameterAndRowsAffectedResultColumn.Add(entity);
+        await context.SaveChangesAsync();
+
+        entity.Name = "Updated";
+
+        ClearLog();
+
+        await SaveChanges(context, async);
+
+        using (Fixture.TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            var actual = await context.WithOutputParameterAndRowsAffectedResultColumn.SingleAsync(w => w.Id == entity.Id);
+
+            Assert.Equal("Updated", actual.Name);
+            Assert.Equal(8, actual.AdditionalProperty);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual async Task Delete(bool async)
     {
         await using var context = CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
@@ -115,6 +115,19 @@ SET NOCOUNT ON;
 EXEC [WithTwoOutputParameters_Update] @p0, @p1, @p2;");
     }
 
+    public override async Task Update_with_output_parameter_and_rows_affected_result_column(bool async)
+    {
+        await base.Update_with_output_parameter_and_rows_affected_result_column(async);
+
+        AssertSql(
+            @"@p0='1'
+@p1='Updated' (Size = 4000)
+@p2=NULL (Nullable = false) (Direction = Output) (DbType = Int32)
+
+SET NOCOUNT ON;
+EXEC [WithOutputParameterAndRowsAffectedResultColumn_Update] @p0, @p1, @p2 OUTPUT;");
+    }
+
     public override async Task Delete(bool async)
     {
         await base.Delete(async);
@@ -384,6 +397,7 @@ TRUNCATE TABLE [WithInputOutputParameterOnNonConcurrencyToken];
 TRUNCATE TABLE [WithOriginalAndCurrentValueOnNonConcurrencyToken];
 TRUNCATE TABLE [WithOutputParameter];
 TRUNCATE TABLE [WithOutputParameterAndResultColumn];
+TRUNCATE TABLE [WithOutputParameterAndRowsAffectedResultColumn];
 TRUNCATE TABLE [WithOutputParameterAndResultColumnAndResultValue];
 TRUNCATE TABLE [WithResultColumn];
 TRUNCATE TABLE [WithTwoResultColumns];
@@ -458,10 +472,19 @@ END;
 
 GO
 
+CREATE PROCEDURE WithOutputParameterAndRowsAffectedResultColumn_Update(@Id int, @Name varchar(max), @AdditionalProperty int OUT)
+AS BEGIN
+    UPDATE [WithOutputParameterAndRowsAffectedResultColumn] SET [Name] = @Name, @AdditionalProperty = [AdditionalProperty] WHERE [Id] = @Id;
+    SELECT @@ROWCOUNT;
+END;
+
+GO
+
 CREATE PROCEDURE WithTwoOutputParameters_Update(@Id int, @Name varchar(max), @AdditionalProperty int)
 AS UPDATE [WithTwoOutputParameters] SET [Name] = @Name, [AdditionalProperty] = @AdditionalProperty WHERE [Id] = @id;
 
 GO
+
 CREATE PROCEDURE WithRowsAffectedParameter_Update(@Id int, @Name varchar(max), @RowsAffected int OUT)
 AS BEGIN
     UPDATE [WithRowsAffectedParameter] SET [Name] = @Name WHERE [Id] = @Id;


### PR DESCRIPTION
Fixes to stored procedure update mapping
    
* Don't attempt to propagate rows affected result columns.
* Warn if an unexpected trailing result set is found.
* Throw an informative message if a result set is missing.

Fixes #28803
