### PR TITLE
TPH sibling metadata bug

### DIFF
--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -1133,21 +1133,18 @@ public class RelationalModel : Annotatable, IRelationalModel
                     entityType.GetMappingStrategy() == RelationalAnnotationNames.TphMappingStrategy,
                     "Expected TPH for " + entityType.DisplayName());
 
-                if (entityType.BaseType == null)
+                foreach (var derivedProperty in entityType.GetRootType().GetDerivedProperties())
                 {
-                    foreach (var derivedProperty in entityType.GetDerivedProperties())
+                    if (derivedProperty.Name == parameter.PropertyName)
                     {
-                        if (derivedProperty.Name == parameter.PropertyName)
-                        {
-                            GetOrCreateStoreStoredProcedureParameter(
-                                parameter,
-                                derivedProperty,
-                                position,
-                                storeStoredProcedure,
-                                identifier,
-                                relationalTypeMappingSource);
-                            break;
-                        }
+                        GetOrCreateStoreStoredProcedureParameter(
+                            parameter,
+                            derivedProperty,
+                            position,
+                            storeStoredProcedure,
+                            identifier,
+                            relationalTypeMappingSource);
+                        break;
                     }
                 }
 
@@ -1201,21 +1198,18 @@ public class RelationalModel : Annotatable, IRelationalModel
                     entityType.GetMappingStrategy() == RelationalAnnotationNames.TphMappingStrategy,
                     "Expected TPH for " + entityType.DisplayName());
 
-                if (entityType.BaseType == null)
+                foreach (var derivedProperty in entityType.GetRootType().GetDerivedProperties())
                 {
-                    foreach (var derivedProperty in entityType.GetDerivedProperties())
+                    if (derivedProperty.Name == resultColumn.PropertyName)
                     {
-                        if (derivedProperty.Name == resultColumn.PropertyName)
-                        {
-                            GetOrCreateStoreStoredProcedureResultColumn(
-                                resultColumn,
-                                derivedProperty,
-                                position,
-                                storeStoredProcedure,
-                                identifier,
-                                relationalTypeMappingSource);
-                            break;
-                        }
+                        GetOrCreateStoreStoredProcedureResultColumn(
+                            resultColumn,
+                            derivedProperty,
+                            position,
+                            storeStoredProcedure,
+                            identifier,
+                            relationalTypeMappingSource);
+                        break;
                     }
                 }
 

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateFixtureBase.cs
@@ -198,9 +198,9 @@ public abstract class StoredProcedureUpdateFixtureBase : SharedStoreFixtureBase<
                         .HasParameter(w => w.Id, pb => pb.IsOutput())
                         .HasParameter("Discriminator")
                         .HasParameter(w => w.Name)
-                        .HasParameter(nameof(TphChild1.Child1Property))
                         .HasParameter(nameof(TphChild2.Child2InputProperty))
                         .HasParameter(nameof(TphChild2.Child2OutputParameterProperty), o => o.IsOutput())
+                        .HasParameter(nameof(TphChild1.Child1Property))
                         .HasResultColumn(nameof(TphChild2.Child2ResultColumnProperty)));
             });
 

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
@@ -306,12 +306,12 @@ EXEC [WithOriginalAndCurrentValueOnNonConcurrencyToken_Update] @p0, @p1, @p2;");
             @"@p0=NULL (Nullable = false) (Direction = Output) (DbType = Int32)
 @p1='TphChild1' (Nullable = false) (Size = 4000)
 @p2='Child' (Size = 4000)
-@p3='8' (Nullable = true)
-@p4=NULL (DbType = Int32)
-@p5=NULL (Direction = Output) (DbType = Int32)
+@p3=NULL (DbType = Int32)
+@p4=NULL (Direction = Output) (DbType = Int32)
+@p5='8' (Nullable = true)
 
 SET NOCOUNT ON;
-EXEC [Tph_Insert] @p0 OUTPUT, @p1, @p2, @p3, @p4, @p5 OUTPUT;");
+EXEC [Tph_Insert] @p0 OUTPUT, @p1, @p2, @p3, @p4 OUTPUT, @p5;");
     }
 
     public override async Task Tpt(bool async)
@@ -576,7 +576,7 @@ END;
 
 GO
 
-CREATE PROCEDURE Tph_Insert(@Id int OUT, @Discriminator varchar(max), @Name varchar(max), @Child1Property int, @Child2InputProperty int, @Child2OutputParameterProperty int OUT)
+CREATE PROCEDURE Tph_Insert(@Id int OUT, @Discriminator varchar(max), @Name varchar(max), @Child2InputProperty int, @Child2OutputParameterProperty int OUT, @Child1Property int)
 AS BEGIN
     DECLARE @Table table ([Child2OutputParameterProperty] int);
     INSERT INTO [Tph] ([Discriminator], [Name], [Child1Property], [Child2InputProperty]) OUTPUT [Inserted].[Child2OutputParameterProperty] INTO @Table VALUES (@Discriminator, @Name, @Child1Property, @Child2InputProperty);


### PR DESCRIPTION
@AndriySvyryd, I think this small code change reproduces a bug in the relational model generation (this PR is based on top of #28908, so ignore the 1st commit).

Basically, when creating the sproc mappings (RelationalModel.CreateStoredProcedureMapping) for a TPH child, we [filter out](https://github.com/dotnet/efcore/blob/release/7.0/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs#L1130)  parameters which aren't mapped to the current child entity type. We'll add these to the StoredStoreProcedure later, but they'll be appended to the ended, meaning that the parameter longer is incorrect.

This is reproduced here by moving Child1Property to the end of the sproc parameter list, after some properties which belong to Child2. Inspecting the final metadata definition shows that in the StoredStoreProcedure, Child1Property comes before the Child2 properties instead of after (the conceptual StoreProcedure is fine).

(feel free to push fixes directly to this PR)