### PR TITLE
Don't undelete dependents if principal key changes

### DIFF
--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosModelValidator.cs
@@ -343,6 +343,29 @@ public class CosmosModelValidator : ModelValidator
     }
 
     /// <summary>
+    ///     Validates the mapping/configuration of mutable in the model.
+    /// </summary>
+    /// <param name="model">The model to validate.</param>
+    /// <param name="logger">The logger to use.</param>
+    protected override void ValidateNoMutableKeys(
+        IModel model,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            foreach (var key in entityType.GetDeclaredKeys())
+            {
+                var mutableProperty = key.Properties.FirstOrDefault(p => p.ValueGenerated.HasFlag(ValueGenerated.OnUpdate));
+                if (mutableProperty != null
+                    && !mutableProperty.IsOrdinalKeyProperty())
+                {
+                    throw new InvalidOperationException(CoreStrings.MutableKeyProperty(mutableProperty.Name));
+                }
+            }
+        }
+    }
+
+    /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
     ///     any release. You should only use it directly in your code with extreme caution and knowing that

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
@@ -78,11 +78,11 @@ public class CosmosValueGenerationConvention :
             {
                 var pk = property.FindContainingPrimaryKey();
                 if (pk != null
-                    && !ownership.Properties.Contains(property)
+                    && !property.IsForeignKey()
                     && pk.Properties.Count == ownership.Properties.Count + 1
                     && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
                 {
-                    return base.GetValueGenerated(property);
+                    return ValueGenerated.OnAddOrUpdate;
                 }
             }
         }

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
@@ -27,6 +27,6 @@ public static class CosmosPropertyExtensions
             && key.Properties.Count > 1
             && !property.IsForeignKey()
             && property.ClrType == typeof(int)
-            && property.ValueGenerated == ValueGenerated.OnAdd;
+            && (property.ValueGenerated & ValueGenerated.OnAdd) != 0;
     }
 }

--- a/src/EFCore.Relational/Extensions/Internal/RelationalPropertyInternalExtensions.cs
+++ b/src/EFCore.Relational/Extensions/Internal/RelationalPropertyInternalExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -21,7 +21,6 @@ public static class RelationalPropertyInternalExtensions
         => property.FindContainingPrimaryKey() is IReadOnlyKey key
             && key.Properties.Count > 1
             && !property.IsForeignKey()
-            && property.IsShadowProperty()
             && property.ClrType == typeof(int)
             && property.GetJsonPropertyName() == null;
 }

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -720,6 +720,29 @@ public class RelationalModelValidator : ModelValidator
             }
         }
     }
+    
+    /// <summary>
+    ///     Validates the mapping/configuration of mutable in the model.
+    /// </summary>
+    /// <param name="model">The model to validate.</param>
+    /// <param name="logger">The logger to use.</param>
+    protected override void ValidateNoMutableKeys(
+        IModel model,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            foreach (var key in entityType.GetDeclaredKeys())
+            {
+                var mutableProperty = key.Properties.FirstOrDefault(p => p.ValueGenerated.HasFlag(ValueGenerated.OnUpdate));
+                if (mutableProperty != null
+                    && !mutableProperty.IsOrdinalKeyProperty())
+                {
+                    throw new InvalidOperationException(CoreStrings.MutableKeyProperty(mutableProperty.Name));
+                }
+            }
+        }
+    }
 
     /// <summary>
     ///     Validates the mapping/configuration of shared tables in the model.

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalValueGenerationConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalValueGenerationConvention.cs
@@ -186,9 +186,9 @@ public class RelationalValueGenerationConvention :
             : table.Name != null
                 ? GetValueGenerated(property, table)
                 : property.DeclaringEntityType.IsMappedToJson()
-                && !property.DeclaringEntityType.FindOwnership()!.IsUnique
-                && property.IsOrdinalKeyProperty()
-                    ? ValueGenerated.OnAdd
+                    && !property.DeclaringEntityType.FindOwnership()!.IsUnique
+                    && property.IsOrdinalKeyProperty()
+                    ? ValueGenerated.OnAddOrUpdate
                     : property.GetMappedStoreObjects(StoreObjectType.InsertStoredProcedure).Any()
                         ? GetValueGenerated((IReadOnlyProperty)property)
                         : null;

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -963,13 +963,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
         }
 
         var collection = GetOrCreateShadowCollection(navigationBase);
-        if (!collectionAccessor.ContainsStandalone(collection, value))
-        {
-            collectionAccessor.AddStandalone(collection, value);
-            return true;
-        }
-
-        return false;
+        return collectionAccessor.AddStandalone(collection, value);
     }
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -525,8 +525,11 @@ public class NavigationFixer : INavigationFixer
                     foreach (InternalEntityEntry dependentEntry in stateManager
                                  .GetDependentsUsingRelationshipSnapshot(entry, foreignKey).ToList())
                     {
+                        if (dependentEntry.EntityState == EntityState.Deleted)
+                        {
+                            continue;
+                        }
                         SetForeignKeyProperties(dependentEntry, entry, foreignKey, setModified: true, fromQuery: false);
-                        UndeleteDependent(dependentEntry, entry);
                     }
 
                     if (foreignKey.IsOwnership)

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3690,6 +3690,7 @@ namespace RootNamespace
                                                 .HasColumnType(""int"");
 
                                             b3.Property<int>(""Id"")
+                                                .ValueGeneratedOnAdd()
                                                 .HasColumnType(""int"");
 
                                             b3.Property<string>(""Name"")


### PR DESCRIPTION
- Don't undelete dependents if principal key changes
- Re-set ordinal values when the principal is added, not only when it's modified
- Mark the ordinal property as ValueGenerated.OnAddOrUpdate
- Override all JSON values for a replaced dependent

Fixes #27918
Fixes #27272
Fixes #24828
