### PR TITLE
Take the value converter into account when creating concurrency tokens for table sharing

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/TableSharingConcurrencyTokenConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableSharingConcurrencyTokenConvention.cs
@@ -103,8 +103,12 @@ public class TableSharingConcurrencyTokenConvention : IModelFinalizingConvention
 
                 foreach (var (conventionEntityType, exampleProperty) in entityTypesMissingConcurrencyColumn)
                 {
+                    var providerType = exampleProperty.GetProviderClrType()
+                        ?? (exampleProperty.GetValueConverter() ??
+                            exampleProperty.FindTypeMapping()?.Converter)?.ProviderClrType
+                        ?? exampleProperty.ClrType;
                     conventionEntityType.Builder.CreateUniqueProperty(
-                            exampleProperty.ClrType,
+                        providerType,
                             ConcurrencyPropertyPrefix + exampleProperty.Name,
                             !exampleProperty.IsNullable)!
                         .HasColumnName(concurrencyColumnName)!


### PR DESCRIPTION
Fixes #22584
Fixes #27888
