### PR TITLE
Take min/max batch size into account again for seeding

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -2190,17 +2190,11 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
             yield break;
         }
 
-        var commands = identityMaps.Values.SelectMany(m => m.Rows).Where(r =>
-        {
-            return r.EntityState switch
-            {
-                EntityState.Added => true,
-                EntityState.Modified => true,
-                EntityState.Unchanged => false,
-                EntityState.Deleted => diffContext.FindDrop(r.Table!) == null,
-                _ => throw new InvalidOperationException($"Unexpected entity state: {r.EntityState}")
-            };
-        });
+        var commands = identityMaps.Values
+            .SelectMany(m => m.Rows)
+            .Where(
+                r => r.EntityState is EntityState.Added or EntityState.Modified
+                    || (r.EntityState is EntityState.Deleted && diffContext.FindDrop(r.Table!) == null));
 
         var commandSets = new CommandBatchPreparer(CommandBatchPreparerDependencies)
             .TopologicalSort(commands);

--- a/src/EFCore.Relational/Update/ICommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/ICommandBatchPreparer.cs
@@ -34,4 +34,13 @@ public interface ICommandBatchPreparer
     /// <param name="updateAdapter">The model data.</param>
     /// <returns>The list of batches to execute.</returns>
     IEnumerable<ModificationCommandBatch> BatchCommands(IList<IUpdateEntry> entries, IUpdateAdapter updateAdapter);
+
+    /// <summary>
+    ///     Given a set of modification commands, returns one more ready-to-execute batches for those commands, taking into account e.g.
+    ///     maximum batch sizes and other batching constraints.
+    /// </summary>
+    /// <param name="commandSet">The set of commands to be organized in batches.</param>
+    /// <param name="moreCommandSets">Whether more command sets are expected after this one within the same save operation.</param>
+    /// <returns>The list of batches to execute.</returns>
+    IEnumerable<ModificationCommandBatch> CreateCommandBatches(IEnumerable<IReadOnlyModificationCommand> commandSet, bool moreCommandSets);
 }


### PR DESCRIPTION
Made MigrationsModelDiffer.GetDataOperations pass through our normal batching logic again, by splitting CommandBatchPreparer.BatchCommands to allow the logic to be called without IUpdateEntries.

On a side note, I was surprised to see we actually have seeding-specific logic for bulk insert... Seeding isn't supposed to be high-perf, and we specifically discourage having a large number of rows (e.g. huge context snapshots), which is where bulk inserting makes the most sense... I'd consider removing it altogether, to simplify the code and avoid bugs (like this one).

Fixes #28876

