### PR TITLE
First round of trimming annotation work

### DIFF
--- a/src/EFCore.Abstractions/ChangeTracking/Internal/ObservableBackedBindingList.cs
+++ b/src/EFCore.Abstractions/ChangeTracking/Internal/ObservableBackedBindingList.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -12,6 +13,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
+[RequiresUnreferencedCode(
+    "BindingList raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
 public class ObservableBackedBindingList<T> : SortableBindingList<T>
 {
     private bool _addingNewInstance;
@@ -28,6 +31,8 @@ public class ObservableBackedBindingList<T> : SortableBindingList<T>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [RequiresUnreferencedCode(
+        "BindingList raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
     public ObservableBackedBindingList(ICollection<T> observableCollection)
         : base(observableCollection.ToList())
     {

--- a/src/EFCore.Abstractions/ChangeTracking/Internal/SortableBindingList.cs
+++ b/src/EFCore.Abstractions/ChangeTracking/Internal/SortableBindingList.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
@@ -12,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
+[RequiresUnreferencedCode("Raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
 public class SortableBindingList<T> : BindingList<T>
 {
     private bool _isSorted;
@@ -24,6 +26,7 @@ public class SortableBindingList<T> : BindingList<T>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [RequiresUnreferencedCode("Raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
     public SortableBindingList(List<T> list)
         : base(list)
     {
@@ -35,6 +38,13 @@ public class SortableBindingList<T> : BindingList<T>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [RequiresUnreferencedCode("Requires accessing property 'Default' on the property descriptor's type")]
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2046",
+        Justification =
+            "This method is an override, and the base method isn't annotated with RequiresUnreferencedCode. " +
+            "The entire type is marked with RequiresUnreferencedCode.")]
     protected override void ApplySortCore(PropertyDescriptor prop, ListSortDirection direction)
     {
         if (PropertyComparer.CanSort(prop.PropertyType))
@@ -101,6 +111,7 @@ public class SortableBindingList<T> : BindingList<T>
         private readonly ListSortDirection _direction;
         private readonly PropertyDescriptor _prop;
 
+        [RequiresUnreferencedCode("Requires accessing property 'Default' on the property descriptor's type")]
         public PropertyComparer(PropertyDescriptor prop, ListSortDirection direction)
         {
             if (!prop.ComponentType.IsAssignableFrom(typeof(T)))

--- a/src/EFCore.Abstractions/ChangeTracking/ObservableCollectionListSource.cs
+++ b/src/EFCore.Abstractions/ChangeTracking/ObservableCollectionListSource.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 
@@ -25,6 +26,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 ///     </para>
 /// </remarks>
 /// <typeparam name="T">The type of elements in the collection.</typeparam>
+[RequiresUnreferencedCode(
+    "BindingList raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
 public class ObservableCollectionListSource<T> : ObservableCollection<T>, IListSource
     where T : class
 {
@@ -71,6 +74,14 @@ public class ObservableCollectionListSource<T> : ObservableCollection<T>, IListS
     /// <returns>
     ///     An <see cref="IBindingList" /> in sync with the ObservableCollection.
     /// </returns>
+    [RequiresUnreferencedCode(
+        "BindingList raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2046",
+        Justification =
+            "This method is an interface implementation, and the interface method isn't annotated with RequiresUnreferencedCode. " +
+            "The entire type is marked with RequiresUnreferencedCode.")]
     IList IListSource.GetList()
         => _bindingList ??= this.ToBindingList();
 }

--- a/src/EFCore.Abstractions/EntityTypeConfigurationAttribute.cs
+++ b/src/EFCore.Abstractions/EntityTypeConfigurationAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore;
@@ -28,5 +29,6 @@ public sealed class EntityTypeConfigurationAttribute : Attribute
     /// <summary>
     ///     Type of the entity type configuration.
     /// </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
     public Type EntityTypeConfigurationType { get; }
 }

--- a/src/EFCore.Abstractions/ObservableCollectionExtensions.cs
+++ b/src/EFCore.Abstractions/ObservableCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
@@ -23,6 +24,8 @@ public static class ObservableCollectionExtensions
     /// <typeparam name="T">The element type.</typeparam>
     /// <param name="source">The collection that the binding list will stay in sync with.</param>
     /// <returns>The binding list.</returns>
+    [RequiresUnreferencedCode(
+        "BindingList raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
     public static BindingList<T> ToBindingList<T>(this ObservableCollection<T> source)
         where T : class
         => new ObservableBackedBindingList<T>(source);

--- a/src/EFCore.Relational/Migrations/IMigrator.cs
+++ b/src/EFCore.Relational/Migrations/IMigrator.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Migrations;
 
 /// <summary>
@@ -30,6 +32,7 @@ public interface IMigrator
     /// <param name="targetMigration">
     ///     The target migration to migrate the database to, or <see langword="null" /> to migrate to the latest.
     /// </param>
+    [RequiresUnreferencedCode("Migration generation currently isn't compatible with trimming")]
     void Migrate(string? targetMigration = null);
 
     /// <summary>
@@ -45,6 +48,7 @@ public interface IMigrator
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    [RequiresUnreferencedCode("Migration generation currently isn't compatible with trimming")]
     Task MigrateAsync(
         string? targetMigration = null,
         CancellationToken cancellationToken = default);
@@ -66,6 +70,7 @@ public interface IMigrator
     ///     The options to use when generating SQL for migrations.
     /// </param>
     /// <returns>The generated script.</returns>
+    [RequiresUnreferencedCode("Migration generation currently isn't compatible with trimming")]
     string GenerateScript(
         string? fromMigration = null,
         string? toMigration = null,

--- a/src/EFCore/ChangeTracking/GeometryValueComparer.cs
+++ b/src/EFCore/ChangeTracking/GeometryValueComparer.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 
 /// <summary>
@@ -9,7 +11,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-value-comparers">EF Core value comparers</see> for more information and examples.
 /// </remarks>
-public class GeometryValueComparer<TGeometry> : ValueComparer<TGeometry>
+public class GeometryValueComparer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TGeometry>
+    : ValueComparer<TGeometry>
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="GeometryValueComparer{TGeometry}" /> class.

--- a/src/EFCore/ChangeTracking/Internal/IdentityMapFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/IdentityMapFactoryFactory.cs
@@ -20,8 +20,8 @@ public class IdentityMapFactoryFactory
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual Func<bool, IIdentityMap> Create(IKey key)
-        => (Func<bool, IIdentityMap>)typeof(IdentityMapFactoryFactory).GetTypeInfo()
-            .GetDeclaredMethod(nameof(CreateFactory))!
+        => (Func<bool, IIdentityMap>)typeof(IdentityMapFactoryFactory)
+            .GetMethod(nameof(CreateFactory), BindingFlags.NonPublic | BindingFlags.Static)!
             .MakeGenericMethod(key.GetKeyType())
             .Invoke(null, new object[] { key })!;
 

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -829,8 +830,9 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
     public void MarkUnknown(IProperty property)
         => _stateData.FlagProperty(property.GetIndex(), PropertyFlag.Unknown, true);
 
-    internal static readonly MethodInfo ReadShadowValueMethod
-        = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadShadowValue))!;
+    internal static MethodInfo MakeReadShadowValueMethod(Type type)
+        => typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadShadowValue))!
+            .MakeGenericMethod(type);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -841,37 +843,62 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
     private T ReadShadowValue<T>(int shadowIndex)
         => _shadowValues.GetValue<T>(shadowIndex);
 
-    internal static readonly MethodInfo ReadOriginalValueMethod
+    private static readonly MethodInfo ReadOriginalValueMethod
         = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadOriginalValue))!;
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060",
+        Justification = "MakeGenericMethod wrapper, see https://github.com/dotnet/linker/issues/2482")]
+    internal static MethodInfo MakeReadOriginalValueMethod(Type type)
+        => ReadOriginalValueMethod.MakeGenericMethod(type);
 
     [UsedImplicitly]
     private T ReadOriginalValue<T>(IProperty property, int originalValueIndex)
         => _originalValues.GetValue<T>(this, property, originalValueIndex);
 
-    internal static readonly MethodInfo ReadRelationshipSnapshotValueMethod
+    private static readonly MethodInfo ReadRelationshipSnapshotValueMethod
         = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadRelationshipSnapshotValue))!;
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060",
+        Justification = "MakeGenericMethod wrapper, see https://github.com/dotnet/linker/issues/2482")]
+    internal static MethodInfo MakeReadRelationshipSnapshotValueMethod(Type type)
+        => ReadRelationshipSnapshotValueMethod.MakeGenericMethod(type);
 
     [UsedImplicitly]
     private T ReadRelationshipSnapshotValue<T>(IPropertyBase propertyBase, int relationshipSnapshotIndex)
         => _relationshipsSnapshot.GetValue<T>(this, propertyBase, relationshipSnapshotIndex);
 
-    internal static readonly MethodInfo ReadStoreGeneratedValueMethod
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060",
+        Justification = "MakeGenericMethod wrapper, see https://github.com/dotnet/linker/issues/2482")]
+    internal static MethodInfo MakeReadStoreGeneratedValueMethod(Type type)
+        => ReadStoreGeneratedValueMethod.MakeGenericMethod(type);
+
+    private static readonly MethodInfo ReadStoreGeneratedValueMethod
         = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadStoreGeneratedValue))!;
 
     [UsedImplicitly]
     private T ReadStoreGeneratedValue<T>(int storeGeneratedIndex)
         => _storeGeneratedValues.GetValue<T>(storeGeneratedIndex);
 
-    internal static readonly MethodInfo ReadTemporaryValueMethod
+    private static readonly MethodInfo ReadTemporaryValueMethod
         = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadTemporaryValue))!;
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060",
+        Justification = "MakeGenericMethod wrapper, see https://github.com/dotnet/linker/issues/2482")]
+    internal static MethodInfo MakeReadTemporaryValueMethod(Type type)
+        => ReadTemporaryValueMethod.MakeGenericMethod(type);
 
     [UsedImplicitly]
     private T ReadTemporaryValue<T>(int storeGeneratedIndex)
         => _temporaryValues.GetValue<T>(storeGeneratedIndex);
 
-    internal static readonly MethodInfo GetCurrentValueMethod
+    private static readonly MethodInfo GetCurrentValueMethod
         = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethods(nameof(GetCurrentValue)).Single(
             m => m.IsGenericMethod);
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060",
+        Justification = "MakeGenericMethod wrapper, see https://github.com/dotnet/linker/issues/2482")]
+    internal static MethodInfo MakeGetCurrentValueMethod(Type type)
+        => GetCurrentValueMethod.MakeGenericMethod(type);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/Snapshot.cs
+++ b/src/EFCore/ChangeTracking/Internal/Snapshot.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 /// <summary>
@@ -82,6 +84,7 @@ public sealed class Snapshot : ISnapshot
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public static Type CreateSnapshotType(Type[] types)
         => types.Length switch
         {

--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -219,7 +219,7 @@ public abstract class SnapshotFactoryFactory
         IPropertyBase property)
         => Expression.Call(
             parameter,
-            InternalEntityEntry.ReadShadowValueMethod.MakeGenericMethod((property as IProperty)?.ClrType ?? typeof(object)),
+            InternalEntityEntry.MakeReadShadowValueMethod((property as IProperty)?.ClrType ?? typeof(object)),
             Expression.Constant(property.GetShadowIndex()));
 
     /// <summary>
@@ -233,7 +233,7 @@ public abstract class SnapshotFactoryFactory
         IPropertyBase property)
         => Expression.Call(
             parameter,
-            InternalEntityEntry.GetCurrentValueMethod.MakeGenericMethod(property.ClrType),
+            InternalEntityEntry.MakeGetCurrentValueMethod(property.ClrType),
             Expression.Constant(property, typeof(IProperty)));
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/TemporaryValuesFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/TemporaryValuesFactoryFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 /// <summary>
@@ -18,7 +20,7 @@ public class TemporaryValuesFactoryFactory : SidecarValuesFactoryFactory
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override Expression CreateSnapshotExpression(
-        Type? entityType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type? entityType,
         ParameterExpression parameter,
         Type[] types,
         IList<IPropertyBase> propertyBases)

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -45,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 ///     </para>
 /// </remarks>
 /// <typeparam name="TEntity">The type of the entity in the local view.</typeparam>
-public class LocalView<TEntity> :
+public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity> :
     ICollection<TEntity>,
     INotifyCollectionChanged,
     INotifyPropertyChanged,
@@ -473,6 +474,8 @@ public class LocalView<TEntity> :
     ///     examples.
     /// </remarks>
     /// <returns>The binding list.</returns>
+    [RequiresUnreferencedCode(
+        "BindingList raises ListChanged events with PropertyDescriptors. PropertyDescriptors require unreferenced code.")]
     public virtual BindingList<TEntity> ToBindingList()
         => _bindingList ??= new ObservableBackedBindingList<TEntity>(ToObservableCollection());
 

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 using ExpressionExtensions = Microsoft.EntityFrameworkCore.Infrastructure.ExpressionExtensions;
 
@@ -25,7 +26,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking;
 ///     </para>
 /// </remarks>
 /// <typeparam name="T">The type.</typeparam>
-public class ValueComparer<T> : ValueComparer, IEqualityComparer<T>
+// PublicMethods is required to preserve e.g. GetHashCode
+public class ValueComparer
+    <[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods
+        | DynamicallyAccessedMemberTypes.NonPublicMethods
+        | DynamicallyAccessedMemberTypes.PublicProperties)] T>
+    : ValueComparer, IEqualityComparer<T>
 {
     private Func<T?, T?, bool>? _equals;
     private Func<T, int>? _hashCode;
@@ -178,6 +184,7 @@ public class ValueComparer<T> : ValueComparer, IEqualityComparer<T>
             return v => v;
         }
 
+        // Comparer implementation for arrays
         var sourceParameter = Expression.Parameter(typeof(T), "source");
         var lengthVariable = Expression.Variable(typeof(int), "length");
         var destinationVariable = Expression.Variable(typeof(T), "destination");
@@ -195,7 +202,7 @@ public class ValueComparer<T> : ValueComparer, IEqualityComparer<T>
                     Expression.Property(sourceParameter, typeof(T).GetTypeInfo().GetProperty(nameof(Array.Length))!)),
                 Expression.Assign(
                     destinationVariable,
-                    Expression.NewArrayBounds(typeof(T).GetSequenceType(), lengthVariable)),
+                    Expression.NewArrayBounds(typeof(T).GetElementType()!, lengthVariable)),
                 Expression.Call(
                     ArrayCopyMethod,
                     sourceParameter,

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -78,6 +79,10 @@ public class DbContext :
     ///     See <see href="https://aka.ms/efcore-docs-dbcontext">DbContext lifetime, configuration, and initialization</see>
     ///     for more information and examples.
     /// </remarks>
+    [RequiresUnreferencedCode(
+        "EF Core isn't fully compatible with trimming, and running the application may generate unexpected runtime failures. " +
+        "Some specific coding pattern are usually required to make trimming work properly, see https://aka.ms/efcore-docs-trimming for " +
+        "more details.")]
     protected DbContext()
         : this(new DbContextOptions<DbContext>())
     {
@@ -93,6 +98,10 @@ public class DbContext :
     ///     <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see> for more information and examples.
     /// </remarks>
     /// <param name="options">The options for this context.</param>
+    [RequiresUnreferencedCode(
+        "EF Core isn't fully compatible with trimming, and running the application may generate unexpected runtime failures. " +
+        "Some specific coding pattern are usually required to make trimming work properly, see https://aka.ms/efcore-docs-trimming for " +
+        "more details.")]
     public DbContext(DbContextOptions options)
     {
         Check.NotNull(options, nameof(options));
@@ -261,7 +270,9 @@ public class DbContext :
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    object IDbSetCache.GetOrAddSet(IDbSetSource source, Type type)
+    object IDbSetCache.GetOrAddSet(
+        IDbSetSource source,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
     {
         CheckDisposed();
 
@@ -284,7 +295,10 @@ public class DbContext :
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    object IDbSetCache.GetOrAddSet(IDbSetSource source, string entityTypeName, Type type)
+    object IDbSetCache.GetOrAddSet(
+        IDbSetSource source,
+        string entityTypeName,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
     {
         CheckDisposed();
 
@@ -328,7 +342,7 @@ public class DbContext :
     /// </remarks>
     /// <typeparam name="TEntity">The type of entity for which a set should be returned.</typeparam>
     /// <returns>A set for the given entity type.</returns>
-    public virtual DbSet<TEntity> Set<TEntity>()
+    public virtual DbSet<TEntity> Set<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>()
         where TEntity : class
         => (DbSet<TEntity>)((IDbSetCache)this).GetOrAddSet(DbContextDependencies.SetSource, typeof(TEntity));
 
@@ -349,11 +363,11 @@ public class DbContext :
     /// <param name="name">The name for the shared-type entity type to use.</param>
     /// <typeparam name="TEntity">The type of entity for which a set should be returned.</typeparam>
     /// <returns>A set for the given entity type.</returns>
-    public virtual DbSet<TEntity> Set<TEntity>(string name)
+    public virtual DbSet<TEntity> Set<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(string name)
         where TEntity : class
         => (DbSet<TEntity>)((IDbSetCache)this).GetOrAddSet(DbContextDependencies.SetSource, name, typeof(TEntity));
 
-    private IEntityFinder Finder(Type type)
+    private IEntityFinder Finder([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
     {
         var entityType = Model.FindEntityType(type);
         if (entityType == null)
@@ -2020,7 +2034,9 @@ public class DbContext :
     /// <param name="entityType">The type of entity to find.</param>
     /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
     /// <returns>The entity found, or <see langword="null" />.</returns>
-    public virtual object? Find(Type entityType, params object?[]? keyValues)
+    public virtual object? Find(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type entityType,
+        params object?[]? keyValues)
     {
         CheckDisposed();
 
@@ -2049,7 +2065,9 @@ public class DbContext :
     /// <param name="entityType">The type of entity to find.</param>
     /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
     /// <returns>The entity found, or <see langword="null" />.</returns>
-    public virtual ValueTask<object?> FindAsync(Type entityType, params object?[]? keyValues)
+    public virtual ValueTask<object?> FindAsync(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type entityType,
+        params object?[]? keyValues)
     {
         CheckDisposed();
 
@@ -2081,7 +2099,7 @@ public class DbContext :
     /// <returns>The entity found, or <see langword="null" />.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     public virtual ValueTask<object?> FindAsync(
-        Type entityType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type entityType,
         object?[]? keyValues,
         CancellationToken cancellationToken)
     {
@@ -2103,7 +2121,8 @@ public class DbContext :
     /// <typeparam name="TEntity">The type of entity to find.</typeparam>
     /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
     /// <returns>The entity found, or <see langword="null" />.</returns>
-    public virtual TEntity? Find<TEntity>(params object?[]? keyValues)
+    public virtual TEntity? Find<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(
+        params object?[]? keyValues)
         where TEntity : class
     {
         CheckDisposed();
@@ -2133,7 +2152,8 @@ public class DbContext :
     /// <typeparam name="TEntity">The type of entity to find.</typeparam>
     /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
     /// <returns>The entity found, or <see langword="null" />.</returns>
-    public virtual ValueTask<TEntity?> FindAsync<TEntity>(params object?[]? keyValues)
+    public virtual ValueTask<TEntity?> FindAsync<
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(params object?[]? keyValues)
         where TEntity : class
     {
         CheckDisposed();
@@ -2165,7 +2185,8 @@ public class DbContext :
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>The entity found, or <see langword="null" />.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public virtual ValueTask<TEntity?> FindAsync<TEntity>(object?[]? keyValues, CancellationToken cancellationToken)
+    public virtual ValueTask<TEntity?> FindAsync<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(
+        object?[]? keyValues, CancellationToken cancellationToken)
         where TEntity : class
     {
         CheckDisposed();
@@ -2232,4 +2253,14 @@ public class DbContext :
         => base.GetHashCode();
 
     #endregion
+
+    internal const DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes =
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors
+        // We preserve public properties on contexts to make sure DbSet properties - and in particular their setters - aren't trimmed.
+        // Since EF implicitly injects DbSet properties via reflection and the user doesn't contain any explicit use, setters get trimmed
+        // and our injection logic no longer recognizes them for injection.
+        // Note that this works only using the DI APIs (e.g. AddDbContext) or DbContextFactory, but not when the context is instantiated
+        // directly (there's no API accepting Type where we'd put [DynamicallyAccessedMemberTypes]).
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties;
 }

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -3,6 +3,8 @@
 
 using System.Collections;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
 
@@ -40,7 +42,8 @@ namespace Microsoft.EntityFrameworkCore;
 ///     </para>
 /// </remarks>
 /// <typeparam name="TEntity">The type of entity being operated on by this set.</typeparam>
-public abstract class DbSet<TEntity> : IQueryable<TEntity>, IInfrastructure<IServiceProvider>, IListSource
+public abstract class DbSet<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>
+    : IQueryable<TEntity>, IInfrastructure<IServiceProvider>, IListSource
     where TEntity : class
 {
     /// <summary>

--- a/src/EFCore/EF.CompileAsyncQuery.cs
+++ b/src/EFCore/EF.CompileAsyncQuery.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -22,7 +23,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TResult">The query result type.</typeparam>
         /// <param name="queryExpression">The LINQ query expression.</param>
         /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
-        public static Func<TContext, IAsyncEnumerable<TResult>> CompileAsyncQuery<TContext, TResult>(
+        public static Func<TContext, IAsyncEnumerable<TResult>> CompileAsyncQuery<
+            TContext,
+            [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TResult>(
             Expression<Func<TContext, DbSet<TResult>>> queryExpression)
             where TContext : DbContext
             where TResult : class

--- a/src/EFCore/EF.cs
+++ b/src/EFCore/EF.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
@@ -16,6 +18,11 @@ public static partial class EF
 {
     internal static readonly MethodInfo PropertyMethod
         = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(Property))!;
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060",
+        Justification = "EF.Property has no DynamicallyAccessedMembers annotations and is safe to construct.")]
+    internal static MethodInfo MakePropertyMethod(Type type)
+        => PropertyMethod.MakeGenericMethod(type);
 
     /// <summary>
     ///     This flag is set to <see langword="true" /> when code is being run from a design-time tool, such

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
@@ -11,6 +12,13 @@ namespace Microsoft.EntityFrameworkCore;
 /// <summary>
 ///     Entity Framework LINQ related extension methods.
 /// </summary>
+[UnconditionalSuppressMessage(
+    "ReflectionAnalysis",
+    "IL2060",
+    Justification =
+        "MakeGenericMethod is used in this class to create MethodCallExpression nodes, but only if the method in question is called " +
+        "from user code - so it's never trimmed. After https://github.com/dotnet/linker/issues/2482 is fixed, the suppression will no " +
+        "longer be necessary.")]
 public static class EntityFrameworkQueryableExtensions
 {
     /// <summary>

--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -54,11 +55,12 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// <param name="contextLifetime">The lifetime with which to register the DbContext service in the container.</param>
     /// <param name="optionsLifetime">The lifetime with which to register the DbContextOptions service in the container.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContext<TContext>(
-        this IServiceCollection serviceCollection,
-        Action<DbContextOptionsBuilder>? optionsAction = null,
-        ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
-        ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
+    public static IServiceCollection AddDbContext
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<DbContextOptionsBuilder>? optionsAction = null,
+            ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
+            ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
         where TContext : DbContext
         => AddDbContext<TContext, TContext>(serviceCollection, optionsAction, contextLifetime, optionsLifetime);
 
@@ -105,11 +107,12 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// <param name="contextLifetime">The lifetime with which to register the DbContext service in the container.</param>
     /// <param name="optionsLifetime">The lifetime with which to register the DbContextOptions service in the container.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContext<TContextService, TContextImplementation>(
-        this IServiceCollection serviceCollection,
-        Action<DbContextOptionsBuilder>? optionsAction = null,
-        ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
-        ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
+    public static IServiceCollection AddDbContext
+        <TContextService, [DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContextImplementation>(
+            this IServiceCollection serviceCollection,
+            Action<DbContextOptionsBuilder>? optionsAction = null,
+            ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
+            ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
         where TContextImplementation : DbContext, TContextService
         => AddDbContext<TContextService, TContextImplementation>(
             serviceCollection,
@@ -156,10 +159,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// </param>
     /// <param name="poolSize">Sets the maximum number of instances retained by the pool. Defaults to 1024.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContextPool<TContext>(
-        this IServiceCollection serviceCollection,
-        Action<DbContextOptionsBuilder> optionsAction,
-        int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
+    public static IServiceCollection AddDbContextPool
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<DbContextOptionsBuilder> optionsAction,
+            int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
         where TContext : DbContext
         => AddDbContextPool<TContext, TContext>(serviceCollection, optionsAction, poolSize);
 
@@ -203,10 +207,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// </param>
     /// <param name="poolSize">Sets the maximum number of instances retained by the pool. Defaults to 1024.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContextPool<TContextService, TContextImplementation>(
-        this IServiceCollection serviceCollection,
-        Action<DbContextOptionsBuilder> optionsAction,
-        int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
+    public static IServiceCollection AddDbContextPool
+        <TContextService, [DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContextImplementation>(
+            this IServiceCollection serviceCollection,
+            Action<DbContextOptionsBuilder> optionsAction,
+            int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
         where TContextImplementation : DbContext, TContextService
         where TContextService : class
     {
@@ -262,10 +267,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// </param>
     /// <param name="poolSize">Sets the maximum number of instances retained by the pool. Defaults to 1024.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContextPool<TContext>(
-        this IServiceCollection serviceCollection,
-        Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
-        int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
+    public static IServiceCollection AddDbContextPool
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
         where TContext : DbContext
         => AddDbContextPool<TContext, TContext>(serviceCollection, optionsAction, poolSize);
 
@@ -318,10 +324,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// </param>
     /// <param name="poolSize">Sets the maximum number of instances retained by the pool. Defaults to 1024.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContextPool<TContextService, TContextImplementation>(
-        this IServiceCollection serviceCollection,
-        Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
-        int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
+    public static IServiceCollection AddDbContextPool
+        <TContextService, [DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContextImplementation>(
+            this IServiceCollection serviceCollection,
+            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
         where TContextImplementation : DbContext, TContextService
         where TContextService : class
     {
@@ -343,7 +350,7 @@ public static class EntityFrameworkServiceCollectionExtensions
         return serviceCollection;
     }
 
-    private static void AddPoolingOptions<TContext>(
+    private static void AddPoolingOptions<[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
         IServiceCollection serviceCollection,
         Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
         int poolSize)
@@ -396,10 +403,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// <param name="contextLifetime">The lifetime with which to register the DbContext service in the container.</param>
     /// <param name="optionsLifetime">The lifetime with which to register the DbContextOptions service in the container.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContext<TContext>(
-        this IServiceCollection serviceCollection,
-        ServiceLifetime contextLifetime,
-        ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
+    public static IServiceCollection AddDbContext
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            ServiceLifetime contextLifetime,
+            ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
         where TContext : DbContext
         => AddDbContext<TContext, TContext>(serviceCollection, contextLifetime, optionsLifetime);
 
@@ -430,10 +438,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// <param name="contextLifetime">The lifetime with which to register the DbContext service in the container.</param>
     /// <param name="optionsLifetime">The lifetime with which to register the DbContextOptions service in the container.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContext<TContextService, TContextImplementation>(
-        this IServiceCollection serviceCollection,
-        ServiceLifetime contextLifetime,
-        ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
+    public static IServiceCollection AddDbContext
+        <TContextService, [DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContextImplementation>(
+            this IServiceCollection serviceCollection,
+            ServiceLifetime contextLifetime,
+            ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
         where TContextImplementation : DbContext, TContextService
         where TContextService : class
         => AddDbContext<TContextService, TContextImplementation>(
@@ -500,11 +509,12 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// <param name="contextLifetime">The lifetime with which to register the DbContext service in the container.</param>
     /// <param name="optionsLifetime">The lifetime with which to register the DbContextOptions service in the container.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContext<TContext>(
-        this IServiceCollection serviceCollection,
-        Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
-        ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
-        ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
+    public static IServiceCollection AddDbContext
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
+            ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
+            ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
         where TContext : DbContext
         => AddDbContext<TContext, TContext>(serviceCollection, optionsAction, contextLifetime, optionsLifetime);
 
@@ -561,11 +571,12 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// <param name="contextLifetime">The lifetime with which to register the DbContext service in the container.</param>
     /// <param name="optionsLifetime">The lifetime with which to register the DbContextOptions service in the container.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContext<TContextService, TContextImplementation>(
-        this IServiceCollection serviceCollection,
-        Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
-        ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
-        ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
+    public static IServiceCollection AddDbContext
+        <TContextService, [DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContextImplementation>(
+            this IServiceCollection serviceCollection,
+            Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
+            ServiceLifetime contextLifetime = ServiceLifetime.Scoped,
+            ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
         where TContextImplementation : DbContext, TContextService
     {
         if (contextLifetime == ServiceLifetime.Singleton)
@@ -660,10 +671,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     ///     The default is <see cref="ServiceLifetime.Singleton" />
     /// </param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContextFactory<TContext>(
-        this IServiceCollection serviceCollection,
-        Action<DbContextOptionsBuilder>? optionsAction = null,
-        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+    public static IServiceCollection AddDbContextFactory
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<DbContextOptionsBuilder>? optionsAction = null,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
         where TContext : DbContext
         => AddDbContextFactory<TContext, DbContextFactory<TContext>>(serviceCollection, optionsAction, lifetime);
 
@@ -728,7 +740,9 @@ public static class EntityFrameworkServiceCollectionExtensions
     ///     The default is <see cref="ServiceLifetime.Singleton" />
     /// </param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContextFactory<TContext, TFactory>(
+    public static IServiceCollection AddDbContextFactory
+    <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TFactory>(
         this IServiceCollection serviceCollection,
         Action<DbContextOptionsBuilder>? optionsAction = null,
         ServiceLifetime lifetime = ServiceLifetime.Singleton)
@@ -805,10 +819,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     ///     The default is <see cref="ServiceLifetime.Singleton" />
     /// </param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContextFactory<TContext>(
-        this IServiceCollection serviceCollection,
-        Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
-        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+    public static IServiceCollection AddDbContextFactory
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
         where TContext : DbContext
         => AddDbContextFactory<TContext, DbContextFactory<TContext>>(serviceCollection, optionsAction, lifetime);
 
@@ -881,7 +896,9 @@ public static class EntityFrameworkServiceCollectionExtensions
     ///     The default is <see cref="ServiceLifetime.Singleton" />
     /// </param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddDbContextFactory<TContext, TFactory>(
+    public static IServiceCollection AddDbContextFactory
+    <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TFactory>(
         this IServiceCollection serviceCollection,
         Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
         ServiceLifetime lifetime = ServiceLifetime.Singleton)
@@ -948,10 +965,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// </param>
     /// <param name="poolSize">Sets the maximum number of instances retained by the pool. Defaults to 1024.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddPooledDbContextFactory<TContext>(
-        this IServiceCollection serviceCollection,
-        Action<DbContextOptionsBuilder> optionsAction,
-        int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
+    public static IServiceCollection AddPooledDbContextFactory
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<DbContextOptionsBuilder> optionsAction,
+            int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
         where TContext : DbContext
     {
         Check.NotNull(optionsAction, nameof(optionsAction));
@@ -998,10 +1016,11 @@ public static class EntityFrameworkServiceCollectionExtensions
     /// </param>
     /// <param name="poolSize">Sets the maximum number of instances retained by the pool. Defaults to 1024.</param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
-    public static IServiceCollection AddPooledDbContextFactory<TContext>(
-        this IServiceCollection serviceCollection,
-        Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
-        int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
+    public static IServiceCollection AddPooledDbContextFactory
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            int poolSize = DbContextPool<DbContext>.DefaultPoolSize)
         where TContext : DbContext
     {
         Check.NotNull(optionsAction, nameof(optionsAction));

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -225,7 +225,7 @@ public static class ExpressionExtensions
                 && !(nonNullableType == typeof(bool) || nonNullableType.IsNumeric() || nonNullableType.IsEnum)
                     ? Infrastructure.ExpressionExtensions.CreateEqualsExpression(
                         Expression.Call(
-                            EF.PropertyMethod.MakeGenericMethod(typeof(object)),
+                            EF.MakePropertyMethod(typeof(object)),
                             entityParameterExpression,
                             Expression.Constant(property.Name, typeof(string))),
                         Expression.Call(
@@ -234,7 +234,7 @@ public static class ExpressionExtensions
                             Expression.Constant(i)))
                     : Expression.Equal(
                         Expression.Call(
-                            EF.PropertyMethod.MakeGenericMethod(property.ClrType),
+                            EF.MakePropertyMethod(property.ClrType),
                             entityParameterExpression,
                             Expression.Constant(property.Name, typeof(string))),
                         Expression.Convert(

--- a/src/EFCore/Extensions/Internal/TypeExtensions.cs
+++ b/src/EFCore/Extensions/Internal/TypeExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 // ReSharper disable once CheckNamespace
@@ -20,7 +21,9 @@ public static class TypeExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static bool IsDefaultValue(this Type type, object? value)
+    public static bool IsDefaultValue(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type type,
+        object? value)
         => (value?.Equals(type.GetDefaultValue()) != false);
 
     /// <summary>
@@ -52,7 +55,9 @@ public static class TypeExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static PropertyInfo? FindIndexerProperty(this Type type)
+    public static PropertyInfo? FindIndexerProperty(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        this Type type)
     {
         var defaultPropertyAttribute = type.GetCustomAttributes<DefaultMemberAttribute>().FirstOrDefault();
 

--- a/src/EFCore/IDbContextFactory.cs
+++ b/src/EFCore/IDbContextFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore;
 ///     See <see href="https://aka.ms/efcore-docs-dbcontext-factory">Using DbContextFactory</see> for more information and examples.
 /// </remarks>
 /// <typeparam name="TContext">The <see cref="DbContext" /> type to create.</typeparam>
-public interface IDbContextFactory<TContext>
+public interface IDbContextFactory<[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>
     where TContext : DbContext
 {
     /// <summary>

--- a/src/EFCore/IEntityTypeConfiguration.cs
+++ b/src/EFCore/IEntityTypeConfiguration.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
@@ -17,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore;
 ///     examples.
 /// </remarks>
 /// <typeparam name="TEntity">The entity type to be configured.</typeparam>
-public interface IEntityTypeConfiguration<TEntity>
+public interface IEntityTypeConfiguration<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>
     where TEntity : class
 {
     /// <summary>

--- a/src/EFCore/Infrastructure/DbSetProperty.cs
+++ b/src/EFCore/Infrastructure/DbSetProperty.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
 
 /// <summary>
@@ -16,7 +19,7 @@ public readonly struct DbSetProperty
     /// <param name="setter">The setter for DbSet property.</param>
     public DbSetProperty(
         string name,
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         IClrPropertySetter? setter)
     {
         Name = name;
@@ -32,6 +35,7 @@ public readonly struct DbSetProperty
     /// <summary>
     ///     Gets the clr type of entity type this DbSet property represent.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     public Type Type { get; }
 
     /// <summary>

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
@@ -359,7 +360,9 @@ public class EntityFrameworkServicesBuilder
     /// <typeparam name="TService">The contract for the service.</typeparam>
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <returns>This builder, such that further calls can be chained.</returns>
-    public virtual EntityFrameworkServicesBuilder TryAdd<TService, TImplementation>()
+    public virtual EntityFrameworkServicesBuilder TryAdd<
+        TService,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
         where TService : class
         where TImplementation : class, TService
         => TryAdd(typeof(TService), typeof(TImplementation));
@@ -375,7 +378,9 @@ public class EntityFrameworkServicesBuilder
     /// <param name="serviceType">The contract for the service.</param>
     /// <param name="implementationType">The concrete type that implements the service.</param>
     /// <returns>This builder, such that further calls can be chained.</returns>
-    public virtual EntityFrameworkServicesBuilder TryAdd(Type serviceType, Type implementationType)
+    public virtual EntityFrameworkServicesBuilder TryAdd(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
     {
         var characteristics = GetServiceCharacteristics(serviceType);
 
@@ -402,7 +407,8 @@ public class EntityFrameworkServicesBuilder
     /// <typeparam name="TService">The contract for the service.</typeparam>
     /// <param name="factory">The factory that will create the service instance.</param>
     /// <returns>This builder, such that further calls can be chained.</returns>
-    public virtual EntityFrameworkServicesBuilder TryAdd<TService>(Func<IServiceProvider, TService> factory)
+    public virtual EntityFrameworkServicesBuilder TryAdd
+        <[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(Func<IServiceProvider, TService> factory)
         where TService : class
         => TryAdd(typeof(TService), typeof(TService), factory);
 
@@ -418,7 +424,8 @@ public class EntityFrameworkServicesBuilder
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <param name="factory">The factory that will create the service instance.</param>
     /// <returns>This builder, such that further calls can be chained.</returns>
-    public virtual EntityFrameworkServicesBuilder TryAdd<TService, TImplementation>(
+    public virtual EntityFrameworkServicesBuilder TryAdd
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(
         Func<IServiceProvider, TImplementation> factory)
         where TService : class
         where TImplementation : class, TService
@@ -438,7 +445,7 @@ public class EntityFrameworkServicesBuilder
     /// <returns>This builder, such that further calls can be chained.</returns>
     public virtual EntityFrameworkServicesBuilder TryAdd(
         Type serviceType,
-        Type implementationType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
         Func<IServiceProvider, object> factory)
     {
         var characteristics = GetServiceCharacteristics(serviceType);

--- a/src/EFCore/Infrastructure/IInternalServiceCollectionMap.cs
+++ b/src/EFCore/Infrastructure/IInternalServiceCollectionMap.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
 
 /// <summary>
@@ -23,12 +25,14 @@ public interface IInternalServiceCollectionMap
     /// </summary>
     /// <typeparam name="TDependencies">The dependency type.</typeparam>
     /// <returns>The same collection map so that further methods can be chained.</returns>
-    IInternalServiceCollectionMap AddDependencySingleton<TDependencies>();
+    IInternalServiceCollectionMap AddDependencySingleton<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TDependencies>();
 
     /// <summary>
     ///     Adds a <see cref="ServiceLifetime.Scoped" />  dependency object.
     /// </summary>
     /// <typeparam name="TDependencies">The dependency type.</typeparam>
     /// <returns>The same collection map so that further methods can be chained.</returns>
-    IInternalServiceCollectionMap AddDependencyScoped<TDependencies>();
+    IInternalServiceCollectionMap
+        AddDependencyScoped<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TDependencies>();
 }

--- a/src/EFCore/Infrastructure/Internal/InternalServiceCollectionMap.cs
+++ b/src/EFCore/Infrastructure/Internal/InternalServiceCollectionMap.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal;
@@ -76,7 +77,8 @@ public class InternalServiceCollectionMap : IInternalServiceCollectionMap
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IInternalServiceCollectionMap AddDependencySingleton<TDependencies>()
+    public virtual IInternalServiceCollectionMap AddDependencySingleton<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TDependencies>()
         => AddDependency(typeof(TDependencies), ServiceLifetime.Singleton);
 
     /// <summary>
@@ -85,7 +87,8 @@ public class InternalServiceCollectionMap : IInternalServiceCollectionMap
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IInternalServiceCollectionMap AddDependencyScoped<TDependencies>()
+    public virtual IInternalServiceCollectionMap
+        AddDependencyScoped<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TDependencies>()
         => AddDependency(typeof(TDependencies), ServiceLifetime.Scoped);
 
     /// <summary>
@@ -94,7 +97,9 @@ public class InternalServiceCollectionMap : IInternalServiceCollectionMap
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual IInternalServiceCollectionMap AddDependency(Type serviceType, ServiceLifetime lifetime)
+    public virtual IInternalServiceCollectionMap AddDependency(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type serviceType,
+        ServiceLifetime lifetime)
     {
         var indexes = GetOrCreateDescriptorIndexes(serviceType);
         if (!indexes.Any())

--- a/src/EFCore/Infrastructure/PooledDbContextFactory.cs
+++ b/src/EFCore/Infrastructure/PooledDbContextFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
@@ -20,7 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure;
 ///         <see href="https://aka.ms/efcore-docs-dbcontext-pooling">Using DbContext pooling</see> for more information and examples.
 ///     </para>
 /// </remarks>
-public class PooledDbContextFactory<TContext> : IDbContextFactory<TContext>
+public class PooledDbContextFactory<[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>
+    : IDbContextFactory<TContext>
     where TContext : DbContext
 {
     private readonly IDbContextPool<TContext> _pool;

--- a/src/EFCore/Infrastructure/ServiceCollectionMap.cs
+++ b/src/EFCore/Infrastructure/ServiceCollectionMap.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure;
@@ -49,7 +50,8 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TService">The contract for the service.</typeparam>
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddTransient<TService, TImplementation>()
+    public virtual ServiceCollectionMap TryAddTransient
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
         where TService : class
         where TImplementation : class, TService
         => TryAdd(typeof(TService), typeof(TImplementation), ServiceLifetime.Transient);
@@ -61,7 +63,8 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TService">The contract for the service.</typeparam>
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddScoped<TService, TImplementation>()
+    public virtual ServiceCollectionMap TryAddScoped
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
         where TService : class
         where TImplementation : class, TService
         => TryAdd(typeof(TService), typeof(TImplementation), ServiceLifetime.Scoped);
@@ -73,7 +76,8 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TService">The contract for the service.</typeparam>
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddSingleton<TService, TImplementation>()
+    public virtual ServiceCollectionMap TryAddSingleton
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
         where TService : class
         where TImplementation : class, TService
         => TryAdd(typeof(TService), typeof(TImplementation), ServiceLifetime.Singleton);
@@ -85,7 +89,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <param name="serviceType">The contract for the service.</param>
     /// <param name="implementationType">The concrete type that implements the service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddTransient(Type serviceType, Type implementationType)
+    public virtual ServiceCollectionMap TryAddTransient(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         => TryAdd(serviceType, implementationType, ServiceLifetime.Transient);
 
     /// <summary>
@@ -95,7 +101,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <param name="serviceType">The contract for the service.</param>
     /// <param name="implementationType">The concrete type that implements the service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddScoped(Type serviceType, Type implementationType)
+    public virtual ServiceCollectionMap TryAddScoped(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         => TryAdd(serviceType, implementationType, ServiceLifetime.Scoped);
 
     /// <summary>
@@ -105,7 +113,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <param name="serviceType">The contract for the service.</param>
     /// <param name="implementationType">The concrete type that implements the service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddSingleton(Type serviceType, Type implementationType)
+    public virtual ServiceCollectionMap TryAddSingleton(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         => TryAdd(serviceType, implementationType, ServiceLifetime.Singleton);
 
     /// <summary>
@@ -118,7 +128,7 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <returns>The map, such that further calls can be chained.</returns>
     public virtual ServiceCollectionMap TryAdd(
         Type serviceType,
-        Type implementationType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
         ServiceLifetime lifetime)
     {
         Validate?.Invoke(serviceType);
@@ -300,7 +310,8 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TService">The contract for the service.</typeparam>
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddTransientEnumerable<TService, TImplementation>()
+    public virtual ServiceCollectionMap TryAddTransientEnumerable
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
         where TService : class
         where TImplementation : class, TService
         => TryAddEnumerable(typeof(TService), typeof(TImplementation), ServiceLifetime.Transient);
@@ -313,7 +324,8 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TService">The contract for the service.</typeparam>
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddScopedEnumerable<TService, TImplementation>()
+    public virtual ServiceCollectionMap TryAddScopedEnumerable
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
         where TService : class
         where TImplementation : class, TService
         => TryAddEnumerable(typeof(TService), typeof(TImplementation), ServiceLifetime.Scoped);
@@ -326,7 +338,8 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TService">The contract for the service.</typeparam>
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddSingletonEnumerable<TService, TImplementation>()
+    public virtual ServiceCollectionMap TryAddSingletonEnumerable
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
         where TService : class
         where TImplementation : class, TService
         => TryAddEnumerable(typeof(TService), typeof(TImplementation), ServiceLifetime.Singleton);
@@ -339,7 +352,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <param name="serviceType">The contract for the service.</param>
     /// <param name="implementationType">The concrete type that implements the service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddTransientEnumerable(Type serviceType, Type implementationType)
+    public virtual ServiceCollectionMap TryAddTransientEnumerable(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         => TryAddEnumerable(serviceType, implementationType, ServiceLifetime.Transient);
 
     /// <summary>
@@ -350,7 +365,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <param name="serviceType">The contract for the service.</param>
     /// <param name="implementationType">The concrete type that implements the service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddScopedEnumerable(Type serviceType, Type implementationType)
+    public virtual ServiceCollectionMap TryAddScopedEnumerable(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         => TryAddEnumerable(serviceType, implementationType, ServiceLifetime.Scoped);
 
     /// <summary>
@@ -361,7 +378,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <param name="serviceType">The contract for the service.</param>
     /// <param name="implementationType">The concrete type that implements the service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddSingletonEnumerable(Type serviceType, Type implementationType)
+    public virtual ServiceCollectionMap TryAddSingletonEnumerable(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         => TryAddEnumerable(serviceType, implementationType, ServiceLifetime.Singleton);
 
     /// <summary>
@@ -375,7 +394,7 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <returns>The map, such that further calls can be chained.</returns>
     public virtual ServiceCollectionMap TryAddEnumerable(
         Type serviceType,
-        Type implementationType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
         ServiceLifetime lifetime)
     {
         Validate?.Invoke(serviceType);
@@ -398,7 +417,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <param name="factory">The factory that implements this service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddTransientEnumerable<TService, TImplementation>(
+    public virtual ServiceCollectionMap TryAddTransientEnumerable<
+        TService,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(
         Func<IServiceProvider, TImplementation> factory)
         where TService : class
         where TImplementation : class, TService
@@ -413,8 +434,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <param name="factory">The factory that implements this service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddScopedEnumerable<TService, TImplementation>(
-        Func<IServiceProvider, TImplementation> factory)
+    public virtual ServiceCollectionMap TryAddScopedEnumerable
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(
+            Func<IServiceProvider, TImplementation> factory)
         where TService : class
         where TImplementation : class, TService
         => TryAddEnumerable(typeof(TService), typeof(TImplementation), factory, ServiceLifetime.Scoped);
@@ -428,8 +450,9 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <typeparam name="TImplementation">The concrete type that implements the service.</typeparam>
     /// <param name="factory">The factory that implements this service.</param>
     /// <returns>The map, such that further calls can be chained.</returns>
-    public virtual ServiceCollectionMap TryAddSingletonEnumerable<TService, TImplementation>(
-        Func<IServiceProvider, TImplementation> factory)
+    public virtual ServiceCollectionMap TryAddSingletonEnumerable
+        <TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(
+            Func<IServiceProvider, TImplementation> factory)
         where TService : class
         where TImplementation : class, TService
         => TryAddEnumerable(typeof(TService), typeof(TImplementation), factory, ServiceLifetime.Singleton);
@@ -446,7 +469,7 @@ public class ServiceCollectionMap : IInfrastructure<IInternalServiceCollectionMa
     /// <returns>The map, such that further calls can be chained.</returns>
     public virtual ServiceCollectionMap TryAddEnumerable(
         Type serviceType,
-        Type implementationType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
         Func<IServiceProvider, object> factory,
         ServiceLifetime lifetime)
     {

--- a/src/EFCore/Internal/DbContextFactory.cs
+++ b/src/EFCore/Internal/DbContextFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Internal;
 
 /// <summary>
@@ -9,7 +11,8 @@ namespace Microsoft.EntityFrameworkCore.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class DbContextFactory<TContext> : IDbContextFactory<TContext>
+public class DbContextFactory<[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>
+    : IDbContextFactory<TContext>
     where TContext : DbContext
 {
     private readonly IServiceProvider _serviceProvider;

--- a/src/EFCore/Internal/IDbSetCache.cs
+++ b/src/EFCore/Internal/IDbSetCache.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Internal;
 
 /// <summary>
@@ -17,7 +20,7 @@ public interface IDbSetCache
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    object GetOrAddSet(IDbSetSource source, Type type);
+    object GetOrAddSet(IDbSetSource source, [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -25,7 +28,10 @@ public interface IDbSetCache
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    object GetOrAddSet(IDbSetSource source, string entityTypeName, Type type);
+    object GetOrAddSet(
+        IDbSetSource source,
+        string entityTypeName,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/IDbSetSource.cs
+++ b/src/EFCore/Internal/IDbSetSource.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Internal;
 
 /// <summary>
@@ -22,7 +25,9 @@ public interface IDbSetSource
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    object Create(DbContext context, Type type);
+    object Create(
+        DbContext context,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -30,5 +35,8 @@ public interface IDbSetSource
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    object Create(DbContext context, string name, Type type);
+    object Create(
+        DbContext context,
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 }

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -14,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class InternalDbSet<TEntity> :
+public class InternalDbSet<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity> :
     DbSet<TEntity>,
     IQueryable<TEntity>,
     IAsyncEnumerable<TEntity>,

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>
@@ -18,7 +20,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 /// </remarks>
 /// <typeparam name="TLeftEntity">One of the entity types in this relationship.</typeparam>
 /// <typeparam name="TRightEntity">One of the entity types in this relationship.</typeparam>
-public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : CollectionCollectionBuilder
+public class CollectionCollectionBuilder<
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TLeftEntity,
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRightEntity> : CollectionCollectionBuilder
     where TLeftEntity : class
     where TRightEntity : class
 {
@@ -43,7 +47,8 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// </summary>
     /// <typeparam name="TJoinEntity">The CLR type of the join entity.</typeparam>
     /// <returns>The builder for the join entity type.</returns>
-    public virtual EntityTypeBuilder<TJoinEntity> UsingEntity<TJoinEntity>()
+    public virtual EntityTypeBuilder<TJoinEntity> UsingEntity
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>()
         where TJoinEntity : class
         => Using<TJoinEntity>(joinEntityName: null, configureRight: null, configureLeft: null);
 
@@ -53,8 +58,8 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <param name="joinEntityName">The name of the join entity.</param>
     /// <typeparam name="TJoinEntity">The CLR type of the join entity.</typeparam>
     /// <returns>The builder for the join entity type.</returns>
-    public virtual EntityTypeBuilder<TJoinEntity> UsingEntity<TJoinEntity>(
-        string joinEntityName)
+    public virtual EntityTypeBuilder<TJoinEntity> UsingEntity
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>(string joinEntityName)
         where TJoinEntity : class
     {
         Check.NotEmpty(joinEntityName, nameof(joinEntityName));
@@ -125,7 +130,7 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <returns>The builder for the originating entity type so that multiple configuration calls can be chained.</returns>
     public new virtual EntityTypeBuilder<TRightEntity> UsingEntity(
         string joinEntityName,
-        Type joinEntityType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type joinEntityType,
         Action<EntityTypeBuilder> configureJoinEntityType)
     {
         Check.NotNull(configureJoinEntityType, nameof(configureJoinEntityType));
@@ -141,8 +146,9 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <param name="configureJoinEntityType">The configuration of the join entity type.</param>
     /// <typeparam name="TJoinEntity">The CLR type of the join entity.</typeparam>
     /// <returns>The builder for the originating entity type so that multiple configuration calls can be chained.</returns>
-    public virtual EntityTypeBuilder<TRightEntity> UsingEntity<TJoinEntity>(
-        Action<EntityTypeBuilder<TJoinEntity>> configureJoinEntityType)
+    public virtual EntityTypeBuilder<TRightEntity> UsingEntity
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>(
+            Action<EntityTypeBuilder<TJoinEntity>> configureJoinEntityType)
         where TJoinEntity : class
     {
         Check.NotNull(configureJoinEntityType, nameof(configureJoinEntityType));
@@ -160,9 +166,10 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <param name="configureJoinEntityType">The configuration of the join entity type.</param>
     /// <typeparam name="TJoinEntity">The CLR type of the join entity.</typeparam>
     /// <returns>The builder for the originating entity type so that multiple configuration calls can be chained.</returns>
-    public virtual EntityTypeBuilder<TRightEntity> UsingEntity<TJoinEntity>(
-        string joinEntityName,
-        Action<EntityTypeBuilder<TJoinEntity>> configureJoinEntityType)
+    public virtual EntityTypeBuilder<TRightEntity> UsingEntity
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>(
+            string joinEntityName,
+            Action<EntityTypeBuilder<TJoinEntity>> configureJoinEntityType)
         where TJoinEntity : class
     {
         Check.NotNull(configureJoinEntityType, nameof(configureJoinEntityType));
@@ -180,9 +187,10 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <param name="configureLeft">The configuration for the relationship to the left entity type.</param>
     /// <typeparam name="TJoinEntity">The CLR type of the join entity.</typeparam>
     /// <returns>The builder for the join type.</returns>
-    public virtual EntityTypeBuilder<TJoinEntity> UsingEntity<TJoinEntity>(
-        Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TLeftEntity, TJoinEntity>> configureRight,
-        Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TRightEntity, TJoinEntity>> configureLeft)
+    public virtual EntityTypeBuilder<TJoinEntity> UsingEntity
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>(
+            Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TLeftEntity, TJoinEntity>> configureRight,
+            Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TRightEntity, TJoinEntity>> configureLeft)
         where TJoinEntity : class
     {
         Check.NotNull(configureRight, nameof(configureRight));
@@ -199,10 +207,11 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <param name="configureLeft">The configuration for the relationship to the left entity type.</param>
     /// <typeparam name="TJoinEntity">The CLR type of the join entity.</typeparam>
     /// <returns>The builder for the join entity type.</returns>
-    public virtual EntityTypeBuilder<TJoinEntity> UsingEntity<TJoinEntity>(
-        string joinEntityName,
-        Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TLeftEntity, TJoinEntity>> configureRight,
-        Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TRightEntity, TJoinEntity>> configureLeft)
+    public virtual EntityTypeBuilder<TJoinEntity> UsingEntity
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>(
+            string joinEntityName,
+            Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TLeftEntity, TJoinEntity>> configureRight,
+            Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TRightEntity, TJoinEntity>> configureLeft)
         where TJoinEntity : class
     {
         Check.NotEmpty(joinEntityName, nameof(joinEntityName));
@@ -240,7 +249,7 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <param name="configureJoinEntityType">The configuration of the join entity type.</param>
     /// <returns>The builder for the originating entity type so that multiple configuration calls can be chained.</returns>
     public new virtual EntityTypeBuilder<TRightEntity> UsingEntity(
-        Type joinEntityType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type joinEntityType,
         Func<EntityTypeBuilder, ReferenceCollectionBuilder> configureRight,
         Func<EntityTypeBuilder, ReferenceCollectionBuilder> configureLeft,
         Action<EntityTypeBuilder> configureJoinEntityType)
@@ -284,7 +293,7 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <returns>The builder for the originating entity type so that multiple configuration calls can be chained.</returns>
     public new virtual EntityTypeBuilder<TRightEntity> UsingEntity(
         string joinEntityName,
-        Type joinEntityType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type joinEntityType,
         Func<EntityTypeBuilder, ReferenceCollectionBuilder> configureRight,
         Func<EntityTypeBuilder, ReferenceCollectionBuilder> configureLeft,
         Action<EntityTypeBuilder> configureJoinEntityType)
@@ -304,10 +313,11 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <param name="configureJoinEntityType">The configuration of the join entity type.</param>
     /// <typeparam name="TJoinEntity">The CLR type of the join entity.</typeparam>
     /// <returns>The builder for the originating entity type so that multiple configuration calls can be chained.</returns>
-    public virtual EntityTypeBuilder<TRightEntity> UsingEntity<TJoinEntity>(
-        Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TLeftEntity, TJoinEntity>> configureRight,
-        Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TRightEntity, TJoinEntity>> configureLeft,
-        Action<EntityTypeBuilder<TJoinEntity>> configureJoinEntityType)
+    public virtual EntityTypeBuilder<TRightEntity> UsingEntity
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>(
+            Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TLeftEntity, TJoinEntity>> configureRight,
+            Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TRightEntity, TJoinEntity>> configureLeft,
+            Action<EntityTypeBuilder<TJoinEntity>> configureJoinEntityType)
         where TJoinEntity : class
     {
         Check.NotNull(configureJoinEntityType, nameof(configureJoinEntityType));
@@ -327,7 +337,8 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
     /// <param name="configureJoinEntityType">The configuration of the join entity type.</param>
     /// <typeparam name="TJoinEntity">The CLR type of the join entity.</typeparam>
     /// <returns>The builder for the originating entity type so that multiple configuration calls can be chained.</returns>
-    public virtual EntityTypeBuilder<TRightEntity> UsingEntity<TJoinEntity>(
+    public virtual EntityTypeBuilder<TRightEntity> UsingEntity<
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>(
         string joinEntityName,
         Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TLeftEntity, TJoinEntity>> configureRight,
         Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TRightEntity, TJoinEntity>> configureLeft,
@@ -342,7 +353,7 @@ public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : Collection
         return new EntityTypeBuilder<TRightEntity>(RightEntityType);
     }
 
-    private EntityTypeBuilder<TJoinEntity> Using<TJoinEntity>(
+    private EntityTypeBuilder<TJoinEntity> Using<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TJoinEntity>(
         string? joinEntityName,
         Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TLeftEntity, TJoinEntity>>? configureRight,
         Func<EntityTypeBuilder<TJoinEntity>, ReferenceCollectionBuilder<TRightEntity, TJoinEntity>>? configureLeft)

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>
@@ -16,7 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 /// </remarks>
 /// <typeparam name="TEntity">The entity type to be configured.</typeparam>
 /// <typeparam name="TRelatedEntity">The entity type that this relationship targets.</typeparam>
-public class CollectionNavigationBuilder<TEntity, TRelatedEntity> : CollectionNavigationBuilder
+public class CollectionNavigationBuilder<
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity,
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity> : CollectionNavigationBuilder
     where TEntity : class
     where TRelatedEntity : class
 {

--- a/src/EFCore/Metadata/Builders/DiscriminatorBuilder.cs
+++ b/src/EFCore/Metadata/Builders/DiscriminatorBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -79,7 +80,8 @@ public class DiscriminatorBuilder : IConventionDiscriminatorBuilder
     /// <typeparam name="TEntity">The entity type for which a discriminator value is being set.</typeparam>
     /// <param name="value">The discriminator value.</param>
     /// <returns>The same builder so that multiple calls can be chained.</returns>
-    public virtual DiscriminatorBuilder HasValue<TEntity>(object? value)
+    public virtual DiscriminatorBuilder HasValue<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(
+        object? value)
         => HasValue(typeof(TEntity), value);
 
     /// <summary>
@@ -88,7 +90,9 @@ public class DiscriminatorBuilder : IConventionDiscriminatorBuilder
     /// <param name="entityType">The entity type for which a discriminator value is being set.</param>
     /// <param name="value">The discriminator value.</param>
     /// <returns>The same builder so that multiple calls can be chained.</returns>
-    public virtual DiscriminatorBuilder HasValue(Type entityType, object? value)
+    public virtual DiscriminatorBuilder HasValue(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type entityType,
+        object? value)
     {
         var entityTypeBuilder = EntityTypeBuilder.ModelBuilder.Entity(
             entityType, ConfigurationSource.Explicit);

--- a/src/EFCore/Metadata/Builders/DiscriminatorBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/DiscriminatorBuilder`.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>
@@ -48,7 +50,8 @@ public class DiscriminatorBuilder<TDiscriminator>
     /// <typeparam name="TEntity">The entity type for which a discriminator value is being set.</typeparam>
     /// <param name="value">The discriminator value.</param>
     /// <returns>The same builder so that multiple calls can be chained.</returns>
-    public virtual DiscriminatorBuilder<TDiscriminator> HasValue<TEntity>(TDiscriminator value)
+    public virtual DiscriminatorBuilder<TDiscriminator> HasValue
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(TDiscriminator value)
         => HasValue(typeof(TEntity), value);
 
     /// <summary>
@@ -57,7 +60,9 @@ public class DiscriminatorBuilder<TDiscriminator>
     /// <param name="entityType">The entity type for which a discriminator value is being set.</param>
     /// <param name="value">The discriminator value.</param>
     /// <returns>The same builder so that multiple calls can be chained.</returns>
-    public virtual DiscriminatorBuilder<TDiscriminator> HasValue(Type entityType, TDiscriminator value)
+    public virtual DiscriminatorBuilder<TDiscriminator> HasValue(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type entityType,
+        TDiscriminator value)
         => new(Builder.HasValue(entityType, value));
 
     /// <summary>

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -173,7 +174,8 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// <typeparam name="TProperty">The type of the property to be configured.</typeparam>
     /// <param name="propertyName">The name of the property to be configured.</param>
     /// <returns>An object that can be used to configure the property.</returns>
-    public virtual PropertyBuilder<TProperty> IndexerProperty<TProperty>(string propertyName)
+    public virtual PropertyBuilder<TProperty> IndexerProperty
+        <[DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] TProperty>(string propertyName)
         => new(
             Builder.IndexerProperty(
                 typeof(TProperty),
@@ -191,11 +193,17 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// <param name="propertyType">The type of the property to be configured.</param>
     /// <param name="propertyName">The name of the property to be configured.</param>
     /// <returns>An object that can be used to configure the property.</returns>
-    public virtual PropertyBuilder IndexerProperty(Type propertyType, string propertyName)
-        => new(
+    public virtual PropertyBuilder IndexerProperty(
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
+        string propertyName)
+    {
+        Check.NotNull(propertyType, nameof(propertyType));
+
+        return new(
             Builder.IndexerProperty(
-                Check.NotNull(propertyType, nameof(propertyType)),
+                propertyType,
                 Check.NotEmpty(propertyName, nameof(propertyName)), ConfigurationSource.Explicit)!.Metadata);
+    }
 
     /// <summary>
     ///     Returns an object that can be used to configure an existing navigation property of the entity type.
@@ -315,7 +323,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
     public virtual OwnedNavigationBuilder OwnsOne(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName)
         => OwnsOneBuilder(
             new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), ownedType),
@@ -344,11 +352,15 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
     public virtual OwnedNavigationBuilder OwnsOne(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName)
-        => OwnsOneBuilder(
-            new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType)), (Model)Metadata.Model),
+    {
+        Check.NotNull(ownedType, nameof(ownedType));
+
+        return OwnsOneBuilder(
+            new TypeIdentity(ownedType, (Model)Metadata.Model),
             Check.NotEmpty(navigationName, nameof(navigationName)));
+    }
 
     /// <summary>
     ///     Configures a relationship where the target entity is owned by (or part of) this entity.
@@ -412,7 +424,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public virtual EntityTypeBuilder OwnsOne(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
     {
@@ -449,7 +461,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public virtual EntityTypeBuilder OwnsOne(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
     {
@@ -529,11 +541,15 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
     public virtual OwnedNavigationBuilder OwnsMany(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName)
-        => OwnsManyBuilder(
-            new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), Check.NotNull(ownedType, nameof(ownedType))),
+    {
+        Check.NotNull(ownedType, nameof(ownedType));
+
+        return OwnsManyBuilder(
+            new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), ownedType),
             Check.NotEmpty(navigationName, nameof(navigationName)));
+    }
 
     /// <summary>
     ///     Configures a relationship where the target entity is owned by (or part of) this entity.
@@ -558,11 +574,15 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
     public virtual OwnedNavigationBuilder OwnsMany(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName)
-        => OwnsManyBuilder(
-            new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType)), (Model)Metadata.Model),
+    {
+        Check.NotNull(ownedType, nameof(ownedType));
+
+        return OwnsManyBuilder(
+            new TypeIdentity(ownedType, (Model)Metadata.Model),
             Check.NotEmpty(navigationName, nameof(navigationName)));
+    }
 
     /// <summary>
     ///     Configures a relationship where the target entity is owned by (or part of) this entity.
@@ -626,7 +646,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public virtual EntityTypeBuilder OwnsMany(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
     {
@@ -663,7 +683,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public virtual EntityTypeBuilder OwnsMany(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
     {
@@ -758,7 +778,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
     public virtual ReferenceNavigationBuilder HasOne(
-        Type relatedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type relatedType,
         string? navigationName = null)
     {
         Check.NotNull(relatedType, nameof(relatedType));
@@ -791,6 +811,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     ///     the relationship. The navigation must be a CLR property on the entity type.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
+    [RequiresUnreferencedCode("Use an overload that accepts a type")]
     public virtual ReferenceNavigationBuilder HasOne(string? navigationName)
     {
         Check.NotEmpty(navigationName, nameof(navigationName));
@@ -872,6 +893,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     ///     The navigation must be a CLR property on the entity type.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
+    [RequiresUnreferencedCode("Use the generic overload instead")]
     public virtual CollectionNavigationBuilder HasMany(string navigationName)
     {
         Check.NotEmpty(navigationName, nameof(navigationName));
@@ -917,7 +939,7 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
     public virtual CollectionNavigationBuilder HasMany(
-        Type relatedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type relatedType,
         string? navigationName = null)
     {
         Check.NotNull(relatedType, nameof(relatedType));
@@ -974,7 +996,9 @@ public class EntityTypeBuilder : IInfrastructure<IConventionEntityTypeBuilder>
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    protected virtual EntityType FindRelatedEntityType(Type relatedType, string? navigationName)
+    protected virtual EntityType FindRelatedEntityType(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type relatedType,
+        string? navigationName)
         => (navigationName == null || !Builder.ModelBuilder.Metadata.IsShared(relatedType)
                 ? null
                 : Builder.ModelBuilder.Metadata.FindEntityType(relatedType, navigationName, Builder.Metadata))

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -16,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
 /// <typeparam name="TEntity">The entity type being configured.</typeparam>
-public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
+public class EntityTypeBuilder<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity> : EntityTypeBuilder
     where TEntity : class
 {
     /// <summary>
@@ -338,8 +339,8 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
-        string navigationName)
+    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(string navigationName)
         where TRelatedEntity : class
         => OwnsOneBuilder<TRelatedEntity>(
             new TypeIdentity(typeof(TRelatedEntity), (Model)Metadata.Model),
@@ -368,9 +369,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
-        string ownedTypeName,
-        string navigationName)
+    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string ownedTypeName,
+            string navigationName)
         where TRelatedEntity : class
         => OwnsOneBuilder<TRelatedEntity>(
             new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), typeof(TRelatedEntity)),
@@ -399,7 +401,8 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     the relationship (<c>customer => customer.Address</c>).
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
+    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
         Expression<Func<TEntity, TRelatedEntity?>> navigationExpression)
         where TRelatedEntity : class
         => OwnsOneBuilder<TRelatedEntity>(
@@ -430,9 +433,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     the relationship (<c>customer => customer.Address</c>).
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
-        string ownedTypeName,
-        Expression<Func<TEntity, TRelatedEntity?>> navigationExpression)
+    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string ownedTypeName,
+            Expression<Func<TEntity, TRelatedEntity?>> navigationExpression)
         where TRelatedEntity : class
         => OwnsOneBuilder<TRelatedEntity>(
             new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), typeof(TRelatedEntity)),
@@ -461,9 +465,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
-        string navigationName,
-        Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+    public virtual EntityTypeBuilder<TEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string navigationName,
+            Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
         where TRelatedEntity : class
     {
         Check.NotEmpty(navigationName, nameof(navigationName));
@@ -528,7 +533,7 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public new virtual EntityTypeBuilder<TEntity> OwnsOne(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
         => (EntityTypeBuilder<TEntity>)base.OwnsOne(ownedType, navigationName, buildAction);
@@ -559,7 +564,7 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// <returns>An object that can be used to configure the entity type.</returns>
     public new virtual EntityTypeBuilder<TEntity> OwnsOne(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
         => (EntityTypeBuilder<TEntity>)base.OwnsOne(ownedTypeName, ownedType, navigationName, buildAction);
@@ -588,10 +593,11 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
-        string ownedTypeName,
-        string navigationName,
-        Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+    public virtual EntityTypeBuilder<TEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string ownedTypeName,
+            string navigationName,
+            Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
         where TRelatedEntity : class
     {
         Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
@@ -628,9 +634,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
-        Expression<Func<TEntity, TRelatedEntity?>> navigationExpression,
-        Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+    public virtual EntityTypeBuilder<TEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            Expression<Func<TEntity, TRelatedEntity?>> navigationExpression,
+            Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
         where TRelatedEntity : class
     {
         Check.NotNull(navigationExpression, nameof(navigationExpression));
@@ -668,10 +675,11 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
-        string ownedTypeName,
-        Expression<Func<TEntity, TRelatedEntity?>> navigationExpression,
-        Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+    public virtual EntityTypeBuilder<TEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string ownedTypeName,
+            Expression<Func<TEntity, TRelatedEntity?>> navigationExpression,
+            Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
         where TRelatedEntity : class
     {
         Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
@@ -684,9 +692,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
         return this;
     }
 
-    private OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOneBuilder<TRelatedEntity>(
-        TypeIdentity ownedType,
-        MemberIdentity navigation)
+    private OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOneBuilder
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            TypeIdentity ownedType,
+            MemberIdentity navigation)
         where TRelatedEntity : class
     {
         InternalForeignKeyBuilder relationship;
@@ -722,8 +731,9 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
-        string navigationName)
+    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string navigationName)
         where TRelatedEntity : class
         => OwnsManyBuilder<TRelatedEntity>(
             new TypeIdentity(typeof(TRelatedEntity), (Model)Metadata.Model),
@@ -752,9 +762,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
-        string ownedTypeName,
-        string navigationName)
+    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity>
+        OwnsMany<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string ownedTypeName,
+            string navigationName)
         where TRelatedEntity : class
         => OwnsManyBuilder<TRelatedEntity>(
             new TypeIdentity(ownedTypeName, typeof(TRelatedEntity)),
@@ -783,8 +794,9 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     the relationship (<c>customer => customer.Address</c>).
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
-        Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>> navigationExpression)
+    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>> navigationExpression)
         where TRelatedEntity : class
         => OwnsManyBuilder<TRelatedEntity>(
             new TypeIdentity(typeof(TRelatedEntity), (Model)Metadata.Model),
@@ -814,9 +826,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     the relationship (<c>customer => customer.Address</c>).
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
-        string ownedTypeName,
-        Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>> navigationExpression)
+    public virtual OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string ownedTypeName,
+            Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>> navigationExpression)
         where TRelatedEntity : class
         => OwnsManyBuilder<TRelatedEntity>(
             new TypeIdentity(ownedTypeName, typeof(TRelatedEntity)),
@@ -845,9 +858,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
-        string navigationName,
-        Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+    public virtual EntityTypeBuilder<TEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string navigationName,
+            Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
         where TRelatedEntity : class
     {
         Check.NotEmpty(navigationName, nameof(navigationName));
@@ -912,7 +926,7 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public new virtual EntityTypeBuilder<TEntity> OwnsMany(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
         => (EntityTypeBuilder<TEntity>)base.OwnsMany(ownedType, navigationName, buildAction);
@@ -943,7 +957,7 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// <returns>An object that can be used to configure the entity type.</returns>
     public new virtual EntityTypeBuilder<TEntity> OwnsMany(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
         => (EntityTypeBuilder<TEntity>)base.OwnsMany(ownedTypeName, ownedType, navigationName, buildAction);
@@ -972,10 +986,11 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
-        string ownedTypeName,
-        string navigationName,
-        Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+    public virtual EntityTypeBuilder<TEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string ownedTypeName,
+            string navigationName,
+            Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
         where TRelatedEntity : class
     {
         Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
@@ -1012,9 +1027,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
-        Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>> navigationExpression,
-        Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+    public virtual EntityTypeBuilder<TEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>> navigationExpression,
+            Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
         where TRelatedEntity : class
     {
         Check.NotNull(navigationExpression, nameof(navigationExpression));
@@ -1052,10 +1068,11 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
-        string ownedTypeName,
-        Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>> navigationExpression,
-        Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+    public virtual EntityTypeBuilder<TEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string ownedTypeName,
+            Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>> navigationExpression,
+            Action<OwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
         where TRelatedEntity : class
     {
         Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
@@ -1068,9 +1085,10 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
         return this;
     }
 
-    private OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsManyBuilder<TRelatedEntity>(
-        TypeIdentity ownedType,
-        MemberIdentity navigation)
+    private OwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsManyBuilder
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            TypeIdentity ownedType,
+            MemberIdentity navigation)
         where TRelatedEntity : class
     {
         InternalForeignKeyBuilder relationship;
@@ -1111,8 +1129,9 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     end.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
-    public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
-        string? navigationName)
+    public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            string? navigationName)
         where TRelatedEntity : class
     {
         var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigationName);
@@ -1154,8 +1173,9 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     configured without a navigation property on this end.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
-    public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
-        Expression<Func<TEntity, TRelatedEntity?>>? navigationExpression = null)
+    public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
+            Expression<Func<TEntity, TRelatedEntity?>>? navigationExpression = null)
         where TRelatedEntity : class
     {
         var navigationMember = navigationExpression?.GetMemberAccess();
@@ -1195,8 +1215,8 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     end.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
-    public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
-        string? navigationName)
+    public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(string? navigationName)
         where TRelatedEntity : class
     {
         Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -1250,7 +1270,8 @@ public class EntityTypeBuilder<TEntity> : EntityTypeBuilder
     ///     configured without a navigation property on this end.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
-    public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
+    public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TRelatedEntity>(
         Expression<Func<TEntity, IEnumerable<TRelatedEntity>?>>? navigationExpression = null)
         where TRelatedEntity : class
     {

--- a/src/EFCore/Metadata/Builders/IConventionModelBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionModelBuilder.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>
@@ -65,7 +67,7 @@ public interface IConventionModelBuilder : IConventionAnnotatableBuilder
     /// </returns>
     IConventionEntityTypeBuilder? SharedTypeEntity(
         string name,
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         bool? shouldBeOwned = false,
         bool fromDataAnnotation = false);
 
@@ -84,7 +86,10 @@ public interface IConventionModelBuilder : IConventionAnnotatableBuilder
     ///     An object that can be used to configure the entity type if the entity type was added or already part of the model,
     ///     <see langword="null" /> otherwise.
     /// </returns>
-    IConventionEntityTypeBuilder? Entity(Type type, bool? shouldBeOwned = false, bool fromDataAnnotation = false);
+    IConventionEntityTypeBuilder? Entity(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool? shouldBeOwned = false,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns an object that can be used to configure a given entity type with defining navigation.
@@ -119,7 +124,7 @@ public interface IConventionModelBuilder : IConventionAnnotatableBuilder
     ///     <see langword="null" /> otherwise.
     /// </returns>
     IConventionEntityTypeBuilder? Entity(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         string definingNavigationName,
         IConventionEntityType definingEntityType,
         bool fromDataAnnotation = false);
@@ -133,7 +138,9 @@ public interface IConventionModelBuilder : IConventionAnnotatableBuilder
     /// <returns>
     ///     An object that can be used to provide default configuration for the owned entity types.
     /// </returns>
-    IConventionOwnedEntityTypeBuilder? Owned(Type type, bool fromDataAnnotation = false);
+    IConventionOwnedEntityTypeBuilder? Owned(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Indicates whether the given entity type name is ignored for the current configuration source.
@@ -141,7 +148,7 @@ public interface IConventionModelBuilder : IConventionAnnotatableBuilder
     /// <param name="type">The name of the entity type that might be ignored.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the given entity type name is ignored.</returns>
-    bool IsIgnored(Type type, bool fromDataAnnotation = false);
+    bool IsIgnored([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type, bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Indicates whether the given entity type name is ignored for the current configuration source.
@@ -160,7 +167,9 @@ public interface IConventionModelBuilder : IConventionAnnotatableBuilder
     ///     The same builder instance so that additional configuration calls can be chained
     ///     if the given entity type was ignored, <see langword="null" /> otherwise.
     /// </returns>
-    IConventionModelBuilder? Ignore(Type type, bool fromDataAnnotation = false);
+    IConventionModelBuilder? Ignore(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Excludes the given entity type name from the model and prevents it from being added by convention.
@@ -189,7 +198,7 @@ public interface IConventionModelBuilder : IConventionAnnotatableBuilder
     /// <param name="type">The entity type to be removed from the model.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns><see langword="true" /> if the given entity type can be ignored.</returns>
-    bool CanIgnore(Type type, bool fromDataAnnotation = false);
+    bool CanIgnore([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type, bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns a value indicating whether the given entity type name can be ignored from the current configuration source

--- a/src/EFCore/Metadata/Builders/IConventionPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionPropertyBuilder.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>
@@ -282,7 +284,9 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     ///     The same builder instance if the configuration was applied,
     ///     <see langword="null" /> otherwise.
     /// </returns>
-    IConventionPropertyBuilder? HasValueGenerator(Type? valueGeneratorType, bool fromDataAnnotation = false);
+    IConventionPropertyBuilder? HasValueGenerator(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? valueGeneratorType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Configures the <see cref="ValueGenerator" /> that will generate values for this property.
@@ -307,7 +311,9 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     ///     The same builder instance if the configuration was applied,
     ///     <see langword="null" /> otherwise.
     /// </returns>
-    IConventionPropertyBuilder? HasValueGeneratorFactory(Type? valueGeneratorFactoryType, bool fromDataAnnotation = false);
+    IConventionPropertyBuilder? HasValueGeneratorFactory(
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactoryType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns a value indicating whether the <see cref="ValueGenerator" /> can be configured for this property
@@ -340,7 +346,7 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     ///     <see langword="true" /> if the <see cref="ValueGenerator" /> can be configured for this property.
     /// </returns>
     bool CanSetValueGeneratorFactory(
-        Type? valueGeneratorFactoryType,
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactoryType,
         bool fromDataAnnotation = false);
 
     /// <summary>
@@ -402,7 +408,9 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     ///     The same builder instance if the configuration was applied,
     ///     <see langword="null" /> otherwise.
     /// </returns>
-    IConventionPropertyBuilder? HasConverter(Type? converterType, bool fromDataAnnotation = false);
+    IConventionPropertyBuilder? HasConverter(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns a value indicating whether the <see cref="ValueConverter" /> can be configured for this property
@@ -416,7 +424,7 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     /// <returns>
     ///     <see langword="true" /> if the <see cref="ValueConverter" /> can be configured for this property.
     /// </returns>
-    bool CanSetConverter(Type? converterType, bool fromDataAnnotation = false);
+    bool CanSetConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType, bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Configures the <see cref="CoreTypeMapping" /> for this property.
@@ -472,7 +480,9 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     /// <returns>
     ///     The same builder instance if the configuration was applied, <see langword="null" /> otherwise.
     /// </returns>
-    IConventionPropertyBuilder? HasValueComparer(Type? comparerType, bool fromDataAnnotation = false);
+    IConventionPropertyBuilder? HasValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns a value indicating whether the given <see cref="ValueComparer" />
@@ -486,7 +496,9 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     /// <returns>
     ///     <see langword="true" /> if the given <see cref="ValueComparer" /> can be configured for this property.
     /// </returns>
-    bool CanSetValueComparer(Type? comparerType, bool fromDataAnnotation = false);
+    bool CanSetValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Configures the <see cref="ValueComparer" /> to use for the provider values for this property.
@@ -520,7 +532,9 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     /// <returns>
     ///     The same builder instance if the configuration was applied, <see langword="null" /> otherwise.
     /// </returns>
-    IConventionPropertyBuilder? HasProviderValueComparer(Type? comparerType, bool fromDataAnnotation = false);
+    IConventionPropertyBuilder? HasProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns a value indicating whether the given <see cref="ValueComparer" />
@@ -534,5 +548,7 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder
     /// <returns>
     ///     <see langword="true" /> if the given <see cref="ValueComparer" /> can be configured for this property.
     /// </returns>
-    bool CanSetProviderValueComparer(Type? comparerType, bool fromDataAnnotation = false);
+    bool CanSetProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation = false);
 }

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -202,7 +203,8 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// <typeparam name="TProperty">The type of the property to be configured.</typeparam>
     /// <param name="propertyName">The name of the property to be configured.</param>
     /// <returns>An object that can be used to configure the property.</returns>
-    public virtual PropertyBuilder<TProperty> IndexerProperty<TProperty>(string propertyName)
+    public virtual PropertyBuilder<TProperty> IndexerProperty
+        <[DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] TProperty>(string propertyName)
         => new(
             DependentEntityType.Builder.IndexerProperty(
                 typeof(TProperty),
@@ -220,11 +222,17 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// <param name="propertyType">The type of the property to be configured.</param>
     /// <param name="propertyName">The name of the property to be configured.</param>
     /// <returns>An object that can be used to configure the property.</returns>
-    public virtual PropertyBuilder IndexerProperty(Type propertyType, string propertyName)
-        => new(
+    public virtual PropertyBuilder IndexerProperty(
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
+        string propertyName)
+    {
+        Check.NotNull(propertyType, nameof(propertyType));
+
+        return new(
             DependentEntityType.Builder.IndexerProperty(
-                Check.NotNull(propertyType, nameof(propertyType)),
+                propertyType,
                 Check.NotEmpty(propertyName, nameof(propertyName)), ConfigurationSource.Explicit)!.Metadata);
+    }
 
     /// <summary>
     ///     Returns an object that can be used to configure an existing navigation property
@@ -346,11 +354,15 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// <returns>An object that can be used to configure the relationship.</returns>
     public virtual OwnedNavigationBuilder OwnsOne(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName)
-        => OwnsOneBuilder(
-            new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), Check.NotNull(ownedType, nameof(ownedType))),
+    {
+        Check.NotNull(ownedType, nameof(ownedType));
+
+        return OwnsOneBuilder(
+            new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), ownedType),
             Check.NotEmpty(navigationName, nameof(navigationName)));
+    }
 
     /// <summary>
     ///     Configures a relationship where the target entity is owned by (or part of) this entity.
@@ -376,11 +388,15 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
     public virtual OwnedNavigationBuilder OwnsOne(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName)
-        => OwnsOneBuilder(
-            new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType)), DependentEntityType.Model),
+    {
+        Check.NotNull(ownedType, nameof(ownedType));
+
+        return OwnsOneBuilder(
+            new TypeIdentity(ownedType, DependentEntityType.Model),
             Check.NotEmpty(navigationName, nameof(navigationName)));
+    }
 
     /// <summary>
     ///     Configures a relationship where the target entity is owned by (or part of) this entity.
@@ -449,7 +465,7 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// <returns>An object that can be used to configure the entity type.</returns>
     public virtual OwnedNavigationBuilder OwnsOne(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
     {
@@ -490,7 +506,7 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// <param name="buildAction">An action that performs configuration of the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public virtual OwnedNavigationBuilder OwnsOne(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
     {
@@ -573,11 +589,15 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
     public virtual OwnedNavigationBuilder OwnsMany(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName)
-        => OwnsManyBuilder(
-            new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), Check.NotNull(ownedType, nameof(ownedType))),
+    {
+        Check.NotNull(ownedType, nameof(ownedType));
+
+        return OwnsManyBuilder(
+            new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName)), ownedType),
             Check.NotEmpty(navigationName, nameof(navigationName)));
+    }
 
     /// <summary>
     ///     Configures a relationship where the target entity is owned by (or part of) this entity.
@@ -602,11 +622,15 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
     public virtual OwnedNavigationBuilder OwnsMany(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName)
-        => OwnsManyBuilder(
-            new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType)), DependentEntityType.Model),
+    {
+        Check.NotNull(ownedType, nameof(ownedType));
+
+        return OwnsManyBuilder(
+            new TypeIdentity(ownedType, DependentEntityType.Model),
             Check.NotEmpty(navigationName, nameof(navigationName)));
+    }
 
     /// <summary>
     ///     Configures a relationship where the target entity is owned by (or part of) this entity.
@@ -673,7 +697,7 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// <returns>An object that can be used to configure the entity type.</returns>
     public virtual OwnedNavigationBuilder OwnsMany(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
     {
@@ -713,7 +737,7 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public virtual OwnedNavigationBuilder OwnsMany(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
     {
@@ -807,6 +831,7 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
+    [RequiresUnreferencedCode("Use an overload that accepts a type")]
     public virtual ReferenceNavigationBuilder HasOne(string navigationName)
     {
         Check.NotEmpty(navigationName, nameof(navigationName));
@@ -842,7 +867,7 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
     public virtual ReferenceNavigationBuilder HasOne(
-        Type relatedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type relatedType,
         string? navigationName = null)
     {
         Check.NotNull(relatedType, nameof(relatedType));
@@ -900,7 +925,9 @@ public class OwnedNavigationBuilder : IInfrastructure<IConventionEntityTypeBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    protected virtual EntityType FindRelatedEntityType(Type relatedType, string? navigationName)
+    protected virtual EntityType FindRelatedEntityType(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type relatedType,
+        string? navigationName)
     {
         var relatedEntityType = (EntityType?)DependentEntityType.FindInOwnershipPath(relatedType);
         if (relatedEntityType != null)

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -11,7 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
-public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavigationBuilder
+public class OwnedNavigationBuilder<
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TOwnerEntity,
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TDependentEntity> : OwnedNavigationBuilder
     where TOwnerEntity : class
     where TDependentEntity : class
 {
@@ -257,8 +260,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne<TNewDependentEntity>(
-        string navigationName)
+    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(string navigationName)
         where TNewDependentEntity : class
         => OwnsOneBuilder<TNewDependentEntity>(
             new TypeIdentity(typeof(TNewDependentEntity), (Model)Metadata.DeclaringEntityType.Model),
@@ -288,7 +291,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne<TNewDependentEntity>(
+    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
         string ownedTypeName,
         string navigationName)
         where TNewDependentEntity : class
@@ -320,8 +324,9 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     the relationship (<c>customer => customer.Address</c>).
     /// </param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne<TNewDependentEntity>(
-        Expression<Func<TDependentEntity, TNewDependentEntity?>> navigationExpression)
+    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
+            Expression<Func<TDependentEntity, TNewDependentEntity?>> navigationExpression)
         where TNewDependentEntity : class
         => OwnsOneBuilder<TNewDependentEntity>(
             new TypeIdentity(typeof(TNewDependentEntity), (Model)Metadata.DeclaringEntityType.Model),
@@ -352,7 +357,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     the relationship (<c>customer => customer.Address</c>).
     /// </param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne<TNewDependentEntity>(
+    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
         string ownedTypeName,
         Expression<Func<TDependentEntity, TNewDependentEntity?>> navigationExpression)
         where TNewDependentEntity : class
@@ -384,9 +390,10 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne<TNewDependentEntity>(
-        string navigationName,
-        Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
+            string navigationName,
+            Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
         where TNewDependentEntity : class
     {
         Check.NotEmpty(navigationName, nameof(navigationName));
@@ -456,7 +463,7 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// <returns>An object that can be used to configure the entity type.</returns>
     public new virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
         => (OwnedNavigationBuilder<TOwnerEntity, TDependentEntity>)base.OwnsOne(ownedTypeName, ownedType, navigationName, buildAction);
@@ -486,7 +493,7 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// <param name="buildAction">An action that performs configuration of the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public new virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
         => (OwnedNavigationBuilder<TOwnerEntity, TDependentEntity>)base.OwnsOne(ownedType, navigationName, buildAction);
@@ -516,10 +523,11 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne<TNewDependentEntity>(
-        string ownedTypeName,
-        string navigationName,
-        Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
+            string ownedTypeName,
+            string navigationName,
+            Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
         where TNewDependentEntity : class
     {
         Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
@@ -557,9 +565,10 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne<TNewDependentEntity>(
-        Expression<Func<TDependentEntity, TNewDependentEntity?>> navigationExpression,
-        Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
+            Expression<Func<TDependentEntity, TNewDependentEntity?>> navigationExpression,
+            Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
         where TNewDependentEntity : class
     {
         Check.NotNull(navigationExpression, nameof(navigationExpression));
@@ -598,10 +607,11 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne<TNewDependentEntity>(
-        string ownedTypeName,
-        Expression<Func<TDependentEntity, TNewDependentEntity?>> navigationExpression,
-        Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
+            string ownedTypeName,
+            Expression<Func<TDependentEntity, TNewDependentEntity?>> navigationExpression,
+            Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
         where TNewDependentEntity : class
     {
         Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
@@ -615,7 +625,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
         return this;
     }
 
-    private OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOneBuilder<TNewDependentEntity>(
+    private OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOneBuilder
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
         TypeIdentity ownedType,
         MemberIdentity navigation)
         where TNewDependentEntity : class
@@ -653,8 +664,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
-        string navigationName)
+    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(string navigationName)
         where TNewDependentEntity : class
         => OwnsManyBuilder<TNewDependentEntity>(
             new TypeIdentity(typeof(TNewDependentEntity), (Model)Metadata.DeclaringEntityType.Model),
@@ -683,7 +694,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     The name of the reference navigation property on this entity type that represents the relationship.
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
+    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
         string ownedTypeName,
         string navigationName)
         where TNewDependentEntity : class
@@ -714,7 +726,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     the relationship (<c>customer => customer.Address</c>).
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
+    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
         Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>?>> navigationExpression)
         where TNewDependentEntity : class
         => OwnsManyBuilder<TNewDependentEntity>(
@@ -745,7 +758,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     the relationship (<c>customer => customer.Address</c>).
     /// </param>
     /// <returns>An object that can be used to configure the owned type and the relationship.</returns>
-    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
+    public virtual OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
         string ownedTypeName,
         Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>?>> navigationExpression)
         where TNewDependentEntity : class
@@ -776,7 +790,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
+    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
         string navigationName,
         Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
         where TNewDependentEntity : class
@@ -847,7 +862,7 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
     public new virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany(
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
         => (OwnedNavigationBuilder<TOwnerEntity, TDependentEntity>)base.OwnsMany(ownedType, navigationName, buildAction);
@@ -878,7 +893,7 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// <returns>An object that can be used to configure the entity type.</returns>
     public new virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany(
         string ownedTypeName,
-        Type ownedType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type ownedType,
         string navigationName,
         Action<OwnedNavigationBuilder> buildAction)
         => (OwnedNavigationBuilder<TOwnerEntity, TDependentEntity>)base.OwnsMany(ownedTypeName, ownedType, navigationName, buildAction);
@@ -907,10 +922,11 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
-        string ownedTypeName,
-        string navigationName,
-        Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
+            string ownedTypeName,
+            string navigationName,
+            Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
         where TNewDependentEntity : class
     {
         Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
@@ -950,9 +966,10 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
-        Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>?>> navigationExpression,
-        Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
+            Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>?>> navigationExpression,
+            Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
         where TNewDependentEntity : class
     {
         Check.NotNull(navigationExpression, nameof(navigationExpression));
@@ -993,10 +1010,11 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     /// </param>
     /// <param name="buildAction">An action that performs configuration of the owned type and the relationship.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
-        string ownedTypeName,
-        Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>?>> navigationExpression,
-        Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+    public virtual OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> OwnsMany
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewDependentEntity>(
+            string ownedTypeName,
+            Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>?>> navigationExpression,
+            Action<OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
         where TNewDependentEntity : class
     {
         Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
@@ -1013,9 +1031,10 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
         }
     }
 
-    private OwnedNavigationBuilder<TDependentEntity, TNewRelatedEntity> OwnsManyBuilder<TNewRelatedEntity>(
-        TypeIdentity ownedType,
-        MemberIdentity navigation)
+    private OwnedNavigationBuilder<TDependentEntity, TNewRelatedEntity> OwnsManyBuilder
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewRelatedEntity>(
+            TypeIdentity ownedType,
+            MemberIdentity navigation)
         where TNewRelatedEntity : class
     {
         InternalForeignKeyBuilder relationship;
@@ -1055,8 +1074,8 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     end.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
-    public virtual ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
-        string? navigationName)
+    public virtual ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity> HasOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewRelatedEntity>(string? navigationName)
         where TNewRelatedEntity : class
     {
         var relatedEntityType = FindRelatedEntityType(typeof(TNewRelatedEntity), navigationName);
@@ -1098,8 +1117,9 @@ public class OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> : OwnedNavig
     ///     configured without a navigation property on this end.
     /// </param>
     /// <returns>An object that can be used to configure the relationship.</returns>
-    public virtual ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
-        Expression<Func<TDependentEntity, TNewRelatedEntity?>>? navigationExpression = null)
+    public virtual ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity> HasOne
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TNewRelatedEntity>(
+            Expression<Func<TDependentEntity, TNewRelatedEntity?>>? navigationExpression = null)
         where TNewRelatedEntity : class
     {
         var navigation = navigationExpression?.GetMemberAccess();

--- a/src/EFCore/Metadata/Builders/PropertyBuilder.cs
+++ b/src/EFCore/Metadata/Builders/PropertyBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -169,7 +170,8 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// </remarks>
     /// <typeparam name="TGenerator">A type that inherits from <see cref="ValueGenerator" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasValueGenerator<TGenerator>()
+    public virtual PropertyBuilder HasValueGenerator
+        <[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGenerator>()
         where TGenerator : ValueGenerator
     {
         Builder.HasValueGenerator(typeof(TGenerator), ConfigurationSource.Explicit);
@@ -202,7 +204,8 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// </remarks>
     /// <param name="valueGeneratorType">A type that inherits from <see cref="ValueGenerator" />.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasValueGenerator(Type? valueGeneratorType)
+    public virtual PropertyBuilder HasValueGenerator(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? valueGeneratorType)
     {
         Builder.HasValueGenerator(valueGeneratorType, ConfigurationSource.Explicit);
 
@@ -266,7 +269,8 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// </remarks>
     /// <typeparam name="TFactory">A type that inherits from <see cref="ValueGeneratorFactory" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasValueGeneratorFactory<TFactory>()
+    public virtual PropertyBuilder HasValueGeneratorFactory
+        <[DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] TFactory>()
         where TFactory : ValueGeneratorFactory
         => HasValueGeneratorFactory(typeof(TFactory));
 
@@ -296,7 +300,8 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// </remarks>
     /// <param name="valueGeneratorFactoryType">A type that inherits from <see cref="ValueGeneratorFactory" />.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasValueGeneratorFactory(Type? valueGeneratorFactoryType)
+    public virtual PropertyBuilder HasValueGeneratorFactory(
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactoryType)
     {
         Builder.HasValueGeneratorFactory(valueGeneratorFactoryType, ConfigurationSource.Explicit);
 
@@ -441,7 +446,7 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// </summary>
     /// <typeparam name="TConversion">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion<TConversion>()
+    public virtual PropertyBuilder HasConversion<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion>()
         => HasConversion(typeof(TConversion));
 
     /// <summary>
@@ -450,7 +455,8 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// </summary>
     /// <param name="conversionType">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion(Type? conversionType)
+    public virtual PropertyBuilder HasConversion(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? conversionType)
     {
         if (typeof(ValueConverter).IsAssignableFrom(conversionType))
         {
@@ -480,7 +486,9 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// <param name="valueComparer">The comparer to use for values before conversion.</param>
     /// <typeparam name="TConversion">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion<TConversion>(ValueComparer? valueComparer)
+    public virtual PropertyBuilder HasConversion<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion>(
+            ValueComparer? valueComparer)
         => HasConversion(typeof(TConversion), valueComparer);
 
     /// <summary>
@@ -491,7 +499,10 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// <param name="providerComparer">The comparer to use for the provider values.</param>
     /// <typeparam name="TConversion">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion<TConversion>(ValueComparer? valueComparer, ValueComparer? providerComparer)
+    public virtual PropertyBuilder HasConversion
+        <[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion>(
+            ValueComparer? valueComparer,
+            ValueComparer? providerComparer)
         => HasConversion(typeof(TConversion), valueComparer, providerComparer);
 
     /// <summary>
@@ -501,9 +512,12 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// <param name="conversionType">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</param>
     /// <param name="valueComparer">The comparer to use for values before conversion.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion(Type conversionType, ValueComparer? valueComparer)
+    public virtual PropertyBuilder HasConversion(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type conversionType,
+        ValueComparer? valueComparer)
         => HasConversion(conversionType, valueComparer, null);
 
+    // DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
     /// <summary>
     ///     Configures the property so that the property value is converted before
     ///     writing to the database and converted back when reading from the database.
@@ -512,7 +526,10 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// <param name="valueComparer">The comparer to use for values before conversion.</param>
     /// <param name="providerComparer">The comparer to use for the provider values.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion(Type conversionType, ValueComparer? valueComparer, ValueComparer? providerComparer)
+    public virtual PropertyBuilder HasConversion(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type conversionType,
+        ValueComparer? valueComparer,
+        ValueComparer? providerComparer)
     {
         Check.NotNull(conversionType, nameof(conversionType));
 
@@ -565,7 +582,9 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// <typeparam name="TConversion">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</typeparam>
     /// <typeparam name="TComparer">A type that inherits from <see cref="ValueComparer" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion<TConversion, TComparer>()
+    public virtual PropertyBuilder HasConversion<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TComparer>()
         where TComparer : ValueComparer
         => HasConversion(typeof(TConversion), typeof(TComparer));
 
@@ -577,7 +596,10 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// <typeparam name="TComparer">A type that inherits from <see cref="ValueComparer" />.</typeparam>
     /// <typeparam name="TProviderComparer">A type that inherits from <see cref="ValueComparer" /> to use for the provider values.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion<TConversion, TComparer, TProviderComparer>()
+    public virtual PropertyBuilder HasConversion<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TComparer,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TProviderComparer>()
         where TComparer : ValueComparer
         where TProviderComparer : ValueComparer
         => HasConversion(typeof(TConversion), typeof(TComparer), typeof(TProviderComparer));
@@ -589,7 +611,9 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// <param name="conversionType">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</param>
     /// <param name="comparerType">A type that inherits from <see cref="ValueComparer" />.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion(Type conversionType, Type? comparerType)
+    public virtual PropertyBuilder HasConversion(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type conversionType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType)
         => HasConversion(conversionType, comparerType, null);
 
     /// <summary>
@@ -600,7 +624,10 @@ public class PropertyBuilder : IInfrastructure<IConventionPropertyBuilder>
     /// <param name="comparerType">A type that inherits from <see cref="ValueComparer" />.</param>
     /// <param name="providerComparerType">A type that inherits from <see cref="ValueComparer" /> to use for the provider values.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public virtual PropertyBuilder HasConversion(Type conversionType, Type? comparerType, Type? providerComparerType)
+    public virtual PropertyBuilder HasConversion(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type conversionType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? providerComparerType)
     {
         Check.NotNull(conversionType, nameof(conversionType));
 

--- a/src/EFCore/Metadata/Builders/PropertyBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/PropertyBuilder`.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 /// <summary>
@@ -118,7 +120,8 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// </remarks>
     /// <typeparam name="TGenerator">A type that inherits from <see cref="ValueGenerator" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasValueGenerator<TGenerator>()
+    public new virtual PropertyBuilder<TProperty> HasValueGenerator
+        <[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGenerator>()
         where TGenerator : ValueGenerator
         => (PropertyBuilder<TProperty>)base.HasValueGenerator<TGenerator>();
 
@@ -147,7 +150,8 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// </remarks>
     /// <param name="valueGeneratorType">A type that inherits from <see cref="ValueGenerator" />.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasValueGenerator(Type? valueGeneratorType)
+    public new virtual PropertyBuilder<TProperty> HasValueGenerator(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? valueGeneratorType)
         => (PropertyBuilder<TProperty>)base.HasValueGenerator(valueGeneratorType);
 
     /// <summary>
@@ -201,7 +205,8 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// </remarks>
     /// <typeparam name="TFactory">A type that inherits from <see cref="ValueGeneratorFactory" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasValueGeneratorFactory<TFactory>()
+    public new virtual PropertyBuilder<TProperty> HasValueGeneratorFactory
+        <[DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] TFactory>()
         where TFactory : ValueGeneratorFactory
         => (PropertyBuilder<TProperty>)base.HasValueGeneratorFactory<TFactory>();
 
@@ -231,7 +236,8 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// </remarks>
     /// <param name="valueGeneratorFactoryType">A type that inherits from <see cref="ValueGeneratorFactory" />.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasValueGeneratorFactory(Type? valueGeneratorFactoryType)
+    public new virtual PropertyBuilder<TProperty> HasValueGeneratorFactory(
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactoryType)
         => (PropertyBuilder<TProperty>)base.HasValueGeneratorFactory(valueGeneratorFactoryType);
 
     /// <summary>
@@ -339,7 +345,8 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// </summary>
     /// <typeparam name="TConversion">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasConversion<TConversion>()
+    public new virtual PropertyBuilder<TProperty> HasConversion
+        <[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion>()
         => (PropertyBuilder<TProperty>)base.HasConversion<TConversion>();
 
     /// <summary>
@@ -348,7 +355,8 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// </summary>
     /// <param name="providerClrType">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasConversion(Type? providerClrType)
+    public new virtual PropertyBuilder<TProperty> HasConversion(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? providerClrType)
         => (PropertyBuilder<TProperty>)base.HasConversion(providerClrType);
 
     /// <summary>
@@ -393,7 +401,9 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// <typeparam name="TConversion">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</typeparam>
     /// <param name="valueComparer">The comparer to use for values before conversion.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasConversion<TConversion>(ValueComparer? valueComparer)
+    public new virtual PropertyBuilder<TProperty> HasConversion
+        <[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion>(
+            ValueComparer? valueComparer)
         => (PropertyBuilder<TProperty>)base.HasConversion<TConversion>(valueComparer);
 
     /// <summary>
@@ -404,7 +414,10 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// <param name="valueComparer">The comparer to use for values before conversion.</param>
     /// <param name="providerComparer">The comparer to use for the provider values.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasConversion<TConversion>(ValueComparer? valueComparer, ValueComparer? providerComparer)
+    public new virtual PropertyBuilder<TProperty> HasConversion
+        <[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion>(
+            ValueComparer? valueComparer,
+            ValueComparer? providerComparer)
         => (PropertyBuilder<TProperty>)base.HasConversion<TConversion>(valueComparer, providerComparer);
 
     /// <summary>
@@ -415,7 +428,7 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// <param name="valueComparer">The comparer to use for values before conversion.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
     public new virtual PropertyBuilder<TProperty> HasConversion(
-        Type conversionType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type conversionType,
         ValueComparer? valueComparer)
         => (PropertyBuilder<TProperty>)base.HasConversion(conversionType, valueComparer);
 
@@ -428,7 +441,7 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// <param name="providerComparer">The comparer to use for the provider values.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
     public new virtual PropertyBuilder<TProperty> HasConversion(
-        Type conversionType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type conversionType,
         ValueComparer? valueComparer,
         ValueComparer? providerComparer)
         => (PropertyBuilder<TProperty>)base.HasConversion(conversionType, valueComparer, providerComparer);
@@ -535,7 +548,9 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// <typeparam name="TConversion">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</typeparam>
     /// <typeparam name="TComparer">A type that inherits from <see cref="ValueComparer" />.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasConversion<TConversion, TComparer>()
+    public new virtual PropertyBuilder<TProperty> HasConversion<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TComparer>()
         where TComparer : ValueComparer
         => (PropertyBuilder<TProperty>)base.HasConversion<TConversion, TComparer>();
 
@@ -547,7 +562,10 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// <typeparam name="TComparer">A type that inherits from <see cref="ValueComparer" />.</typeparam>
     /// <typeparam name="TProviderComparer">A type that inherits from <see cref="ValueComparer" /> to use for the provider values.</typeparam>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasConversion<TConversion, TComparer, TProviderComparer>()
+    public new virtual PropertyBuilder<TProperty> HasConversion<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TConversion,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TComparer,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TProviderComparer>()
         where TComparer : ValueComparer
         where TProviderComparer : ValueComparer
         => (PropertyBuilder<TProperty>)base.HasConversion<TConversion, TComparer, TProviderComparer>();
@@ -559,7 +577,9 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// <param name="conversionType">The type to convert to and from or a type that inherits from <see cref="ValueConverter" />.</param>
     /// <param name="comparerType">A type that inherits from <see cref="ValueComparer" />.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasConversion(Type conversionType, Type? comparerType)
+    public new virtual PropertyBuilder<TProperty> HasConversion(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type conversionType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType)
         => (PropertyBuilder<TProperty>)base.HasConversion(conversionType, comparerType);
 
     /// <summary>
@@ -570,6 +590,9 @@ public class PropertyBuilder<TProperty> : PropertyBuilder
     /// <param name="comparerType">A type that inherits from <see cref="ValueComparer" />.</param>
     /// <param name="providerComparerType">A type that inherits from <see cref="ValueComparer" /> to use for the provider values.</param>
     /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
-    public new virtual PropertyBuilder<TProperty> HasConversion(Type conversionType, Type? comparerType, Type? providerComparerType)
+    public new virtual PropertyBuilder<TProperty> HasConversion(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type conversionType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? providerComparerType)
         => (PropertyBuilder<TProperty>)base.HasConversion(conversionType, comparerType, providerComparerType);
 }

--- a/src/EFCore/Metadata/IConventionEntityType.cs
+++ b/src/EFCore/Metadata/IConventionEntityType.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata;
@@ -784,6 +785,7 @@ public interface IConventionEntityType : IReadOnlyEntityType, IConventionTypeBas
     /// <param name="memberInfo">The corresponding member on the entity class.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The newly created property.</returns>
+    [RequiresUnreferencedCode("Currently used only in tests")]
     IConventionProperty? AddProperty(MemberInfo memberInfo, bool fromDataAnnotation = false)
         => AddProperty(
             memberInfo.GetSimpleMemberName(), memberInfo.GetMemberType(),
@@ -807,7 +809,7 @@ public interface IConventionEntityType : IReadOnlyEntityType, IConventionTypeBas
     /// <returns>The newly created property.</returns>
     IConventionProperty? AddProperty(
         string name,
-        Type propertyType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
         bool setTypeConfigurationSource = true,
         bool fromDataAnnotation = false);
 
@@ -829,7 +831,7 @@ public interface IConventionEntityType : IReadOnlyEntityType, IConventionTypeBas
     /// <returns>The newly created property.</returns>
     IConventionProperty? AddProperty(
         string name,
-        Type propertyType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
         MemberInfo? memberInfo,
         bool setTypeConfigurationSource = true,
         bool fromDataAnnotation = false);
@@ -844,7 +846,7 @@ public interface IConventionEntityType : IReadOnlyEntityType, IConventionTypeBas
     /// <returns>The newly created property.</returns>
     IConventionProperty? AddIndexerProperty(
         string name,
-        Type propertyType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
         bool setTypeConfigurationSource = true,
         bool fromDataAnnotation = false)
     {

--- a/src/EFCore/Metadata/IConventionModel.cs
+++ b/src/EFCore/Metadata/IConventionModel.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -18,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 ///         See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.
 ///     </para>
 /// </remarks>
+[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072", Justification = "TODO")]
 public interface IConventionModel : IReadOnlyModel, IConventionAnnotatable
 {
     /// <summary>
@@ -88,7 +91,9 @@ public interface IConventionModel : IReadOnlyModel, IConventionAnnotatable
     /// <param name="type">The CLR class that is used to represent instances of the entity type.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The new entity type.</returns>
-    IConventionEntityType? AddEntityType(Type type, bool fromDataAnnotation = false);
+    IConventionEntityType? AddEntityType(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Adds a shared type entity type to the model.
@@ -101,7 +106,10 @@ public interface IConventionModel : IReadOnlyModel, IConventionAnnotatable
     /// <param name="clrType">The CLR class that is used to represent instances of the entity type.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The new entity type.</returns>
-    IConventionEntityType? AddEntityType(string name, Type clrType, bool fromDataAnnotation = false);
+    IConventionEntityType? AddEntityType(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type clrType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Adds an owned entity type with a defining navigation to the model.
@@ -126,7 +134,7 @@ public interface IConventionModel : IReadOnlyModel, IConventionAnnotatable
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The new entity type.</returns>
     IConventionEntityType? AddEntityType(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         string definingNavigationName,
         IConventionEntityType definingEntityType,
         bool fromDataAnnotation = false);
@@ -149,7 +157,9 @@ public interface IConventionModel : IReadOnlyModel, IConventionAnnotatable
     /// <param name="type">The CLR class that is used to represent instances of the entity type.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The new entity type.</returns>
-    IConventionEntityType? AddOwnedEntityType(Type type, bool fromDataAnnotation = false);
+    IConventionEntityType? AddOwnedEntityType(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Adds an owned shared type entity type to the model.
@@ -162,7 +172,10 @@ public interface IConventionModel : IReadOnlyModel, IConventionAnnotatable
     /// <param name="clrType">The CLR class that is used to represent instances of the entity type.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The new entity type.</returns>
-    IConventionEntityType? AddOwnedEntityType(string name, Type clrType, bool fromDataAnnotation = false);
+    IConventionEntityType? AddOwnedEntityType(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type clrType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Gets the entity with the given name. Returns <see langword="null" /> if no entity type with the given name is found
@@ -332,7 +345,7 @@ public interface IConventionModel : IReadOnlyModel, IConventionAnnotatable
     ///     <see langword="true" /> if the given type is marked as owned,
     ///     <see langword="null" /> otherwise.
     /// </returns>
-    bool IsOwned(Type type)
+    bool IsOwned([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
         => FindIsOwnedConfigurationSource(type) != null;
 
     /// <summary>
@@ -388,7 +401,7 @@ public interface IConventionModel : IReadOnlyModel, IConventionAnnotatable
     /// </summary>
     /// <param name="type">The entity type that might be ignored.</param>
     /// <returns><see langword="true" /> if the given entity type is ignored.</returns>
-    bool IsIgnoredType(Type type);
+    bool IsIgnoredType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type);
 
     /// <summary>
     ///     Indicates whether the given entity type name is ignored.

--- a/src/EFCore/Metadata/IConventionProperty.cs
+++ b/src/EFCore/Metadata/IConventionProperty.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -317,7 +319,7 @@ public interface IConventionProperty : IReadOnlyProperty, IConventionPropertyBas
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
     Type? SetValueGeneratorFactory(
-        Type? valueGeneratorFactory,
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactory,
         bool fromDataAnnotation = false);
 
     /// <summary>
@@ -342,7 +344,9 @@ public interface IConventionProperty : IReadOnlyProperty, IConventionPropertyBas
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
-    Type? SetValueConverter(Type? converterType, bool fromDataAnnotation = false);
+    Type? SetValueConverter(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns the configuration source for <see cref="IReadOnlyProperty.GetValueConverter" />.
@@ -380,7 +384,10 @@ public interface IConventionProperty : IReadOnlyProperty, IConventionPropertyBas
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
-    Type? SetValueComparer(Type? comparerType, bool fromDataAnnotation = false);
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    Type? SetValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns the configuration source for <see cref="IReadOnlyProperty.GetValueComparer" />.
@@ -404,7 +411,10 @@ public interface IConventionProperty : IReadOnlyProperty, IConventionPropertyBas
     /// </param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configured value.</returns>
-    Type? SetProviderValueComparer(Type? comparerType, bool fromDataAnnotation = false);
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    Type? SetProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns the configuration source for <see cref="IReadOnlyProperty.GetProviderValueComparer" />.

--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -576,4 +578,13 @@ public interface IEntityType : IReadOnlyEntityType, ITypeBase
     ///     Returns the declared triggers on the entity type.
     /// </summary>
     new IEnumerable<ITrigger> GetDeclaredTriggers();
+
+    internal const DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes =
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces;
 }

--- a/src/EFCore/Metadata/IModel.cs
+++ b/src/EFCore/Metadata/IModel.cs
@@ -126,7 +126,7 @@ public interface IModel : IReadOnlyModel, IAnnotatable
     /// </remarks>
     /// <param name="type">The type to find the corresponding entity type for.</param>
     /// <returns>The entity type, or <see langword="null" /> if none is found.</returns>
-    new IEntityType? FindEntityType(Type type);
+    new IEntityType? FindEntityType([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 
     /// <summary>
     ///     Gets the entity type for the given name, defining navigation name

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata;
@@ -677,7 +678,10 @@ public interface IMutableEntityType : IReadOnlyEntityType, IMutableTypeBase
     ///     </para>
     /// </param>
     /// <returns>The newly created property.</returns>
-    IMutableProperty AddProperty(string name, Type propertyType, MemberInfo? memberInfo);
+    IMutableProperty AddProperty(
+        string name,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
+        MemberInfo? memberInfo);
 
     /// <summary>
     ///     Gets a property on the given entity type. Returns <see langword="null" /> if no property is found.
@@ -740,6 +744,7 @@ public interface IMutableEntityType : IReadOnlyEntityType, IMutableTypeBase
     /// </summary>
     /// <param name="memberInfo">The corresponding member on the entity class.</param>
     /// <returns>The newly created property.</returns>
+    [RequiresUnreferencedCode("Currently used only in tests")]
     IMutableProperty AddProperty(MemberInfo memberInfo)
         => AddProperty(memberInfo.GetSimpleMemberName(), memberInfo.GetMemberType(), memberInfo);
 
@@ -756,7 +761,7 @@ public interface IMutableEntityType : IReadOnlyEntityType, IMutableTypeBase
     /// <param name="name">The name of the property to add.</param>
     /// <param name="propertyType">The type of value the property will hold.</param>
     /// <returns>The newly created property.</returns>
-    IMutableProperty AddProperty(string name, Type propertyType);
+    IMutableProperty AddProperty(string name, [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType);
 
     /// <summary>
     ///     Adds a property backed up by an indexer to this entity type.
@@ -766,7 +771,7 @@ public interface IMutableEntityType : IReadOnlyEntityType, IMutableTypeBase
     /// <returns>The newly created property.</returns>
     IMutableProperty AddIndexerProperty(
         string name,
-        Type propertyType)
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType)
     {
         var indexerPropertyInfo = FindIndexerPropertyInfo();
         if (indexerPropertyInfo == null)

--- a/src/EFCore/Metadata/IMutableModel.cs
+++ b/src/EFCore/Metadata/IMutableModel.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -66,7 +68,7 @@ public interface IMutableModel : IReadOnlyModel, IMutableAnnotatable
     /// </summary>
     /// <param name="type">The CLR class that is used to represent instances of the entity type.</param>
     /// <returns>The new entity type.</returns>
-    IMutableEntityType AddEntityType(Type type);
+    IMutableEntityType AddEntityType([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 
     /// <summary>
     ///     Adds a shared type entity type to the model.
@@ -78,7 +80,7 @@ public interface IMutableModel : IReadOnlyModel, IMutableAnnotatable
     /// <param name="name">The name of the entity to be added.</param>
     /// <param name="type">The CLR class that is used to represent instances of the entity type.</param>
     /// <returns>The new entity type.</returns>
-    IMutableEntityType AddEntityType(string name, Type type);
+    IMutableEntityType AddEntityType(string name, [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 
     /// <summary>
     ///     Adds an owned entity type with a defining navigation to the model.
@@ -100,7 +102,7 @@ public interface IMutableModel : IReadOnlyModel, IMutableAnnotatable
     /// <param name="definingEntityType">The defining entity type.</param>
     /// <returns>The new entity type.</returns>
     IMutableEntityType AddEntityType(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         string definingNavigationName,
         IMutableEntityType definingEntityType);
 
@@ -120,7 +122,7 @@ public interface IMutableModel : IReadOnlyModel, IMutableAnnotatable
     /// </summary>
     /// <param name="type">The CLR class that is used to represent instances of the entity type.</param>
     /// <returns>The new entity type.</returns>
-    IMutableEntityType AddOwnedEntityType(Type type);
+    IMutableEntityType AddOwnedEntityType([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 
     /// <summary>
     ///     Adds an owned shared type entity type to the model.
@@ -132,7 +134,7 @@ public interface IMutableModel : IReadOnlyModel, IMutableAnnotatable
     /// <param name="name">The name of the entity to be added.</param>
     /// <param name="type">The CLR class that is used to represent instances of the entity type.</param>
     /// <returns>The new entity type.</returns>
-    IMutableEntityType AddOwnedEntityType(string name, Type type);
+    IMutableEntityType AddOwnedEntityType(string name, [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type);
 
     /// <summary>
     ///     Gets the entity with the given name. Returns <see langword="null" /> if no entity type with the given name is found
@@ -292,7 +294,7 @@ public interface IMutableModel : IReadOnlyModel, IMutableAnnotatable
     ///     <see langword="true" /> if a matching entity type should be configured as owned when discovered,
     ///     <see langword="false" /> otherwise.
     /// </returns>
-    bool IsOwned(Type type);
+    bool IsOwned([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type);
 
     /// <summary>
     ///     Marks the given entity type name as ignored, preventing conventions from adding a matching entity type to the model.

--- a/src/EFCore/Metadata/IMutableProperty.cs
+++ b/src/EFCore/Metadata/IMutableProperty.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -194,7 +196,8 @@ public interface IMutableProperty : IReadOnlyProperty, IMutablePropertyBase
     ///     A factory that will be used to create the value generator, or <see langword="null" /> to
     ///     clear any previously set factory.
     /// </param>
-    void SetValueGeneratorFactory(Type? valueGeneratorFactory);
+    void SetValueGeneratorFactory(
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactory);
 
     /// <summary>
     ///     Sets the custom <see cref="ValueConverter" /> for this property.
@@ -208,7 +211,7 @@ public interface IMutableProperty : IReadOnlyProperty, IMutablePropertyBase
     /// <param name="converterType">
     ///     A type that derives from <see cref="ValueConverter" />, or <see langword="null" /> to remove any previously set converter.
     /// </param>
-    void SetValueConverter(Type? converterType);
+    void SetValueConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType);
 
     /// <summary>
     ///     Sets the type that the property value will be converted to before being sent to the database provider.
@@ -234,7 +237,7 @@ public interface IMutableProperty : IReadOnlyProperty, IMutablePropertyBase
     /// <param name="comparerType">
     ///     A type that derives from <see cref="ValueComparer" />, or <see langword="null" /> to remove any previously set comparer.
     /// </param>
-    void SetValueComparer(Type? comparerType);
+    void SetValueComparer([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType);
 
     /// <summary>
     ///     Sets the custom <see cref="ValueComparer" /> to use for the provider values for this property.
@@ -248,5 +251,5 @@ public interface IMutableProperty : IReadOnlyProperty, IMutablePropertyBase
     /// <param name="comparerType">
     ///     A type that derives from <see cref="ValueComparer" />, or <see langword="null" /> to remove any previously set comparer.
     /// </param>
-    void SetProviderValueComparer(Type? comparerType);
+    void SetProviderValueComparer([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType);
 }

--- a/src/EFCore/Metadata/IProperty.cs
+++ b/src/EFCore/Metadata/IProperty.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata;
@@ -96,4 +97,13 @@ public interface IProperty : IReadOnlyProperty, IPropertyBase
     /// </summary>
     /// <returns>The comparer.</returns>
     new ValueComparer GetProviderValueComparer();
+
+    internal const DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes =
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces;
 }

--- a/src/EFCore/Metadata/IReadOnlyModel.cs
+++ b/src/EFCore/Metadata/IReadOnlyModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -61,7 +62,7 @@ public interface IReadOnlyModel : IReadOnlyAnnotatable
     /// </remarks>
     /// <param name="type">The CLR type.</param>
     /// <returns>Whether the CLR type is used by shared type entities in the model.</returns>
-    bool IsShared(Type type);
+    bool IsShared([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type);
 
     /// <summary>
     ///     Gets all entity types defined in the model.

--- a/src/EFCore/Metadata/IReadOnlyPropertyBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyPropertyBase.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -24,6 +26,7 @@ public interface IReadOnlyPropertyBase : IReadOnlyAnnotatable
     /// <summary>
     ///     Gets the type of value that this property-like object holds.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes | IProperty.DynamicallyAccessedMemberTypes)]
     Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/Metadata/IReadOnlyTypeBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyTypeBase.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Metadata;
 
 /// <summary>
@@ -29,6 +32,7 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
     ///     Shadow types are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
     ///     Therefore, shadow types will only exist in migration model snapshots, etc.
     /// </remarks>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/CollectionTypeFactory.cs
+++ b/src/EFCore/Metadata/Internal/CollectionTypeFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -21,6 +22,10 @@ public class CollectionTypeFactory
     /// </summary>
     public virtual Type? TryFindTypeToInstantiate(
         Type entityType,
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.NonPublicConstructors |
+            DynamicallyAccessedMemberTypes.Interfaces)]
         Type collectionType,
         bool requireFullNotifications)
     {

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -94,7 +95,11 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public EntityType(Type type, Model model, bool owned, ConfigurationSource configurationSource)
+    public EntityType(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        Model model,
+        bool owned,
+        ConfigurationSource configurationSource)
         : base(type, model, configurationSource)
     {
         if (!type.IsValidEntityType())
@@ -120,7 +125,12 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public EntityType(string name, Type type, Model model, bool owned, ConfigurationSource configurationSource)
+    public EntityType(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        Model model,
+        bool owned,
+        ConfigurationSource configurationSource)
         : base(name, type, model, configurationSource)
     {
         if (!type.IsValidEntityType())
@@ -2304,7 +2314,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     /// </summary>
     public virtual Property? AddProperty(
         string name,
-        Type propertyType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
         ConfigurationSource? typeConfigurationSource,
         ConfigurationSource configurationSource)
     {
@@ -2325,6 +2335,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [RequiresUnreferencedCode("Use an overload that accepts a type")]
     public virtual Property? AddProperty(
         MemberInfo memberInfo,
         ConfigurationSource configurationSource)
@@ -2341,6 +2352,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [RequiresUnreferencedCode("Use an overload that accepts a type")]
     public virtual Property? AddProperty(
         string name,
         ConfigurationSource configurationSource)
@@ -2370,7 +2382,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     /// </summary>
     public virtual Property? AddProperty(
         string name,
-        Type propertyType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
         MemberInfo? memberInfo,
         ConfigurationSource? typeConfigurationSource,
         ConfigurationSource configurationSource)
@@ -4859,7 +4871,9 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IMutableProperty IMutableEntityType.AddProperty(string name, Type propertyType)
+    IMutableProperty IMutableEntityType.AddProperty(
+        string name,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType)
         => AddProperty(
             name,
             propertyType,
@@ -4875,7 +4889,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     [DebuggerStepThrough]
     IConventionProperty? IConventionEntityType.AddProperty(
         string name,
-        Type propertyType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
         bool setTypeConfigurationSource,
         bool fromDataAnnotation)
         => AddProperty(
@@ -4893,7 +4907,10 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IMutableProperty IMutableEntityType.AddProperty(string name, Type propertyType, MemberInfo? memberInfo)
+    IMutableProperty IMutableEntityType.AddProperty(
+        string name,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
+        MemberInfo? memberInfo)
         => AddProperty(
             name, propertyType, memberInfo,
             ConfigurationSource.Explicit, ConfigurationSource.Explicit)!;
@@ -4907,7 +4924,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     [DebuggerStepThrough]
     IConventionProperty? IConventionEntityType.AddProperty(
         string name,
-        Type propertyType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type propertyType,
         MemberInfo? memberInfo,
         bool setTypeConfigurationSource,
         bool fromDataAnnotation)

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 
@@ -484,7 +485,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalPropertyBuilder? Property(
-        Type? propertyType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? propertyType,
         string propertyName,
         ConfigurationSource? typeConfigurationSource,
         ConfigurationSource? configurationSource)
@@ -518,7 +519,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalPropertyBuilder? IndexerProperty(
-        Type? propertyType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type? propertyType,
         string propertyName,
         ConfigurationSource? configurationSource)
     {
@@ -533,7 +534,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     }
 
     private InternalPropertyBuilder? Property(
-        Type? propertyType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? propertyType,
         string propertyName,
         MemberInfo? memberInfo,
         ConfigurationSource? typeConfigurationSource,
@@ -706,7 +707,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool CanHaveProperty(
-        Type? propertyType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? propertyType,
         string propertyName,
         MemberInfo? memberInfo,
         ConfigurationSource? typeConfigurationSource,
@@ -727,7 +728,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     }
 
     private bool CanAddProperty(
-        Type? propertyType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? propertyType,
         string propertyName,
         ConfigurationSource configurationSource,
         bool checkClrProperty = false)
@@ -1065,7 +1066,10 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool CanHaveNavigation(string navigationName, Type? type, ConfigurationSource? configurationSource)
+    public virtual bool CanHaveNavigation(
+        string navigationName,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? type,
+        ConfigurationSource? configurationSource)
     {
         var existingNavigation = Metadata.FindNavigation(navigationName);
         return existingNavigation != null
@@ -1082,7 +1086,10 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool CanAddNavigation(string navigationName, Type? type, ConfigurationSource configurationSource)
+    public virtual bool CanAddNavigation(
+        string navigationName,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? type,
+        ConfigurationSource configurationSource)
         => !IsIgnored(navigationName, configurationSource)
             && (type == null || CanBeNavigation(type, configurationSource))
             && Metadata.FindPropertiesInHierarchy(navigationName).Cast<IConventionPropertyBase>()
@@ -1115,7 +1122,10 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
             && CanAddSkipNavigation(skipNavigationName, type, configurationSource.Value);
     }
 
-    private bool CanAddSkipNavigation(string skipNavigationName, Type? type, ConfigurationSource configurationSource)
+    private bool CanAddSkipNavigation(
+        string skipNavigationName,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? type,
+        ConfigurationSource configurationSource)
         => !IsIgnored(skipNavigationName, configurationSource)
             && (type == null || CanBeNavigation(type, configurationSource))
             && Metadata.FindPropertiesInHierarchy(skipNavigationName).Cast<IConventionPropertyBase>()
@@ -3727,7 +3737,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalEntityTypeBuilder? GetTargetEntityTypeBuilder(
-        Type targetClrType,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type targetClrType,
         MemberInfo navigationInfo,
         ConfigurationSource? configurationSource,
         bool? targetShouldBeOwned = null)
@@ -5892,7 +5902,10 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    bool IConventionEntityTypeBuilder.CanHaveNavigation(string navigationName, Type? type, bool fromDataAnnotation)
+    bool IConventionEntityTypeBuilder.CanHaveNavigation(
+        string navigationName,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? type,
+        bool fromDataAnnotation)
         => CanHaveNavigation(
             navigationName,
             type,

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 /// <summary>
@@ -51,7 +53,7 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     /// </summary>
     public virtual InternalEntityTypeBuilder? SharedTypeEntity(
         string name,
-        Type? type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type? type,
         ConfigurationSource configurationSource,
         bool? shouldBeOwned = false)
         => Entity(new TypeIdentity(name, type ?? Model.DefaultPropertyBagType), configurationSource, shouldBeOwned);
@@ -63,7 +65,7 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalEntityTypeBuilder? Entity(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         ConfigurationSource configurationSource,
         bool? shouldBeOwned = null)
         => Entity(new TypeIdentity(type, Metadata), configurationSource, shouldBeOwned);
@@ -267,7 +269,7 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalEntityTypeBuilder? Entity(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         string definingNavigationName,
         EntityType definingEntityType,
         ConfigurationSource configurationSource)
@@ -306,7 +308,7 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual IConventionOwnedEntityTypeBuilder? Owned(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         ConfigurationSource configurationSource)
     {
         if (IsIgnored(type, configurationSource)
@@ -361,7 +363,9 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool IsIgnored(Type type, ConfigurationSource? configurationSource)
+    public virtual bool IsIgnored(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        ConfigurationSource? configurationSource)
         => IsIgnored(new TypeIdentity(type, Metadata), configurationSource);
 
     /// <summary>
@@ -397,7 +401,10 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool CanBeConfigured(Type type, TypeConfigurationType configurationType, ConfigurationSource configurationSource)
+    public virtual bool CanBeConfigured(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type,
+        TypeConfigurationType configurationType,
+        ConfigurationSource configurationSource)
     {
         if (configurationSource == ConfigurationSource.Explicit)
         {
@@ -423,7 +430,9 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual InternalModelBuilder? Ignore(Type type, ConfigurationSource configurationSource)
+    public virtual InternalModelBuilder? Ignore(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        ConfigurationSource configurationSource)
         => Ignore(new TypeIdentity(type, Metadata), configurationSource);
 
     /// <summary>
@@ -487,7 +496,9 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool CanIgnore(Type type, ConfigurationSource configurationSource)
+    public virtual bool CanIgnore(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        ConfigurationSource configurationSource)
         => CanIgnore(new TypeIdentity(type, Metadata), configurationSource);
 
     /// <summary>
@@ -683,7 +694,7 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     [DebuggerStepThrough]
     IConventionEntityTypeBuilder? IConventionModelBuilder.SharedTypeEntity(
         string name,
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         bool? shouldBeOwned,
         bool fromDataAnnotation)
         => SharedTypeEntity(
@@ -696,7 +707,10 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IConventionEntityTypeBuilder? IConventionModelBuilder.Entity(Type type, bool? shouldBeOwned, bool fromDataAnnotation)
+    IConventionEntityTypeBuilder? IConventionModelBuilder.Entity(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool? shouldBeOwned,
+        bool fromDataAnnotation)
         => Entity(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention, shouldBeOwned);
 
     /// <summary>
@@ -725,7 +739,7 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     /// </summary>
     [DebuggerStepThrough]
     IConventionEntityTypeBuilder? IConventionModelBuilder.Entity(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         string definingNavigationName,
         IConventionEntityType definingEntityType,
         bool fromDataAnnotation)
@@ -742,7 +756,9 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IConventionOwnedEntityTypeBuilder? IConventionModelBuilder.Owned(Type type, bool fromDataAnnotation)
+    IConventionOwnedEntityTypeBuilder? IConventionModelBuilder.Owned(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation)
         => Owned(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -752,7 +768,9 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    bool IConventionModelBuilder.IsIgnored(Type type, bool fromDataAnnotation)
+    bool IConventionModelBuilder.IsIgnored(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation)
         => IsIgnored(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -772,7 +790,9 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IConventionModelBuilder? IConventionModelBuilder.Ignore(Type type, bool fromDataAnnotation)
+    IConventionModelBuilder? IConventionModelBuilder.Ignore(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation)
         => Ignore(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -803,7 +823,9 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    bool IConventionModelBuilder.CanIgnore(Type type, bool fromDataAnnotation)
+    bool IConventionModelBuilder.CanIgnore(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation)
         => CanIgnore(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 /// <summary>
@@ -340,7 +342,7 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalPropertyBuilder? HasValueGenerator(
-        Type? valueGeneratorType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? valueGeneratorType,
         ConfigurationSource configurationSource)
     {
         if (valueGeneratorType == null)
@@ -398,7 +400,7 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalPropertyBuilder? HasValueGeneratorFactory(
-        Type? factory,
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)]  Type? factory,
         ConfigurationSource configurationSource)
     {
         if (CanSetValueGeneratorFactory(factory, configurationSource))
@@ -431,7 +433,7 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool CanSetValueGeneratorFactory(
-        Type? factory,
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? factory,
         ConfigurationSource? configurationSource)
         => configurationSource.Overrides(Metadata.GetValueGeneratorFactoryConfigurationSource())
             || (Metadata[CoreAnnotationNames.ValueGeneratorFactory] == null
@@ -508,7 +510,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual InternalPropertyBuilder? HasConverter(Type? converterType, ConfigurationSource configurationSource)
+    public virtual InternalPropertyBuilder? HasConverter(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType,
+        ConfigurationSource configurationSource)
     {
         if (CanSetConverter(converterType, configurationSource))
         {
@@ -527,7 +531,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool CanSetConverter(Type? converterType, ConfigurationSource? configurationSource)
+    public virtual bool CanSetConverter(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType,
+        ConfigurationSource? configurationSource)
         => configurationSource.Overrides(Metadata.GetValueConverterConfigurationSource())
             || (Metadata[CoreAnnotationNames.ValueConverter] == null
                 && (Type?)Metadata[CoreAnnotationNames.ValueConverterType] == converterType);
@@ -617,7 +623,7 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalPropertyBuilder? HasValueComparer(
-        Type? comparerType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
         ConfigurationSource configurationSource)
     {
         if (CanSetValueComparer(comparerType, configurationSource))
@@ -685,7 +691,7 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual InternalPropertyBuilder? HasProviderValueComparer(
-        Type? comparerType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
         ConfigurationSource configurationSource)
     {
         if (CanSetProviderValueComparer(comparerType, configurationSource))
@@ -704,7 +710,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool CanSetProviderValueComparer(Type? comparerType, ConfigurationSource? configurationSource)
+    public virtual bool CanSetProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        ConfigurationSource? configurationSource)
         => configurationSource.Overrides(Metadata.GetProviderValueComparerConfigurationSource())
             || (Metadata[CoreAnnotationNames.ProviderValueComparer] == null
                 && (Type?)Metadata[CoreAnnotationNames.ProviderValueComparerType] == comparerType);
@@ -1101,7 +1109,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IConventionPropertyBuilder? IConventionPropertyBuilder.HasValueGenerator(Type? valueGeneratorType, bool fromDataAnnotation)
+    IConventionPropertyBuilder? IConventionPropertyBuilder.HasValueGenerator(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? valueGeneratorType,
+        bool fromDataAnnotation)
         => HasValueGenerator(
             valueGeneratorType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -1132,7 +1142,7 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     IConventionPropertyBuilder? IConventionPropertyBuilder.HasValueGeneratorFactory(
-        Type? valueGeneratorFactoryType,
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactoryType,
         bool fromDataAnnotation)
         => HasValueGeneratorFactory(
             valueGeneratorFactoryType,
@@ -1144,7 +1154,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool IConventionPropertyBuilder.CanSetValueGeneratorFactory(Type? valueGeneratorFactoryType, bool fromDataAnnotation)
+    bool IConventionPropertyBuilder.CanSetValueGeneratorFactory(
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactoryType,
+        bool fromDataAnnotation)
         => CanSetValueGeneratorFactory(
             valueGeneratorFactoryType,
             fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -1173,7 +1185,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IConventionPropertyBuilder? IConventionPropertyBuilder.HasConverter(Type? converterType, bool fromDataAnnotation)
+    IConventionPropertyBuilder? IConventionPropertyBuilder.HasConverter(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType,
+        bool fromDataAnnotation)
         => HasConverter(converterType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -1182,7 +1196,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool IConventionPropertyBuilder.CanSetConverter(Type? converterType, bool fromDataAnnotation)
+    bool IConventionPropertyBuilder.CanSetConverter(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType,
+        bool fromDataAnnotation)
         => CanSetConverter(converterType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -1235,7 +1251,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IConventionPropertyBuilder? IConventionPropertyBuilder.HasValueComparer(Type? comparerType, bool fromDataAnnotation)
+    IConventionPropertyBuilder? IConventionPropertyBuilder.HasValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation)
         => HasValueComparer(comparerType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -1244,7 +1262,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool IConventionPropertyBuilder.CanSetValueComparer(Type? comparerType, bool fromDataAnnotation)
+    bool IConventionPropertyBuilder.CanSetValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation)
         => CanSetValueComparer(comparerType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -1271,7 +1291,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IConventionPropertyBuilder? IConventionPropertyBuilder.HasProviderValueComparer(Type? comparerType, bool fromDataAnnotation)
+    IConventionPropertyBuilder? IConventionPropertyBuilder.HasProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation)
         => HasProviderValueComparer(comparerType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -1280,7 +1302,9 @@ public class InternalPropertyBuilder : InternalPropertyBaseBuilder<Property>, IC
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool IConventionPropertyBuilder.CanSetProviderValueComparer(Type? comparerType, bool fromDataAnnotation)
+    bool IConventionPropertyBuilder.CanSetProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation)
         => CanSetProviderValueComparer(
             comparerType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 }

--- a/src/EFCore/Metadata/Internal/MemberClassifier.cs
+++ b/src/EFCore/Metadata/Internal/MemberClassifier.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -134,7 +135,7 @@ public class MemberClassifier : IMemberClassifier
     }
 
     private bool IsCandidateNavigationPropertyType(
-        Type targetType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type targetType,
         MemberInfo memberInfo,
         Model model,
         out bool? shouldBeOwned)

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -22,6 +22,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     public static readonly Type DefaultPropertyBagType = typeof(Dictionary<string, object>);
 
     private readonly SortedDictionary<string, EntityType> _entityTypes = new(StringComparer.Ordinal);
@@ -158,7 +159,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual EntityType? AddEntityType(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         bool owned,
         ConfigurationSource configurationSource)
     {
@@ -177,7 +178,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     /// </summary>
     public virtual EntityType? AddEntityType(
         string name,
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         bool owned,
         ConfigurationSource configurationSource)
     {
@@ -360,7 +361,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual EntityType? AddEntityType(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         string definingNavigationName,
         EntityType definingEntityType,
         ConfigurationSource configurationSource)
@@ -496,7 +497,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool IsShared(Type type)
+    public virtual bool IsShared([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
         => FindIsSharedConfigurationSource(type) != null
             || Configuration?.GetConfigurationType(type) == TypeConfigurationType.SharedTypeEntityType;
 
@@ -601,7 +602,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool IsIgnoredType(Type type)
+    public virtual bool IsIgnoredType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
         => Configuration?.GetConfigurationType(type) == TypeConfigurationType.Ignored;
 
     /// <summary>
@@ -654,7 +655,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool IsOwned(Type type)
+    public virtual bool IsOwned([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
         => FindIsOwnedConfigurationSource(type) != null
             || Configuration?.GetConfigurationType(type) == TypeConfigurationType.OwnedEntityType;
 
@@ -1156,7 +1157,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IEntityType? IModel.FindEntityType(Type type)
+    IEntityType? IModel.FindEntityType([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
         => FindEntityType(type);
 
     /// <summary>
@@ -1311,7 +1312,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IMutableEntityType IMutableModel.AddEntityType(Type type)
+    IMutableEntityType IMutableModel.AddEntityType([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
         => AddEntityType(type, owned: false, ConfigurationSource.Explicit)!;
 
     /// <summary>
@@ -1321,7 +1322,9 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IConventionEntityType? IConventionModel.AddEntityType(Type type, bool fromDataAnnotation)
+    IConventionEntityType? IConventionModel.AddEntityType(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation)
         => AddEntityType(type, owned: false, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -1331,7 +1334,9 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IMutableEntityType IMutableModel.AddEntityType(string name, Type type)
+    IMutableEntityType IMutableModel.AddEntityType(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
         => AddEntityType(name, type, owned: false, ConfigurationSource.Explicit)!;
 
     /// <summary>
@@ -1341,7 +1346,10 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IConventionEntityType? IConventionModel.AddEntityType(string name, Type type, bool fromDataAnnotation)
+    IConventionEntityType? IConventionModel.AddEntityType(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation)
         => AddEntityType(
             name, type, owned: false, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -1383,7 +1391,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     /// </summary>
     [DebuggerStepThrough]
     IMutableEntityType IMutableModel.AddEntityType(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         string definingNavigationName,
         IMutableEntityType definingEntityType)
         => AddEntityType(type, definingNavigationName, (EntityType)definingEntityType, ConfigurationSource.Explicit)!;
@@ -1397,7 +1405,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     [Obsolete] // The interface didn't mark method obsolete
     [DebuggerStepThrough]
     IConventionEntityType? IConventionModel.AddEntityType(
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         string definingNavigationName,
         IConventionEntityType definingEntityType,
         bool fromDataAnnotation)
@@ -1432,7 +1440,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IMutableEntityType IMutableModel.AddOwnedEntityType(Type type)
+    IMutableEntityType IMutableModel.AddOwnedEntityType([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
         => AddEntityType(type, owned: true, ConfigurationSource.Explicit)!;
 
     /// <summary>
@@ -1442,7 +1450,9 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IConventionEntityType? IConventionModel.AddOwnedEntityType(Type type, bool fromDataAnnotation)
+    IConventionEntityType? IConventionModel.AddOwnedEntityType(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        bool fromDataAnnotation)
         => AddEntityType(type, owned: true, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -1452,7 +1462,9 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IMutableEntityType IMutableModel.AddOwnedEntityType(string name, Type type)
+    IMutableEntityType IMutableModel.AddOwnedEntityType(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
         => AddEntityType(name, type, owned: true, ConfigurationSource.Explicit)!;
 
     /// <summary>
@@ -1462,7 +1474,9 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IConventionEntityType? IConventionModel.AddOwnedEntityType(string name, Type type, bool fromDataAnnotation)
+    IConventionEntityType? IConventionModel.AddOwnedEntityType(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type, bool fromDataAnnotation)
         => AddEntityType(
             name, type, owned: true,
             fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);

--- a/src/EFCore/Metadata/Internal/ModelConfiguration.cs
+++ b/src/EFCore/Metadata/Internal/ModelConfiguration.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -83,14 +84,15 @@ public class ModelConfiguration
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual TypeConfigurationType? GetConfigurationType(Type type)
+    public virtual TypeConfigurationType? GetConfigurationType(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
     {
         Type? configuredType = null;
         return GetConfigurationType(type, null, ref configuredType);
     }
 
     private TypeConfigurationType? GetConfigurationType(
-        Type type,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type,
         TypeConfigurationType? previousConfiguration,
         ref Type? previousType,
         bool getBaseTypes = true)

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -43,6 +44,7 @@ public class Navigation : PropertyBase, IMutableNavigation, IConventionNavigatio
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     public override Type ClrType
         => this.GetIdentifyingMemberInfo()?.GetMemberType()
             ?? (((IReadOnlyNavigation)this).IsCollection

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -35,7 +35,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     /// </summary>
     public Property(
         string name,
-        Type clrType,
+        [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)] Type clrType,
         PropertyInfo? propertyInfo,
         FieldInfo? fieldInfo,
         EntityType declaringEntityType,
@@ -76,6 +76,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)]
     public override Type ClrType { get; }
 
     /// <summary>
@@ -538,7 +539,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual Type? SetValueGeneratorFactory(
-        Type? factoryType,
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? factoryType,
         ConfigurationSource configurationSource)
     {
         if (factoryType != null)
@@ -620,7 +621,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual Type? SetValueConverter(
-        Type? converterType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType,
         ConfigurationSource configurationSource)
     {
         ValueConverter? converter = null;
@@ -782,7 +783,10 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Type? SetValueComparer(Type? comparerType, ConfigurationSource configurationSource)
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public virtual Type? SetValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        ConfigurationSource configurationSource)
     {
         ValueComparer? comparer = null;
         if (comparerType != null)
@@ -881,7 +885,10 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Type? SetProviderValueComparer(Type? comparerType, ConfigurationSource configurationSource)
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public virtual Type? SetProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        ConfigurationSource configurationSource)
     {
         ValueComparer? comparer = null;
         if (comparerType != null)
@@ -1546,7 +1553,8 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    void IMutableProperty.SetValueGeneratorFactory(Type? valueGeneratorFactory)
+    void IMutableProperty.SetValueGeneratorFactory(
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactory)
         => SetValueGeneratorFactory(valueGeneratorFactory, ConfigurationSource.Explicit);
 
     /// <summary>
@@ -1557,7 +1565,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     /// </summary>
     [DebuggerStepThrough]
     Type? IConventionProperty.SetValueGeneratorFactory(
-        Type? valueGeneratorFactory,
+        [DynamicallyAccessedMembers(ValueGeneratorFactory.DynamicallyAccessedMemberTypes)] Type? valueGeneratorFactory,
         bool fromDataAnnotation)
         => SetValueGeneratorFactory(
             valueGeneratorFactory,
@@ -1592,7 +1600,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    void IMutableProperty.SetValueConverter(Type? converterType)
+    void IMutableProperty.SetValueConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType)
         => SetValueConverter(converterType, ConfigurationSource.Explicit);
 
     /// <summary>
@@ -1602,7 +1610,9 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    Type? IConventionProperty.SetValueConverter(Type? converterType, bool fromDataAnnotation)
+    Type? IConventionProperty.SetValueConverter(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? converterType,
+        bool fromDataAnnotation)
         => SetValueConverter(
             converterType,
             fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -1658,7 +1668,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    void IMutableProperty.SetValueComparer(Type? comparerType)
+    void IMutableProperty.SetValueComparer([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType)
         => SetValueComparer(comparerType, ConfigurationSource.Explicit);
 
     /// <summary>
@@ -1668,7 +1678,10 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    Type? IConventionProperty.SetValueComparer(Type? comparerType, bool fromDataAnnotation)
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    Type? IConventionProperty.SetValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation)
         => SetValueComparer(
             comparerType,
             fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -1721,7 +1734,8 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    void IMutableProperty.SetProviderValueComparer(Type? comparerType)
+    void IMutableProperty.SetProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType)
         => SetProviderValueComparer(comparerType, ConfigurationSource.Explicit);
 
     /// <summary>
@@ -1731,7 +1745,10 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    Type? IConventionProperty.SetProviderValueComparer(Type? comparerType, bool fromDataAnnotation)
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    Type? IConventionProperty.SetProviderValueComparer(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type? comparerType,
+        bool fromDataAnnotation)
         => SetProviderValueComparer(
             comparerType,
             fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);

--- a/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -56,7 +56,7 @@ public class PropertyAccessorsFactory
         {
             currentValueExpression = Expression.Call(
                 entryParameter,
-                InternalEntityEntry.ReadShadowValueMethod.MakeGenericMethod(typeof(TProperty)),
+                InternalEntityEntry.MakeReadShadowValueMethod(typeof(TProperty)),
                 Expression.Constant(shadowIndex));
         }
         else
@@ -93,7 +93,7 @@ public class PropertyAccessorsFactory
                         Expression.Constant(default(TProperty), typeof(TProperty))),
                     Expression.Call(
                         entryParameter,
-                        InternalEntityEntry.ReadStoreGeneratedValueMethod.MakeGenericMethod(typeof(TProperty)),
+                        InternalEntityEntry.MakeReadStoreGeneratedValueMethod(typeof(TProperty)),
                         Expression.Constant(storeGeneratedIndex)),
                     currentValueExpression);
             }
@@ -106,7 +106,7 @@ public class PropertyAccessorsFactory
                     Expression.Constant(default(TProperty), typeof(TProperty))),
                 Expression.Call(
                     entryParameter,
-                    InternalEntityEntry.ReadTemporaryValueMethod.MakeGenericMethod(typeof(TProperty)),
+                    InternalEntityEntry.MakeReadTemporaryValueMethod(typeof(TProperty)),
                     Expression.Constant(storeGeneratedIndex)),
                 currentValueExpression);
         }
@@ -127,7 +127,7 @@ public class PropertyAccessorsFactory
                 originalValuesIndex >= 0
                     ? Expression.Call(
                         entryParameter,
-                        InternalEntityEntry.ReadOriginalValueMethod.MakeGenericMethod(typeof(TProperty)),
+                        InternalEntityEntry.MakeReadOriginalValueMethod(typeof(TProperty)),
                         Expression.Constant(property),
                         Expression.Constant(originalValuesIndex))
                     : Expression.Block(
@@ -152,12 +152,12 @@ public class PropertyAccessorsFactory
                 relationshipIndex >= 0
                     ? Expression.Call(
                         entryParameter,
-                        InternalEntityEntry.ReadRelationshipSnapshotValueMethod.MakeGenericMethod(typeof(TProperty)),
+                        InternalEntityEntry.MakeReadRelationshipSnapshotValueMethod(typeof(TProperty)),
                         Expression.Constant(propertyBase),
                         Expression.Constant(relationshipIndex))
                     : Expression.Call(
                         entryParameter,
-                        InternalEntityEntry.GetCurrentValueMethod.MakeGenericMethod(typeof(TProperty)),
+                        InternalEntityEntry.MakeGetCurrentValueMethod(typeof(TProperty)),
                         Expression.Constant(propertyBase)),
                 updateParameter)
             .Compile();

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -338,6 +339,7 @@ public abstract class PropertyBase : ConventionAnnotatable, IMutablePropertyBase
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     public abstract Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -64,6 +65,7 @@ public class ServiceProperty : PropertyBase, IMutableServiceProperty, IConventio
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     public override Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -29,7 +30,10 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected TypeBase(Type type, Model model, ConfigurationSource configurationSource)
+    protected TypeBase(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        Model model,
+        ConfigurationSource configurationSource)
     {
         Check.NotNull(model, nameof(model));
 
@@ -47,7 +51,11 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected TypeBase(string name, Type type, Model model, ConfigurationSource configurationSource)
+    protected TypeBase(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        Model model,
+        ConfigurationSource configurationSource)
     {
         Name = name;
         ClrType = type;
@@ -63,6 +71,7 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     public virtual Type ClrType { [DebuggerStepThrough] get; }
 
     /// <summary>
@@ -376,6 +385,7 @@ public abstract class TypeBase : ConventionAnnotatable, IMutableTypeBase, IConve
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     Type IReadOnlyTypeBase.ClrType
     {
         [DebuggerStepThrough]

--- a/src/EFCore/Metadata/Internal/TypeIdentity.cs
+++ b/src/EFCore/Metadata/Internal/TypeIdentity.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 /// <summary>
@@ -33,7 +35,7 @@ public readonly struct TypeIdentity : IEquatable<TypeIdentity>
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    public TypeIdentity(string name, Type type)
+    public TypeIdentity(string name, [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
     {
         Name = name;
         Type = type;
@@ -47,7 +49,7 @@ public readonly struct TypeIdentity : IEquatable<TypeIdentity>
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    public TypeIdentity(Type type, Model model)
+    public TypeIdentity([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type, Model model)
     {
         Name = model.GetDisplayName(type);
         Type = type;
@@ -68,6 +70,7 @@ public readonly struct TypeIdentity : IEquatable<TypeIdentity>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     public Type? Type { [DebuggerStepThrough] get; }
 
     /// <summary>

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -42,6 +43,7 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
 
     private RuntimeKey? _primaryKey;
     private readonly bool _hasSharedClrType;
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     private readonly Type _clrType;
     private readonly RuntimeEntityType? _baseType;
     private readonly SortedSet<RuntimeEntityType> _directlyDerivedTypes = new(EntityTypeFullNameComparer.Instance);
@@ -73,7 +75,7 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
     [EntityFrameworkInternal]
     public RuntimeEntityType(
         string name,
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         bool sharedClrType,
         RuntimeModel model,
         RuntimeEntityType? baseType,
@@ -836,7 +838,9 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
     /// </summary>
     /// <param name="type">The type to look for the indexer on.</param>
     /// <returns>An indexer property or <see langword="null" />.</returns>
-    public static PropertyInfo? FindIndexerProperty(Type type)
+    public static PropertyInfo? FindIndexerProperty(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        Type type)
         => type.FindIndexerProperty();
 
     /// <summary>
@@ -859,6 +863,7 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
             () => ((IReadOnlyEntityType)this).ToDebugString(MetadataDebugStringOptions.LongDefault));
 
     /// <inheritdoc />
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     Type IReadOnlyTypeBase.ClrType
     {
         [DebuggerStepThrough]

--- a/src/EFCore/Metadata/RuntimeModel.cs
+++ b/src/EFCore/Metadata/RuntimeModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -62,7 +63,7 @@ public class RuntimeModel : AnnotatableBase, IRuntimeModel
     /// <returns>The new entity type.</returns>
     public virtual RuntimeEntityType AddEntityType(
         string name,
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         RuntimeEntityType? baseType = null,
         bool sharedClrType = false,
         string? discriminatorProperty = null,
@@ -173,7 +174,7 @@ public class RuntimeModel : AnnotatableBase, IRuntimeModel
     private string GetDisplayName(Type type)
         => _clrTypeNameMap.GetOrAdd(type, t => t.DisplayName());
 
-    private PropertyInfo? FindIndexerPropertyInfo(Type type)
+    private PropertyInfo? FindIndexerPropertyInfo([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
         => _indexerPropertyInfoMap.GetOrAdd(type, type.FindIndexerProperty());
 
     /// <summary>
@@ -240,7 +241,7 @@ public class RuntimeModel : AnnotatableBase, IRuntimeModel
 
     /// <inheritdoc />
     [DebuggerStepThrough]
-    IEntityType? IModel.FindEntityType(Type type)
+    IEntityType? IModel.FindEntityType([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
         => FindEntityType(type);
 
     /// <inheritdoc />
@@ -289,7 +290,7 @@ public class RuntimeModel : AnnotatableBase, IRuntimeModel
 
     /// <inheritdoc />
     [DebuggerStepThrough]
-    bool IReadOnlyModel.IsShared(Type type)
+    bool IReadOnlyModel.IsShared([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
         => _sharedTypes.ContainsKey(type);
 
     /// <inheritdoc />

--- a/src/EFCore/Metadata/RuntimeNavigation.cs
+++ b/src/EFCore/Metadata/RuntimeNavigation.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -46,6 +47,7 @@ public class RuntimeNavigation : RuntimePropertyBase, INavigation
     /// <summary>
     ///     Gets the type of value that this navigation holds.
     /// </summary>
+    [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)]
     protected override Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/Metadata/RuntimeProperty.cs
+++ b/src/EFCore/Metadata/RuntimeProperty.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -107,6 +108,7 @@ public class RuntimeProperty : RuntimePropertyBase, IProperty
     /// <summary>
     ///     Gets the type of value that this property-like object holds.
     /// </summary>
+    [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)]
     protected override Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/Metadata/RuntimePropertyBase.cs
+++ b/src/EFCore/Metadata/RuntimePropertyBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -59,6 +60,7 @@ public abstract class RuntimePropertyBase : AnnotatableBase, IRuntimePropertyBas
     /// <summary>
     ///     Gets the type of value that this property-like object holds.
     /// </summary>
+    [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)]
     protected abstract Type ClrType { get; }
 
     /// <inheritdoc />
@@ -117,6 +119,7 @@ public abstract class RuntimePropertyBase : AnnotatableBase, IRuntimePropertyBas
     }
 
     /// <inheritdoc />
+    [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)]
     Type IReadOnlyPropertyBase.ClrType
     {
         [DebuggerStepThrough]

--- a/src/EFCore/Metadata/RuntimeServiceProperty.cs
+++ b/src/EFCore/Metadata/RuntimeServiceProperty.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata;
@@ -45,6 +46,7 @@ public class RuntimeServiceProperty : RuntimePropertyBase, IServiceProperty
     /// <summary>
     ///     Gets the type of value that this property-like object holds.
     /// </summary>
+    [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)]
     protected override Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/Metadata/RuntimeSkipNavigation.cs
+++ b/src/EFCore/Metadata/RuntimeSkipNavigation.cs
@@ -70,6 +70,7 @@ public class RuntimeSkipNavigation : RuntimePropertyBase, IRuntimeSkipNavigation
     /// <summary>
     ///     Gets the type of value that this navigation holds.
     /// </summary>
+    [DynamicallyAccessedMembers(IProperty.DynamicallyAccessedMemberTypes)]
     protected override Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
@@ -145,7 +146,8 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// </remarks>
     /// <typeparam name="TEntity">The entity type to be configured.</typeparam>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> Entity<TEntity>()
+    public virtual EntityTypeBuilder<TEntity> Entity<
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>()
         where TEntity : class
         => new(Builder.Entity(typeof(TEntity), ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata);
 
@@ -169,7 +171,9 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <typeparam name="TEntity">The CLR type of the entity type to be configured.</typeparam>
     /// <param name="name">The name of the entity type to be configured.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder<TEntity> SharedTypeEntity<TEntity>(string name)
+    public virtual EntityTypeBuilder<TEntity> SharedTypeEntity<
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(
+        string name)
         where TEntity : class
     {
         Check.NotEmpty(name, nameof(name));
@@ -186,7 +190,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// </remarks>
     /// <param name="type">The entity type to be configured.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder Entity(Type type)
+    public virtual EntityTypeBuilder Entity([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
     {
         Check.NotNull(type, nameof(type));
 
@@ -230,7 +234,9 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <param name="name">The name of the entity type to be configured.</param>
     /// <param name="type">The CLR type of the entity type to be configured.</param>
     /// <returns>An object that can be used to configure the entity type.</returns>
-    public virtual EntityTypeBuilder SharedTypeEntity(string name, Type type)
+    public virtual EntityTypeBuilder SharedTypeEntity(
+        string name,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
     {
         Check.NotEmpty(name, nameof(name));
         Check.NotNull(type, nameof(type));
@@ -258,7 +264,8 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <returns>
     ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
     /// </returns>
-    public virtual ModelBuilder Entity<TEntity>(Action<EntityTypeBuilder<TEntity>> buildAction)
+    public virtual ModelBuilder Entity<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(
+        Action<EntityTypeBuilder<TEntity>> buildAction)
         where TEntity : class
     {
         Check.NotNull(buildAction, nameof(buildAction));
@@ -296,7 +303,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <returns>
     ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
     /// </returns>
-    public virtual ModelBuilder SharedTypeEntity<TEntity>(
+    public virtual ModelBuilder SharedTypeEntity<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(
         string name,
         Action<EntityTypeBuilder<TEntity>> buildAction)
         where TEntity : class
@@ -327,7 +334,9 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <returns>
     ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
     /// </returns>
-    public virtual ModelBuilder Entity(Type type, Action<EntityTypeBuilder> buildAction)
+    public virtual ModelBuilder Entity(
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
+        Action<EntityTypeBuilder> buildAction)
     {
         Check.NotNull(buildAction, nameof(buildAction));
 
@@ -395,7 +404,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// </returns>
     public virtual ModelBuilder SharedTypeEntity(
         string name,
-        Type type,
+        [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         Action<EntityTypeBuilder> buildAction)
     {
         Check.NotNull(type, nameof(type));
@@ -417,7 +426,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <returns>
     ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
     /// </returns>
-    public virtual ModelBuilder Ignore<TEntity>()
+    public virtual ModelBuilder Ignore<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>()
         where TEntity : class
         => Ignore(typeof(TEntity));
 
@@ -432,7 +441,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <returns>
     ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
     /// </returns>
-    public virtual ModelBuilder Ignore(Type type)
+    public virtual ModelBuilder Ignore([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
     {
         Check.NotNull(type, nameof(type));
 
@@ -472,7 +481,8 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <returns>
     ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
     /// </returns>
-    public virtual ModelBuilder ApplyConfiguration<TEntity>(IEntityTypeConfiguration<TEntity> configuration)
+    public virtual ModelBuilder ApplyConfiguration
+        <[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] TEntity>(IEntityTypeConfiguration<TEntity> configuration)
         where TEntity : class
     {
         Check.NotNull(configuration, nameof(configuration));
@@ -494,6 +504,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     /// <returns>
     ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
     /// </returns>
+    [RequiresUnreferencedCode("This API isn't safe for trimming, since it searches for types in an arbitrary assembly.")]
     public virtual ModelBuilder ApplyConfigurationsFromAssembly(
         Assembly assembly,
         Func<Type, bool>? predicate = null)
@@ -541,7 +552,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     ///     See <see href="https://aka.ms/efcore-docs-owned">Owned types in EF Core</see> for more information and examples.
     /// </remarks>
     /// <typeparam name="T">The entity type to be configured.</typeparam>
-    public virtual OwnedEntityTypeBuilder<T> Owned<T>()
+    public virtual OwnedEntityTypeBuilder<T> Owned<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] T>()
         where T : class
     {
         Builder.Owned(typeof(T), ConfigurationSource.Explicit);
@@ -557,7 +568,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     ///     See <see href="https://aka.ms/efcore-docs-owned">Owned types in EF Core</see> for more information and examples.
     /// </remarks>
     /// <param name="type">The entity type to be configured.</param>
-    public virtual OwnedEntityTypeBuilder Owned(Type type)
+    public virtual OwnedEntityTypeBuilder Owned([DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type)
     {
         Check.NotNull(type, nameof(type));
 

--- a/src/EFCore/Query/TransparentIdentifierFactory.cs
+++ b/src/EFCore/Query/TransparentIdentifierFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Query;
@@ -28,6 +29,8 @@ public static class TransparentIdentifierFactory
     /// <param name="outerType">The outer type of the transparent identifier.</param>
     /// <param name="innerType">The inner type of the transparent identifier.</param>
     /// <returns>The created transparent identifier type.</returns>
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TransparentIdentifier<,>))]
     public static Type Create(Type outerType, Type innerType)
         => typeof(TransparentIdentifier<,>).MakeGenericType(outerType, innerType);
 

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage;
@@ -35,7 +36,7 @@ public abstract class CoreTypeMapping
         /// <param name="providerValueComparer">Supports custom comparisons between converted provider values.</param>
         /// <param name="valueGeneratorFactory">An optional factory for creating a specific <see cref="ValueGenerator" />.</param>
         public CoreTypeMappingParameters(
-            Type clrType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type clrType,
             ValueConverter? converter = null,
             ValueComparer? comparer = null,
             ValueComparer? keyComparer = null,
@@ -53,6 +54,7 @@ public abstract class CoreTypeMapping
         /// <summary>
         ///     The mapping CLR type.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
         public Type ClrType { get; init; }
 
         /// <summary>
@@ -155,6 +157,9 @@ public abstract class CoreTypeMapping
     /// <summary>
     ///     Gets the .NET type used in the EF model.
     /// </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods
+        | DynamicallyAccessedMemberTypes.NonPublicMethods
+        | DynamicallyAccessedMemberTypes.PublicProperties)]
     public virtual Type ClrType { get; }
 
     /// <summary>

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.NetworkInformation;
 
@@ -559,6 +560,8 @@ public class ValueConverterSelector : IValueConverterSelector
         }
     }
 
-    private static ValueConverterInfo GetDefaultValueConverterInfo(Type converterTypeInfo)
+    private static ValueConverterInfo GetDefaultValueConverterInfo(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        Type converterTypeInfo)
         => (ValueConverterInfo)converterTypeInfo.GetAnyProperty("DefaultInfo")!.GetValue(null)!;
 }

--- a/src/EFCore/ValueGeneration/ValueGeneratorFactory.cs
+++ b/src/EFCore/ValueGeneration/ValueGeneratorFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration;
 
 /// <summary>
@@ -21,4 +23,8 @@ public abstract class ValueGeneratorFactory
     /// <param name="entityType">The entity type for which the value generator will be used.</param>
     /// <returns>The newly created value generator.</returns>
     public abstract ValueGenerator Create(IProperty property, IEntityType entityType);
+
+    internal const DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes =
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors;
 }

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -3,6 +3,12 @@
 
 #nullable enable
 
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -45,7 +51,7 @@ internal static class SharedTypeExtensions
         => type.IsClass
             && !type.IsArray;
 
-    public static bool IsPropertyBagType(this Type type)
+    public static bool IsPropertyBagType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type type)
     {
         if (type.IsGenericTypeDefinition)
         {
@@ -101,7 +107,10 @@ internal static class SharedTypeExtensions
             && type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), inherit: false).Length > 0
             && type.Name.Contains("AnonymousType");
 
-    public static PropertyInfo? GetAnyProperty(this Type type, string name)
+    public static PropertyInfo? GetAnyProperty(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        this Type type,
+        string name)
     {
         var props = type.GetRuntimeProperties().Where(p => p.Name == name).ToList();
         if (props.Count > 1)
@@ -130,7 +139,7 @@ internal static class SharedTypeExtensions
         return isNullable ? MakeNullable(underlyingEnumType) : underlyingEnumType;
     }
 
-    public static Type GetSequenceType(this Type type)
+    public static Type GetSequenceType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type type)
     {
         var sequenceType = TryGetSequenceType(type);
         if (sequenceType == null)
@@ -141,11 +150,13 @@ internal static class SharedTypeExtensions
         return sequenceType;
     }
 
-    public static Type? TryGetSequenceType(this Type type)
+    public static Type? TryGetSequenceType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type type)
         => type.TryGetElementType(typeof(IEnumerable<>))
             ?? type.TryGetElementType(typeof(IAsyncEnumerable<>));
 
-    public static Type? TryGetElementType(this Type type, Type interfaceOrBaseType)
+    public static Type? TryGetElementType(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type type,
+        Type interfaceOrBaseType)
     {
         if (type.IsGenericTypeDefinition)
         {
@@ -275,7 +286,8 @@ internal static class SharedTypeExtensions
         }
     }
 
-    public static IEnumerable<Type> GetDeclaredInterfaces(this Type type)
+    public static IEnumerable<Type> GetDeclaredInterfaces(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type type)
     {
         var interfaces = type.GetInterfaces();
         if (type.BaseType == typeof(object)
@@ -284,10 +296,18 @@ internal static class SharedTypeExtensions
             return interfaces;
         }
 
-        return interfaces.Except(type.BaseType.GetInterfaces());
+        return interfaces.Except(GetInterfacesSuppressed(type.BaseType));
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070", Justification = "https://github.com/dotnet/linker/issues/2473")]
+        static IEnumerable<Type> GetInterfacesSuppressed(Type type)
+            => type.GetInterfaces();
     }
 
-    public static ConstructorInfo? GetDeclaredConstructor(this Type type, Type[]? types)
+    public static ConstructorInfo? GetDeclaredConstructor(
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+        this Type type,
+        Type[]? types)
     {
         types ??= Array.Empty<Type>();
 
@@ -340,7 +360,14 @@ internal static class SharedTypeExtensions
         while (currentType != null);
     }
 
-    public static IEnumerable<MemberInfo> GetMembersInHierarchy(this Type type, string name)
+    public static IEnumerable<MemberInfo> GetMembersInHierarchy(
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicProperties
+            | DynamicallyAccessedMemberTypes.NonPublicProperties
+            | DynamicallyAccessedMemberTypes.PublicFields
+            | DynamicallyAccessedMemberTypes.NonPublicFields)]
+        this Type type,
+        string name)
         => type.GetMembersInHierarchy().Where(m => m.Name == name);
 
     private static readonly Dictionary<Type, object> CommonTypeDictionary = new()
@@ -366,7 +393,8 @@ internal static class SharedTypeExtensions
 #pragma warning restore IDE0034 // Simplify 'default' expression
     };
 
-    public static object? GetDefaultValue(this Type type)
+    public static object? GetDefaultValue(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type type)
     {
         if (!type.IsValueType)
         {
@@ -381,11 +409,13 @@ internal static class SharedTypeExtensions
             : Activator.CreateInstance(type);
     }
 
+    [RequiresUnreferencedCode("Gets all types from the given assembly - unsafe for trimming")]
     public static IEnumerable<TypeInfo> GetConstructibleTypes(this Assembly assembly)
         => assembly.GetLoadableDefinedTypes().Where(
             t => !t.IsAbstract
                 && !t.IsGenericTypeDefinition);
 
+    [RequiresUnreferencedCode("Gets all types from the given assembly - unsafe for trimming")]
     public static IEnumerable<TypeInfo> GetLoadableDefinedTypes(this Assembly assembly)
     {
         try

--- a/test/EFCore.Trimming.Tests/EFCore.Trimming.Tests.csproj
+++ b/test/EFCore.Trimming.Tests/EFCore.Trimming.Tests.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>partial</TrimMode>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/test/EFCore.Trimming.Tests/Program.cs
+++ b/test/EFCore.Trimming.Tests/Program.cs
@@ -11,16 +11,28 @@ await using var ctx = new BlogContext();
 await ctx.Database.EnsureDeletedAsync();
 await ctx.Database.EnsureCreatedAsync();
 
+ctx.Add(new Blog { Name = "Some Blog Name" });
+await ctx.SaveChangesAsync();
+
+ctx.ChangeTracker.Clear();
+
 // Execute any query to make sure the basic query pipeline works
-_ = ctx.Blogs.Where(b => b.Name.StartsWith("foo")).ToList();
+var blog = await ctx.Blogs.Where(b => b.Name.StartsWith("Some ")).SingleAsync();
+if (blog.Name != "Some Blog Name")
+{
+    throw new Exception($"Incorrect blog name ({blog.Name})");
+}
 
 Console.WriteLine("Database query executed successfully.");
 
 public class BlogContext : DbContext
 {
+    public BlogContext()
+        => Blogs = Set<Blog>();
+
     private static readonly string ConnectionString;
 
-    public DbSet<Blog> Blogs { get; set; }
+    public DbSet<Blog> Blogs { get; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         => optionsBuilder.UseSqlServer(ConnectionString);


### PR DESCRIPTION
To make basic save/query scenarios work with aggressive trimming, as long as user types are properly preserved. This is a  conservative/safe wave of annotations that generally avoids risky suppressions; many warnings are still emitted by the linker, but basic scenarios still work. I've kept non-annotation code changes to a minimum, but I did some simple ones were done.

Here are some details and numbers; all scenarios were executed with the modified [trimming tests](https://github.com/dotnet/efcore/blob/d747818c87bad71ebd08b81fb048f205e52f0088/test/EFCore.Trimming.Tests/Program.cs) we run in CI.

Trimming mode               | EF size | Total publish dir size | Notes
--------------------------- | ------- | ---------------------- | -----
No trimming                 | 4588kb  | 93MB                   |
Partial                     | 4588kb  | 54MB                   | Default before 7.0, ASP.NET default in 7.0
Aggressive (before this PR) | 380kb   | 34MB                   | Application fails.
Aggressive (after this PR)  | 3384kb  | 34MB                   | Console app default starting with 7.0. Application works.

To summarize, aggressive trimming mode cuts down 1204kb of pure EF size, totalling a 26% reduction in size. Precise per-assembly sizes are listed below.

<details>
<summary>EF sizes without trimming</summary>

```
28      Microsoft.EntityFrameworkCore.Abstractions.dll
24      Microsoft.EntityFrameworkCore.Analyzers.dll
2144    Microsoft.EntityFrameworkCore.dll
1904    Microsoft.EntityFrameworkCore.Relational.dll
488     Microsoft.EntityFrameworkCore.SqlServer.dll
4588    total
```
</details>

<details>
<summary>EF sizes after aggressive trimming (before this PR)</summary>

```
8       Microsoft.EntityFrameworkCore.Abstractions.dll
220     Microsoft.EntityFrameworkCore.dll
116     Microsoft.EntityFrameworkCore.Relational.dll
36      Microsoft.EntityFrameworkCore.SqlServer.dll
380     total
```

</details>

<details>
<summary>EF sizes after aggressive trimming (after this PR)</summary>

```
12      Microsoft.EntityFrameworkCore.Abstractions.dll
1636    Microsoft.EntityFrameworkCore.dll
1432    Microsoft.EntityFrameworkCore.Relational.dll
304     Microsoft.EntityFrameworkCore.SqlServer.dll
3384    total
```

</details>

Closes #29092

/cc @DamianEdwards after this, the TrimmedTodo console sample in https://github.com/DamianEdwards/TrimmedTodo works in .NET 7.0 even without specifying partial trimming.