### PR TITLE
Override existing explicitly configured values when moving annotations on making owned type shared

### DIFF
--- a/src/EFCore/Infrastructure/AnnotatableBuilder.cs
+++ b/src/EFCore/Infrastructure/AnnotatableBuilder.cs
@@ -195,7 +195,7 @@ public abstract class AnnotatableBuilder<TMetadata, TModelBuilder> : IConvention
                         annotation.Name,
                         annotation.Value,
                         configurationSource,
-                        canOverrideSameSource: false)
+                        canOverrideSameSource: true)
                     ?? builder;
             }
         }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -471,6 +471,9 @@ public class ModelBuilderGenericTest : ModelBuilderTest
         public override TestPropertyBuilder<TProperty> HasMaxLength(int maxLength)
             => Wrap(PropertyBuilder.HasMaxLength(maxLength));
 
+        public override TestPropertyBuilder<TProperty> HasPrecision(int precision)
+            => Wrap(PropertyBuilder.HasPrecision(precision));
+
         public override TestPropertyBuilder<TProperty> HasPrecision(int precision, int scale)
             => Wrap(PropertyBuilder.HasPrecision(precision, scale));
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -551,6 +551,9 @@ public class ModelBuilderNonGenericTest : ModelBuilderTest
         public override TestPropertyBuilder<TProperty> HasMaxLength(int maxLength)
             => Wrap(PropertyBuilder.HasMaxLength(maxLength));
 
+        public override TestPropertyBuilder<TProperty> HasPrecision(int precision)
+            => Wrap(PropertyBuilder.HasPrecision(precision));
+
         public override TestPropertyBuilder<TProperty> HasPrecision(int precision, int scale)
             => Wrap(PropertyBuilder.HasPrecision(precision, scale));
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -374,6 +374,7 @@ public abstract partial class ModelBuilderTest
         public abstract TestPropertyBuilder<TProperty> HasAnnotation(string annotation, object? value);
         public abstract TestPropertyBuilder<TProperty> IsRequired(bool isRequired = true);
         public abstract TestPropertyBuilder<TProperty> HasMaxLength(int maxLength);
+        public abstract TestPropertyBuilder<TProperty> HasPrecision(int precision);
         public abstract TestPropertyBuilder<TProperty> HasPrecision(int precision, int scale);
         public abstract TestPropertyBuilder<TProperty> IsUnicode(bool unicode = true);
         public abstract TestPropertyBuilder<TProperty> IsRowVersion();

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -1232,4 +1232,23 @@ public abstract partial class ModelBuilderTest
         public int? StoreId { get; set; }
         public Store? Store { get; set; }
     }
+
+    protected class MainOtter
+    {
+        public Guid Id { get; set; }
+        public decimal Number { get; set; }
+        public OwnedOtter OwnedEntity { get; set; } = null!;
+    }
+
+    protected class OtherOtter
+    {
+        public Guid Id { get; set; }
+        public decimal Number { get; set; }
+        public List<OwnedOtter> OwnedEntities { get; } = new();
+    }
+
+    protected class OwnedOtter
+    {
+        public decimal Number { get; set; }
+    }
 }


### PR DESCRIPTION
Fixes #28091

This is because property configuration done by pre-convention configuration is explicit, but if that has been changed before the type is made owned, then those changes are lost because the pre-convention configuration is not overwritten.
