### PR TITLE
Fix issues with LocalView

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -671,6 +671,11 @@ public class StateManager : IStateManager
         _needsUnsubscribe = false;
 
         SavingChanges = false;
+
+        foreach (IResettableService set in ((IDbSetCache)Context).GetSets())
+        {
+            set.ResetState();
+        }
     }
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -273,7 +273,9 @@ public class LocalView<TEntity> :
     {
         var entry = _context.GetDependencies().StateManager.TryGetEntry(item);
 
-        return entry != null && entry.EntityState != EntityState.Deleted;
+        return entry != null 
+            && entry.EntityState != EntityState.Deleted
+            && entry.EntityState != EntityState.Detached;
     }
 
     /// <summary>

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -301,6 +301,16 @@ public class DbContext :
     }
 
     /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    IEnumerable<object> IDbSetCache.GetSets()
+        => _sets?.Values ?? Enumerable.Empty<object>();
+
+    /// <summary>
     ///     Creates a <see cref="DbSet{TEntity}" /> that can be used to query and save instances of <typeparamref name="TEntity" />.
     /// </summary>
     /// <remarks>

--- a/src/EFCore/Internal/IDbSetCache.cs
+++ b/src/EFCore/Internal/IDbSetCache.cs
@@ -26,4 +26,12 @@ public interface IDbSetCache
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     object GetOrAddSet(IDbSetSource source, string entityTypeName, Type type);
+    
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    IEnumerable<object> GetSets();
 }

--- a/test/EFCore.Specification.Tests/DatabindingTestBase.cs
+++ b/test/EFCore.Specification.Tests/DatabindingTestBase.cs
@@ -256,13 +256,31 @@ public abstract class DatabindingTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Equal(TotalCount, local.Count);
 
-        foreach (var driver in context.Drivers.Local.Where(d => d.TeamId == UnchangedTeam).ToList())
+        var drivers = context.Drivers.Local.Where(d => d.TeamId == UnchangedTeam).ToList();
+
+        foreach (var driver in drivers)
         {
             context.Entry(driver).State = EntityState.Detached;
         }
 
         Assert.Equal(0, local.Count(d => d.TeamId == UnchangedTeam));
         Assert.Equal(TotalCount - UnchangedCount, local.Count);
+        foreach (var driver in drivers)
+        {
+            Assert.False(local.Contains(driver));
+        }
+
+        foreach (var driver in drivers)
+        {
+            Assert.Equal(EntityState.Detached, context.Entry(driver).State);
+        }
+
+        Assert.Equal(0, local.Count(d => d.TeamId == UnchangedTeam));
+        Assert.Equal(TotalCount - UnchangedCount, local.Count);
+        foreach (var driver in drivers)
+        {
+            Assert.False(local.Contains(driver));
+        }
     }
 
     [ConditionalTheory]

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -3536,6 +3536,19 @@ public class ChangeTrackerTest
         AssertValuesSaved(id, 0, null);
     }
 
+    [ConditionalFact]
+    public void Clearing_change_tracker_resets_local_view_count()
+    {
+        using var context = new LikeAZooContext();
+
+        int originalCount = context.Cats.Local.Count;
+        context.Cats.Add(new Cat(3));
+
+        context.ChangeTracker.Clear();
+
+        Assert.Equal(originalCount, context.Cats.Local.Count);
+    }
+
     private static void AssertValuesSaved(int id, int someInt, string? someString)
     {
         using var context = new TheShadows();


### PR DESCRIPTION
Fixes #27056 (`LocalView<TEntity>.Contains` returns true for detached entity)
Fixes #27750 (`DbSet<T>.Local.Count` not updated when calling `ChangeTracker.Clear()`)


