### PR TITLE
[release/6.0] Clear reference to DbDataReader from RelationalDataReader

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -131,12 +131,22 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 {
                     _disposed = true;
 
-                    if (!interceptionResult.IsSuppressed)
+                    try
                     {
-                        _reader.Dispose();
-                        _command.Parameters.Clear();
-                        _command.Dispose();
-                        _relationalConnection.Close();
+                        if (!interceptionResult.IsSuppressed)
+                        {
+                            _reader.Dispose();
+                            _command.Parameters.Clear();
+                            _command.Dispose();
+                            _relationalConnection.Close();
+                        }
+                    }
+                    finally
+                    {
+                        _reader = null!;
+                        _command = null!;
+                        _relationalConnection = null!;
+                        _logger = null;
                     }
                 }
             }
@@ -171,12 +181,22 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 {
                     _disposed = true;
 
-                    if (!interceptionResult.IsSuppressed)
+                    try
                     {
-                        await _reader.DisposeAsync().ConfigureAwait(false);
-                        _command.Parameters.Clear();
-                        await _command.DisposeAsync().ConfigureAwait(false);
-                        await _relationalConnection.CloseAsync().ConfigureAwait(false);
+                        if (!interceptionResult.IsSuppressed)
+                        {
+                            await _reader.DisposeAsync().ConfigureAwait(false);
+                            _command.Parameters.Clear();
+                            await _command.DisposeAsync().ConfigureAwait(false);
+                            await _relationalConnection.CloseAsync().ConfigureAwait(false);
+                        }
+                    }
+                    finally
+                    {
+                        _reader = null!;
+                        _command = null!;
+                        _relationalConnection = null!;
+                        _logger = null;
                     }
                 }
             }

--- a/test/EFCore.Relational.Tests/Storage/RelationalDataReaderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalDataReaderTest.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
+using Xunit;
+
+// ReSharper disable MethodHasAsyncOverload
+
+namespace Microsoft.EntityFrameworkCore.Storage;
+
+public class RelationalDataReaderTest
+{
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Does_not_hold_reference_to_DbDataReader_after_dispose(bool async)
+    {
+        var fakeConnection = CreateConnection();
+        var relationalCommand = CreateRelationalCommand(commandText: "CommandText");
+
+        var reader = relationalCommand.ExecuteReader(new(
+            fakeConnection,
+            new Dictionary<string, object>(),
+            readerColumns: null,
+            context: null,
+            logger: null));
+
+        Assert.NotNull(reader.DbDataReader);
+
+        if (async)
+        {
+            await reader.DisposeAsync();
+        }
+        else
+        {
+            reader.Dispose();
+        }
+
+        Assert.Null(reader.DbDataReader);
+    }
+
+    private const string ConnectionString = "Fake Connection String";
+
+    private static FakeRelationalConnection CreateConnection(IDbContextOptions options = null)
+        => new(options ?? CreateOptions());
+
+    private static IDbContextOptions CreateOptions(
+        RelationalOptionsExtension optionsExtension = null)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder();
+
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder)
+            .AddOrUpdateExtension(
+                optionsExtension
+                ?? new FakeRelationalOptionsExtension().WithConnectionString(ConnectionString));
+
+        return optionsBuilder.Options;
+    }
+
+    private IRelationalCommand CreateRelationalCommand(
+        string commandText = "Command Text",
+        IReadOnlyList<IRelationalParameter> parameters = null)
+        => new RelationalCommand(
+            new RelationalCommandBuilderDependencies(
+                new TestRelationalTypeMappingSource(
+                    TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())),
+            commandText,
+            parameters ?? Array.Empty<IRelationalParameter>());
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { false }, new object[] { true } };
+}


### PR DESCRIPTION
Fixes #28988

**Description**

In EF Core 6.0, we started recycling RelationalDataReader instances across RelationalCommand invocations, to optimize the query pipeline and cut down on needless allocations. However, the RelationalDataReader retains its reference to its DbDataReader until a new query is executed; if a BufferedDataReader is used, that can mean needlessly preventing garbage collection of lots of all query data. This is exarcebated by context pooling (where the context is kept around for much longer).

**Customer impact**

Significantly increased memory usage when a retrying execution is used, context pooling is activated and large results are queries from the database.

**How found**

Customer reported on 6.0

**Regression**

Yes, in 6.0.

**Testing**

Added a test.

**Risk**

Low.

This is port of #28989 which was already merged for 7.0.
