### PR TITLE
[release/7.0] Scaffolding: Don't scaffold HasColumnOrder

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "tools": {
-    "dotnet": "7.0.100-rc.1.22425.9"
+    "dotnet": "7.0.100-rc.1.22431.12"
   },
   "sdk": {
-    "version": "7.0.100-rc.1.22425.9",
+    "version": "7.0.100-rc.1.22431.12",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },

--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -562,6 +562,8 @@ public static class ScaffoldingModelExtensions
             .ToDictionary(a => a.Name, a => a);
         annotationCodeGenerator.RemoveAnnotationsHandledByConventions(property, annotations);
 
+        annotations.Remove(RelationalAnnotationNames.ColumnOrder);
+
         var annotationsHandledByDataAnnotations = new Dictionary<string, IAnnotation>(annotations);
 
         // Strip out any annotations handled as attributes

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1312,6 +1312,24 @@ public partial class TestDbContext : DbContext
                     Assert.Equal(SqlServerValueGenerationStrategy.None, property.GetValueGenerationStrategy());
                 });
 
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public Task ColumnOrder_is_ignored(bool useDataAnnotations)
+            => TestAsync(
+                modelBuilder => modelBuilder.Entity("Entity").Property<string>("Property").HasColumnOrder(1),
+                new ModelCodeGenerationOptions { UseDataAnnotations = useDataAnnotations },
+                code =>
+                {
+                    Assert.DoesNotContain(".HasColumnOrder(1)", code.ContextFile.Code);
+                    Assert.DoesNotContain("[Column(Order = 1)]", code.ContextFile.Code);
+                },
+                model =>
+                {
+                    var entity = model.FindEntityType("TestNamespace.Entity");
+                    Assert.Null(entity.GetProperty("Property").GetColumnOrder());
+                });
+
         protected override void AddModelServices(IServiceCollection services)
             => services.Replace(ServiceDescriptor.Singleton<IRelationalAnnotationProvider, TestModelAnnotationProvider>());
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1322,7 +1322,7 @@ public partial class TestDbContext : DbContext
                 code =>
                 {
                     Assert.DoesNotContain(".HasColumnOrder(1)", code.ContextFile.Code);
-                    Assert.DoesNotContain("[Column(Order = 1)]", code.ContextFile.Code);
+                    Assert.DoesNotContain("[Column(Order = 1)]", code.AdditionalFiles[0].Code);
                 },
                 model =>
                 {


### PR DESCRIPTION
Fixes #29007

### Customer impact

Without this, a lot of unncessary `HasColumnOrder` calls are generated in the scaffolded code.

### Regression?

Yes.

### Risk

Low. This more closely resembles the code we had in EF Core 6.0.

### Verification

Automated tests added.