### PR TITLE
Templates: Specify a groupIdentity for ef-templates

### DIFF
--- a/src/EFCore.Templates/templates/ef-templates/.template.config/template.json
+++ b/src/EFCore.Templates/templates/ef-templates/.template.config/template.json
@@ -3,6 +3,7 @@
   "author": "Microsoft",
   "classifications": [ "EFCore", "Scaffolding" ],
   "identity": "Microsoft.EntityFrameworkCore.Templates.ef-templates",
+  "groupIdentity": "Microsoft.EntityFrameworkCore.Templates.ef-templates",
   "name": "Entity Framework Core Scaffolding Templates",
   "shortName": "ef-templates",
   "tags": {


### PR DESCRIPTION
Needed for VB templates. https://github.com/efcore/EFCore.VisualBasic/pull/83? /cc @lorcQc

**Description**

EF7 allows templates to be used for scaffolding a DbContext and model from an existing database. We implemented C# support and provided extension points for other languages. This change is needed for the in-progress community implementation of VB support.

**Customer impact**

Allows the community to add VB support for scaffolding templates.

**How found**

Community work implementing VB support.

**Regression**

No. New feature.

**Testing**

The VB implementation will be the primary testing of this.

**Risk**

Low; no impact on C# support.