### PR TITLE
Query: Convert unflattened GroupJoin to correlated subquery

### DIFF
--- a/src/EFCore/Query/QueryTranslationPreprocessor.cs
+++ b/src/EFCore/Query/QueryTranslationPreprocessor.cs
@@ -78,5 +78,5 @@ public class QueryTranslationPreprocessor
     /// <returns>A query expression after normalization has been done.</returns>
     public virtual Expression NormalizeQueryableMethod(Expression expression)
         => new QueryableMethodNormalizingExpressionVisitor(QueryCompilationContext)
-            .Visit(expression);
+            .Normalize(expression);
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -132,14 +132,13 @@ public abstract class QueryNoClientEvalTestBase<TFixture> : IClassFixture<TFixtu
     }
 
     [ConditionalFact]
-    public virtual void Throws_when_group_join()
+    public virtual void Does_not_throws_when_group_join()
     {
         using var context = CreateContext();
-        AssertTranslationFailed(
-            () => (from e1 in context.Employees
+        (from e1 in context.Employees
                    join i in new uint[] { 1, 2, 3 } on e1.EmployeeID equals i into g
                    select e1)
-                .ToList());
+                .ToList();
     }
 
     [ConditionalFact(Skip = "Issue#18923")]

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2073,26 +2073,22 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture> : QueryTestBase<
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task GroupJoin_with_subquery_on_inner(bool async)
-        // SelectMany Skip/Take. Issue #19015.
-        => AssertTranslationFailed(
-            () => AssertQueryScalar(
-                async,
-                ss => from l1 in ss.Set<Level1>()
-                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                      from l2 in groupJoin.Where(gg => gg.Id > 0).OrderBy(gg => gg.Id).Take(10).DefaultIfEmpty()
-                      select l1.Id));
+        => AssertQueryScalar(
+            async,
+            ss => from l1 in ss.Set<Level1>()
+                    join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                    from l2 in groupJoin.Where(gg => gg.Id > 0).OrderBy(gg => gg.Id).Take(10).DefaultIfEmpty()
+                    select l1.Id);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(bool async)
-        // SelectMany Skip/Take. Issue #19015.
-        => AssertTranslationFailed(
-            () => AssertQueryScalar(
-                async,
-                ss => from l1 in ss.Set<Level1>()
-                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                      from l2 in groupJoin.Where(gg => gg.Id > 0).OrderBy(gg => gg.Id).Take(10)
-                      select l1.Id));
+        => AssertQueryScalar(
+            async,
+            ss => from l1 in ss.Set<Level1>()
+                    join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
+                    from l2 in groupJoin.Where(gg => gg.Id > 0).OrderBy(gg => gg.Id).Take(10)
+                    select l1.Id);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
@@ -420,13 +420,18 @@ public abstract class Ef6GroupByTestBase<TFixture> : QueryTestBase<TFixture>
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Group_Join_from_LINQ_101(bool async)
-        // GroupJoin final operator. Issue #19930.
-        => AssertTranslationFailed(
-            () => AssertQuery(
-                async,
-                ss => from c in ss.Set<CustomerForLinq>()
-                      join o in ss.Set<OrderForLinq>() on c equals o.Customer into ps
-                      select new { Customer = c, Products = ps }));
+        => AssertQuery(
+            async,
+            ss => from c in ss.Set<CustomerForLinq>()
+                  join o in ss.Set<OrderForLinq>() on c equals o.Customer into ps
+                  select new { Customer = c, Products = ps },
+            elementSorter: e => e.Customer.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Customer, a.Customer);
+                AssertCollection(e.Products, a.Products);
+            },
+            entryCount: 11);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4410,23 +4410,22 @@ public abstract class GearsOfWarQueryTestBase<TFixture> : QueryTestBase<TFixture
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Join_with_complex_key_selector(bool async)
-        => AssertTranslationFailed(
-            () => AssertQuery(
-                async,
-                ss => ss.Set<Squad>()
-                    .Join(ss.Set<CogTag>().Where(t => t.Note == "Marcus' Tag"), o => true, i => true, (o, i) => new { o, i })
-                    .GroupJoin(
-                        ss.Set<Gear>(),
-                        oo => oo.o.Members.FirstOrDefault(v => v.Tag == oo.i),
-                        ii => ii,
-                        (k, g) => new
-                        {
-                            k.o,
-                            k.i,
-                            value = g.OrderBy(gg => gg.FullName).FirstOrDefault()
-                        })
-                    .Select(r => new { r.o.Id, TagId = r.i.Id }),
-                elementSorter: e => (e.Id, e.TagId)));
+        => AssertQuery(
+            async,
+            ss => ss.Set<Squad>()
+                .Join(ss.Set<CogTag>().Where(t => t.Note == "Marcus' Tag"), o => true, i => true, (o, i) => new { o, i })
+                .GroupJoin(
+                    ss.Set<Gear>(),
+                    oo => oo.o.Members.FirstOrDefault(v => v.Tag == oo.i),
+                    ii => ii,
+                    (k, g) => new
+                    {
+                        k.o,
+                        k.i,
+                        value = g.OrderBy(gg => gg.FullName).FirstOrDefault()
+                    })
+                .Select(r => new { r.o.Id, TagId = r.i.Id }),
+            elementSorter: e => (e.Id, e.TagId));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2114,14 +2114,30 @@ INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]");
     {
         await base.GroupJoin_with_subquery_on_inner(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [l].[Id]
+FROM [LevelOne] AS [l]
+OUTER APPLY (
+    SELECT TOP(10) [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
+    FROM [LevelTwo] AS [l0]
+    WHERE [l].[Id] = [l0].[Level1_Optional_Id] AND [l0].[Id] > 0
+    ORDER BY [l0].[Id]
+) AS [t]");
     }
 
     public override async Task GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(bool async)
     {
         await base.GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [l].[Id]
+FROM [LevelOne] AS [l]
+CROSS APPLY (
+    SELECT TOP(10) [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
+    FROM [LevelTwo] AS [l0]
+    WHERE [l].[Id] = [l0].[Level1_Optional_Id] AND [l0].[Id] > 0
+    ORDER BY [l0].[Id]
+) AS [t]");
     }
 
     public override async Task Optional_navigation_in_subquery_with_unrelated_projection(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -7103,14 +7103,56 @@ END = 0");
     {
         await base.GroupJoin_with_subquery_on_inner(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [l].[Id]
+FROM [Level1] AS [l]
+OUTER APPLY (
+    SELECT TOP(10) [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id] AS [Id0], CASE
+        WHEN [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    END AS [c]
+    FROM [Level1] AS [l0]
+    LEFT JOIN (
+        SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id]
+        FROM [Level1] AS [l1]
+        WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    ) AS [t] ON [l0].[Id] = CASE
+        WHEN [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    END
+    WHERE [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l].[Id] = [t].[Level1_Optional_Id] AND CASE
+        WHEN [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    END > 0
+    ORDER BY CASE
+        WHEN [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    END
+) AS [t0]");
     }
 
     public override async Task GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(bool async)
     {
         await base.GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [l].[Id]
+FROM [Level1] AS [l]
+CROSS APPLY (
+    SELECT TOP(10) [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [l0].[Id] AS [Id0], CASE
+        WHEN [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    END AS [c]
+    FROM [Level1] AS [l0]
+    LEFT JOIN (
+        SELECT [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id]
+        FROM [Level1] AS [l1]
+        WHERE [l1].[OneToOne_Required_PK_Date] IS NOT NULL AND [l1].[Level1_Required_Id] IS NOT NULL AND [l1].[OneToMany_Required_Inverse2Id] IS NOT NULL
+    ) AS [t] ON [l0].[Id] = CASE
+        WHEN [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    END
+    WHERE [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [l].[Id] = [t].[Level1_Optional_Id] AND CASE
+        WHEN [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    END > 0
+    ORDER BY CASE
+        WHEN [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t].[Id]
+    END
+) AS [t0]");
     }
 
     public override async Task Level4_Include(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/Ef6GroupBySqlServerTest.cs
@@ -525,7 +525,16 @@ GROUP BY [a].[Id], [a].[FirstName], [a].[LastName], [a].[Alias]");
     {
         await base.Group_Join_from_LINQ_101(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [c].[Id], [c].[CompanyName], [c].[Region], [t].[Id], [t].[CustomerId], [t].[OrderDate], [t].[Total], [t].[Id0]
+FROM [CustomerForLinq] AS [c]
+OUTER APPLY (
+    SELECT [o].[Id], [o].[CustomerId], [o].[OrderDate], [o].[Total], [c0].[Id] AS [Id0]
+    FROM [OrderForLinq] AS [o]
+    LEFT JOIN [CustomerForLinq] AS [c0] ON [o].[CustomerId] = [c0].[Id]
+    WHERE [c].[Id] = [c0].[Id]
+) AS [t]
+ORDER BY [c].[Id], [t].[Id]");
     }
 
     public override async Task Whats_new_2021_sample_3(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -8553,7 +8553,14 @@ ORDER BY [g].[Nickname], [g].[SquadId], [s].[Id]");
     {
         await base.Join_with_complex_key_selector(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [s].[Id], [t0].[Id] AS [TagId]
+FROM [Squads] AS [s]
+CROSS JOIN (
+    SELECT [t].[Id]
+    FROM [Tags] AS [t]
+    WHERE [t].[Note] = N'Marcus'' Tag'
+) AS [t0]");
     }
 
     public override async Task Streaming_correlated_collection_issue_11403_returning_ordered_enumerable_throws(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -267,6 +267,59 @@ INNER JOIN (
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]");
     }
 
+    public override async Task GroupJoin_as_final_operator(bool async)
+    {
+        await base.GroupJoin_as_final_operator(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Unflattened_GroupJoin_composed(bool async)
+    {
+        await base.Unflattened_GroupJoin_composed(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+) AS [t]
+WHERE ([c].[CustomerID] LIKE N'F%') AND [c].[City] = N'Lisboa'
+ORDER BY [c].[CustomerID]");
+    }
+
+    public override async Task Unflattened_GroupJoin_composed_2(bool async)
+    {
+        await base.Unflattened_GroupJoin_composed_2(async);
+
+        AssertSql(
+            @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[CustomerID], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[City] = N'Lisboa'
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+OUTER APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+) AS [t0]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[CustomerID]");
+    }
+
     public override async Task GroupJoin_DefaultIfEmpty(bool async)
     {
         await base.GroupJoin_DefaultIfEmpty(async);
@@ -395,7 +448,14 @@ INNER JOIN (
     {
         await base.GroupJoin_SelectMany_subquery_with_filter_orderby(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [c].[ContactName], [t].[OrderID]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] > 5
+) AS [t]");
     }
 
     public override async Task GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(bool async)
@@ -417,7 +477,15 @@ WHERE [c].[CustomerID] LIKE N'F%'");
     {
         await base.GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [c].[ContactName], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID] AND [o].[OrderID] > 5
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'");
     }
 
     public override async Task GroupJoin_Subquery_with_Take_Then_SelectMany_Where(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -11611,7 +11611,14 @@ ORDER BY [t].[Nickname], [t].[SquadId]");
     {
         await base.Join_with_complex_key_selector(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [s].[Id], [t0].[Id] AS [TagId]
+FROM [Squads] AS [s]
+CROSS JOIN (
+    SELECT [t].[Id]
+    FROM [Tags] AS [t]
+    WHERE [t].[Note] = N'Marcus'' Tag'
+) AS [t0]");
     }
 
     public override async Task Streaming_correlated_collection_issue_11403_returning_ordered_enumerable_throws(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -9801,7 +9801,14 @@ ORDER BY [g].[Nickname], [g].[SquadId]");
     {
         await base.Join_with_complex_key_selector(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [s].[Id], [t0].[Id] AS [TagId]
+FROM [Squads] AS [s]
+CROSS JOIN (
+    SELECT [t].[Id]
+    FROM [Tags] AS [t]
+    WHERE [t].[Note] = N'Marcus'' Tag'
+) AS [t0]");
     }
 
     public override async Task Streaming_correlated_collection_issue_11403_returning_ordered_enumerable_throws(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -8387,7 +8387,14 @@ ORDER BY [g].[Nickname], [g].[SquadId]");
     {
         await base.Join_with_complex_key_selector(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT [s].[Id], [t0].[Id] AS [TagId]
+FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
+CROSS JOIN (
+    SELECT [t].[Id]
+    FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
+    WHERE [t].[Note] = N'Marcus'' Tag'
+) AS [t0]");
     }
 
     public override async Task Streaming_correlated_collection_issue_11403_returning_ordered_enumerable_throws(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
@@ -42,4 +42,16 @@ public class ComplexNavigationsQuerySqliteTest : ComplexNavigationsQueryRelation
             CoreStrings.QueryUnableToTranslateMethod(
                 "Microsoft.EntityFrameworkCore.Query.ComplexNavigationsQueryTestBase<Microsoft.EntityFrameworkCore.Query.ComplexNavigationsQuerySqliteFixture>",
                 "ClientMethodNullableInt"));
+
+    public override async Task GroupJoin_with_subquery_on_inner(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupJoin_with_subquery_on_inner(async))).Message);
+
+    public override async Task GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(async))).Message);
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
@@ -53,4 +53,16 @@ public class ComplexNavigationsSharedTypeQuerySqliteTest :
     [ConditionalTheory(Skip = "Issue#26104")]
     public override Task GroupBy_aggregate_where_required_relationship_2(bool async)
         => base.GroupBy_aggregate_where_required_relationship_2(async);
+
+    public override async Task GroupJoin_with_subquery_on_inner(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupJoin_with_subquery_on_inner(async))).Message);
+
+    public override async Task GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty(async))).Message);
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/Ef6GroupBySqliteTest.cs
@@ -65,6 +65,12 @@ public class Ef6GroupBySqliteTest : Ef6GroupByTestBase<Ef6GroupBySqliteTest.Ef6G
         => await base.Whats_new_2021_sample_6(async);
 #endif
 
+    public override async Task Group_Join_from_LINQ_101(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Group_Join_from_LINQ_101(async))).Message);
+
     public class Ef6GroupBySqliteFixture : Ef6GroupByFixtureBase
     {
         public TestSqlLoggerFactory TestSqlLoggerFactory

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -8004,7 +8004,14 @@ LEFT JOIN (
     {
         await base.Join_with_complex_key_selector(async);
 
-        AssertSql();
+        AssertSql(
+            @"SELECT ""s"".""Id"", ""t0"".""Id"" AS ""TagId""
+FROM ""Squads"" AS ""s""
+CROSS JOIN (
+    SELECT ""t"".""Id""
+    FROM ""Tags"" AS ""t""
+    WHERE ""t"".""Note"" = 'Marcus'' Tag'
+) AS ""t0""");
     }
 
     public override async Task Streaming_correlated_collection_issue_11403_returning_ordered_enumerable_throws(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindJoinQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindJoinQuerySqliteTest.cs
@@ -55,4 +55,34 @@ public class NorthwindJoinQuerySqliteTest : NorthwindJoinQueryRelationalTestBase
             SqliteStrings.ApplyNotSupported,
             (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Take_in_collection_projection_with_FirstOrDefault_on_top_level(async))).Message);
+
+    public override async Task GroupJoin_as_final_operator(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupJoin_as_final_operator(async))).Message);
+
+    public override async Task Unflattened_GroupJoin_composed(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Unflattened_GroupJoin_composed(async))).Message);
+
+    public override async Task Unflattened_GroupJoin_composed_2(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Unflattened_GroupJoin_composed_2(async))).Message);
+
+    public override async Task GroupJoin_SelectMany_subquery_with_filter_orderby(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupJoin_SelectMany_subquery_with_filter_orderby(async))).Message);
+
+    public override async Task GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty(async))).Message);
 }


### PR DESCRIPTION
Resolves #19930
