### PR TITLE
Fix logic for resetting facets in HasValueGenerationStrategy

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerModelBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerModelBuilderExtensions.cs
@@ -324,20 +324,16 @@ public static class SqlServerModelBuilderExtensions
             {
                 modelBuilder.HasIdentityColumnSeed(null, fromDataAnnotation);
                 modelBuilder.HasIdentityColumnIncrement(null, fromDataAnnotation);
-                RemoveKeySequenceAnnotations();
             }
 
             if (valueGenerationStrategy != SqlServerValueGenerationStrategy.SequenceHiLo)
             {
                 modelBuilder.HasHiLoSequence(null, null, fromDataAnnotation);
-                RemoveKeySequenceAnnotations();
             }
 
             if (valueGenerationStrategy != SqlServerValueGenerationStrategy.Sequence)
             {
-                modelBuilder.HasIdentityColumnSeed(null, fromDataAnnotation);
-                modelBuilder.HasIdentityColumnIncrement(null, fromDataAnnotation);
-                modelBuilder.HasHiLoSequence(null, null, fromDataAnnotation);
+                RemoveKeySequenceAnnotations();
             }
 
             return modelBuilder;


### PR DESCRIPTION
Fixes #28560

The logic is that if we set something different from a given strategy, then we reset facets for that strategy. This means that when a strategy changes, all facets for other strategies are reset.
