### PR TITLE
Async fix for "Generate values for PK properties that are also self-referencing FK properties"

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -77,7 +77,8 @@ public class KeyPropagator : IKeyPropagator
         var principalEntry = TryPropagateValue(entry, property, generationProperty);
 
         if (principalEntry == null
-            && property.IsKey())
+            && property.IsKey()
+            && !property.IsForeignKeyToSelf())
         {
             var valueGenerator = TryGetValueGenerator(
                 generationProperty,

--- a/test/EFCore.Cosmos.FunctionalTests/ConfigPatternsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ConfigPatternsCosmosTest.cs
@@ -59,9 +59,9 @@ public class ConfigPatternsCosmosTest : IClassFixture<ConfigPatternsCosmosTest.C
         using var context = new CustomerContext(options);
         context.Database.EnsureCreated();
 
-        context.Add(customer);
+        await context.AddAsync(customer);
 
-        context.SaveChanges();
+        await context.SaveChangesAsync();
     }
 
     [ConditionalFact]
@@ -78,9 +78,9 @@ public class ConfigPatternsCosmosTest : IClassFixture<ConfigPatternsCosmosTest.C
                 using var context = new CustomerContext(options);
                 context.Database.EnsureCreated();
 
-                context.Add(customer);
+                await context.AddAsync(customer);
 
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             });
 
         Assert.Equal(
@@ -101,9 +101,9 @@ public class ConfigPatternsCosmosTest : IClassFixture<ConfigPatternsCosmosTest.C
         using var context = new CustomerContext(options);
         context.Database.EnsureCreated();
 
-        context.Add(customer);
+        await context.AddAsync(customer);
 
-        context.SaveChanges();
+        await context.SaveChangesAsync();
     }
 
     [ConditionalFact]
@@ -121,9 +121,9 @@ public class ConfigPatternsCosmosTest : IClassFixture<ConfigPatternsCosmosTest.C
                 using var context = new CustomerContext(options);
                 context.Database.EnsureCreated();
 
-                context.Add(customer);
+                await context.AddAsync(customer);
 
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             });
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosConcurrencyTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosConcurrencyTest.cs
@@ -61,7 +61,7 @@ public class CosmosConcurrencyTest : IClassFixture<CosmosConcurrencyTest.CosmosF
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -96,7 +96,7 @@ public class CosmosConcurrencyTest : IClassFixture<CosmosConcurrencyTest.CosmosF
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -144,7 +144,7 @@ public class CosmosConcurrencyTest : IClassFixture<CosmosConcurrencyTest.CosmosF
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
 

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -83,7 +83,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
         using (var context = new EmbeddedTransportationContext(options))
         {
             //Issue #15289
-            var firstVehicleEntry = context.Add(firstVehicle);
+            var firstVehicleEntry = await context.AddAsync(firstVehicle);
             firstVehicleEntry.State = EntityState.Unchanged;
             firstVehicle.Operator.Name += "1";
 
@@ -112,7 +112,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
         Address addedAddress3;
         using (var context = new EmbeddedTransportationContext(options))
         {
-            context.Add(new Person { Id = 1 });
+            await context.AddAsync(new Person { Id = 1 });
             existingAddress1Person2 = new Address
             {
                 Street = "Second",
@@ -140,7 +140,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
                 Street = "First",
                 City = "Village"
             };
-            context.Add(new Person { Id = 2, Addresses = new List<Address> { existingAddress1Person2, existingAddress2Person2 } });
+            await context.AddAsync(new Person { Id = 2, Addresses = new List<Address> { existingAddress1Person2, existingAddress2Person2 } });
             existingAddress1Person3 = new Address
             {
                 Street = "First",
@@ -169,7 +169,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
                 AddressTitle = new AddressTitle { Title = "P3 Billing" }
             };
 
-            context.Add(new Person { Id = 3, Addresses = new List<Address> { existingAddress1Person3, existingAddress2Person3 } });
+            await context.AddAsync(new Person { Id = 3, Addresses = new List<Address> { existingAddress1Person3, existingAddress2Person3 } });
 
             await context.SaveChangesAsync();
 
@@ -407,7 +407,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
                 AddressTitle = new AddressTitle()
             };
 
-            context.Add(new Person { Id = 1, Addresses = new List<Address> { address } });
+            await context.AddAsync(new Person { Id = 1, Addresses = new List<Address> { address } });
             Assert.Equal("DefaultTitle", address.AddressTitle.Title);
 
             await context.SaveChangesAsync();
@@ -441,7 +441,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
             var person = new Person { Id = 1 };
             address = new Address { Street = "Second", City = "Village" };
             person.Addresses.Add(address);
-            context.Add(person);
+            await context.AddAsync(person);
 
             var addressEntry = context.Entry(address);
             addressGuid = (Guid)addressEntry.Property("Id").CurrentValue;
@@ -505,7 +505,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
 
         using (var context = new EmbeddedTransportationContext(options))
         {
-            context.Add(
+            await context.AddAsync(
                 new Person
                 {
                     Id = 3,
@@ -531,7 +531,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
     {
         var options = Fixture.CreateOptions(seed: false);
         using var context = new EmbeddedTransportationContext(options);
-        context.Add(
+        await context.AddAsync(
             new LicensedOperator
             {
                 Name = "Jack Jackson",
@@ -586,7 +586,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
             };
 
             context.Remove(bike);
-            context.Add(newBike);
+            await context.AddAsync(newBike);
 
             TestSqlLoggerFactory.Clear();
             await context.SaveChangesAsync();

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -102,7 +102,7 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
 
@@ -170,11 +170,11 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             await context.Database.EnsureCreatedAsync();
 
-            var entry = context.Add(customer);
+            var entry = await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             storeId = entry.Property<string>(StoreKeyConvention.DefaultIdPropertyName).CurrentValue;
         }
@@ -319,7 +319,7 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             await context.Database.EnsureCreatedAsync();
 
-            var entry = context.Add(customer);
+            var entry = await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
 
@@ -336,7 +336,7 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             Assert.Empty(await context.Set<Customer>().ToListAsync());
 
-            var entry = context.Add(customer);
+            var entry = await context.AddAsync(customer);
 
             entry.Property<JObject>("__jObject").CurrentValue = new JObject { ["key1"] = "value1" };
 
@@ -408,7 +408,7 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -459,7 +459,7 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             await context.Database.EnsureCreatedAsync();
 
-            var entry = context.Add(customer);
+            var entry = await context.AddAsync(customer);
 
             Assert.Equal("CustomerDateTime|0001-01-01T00:00:00.0000000|Theon^2F^5C^23^5C^5C^3F", entry.CurrentValues["__id"]);
 
@@ -588,7 +588,7 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -828,7 +828,7 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -911,8 +911,8 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
                 context.Model.FindEntityType(typeof(CustomerWithResourceId))
                     .FindProperty(StoreKeyConvention.DefaultIdPropertyName));
 
-            context.Add(customer);
-            context.Add(
+            await context.AddAsync(customer);
+            await context.AddAsync(
                 new CustomerWithResourceId
                 {
                     id = "42",
@@ -1039,8 +1039,8 @@ public class EndToEndCosmosTest : IClassFixture<EndToEndCosmosTest.CosmosFixture
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
-            context.Add(
+            await context.AddAsync(customer);
+            await context.AddAsync(
                 new Customer
                 {
                     Id = 42,
@@ -1207,7 +1207,7 @@ OFFSET 0 LIMIT 1");
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -1233,7 +1233,7 @@ OFFSET 0 LIMIT 1");
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -1259,7 +1259,7 @@ OFFSET 0 LIMIT 1");
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -1285,7 +1285,7 @@ OFFSET 0 LIMIT 1");
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
@@ -1449,14 +1449,14 @@ OFFSET 0 LIMIT 1");
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
         }
 
         using (var context = new NoDiscriminatorCustomerContext(options))
         {
-            context.Add(customer).State = EntityState.Modified;
+            (await context.AddAsync(customer)).State = EntityState.Modified;
 
             customer.Name = "Theon Greyjoy";
 
@@ -1470,7 +1470,7 @@ OFFSET 0 LIMIT 1");
             Assert.Equal(42, customerFromStore.Id);
             Assert.Equal("Theon Greyjoy", customerFromStore.Name);
 
-            context.Add(customer).State = EntityState.Deleted;
+            (await context.AddAsync(customer)).State = EntityState.Deleted;
 
             await context.SaveChangesAsync();
         }
@@ -1570,7 +1570,7 @@ OFFSET 0 LIMIT 1");
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
             Assert.Equal("Theon", customer.Name);
@@ -1609,7 +1609,7 @@ OFFSET 0 LIMIT 1");
         var customer = new Customer { Id = 42, Name = "Theon" };
         using (var context = new CustomerContext(options))
         {
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             Assert.StartsWith(
                 "Response status code does not indicate success: NotFound (404); Substatus: 0",
@@ -1618,7 +1618,7 @@ OFFSET 0 LIMIT 1");
 
         using (var context = new CustomerContext(options))
         {
-            context.Add(customer).State = EntityState.Modified;
+            (await context.AddAsync(customer)).State = EntityState.Modified;
 
             Assert.StartsWith(
                 "Response status code does not indicate success: NotFound (404); Substatus: 0",
@@ -1627,7 +1627,7 @@ OFFSET 0 LIMIT 1");
 
         using (var context = new CustomerContext(options))
         {
-            context.Add(customer).State = EntityState.Deleted;
+            (await context.AddAsync(customer)).State = EntityState.Deleted;
 
             Assert.StartsWith(
                 "Response status code does not indicate success: NotFound (404); Substatus: 0",
@@ -1653,7 +1653,7 @@ OFFSET 0 LIMIT 1");
             {
                 await context.Database.EnsureCreatedAsync();
 
-                context.Add(new ConflictingIncompatibleId { id = 42 });
+                await context.AddAsync(new ConflictingIncompatibleId { id = 42 });
 
                 await context.SaveChangesAsync();
             });
@@ -1688,7 +1688,7 @@ OFFSET 0 LIMIT 1");
         {
             await context.Database.EnsureCreatedAsync();
 
-            context.Add(entity);
+            await context.AddAsync(entity);
 
             await context.SaveChangesAsync();
         }
@@ -1754,7 +1754,7 @@ OFFSET 0 LIMIT 1");
         using var context = new NonStringDiscriminatorContext(Fixture.CreateOptions());
         context.Database.EnsureCreated();
 
-        context.Add(new NonStringDiscriminator { Id = 1 });
+        await context.AddAsync(new NonStringDiscriminator { Id = 1 });
         await context.SaveChangesAsync();
 
         Assert.NotNull(await context.Set<NonStringDiscriminator>().OrderBy(e => e.Id).FirstOrDefaultAsync());

--- a/test/EFCore.Cosmos.FunctionalTests/Internal/IdentifierShadowValuePresenceTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Internal/IdentifierShadowValuePresenceTest.cs
@@ -15,7 +15,7 @@ public class IdentifierShadowValuePresenceTest
 
         Assert.Null(item.Id);
 
-        var entry = context.Add(item);
+        var entry = await context.AddAsync(item);
 
         var id = entry.Property("__id").CurrentValue;
 

--- a/test/EFCore.Cosmos.FunctionalTests/ReloadTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ReloadTest.cs
@@ -18,7 +18,7 @@ public class ReloadTest
         using var context = new ReloadTestContext(testDatabase);
         await context.Database.EnsureCreatedAsync();
 
-        var entry = context.Add(new Item { Id = 1337 });
+        var entry = await context.AddAsync(new Item { Id = 1337 });
 
         await context.SaveChangesAsync();
 

--- a/test/EFCore.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -18,7 +18,7 @@ public class CompositeKeyEndToEndTest
 
         using (var context = new BronieContext(serviceProvider))
         {
-            context.Add(
+            await context.AddAsync(
                 new Pegasus
                 {
                     Id1 = ticks,
@@ -67,8 +67,8 @@ public class CompositeKeyEndToEndTest
 
         using (var context = new BronieContext(serviceProvider))
         {
-            var added = context.Add(
-                new Unicorn { Id2 = id2, Name = "Rarity" }).Entity;
+            var added = (await context.AddAsync(
+                new Unicorn { Id2 = id2, Name = "Rarity" })).Entity;
 
             Assert.True(added.Id1 > 0);
             Assert.NotEqual(Guid.Empty, added.Id3);
@@ -121,12 +121,12 @@ public class CompositeKeyEndToEndTest
 
         using (var context = new BronieContext(serviceProvider))
         {
-            var pony1 = context.Add(
-                new EarthPony { Id2 = 7, Name = "Apple Jack 1" }).Entity;
-            var pony2 = context.Add(
-                new EarthPony { Id2 = 7, Name = "Apple Jack 2" }).Entity;
-            var pony3 = context.Add(
-                new EarthPony { Id2 = 7, Name = "Apple Jack 3" }).Entity;
+            var pony1 = (await context.AddAsync(
+                new EarthPony { Id2 = 7, Name = "Apple Jack 1" })).Entity;
+            var pony2 = (await context.AddAsync(
+                new EarthPony { Id2 = 7, Name = "Apple Jack 2" })).Entity;
+            var pony3 = (await context.AddAsync(
+                new EarthPony { Id2 = 7, Name = "Apple Jack 3" })).Entity;
 
             await context.SaveChangesAsync();
 

--- a/test/EFCore.InMemory.FunctionalTests/DatabaseInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/DatabaseInMemoryTest.cs
@@ -34,7 +34,7 @@ public class DatabaseInMemoryTest
 
         using (var context = new DbContext(options))
         {
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             await context.SaveChangesAsync();
 

--- a/test/EFCore.InMemory.FunctionalTests/GuidValueGeneratorEndToEndTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GuidValueGeneratorEndToEndTest.cs
@@ -19,8 +19,8 @@ public class GuidValueGeneratorEndToEndTest
             for (var i = 0; i < 10; i++)
             {
                 guids.Add(
-                    context.Add(
-                        new Pegasus { Name = "Rainbow Dash " + i }).Entity.Id);
+                    (await context.AddAsync(
+                        new Pegasus { Name = "Rainbow Dash " + i })).Entity.Id);
                 guidsHash.Add(guids.Last());
             }
 

--- a/test/EFCore.InMemory.FunctionalTests/IntegerGeneratorEndToEndInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/IntegerGeneratorEndToEndInMemoryTest.cs
@@ -66,9 +66,9 @@ public class IntegerGeneratorEndToEndInMemoryTest
         using var context = new BronieContext(serviceProvider);
         for (var i = 0; i < 50; i++)
         {
-            context.Add(
+            await context.AddAsync(
                 new Pegasus { Name = "Rainbow Dash " + i });
-            context.Add(
+            await context.AddAsync(
                 new Pegasus { Name = "Fluttershy " + i });
         }
 

--- a/test/EFCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -23,7 +23,7 @@ public class ShadowStateUpdateTest : IClassFixture<InMemoryFixture>
 
         using (var context = new DbContext(optionsBuilder.Options))
         {
-            context.Add(customer);
+            await context.AddAsync(customer);
 
             context.Entry(customer).Property("Name").CurrentValue = "Daenerys";
 

--- a/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
@@ -21,7 +21,7 @@ public abstract class EntitySplittingTestBase : NonSharedModelTestBase
         {
             var meterReading = new MeterReading { ReadingStatus = MeterReadingStatus.NotAccesible, CurrentRead = "100" };
 
-            context.Add(meterReading);
+            await context.AddAsync(meterReading);
 
             TestSqlLoggerFactory.Clear();
 

--- a/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
@@ -167,7 +167,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
 
         using (var context = CreateContext())
         {
-            var scooterEntry = context.Add(
+            var scooterEntry = await context.AddAsync(
                 new PoweredVehicle
                 {
                     Name = "Electric scooter",
@@ -212,7 +212,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
 
         using (var context = CreateContext())
         {
-            var scooterEntry = context.Add(
+            var scooterEntry = await context.AddAsync(
                 new PoweredVehicle
                 {
                     Name = "Electric scooter",
@@ -357,14 +357,14 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
         await InitializeAsync(OnModelCreating);
 
         using var context = CreateContext();
-        context.Add(
+        await context.AddAsync(
             new PoweredVehicle
             {
                 Name = "Fuel transport",
                 SeatingCapacity = 1,
                 Operator = new LicensedOperator { Name = "Jack Jackson", LicenseType = "Class A CDC" }
             });
-        context.Add(
+        await context.AddAsync(
             new FuelTank
             {
                 Capacity = 10000_1,
@@ -453,7 +453,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
             };
 
             context.Remove(bike);
-            context.Add(newBike);
+            await context.AddAsync(newBike);
 
             TestSqlLoggerFactory.Clear();
             context.SaveChanges();
@@ -503,7 +503,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
             };
 
             context.Remove(bike);
-            context.Add(newBike);
+            await context.AddAsync(newBike);
 
             TestSqlLoggerFactory.Clear();
             context.SaveChanges();
@@ -545,7 +545,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
         var meterReading = new MeterReading { MeterReadingDetails = new MeterReadingDetail() };
 
         using var context = CreateSharedContext();
-        context.Add(meterReading);
+        await context.AddAsync(meterReading);
 
         context.SaveChanges();
 
@@ -566,7 +566,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
         var meterReading = new MeterReading { MeterReadingDetails = new MeterReadingDetail() };
 
         using var context = CreateSharedContext();
-        context.Add(meterReading);
+        await context.AddAsync(meterReading);
 
         TestSqlLoggerFactory.Clear();
 
@@ -605,7 +605,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
 
         var meterReading = new MeterReading { MeterReadingDetails = new MeterReadingDetail { CurrentRead = "100" } };
 
-        context.Add(meterReading);
+        await context.AddAsync(meterReading);
 
         TestSqlLoggerFactory.Clear();
 

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -37,7 +37,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
         {
             context.Database.AutoTransactionBehavior = AutoTransactionBehavior.Never;
 
-            context.Add(
+            await context.AddAsync(
                 new TransactionCustomer { Id = -77, Name = "Bobble" });
 
             context.Entry(context.Set<TransactionOrder>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -80,7 +80,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
         {
             context.Database.AutoTransactionsEnabled = false;
 
-            context.Add(
+            await context.AddAsync(
                 new TransactionCustomer { Id = -77, Name = "Bobble" });
 
             context.Entry(context.Set<TransactionOrder>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -123,7 +123,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
         {
             context.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
 
-            context.Add(
+            await context.AddAsync(
                 new TransactionCustomer { Id = -77, Name = "Bobble" });
 
             context.Entry(context.Set<TransactionOrder>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -162,7 +162,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
         {
             Assert.Equal(AutoTransactionBehavior.WhenNeeded, context.Database.AutoTransactionBehavior);
 
-            context.Add(
+            await context.AddAsync(
                 new TransactionCustomer { Id = 77, Name = "Bobble" });
 
             context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -196,7 +196,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
                 context.Database.EnlistTransaction(transaction);
                 context.Database.AutoTransactionBehavior = autoTransactionBehavior;
 
-                context.Add(
+                await context.AddAsync(
                     new TransactionCustomer { Id = -77, Name = "Bobble" });
 
                 context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -269,7 +269,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
                 context.Database.EnlistTransaction(transaction);
                 context.Database.AutoTransactionBehavior = autoTransactionBehavior;
 
-                context.Add(
+                await context.AddAsync(
                     new TransactionCustomer { Id = 77, Name = "Bobble" });
 
                 context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -320,7 +320,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
             context.Database.EnlistTransaction(transaction);
             context.Database.AutoTransactionBehavior = autoTransactionBehavior;
 
-            context.Add(
+            await context.AddAsync(
                 new TransactionCustomer { Id = 77, Name = "Bobble" });
 
             context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -362,7 +362,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
             {
                 context.Database.AutoTransactionBehavior = autoTransactionBehavior;
 
-                context.Add(
+                await context.AddAsync(
                     new TransactionCustomer { Id = -77, Name = "Bobble" });
 
                 context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -435,7 +435,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
                 connection = context.Database.GetDbConnection();
                 Assert.Equal(ConnectionState.Closed, connection.State);
 
-                context.Add(
+                await context.AddAsync(
                     new TransactionCustomer { Id = 77, Name = "Bobble" });
 
                 context.Entry(context.Set<TransactionCustomer>().OrderBy(c => c.Id).Last()).State = EntityState.Added;
@@ -627,7 +627,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
 
             Assert.Equal(ConnectionState.Open, connection.State);
 
-            context.Add(
+            await context.AddAsync(
                 new TransactionCustomer { Id = 77, Name = "Bobble" });
 
             if (async)
@@ -1352,7 +1352,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
                 ? await context.Database.BeginTransactionAsync()
                 : context.Database.BeginTransaction();
 
-            context.Add(new TransactionCustomer { Id = 77, Name = "Bobble" });
+            await context.AddAsync(new TransactionCustomer { Id = 77, Name = "Bobble" });
 
             if (async)
             {
@@ -1363,8 +1363,8 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
                 context.SaveChanges();
             }
 
-            context.Add(new TransactionCustomer { Id = 78, Name = "Hobble" });
-            context.Add(new TransactionCustomer { Id = 1, Name = "Gobble" }); // Cause SaveChanges failure
+            await context.AddAsync(new TransactionCustomer { Id = 78, Name = "Hobble" });
+            await context.AddAsync(new TransactionCustomer { Id = 1, Name = "Gobble" }); // Cause SaveChanges failure
 
             if (async)
             {
@@ -1397,7 +1397,7 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
                 ? await context.Database.BeginTransactionAsync()
                 : context.Database.BeginTransaction();
 
-            context.Add(new TransactionCustomer { Id = -77, Name = "Bobble" });
+            await context.AddAsync(new TransactionCustomer { Id = -77, Name = "Bobble" });
 
             if (async)
             {
@@ -1408,8 +1408,8 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
                 context.SaveChanges();
             }
 
-            context.Add(new TransactionCustomer { Id = -78, Name = "Hobble" });
-            context.Add(new TransactionOrder { Id = 100 }); // Cause SaveChanges failure
+            await context.AddAsync(new TransactionCustomer { Id = -78, Name = "Hobble" });
+            await context.AddAsync(new TransactionOrder { Id = 100 }); // Cause SaveChanges failure
 
             if (async)
             {

--- a/test/EFCore.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Update/BatchExecutorTest.cs
@@ -15,8 +15,8 @@ public class BatchExecutorTest
         using var context = new TestContext();
         var connection = SetupConnection(context);
 
-        context.Add(new Foo { Id = "1" });
-        context.Add(new Bar { Id = "1" });
+        await context.AddAsync(new Foo { Id = "1" });
+        await context.AddAsync(new Bar { Id = "1" });
 
         if (async)
         {
@@ -40,7 +40,7 @@ public class BatchExecutorTest
         var transaction = new FakeDbTransaction(connection);
         context.Database.UseTransaction(transaction);
 
-        context.Add(
+        await context.AddAsync(
             new Foo { Id = "1" });
 
         if (async)

--- a/test/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
+++ b/test/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
@@ -23,7 +23,7 @@ public abstract class CompositeKeyEndToEndTestBase<TFixture> : IClassFixture<TFi
 
         using (var context = CreateContext())
         {
-            var pegasus = context.Add(
+            var pegasus = await context.AddAsync(
                 new Pegasus
                 {
                     Id1 = ticks,
@@ -74,8 +74,8 @@ public abstract class CompositeKeyEndToEndTestBase<TFixture> : IClassFixture<TFi
         {
             context.Database.EnsureCreatedResiliently();
 
-            var added = context.Add(
-                new Unicorn { Id2 = id2, Name = "Rarity" }).Entity;
+            var added = (await context.AddAsync(
+                new Unicorn { Id2 = id2, Name = "Rarity" })).Entity;
 
             await context.SaveChangesAsync();
 
@@ -124,27 +124,27 @@ public abstract class CompositeKeyEndToEndTestBase<TFixture> : IClassFixture<TFi
 
         using (var context = CreateContext())
         {
-            var pony1 = context.Add(
+            var pony1 = (await context.AddAsync(
                 new EarthPony
                 {
                     Id1 = 1,
                     Id2 = 7,
                     Name = "Apple Jack 1"
-                }).Entity;
-            var pony2 = context.Add(
+                })).Entity;
+            var pony2 = (await context.AddAsync(
                 new EarthPony
                 {
                     Id1 = 2,
                     Id2 = 7,
                     Name = "Apple Jack 2"
-                }).Entity;
-            var pony3 = context.Add(
+                })).Entity;
+            var pony3 = (await context.AddAsync(
                 new EarthPony
                 {
                     Id1 = 3,
                     Id2 = 7,
                     Name = "Apple Jack 3"
-                }).Entity;
+                })).Entity;
 
             await context.SaveChangesAsync();
 

--- a/test/EFCore.Specification.Tests/MusicStoreTestBase.cs
+++ b/test/EFCore.Specification.Tests/MusicStoreTestBase.cs
@@ -119,10 +119,10 @@ public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
 
                     foreach (var album in albums)
                     {
-                        context.Add(album);
+                        await context.AddAsync(album);
                     }
 
-                    context.SaveChanges();
+                    await context.SaveChangesAsync();
 
                     var result = await controller.Index(context);
 
@@ -256,8 +256,8 @@ public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
                 {
                     var controller = new CheckoutController();
 
-                    var order = context.Add(CreateOrder()).Entity;
-                    context.SaveChanges();
+                    var order = (await context.AddAsync(CreateOrder())).Entity;
+                    await context.SaveChangesAsync();
 
                     var result = await controller.Complete(context, order.OrderId);
 

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -20,13 +20,13 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     {
         using (var context = CreateContext())
         {
-            context.Add(
+            await context.AddAsync(
                 new HeliumBalloon
                 {
                     Id = Guid.NewGuid().ToString(), Gas = new Helium(),
                 });
 
-            context.Add(new HydrogenBalloon { Id = Guid.NewGuid().ToString(), Gas = new Hydrogen() });
+            await context.AddAsync(new HydrogenBalloon { Id = Guid.NewGuid().ToString(), Gas = new Hydrogen() });
 
             _ = async ? await context.SaveChangesAsync() : context.SaveChanges();
         }

--- a/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
@@ -47,7 +47,7 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
             exceptionFromEvent = args.Exception;
         };
 
-        context.Add(new Singularity { Id = 35, Type = "Red Dwarf" });
+        await context.AddAsync(new Singularity { Id = 35, Type = "Red Dwarf" });
 
         using var transaction = context.Database.BeginTransaction();
 
@@ -117,7 +117,7 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
             exceptionFromEvent = args.Exception;
         };
 
-        context.Add(new Singularity { Id = 35, Type = "Red Dwarf" });
+        await context.AddAsync(new Singularity { Id = 35, Type = "Red Dwarf" });
 
         using var transaction = context.Database.BeginTransaction();
 
@@ -203,7 +203,7 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
             exceptionFromEvent = args.Exception;
         };
 
-        context.Add(new Singularity { Id = 35, Type = "Red Dwarf" });
+        await context.AddAsync(new Singularity { Id = 35, Type = "Red Dwarf" });
 
         using var transaction = context.Database.BeginTransaction();
 
@@ -285,7 +285,7 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
 
         if (!concurrencyError)
         {
-            context.Add(new Singularity { Id = 35, Type = "Red Dwarf" });
+            await context.AddAsync(new Singularity { Id = 35, Type = "Red Dwarf" });
             var ___ = async ? await context.SaveChangesAsync() : context.SaveChanges();
             context.ChangeTracker.Clear();
         }
@@ -490,7 +490,7 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
             new IInterceptor[] { new PassiveSaveChangesInterceptor(), interceptor1, interceptor2 },
             new IInterceptor[] { interceptor3, interceptor4, new PassiveSaveChangesInterceptor() });
 
-        context.Add(new Singularity { Id = 35, Type = "Red Dwarf" });
+        await context.AddAsync(new Singularity { Id = 35, Type = "Red Dwarf" });
 
         using var transaction = context.Database.BeginTransaction();
 

--- a/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -741,7 +741,7 @@ public abstract class WithConstructorsTestBase<TFixture> : IClassFixture<TFixtur
         {
             var immutableBlog = new BlogAsImmutableRecord(title);
 
-            context.Add(immutableBlog);
+            await context.AddAsync(immutableBlog);
             await context.SaveChangesAsync();
 
             Assert.NotEqual(0, immutableBlog.BlogId);

--- a/test/EFCore.SqlServer.FunctionalTests/EntitySplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EntitySplittingSqlServerTest.cs
@@ -46,7 +46,7 @@ END");
         {
             var meterReading = new MeterReading { ReadingStatus = MeterReadingStatus.NotAccesible, CurrentRead = "100" };
 
-            context.Add(meterReading);
+            await context.AddAsync(meterReading);
 
             TestSqlLoggerFactory.Clear();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3974,7 +3974,7 @@ ORDER BY [p].[Id]");
 
         using (var context = contextFactory.CreateContext())
         {
-            context.Add(new MyContext13079.BaseEntity13079());
+            await context.AddAsync(new MyContext13079.BaseEntity13079());
             context.SaveChanges();
 
             AssertSql(
@@ -9058,7 +9058,7 @@ WHERE JSON_VALUE([b].[JObject], '$.Author') = N'Maumar'");
 
         try
         {
-            context.Add(observableThing);
+            await context.AddAsync(observableThing);
             await context.SaveChangesAsync();
         }
         finally

--- a/test/EFCore.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
@@ -20,7 +20,7 @@ public class SequentialGuidEndToEndTest : IDisposable
 
             for (var i = 0; i < 50; i++)
             {
-                context.Add(
+                await context.AddAsync(
                     new Pegasus { Name = "Rainbow Dash " + i });
             }
 
@@ -54,13 +54,13 @@ public class SequentialGuidEndToEndTest : IDisposable
             for (var i = 0; i < 50; i++)
             {
                 guids.Add(
-                    context.Add(
+                    (await context.AddAsync(
                         new Pegasus
                         {
                             Name = "Rainbow Dash " + i,
                             Index = i,
                             Id = Guid.NewGuid()
-                        }).Entity.Id);
+                        })).Entity.Id);
             }
 
             await context.SaveChangesAsync();

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -443,11 +443,11 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
             context.Database.EnsureCreatedResiliently();
             var first = new Int32CompositeKeys { Id1 = 1, Id2 = 2 };
 
-            context.Add(first);
+            await context.AddAsync(first);
 
             var second = new Int64CompositeKeys { Id1 = 1, Id2 = 2 };
 
-            context.Add(second);
+            await context.AddAsync(second);
             await context.SaveChangesAsync();
         }
 
@@ -567,7 +567,7 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
             context.Database.EnsureCreatedResiliently();
 
             var ferrari = new Ferrari { Special = new Car() };
-            context.Add(ferrari);
+            await context.AddAsync(ferrari);
 
             await context.SaveChangesAsync();
 
@@ -1440,9 +1440,9 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
 
         using (var context = new SchemaContext(options))
         {
-            context.Add(
+            await context.AddAsync(
                 new Jack { MyKey = 1 });
-            context.Add(
+            await context.AddAsync(
                 new Black { MyKey = 2 });
             context.SaveChanges();
         }
@@ -1549,7 +1549,7 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
             blog2.NotFigTime = new DateTime();
             blog2.AndChew = null;
 
-            var blog3 = context.Add(new TBlog()).Entity;
+            var blog3 = (await context.AddAsync(new TBlog())).Entity;
 
             await context.SaveChangesAsync();
 
@@ -1581,7 +1581,7 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
     {
         context.Database.EnsureCreatedResiliently();
 
-        var blog1 = context.Add(
+        var blog1 = (await context.AddAsync(
             new TBlog
             {
                 Name = "Blog1",
@@ -1599,8 +1599,8 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
                 OrUSkint = 8888888,
                 OrUShort = 888888888888888,
                 AndChew = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
-            }).Entity;
-        var blog2 = context.Add(
+            })).Entity;
+        var blog2 = (await context.AddAsync(
             new TBlog
             {
                 Name = "Blog2",
@@ -1618,7 +1618,7 @@ public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
                 OrUSkint = 8888888,
                 OrUShort = 888888888888888,
                 AndChew = new byte[16]
-            }).Entity;
+            })).Entity;
         await context.SaveChangesAsync();
 
         return new[] { blog1, blog2 };

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -1011,7 +1011,7 @@ END");
         {
             using (var context = new BlogContextComputedColumn(testStore.Name))
             {
-                context.Add(new FullNameBlog());
+                await context.AddAsync(new FullNameBlog());
 
                 var exception = async
                     ? await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync())
@@ -1056,7 +1056,7 @@ END");
         {
             using (var context = new BlogContextComputedColumn(testStore.Name))
             {
-                context.Add(new FullNameBlog());
+                await context.AddAsync(new FullNameBlog());
 
                 var exception = async
                     ? await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync())

--- a/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
@@ -46,7 +46,7 @@ public class TransactionSqlServerTest : TransactionTestBase<TransactionSqlServer
         var orderId = 300;
         foreach (var _ in context.Set<TransactionCustomer>())
         {
-            context.Add(new TransactionOrder { Id = orderId++, Name = "Order " + orderId });
+            await context.AddAsync(new TransactionOrder { Id = orderId++, Name = "Order " + orderId });
             if (async)
             {
                 await context.SaveChangesAsync();

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -4754,7 +4754,7 @@ public class OwnedFixupTest
         {
             // Trying to do the same thing again will throw since only one row can have ID zero.
 
-            context.Add(new Blog { Type = new OwnedType { Value = "A" } });
+            await context.AddAsync(new Blog { Type = new OwnedType { Value = "A" } });
             Assert.Throws<ArgumentException>(() => context.SaveChanges());
         }
     }

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -499,8 +499,8 @@ public partial class DbContextTest
         {
             Assert.True(context.ChangeTracker.AutoDetectChangesEnabled);
 
-            var product = context.Add(
-                new Product { Id = 1, Name = "Little Hedgehogs" }).Entity;
+            var product = (await context.AddAsync(
+                new Product { Id = 1, Name = "Little Hedgehogs" })).Entity;
 
             if (async)
             {
@@ -541,8 +541,8 @@ public partial class DbContextTest
             context.ChangeTracker.AutoDetectChangesEnabled = false;
             Assert.False(context.ChangeTracker.AutoDetectChangesEnabled);
 
-            var product = context.Add(
-                new Product { Id = 1, Name = "Little Hedgehogs" }).Entity;
+            var product = (await context.AddAsync(
+                new Product { Id = 1, Name = "Little Hedgehogs" })).Entity;
 
             if (async)
             {

--- a/test/EFCore.Tests/EventSourceTest.cs
+++ b/test/EFCore.Tests/EventSourceTest.cs
@@ -37,7 +37,7 @@ public class EventSourceTest
         {
             using var context = new SomeDbContext();
 
-            context.Add(new Foo());
+            await context.AddAsync(new Foo());
 
             _ = async ? await context.SaveChangesAsync() : context.SaveChanges();
 
@@ -109,7 +109,7 @@ public class EventSourceTest
             using var context = new SomeDbContext();
 
             var entity = new Foo();
-            context.Add(entity);
+            await context.AddAsync(entity);
             context.SaveChanges();
 
             using (var innerContext = new SomeDbContext())

--- a/test/EFCore.Tests/Storage/ValueConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConverterTest.cs
@@ -15,7 +15,7 @@ public class ValueConverterTest
     {
         using (var context = new InMemoryConvertersContext())
         {
-            context.Add(
+            await context.AddAsync(
                 new Person
                 {
                     Id = async ? 1 : 2,


### PR DESCRIPTION
See #22585, #22573, #26448

Async code pat was not fixed in original PR. However, this was not exposed until additional bug fix for #26448 in EF7 RC2

**Description**

Using the async overload of `Add` fails to generate a key value for TPT mappings where the primary keys of sub-tables are also foreign keys to the main table.

**Customer impact**

Exception when using `AddAsync` in many TPT scenarios.

**How found**

Found while writing samples for EF7.

**Regression**

Yes; worked in EF Core 6.0.

**Testing**

Added more use of `AddAsync` in tests.

**Risk**

Low; async code path was missing a check that existed in the sync code path.

