### PR TITLE
Allow specify property value without lambda in ExecuteUpdate 

### DIFF
--- a/src/EFCore.Relational/Query/SetPropertyCalls.cs
+++ b/src/EFCore.Relational/Query/SetPropertyCalls.cs
@@ -34,11 +34,27 @@ public sealed class SetPropertyCalls<TSource>
     /// <param name="valueExpression">A value expression.</param>
     /// <returns>
     ///     The same instance so that multiple calls to
-    ///     <see cref="SetProperty{TProperty}(Expression{Func{TSource, TProperty}}, Expression{Func{TSource, TProperty}})" /> can be chained.
+    ///     <see cref="SetPropertyCalls{TSource}.SetProperty{TProperty}(Func{TSource, TProperty}, Func{TSource, TProperty})" />
+    ///     can be chained.
     /// </returns>
     public SetPropertyCalls<TSource> SetProperty<TProperty>(
-        Expression<Func<TSource, TProperty>> propertyExpression,
-        Expression<Func<TSource, TProperty>> valueExpression)
+        Func<TSource, TProperty> propertyExpression,
+        Func<TSource, TProperty> valueExpression)
+        => throw new InvalidOperationException(RelationalStrings.SetPropertyMethodInvoked);
+
+    /// <summary>
+    ///     Specifies a property and corresponding value it should be updated to in ExecuteUpdate method.
+    /// </summary>
+    /// <typeparam name="TProperty">The type of property.</typeparam>
+    /// <param name="propertyExpression">A property access expression.</param>
+    /// <param name="valueExpression">A value expression.</param>
+    /// <returns>
+    ///     The same instance so that multiple calls to
+    ///     <see cref="SetPropertyCalls{TSource}.SetProperty{TProperty}(Func{TSource, TProperty}, TProperty)" /> can be chained.
+    /// </returns>
+    public SetPropertyCalls<TSource> SetProperty<TProperty>(
+        Func<TSource, TProperty> propertyExpression,
+        TProperty valueExpression)
         => throw new InvalidOperationException(RelationalStrings.SetPropertyMethodInvoked);
 
     #region Hidden System.Object members

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/FiltersInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/FiltersInheritanceBulkUpdatesTestBase.cs
@@ -102,7 +102,7 @@ public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpda
             async,
             ss => ss.Set<Animal>().Where(e => e.Name == "Great spotted kiwi"),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Animal"),
+            s => s.SetProperty(e => e.Name, "Animal"),
             rowsAffectedCount: 1,
             (b, a) => a.ForEach(e => Assert.Equal("Animal", e.Name)));
 
@@ -113,7 +113,7 @@ public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpda
             async,
             ss => ss.Set<Animal>().Where(e => e.Name == "Great spotted kiwi").OrderBy(e => e.Name).Skip(0).Take(3),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Animal"),
+            s => s.SetProperty(e => e.Name, "Animal"),
             rowsAffectedCount: 1);
 
     [ConditionalTheory]
@@ -123,7 +123,7 @@ public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpda
             async,
             ss => ss.Set<Kiwi>().Where(e => e.Name == "Great spotted kiwi"),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Kiwi"),
+            s => s.SetProperty(e => e.Name, "Kiwi"),
             rowsAffectedCount: 1);
 
     [ConditionalTheory]
@@ -133,7 +133,7 @@ public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpda
             async,
             ss => ss.Set<Country>().Where(e => e.Animals.Where(a => a.CountryId > 0).Count() > 0),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Monovia"),
+            s => s.SetProperty(e => e.Name, "Monovia"),
             rowsAffectedCount: 1);
 
     [ConditionalTheory]
@@ -143,7 +143,7 @@ public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpda
             async,
             ss => ss.Set<Country>().Where(e => e.Animals.OfType<Kiwi>().Where(a => a.CountryId > 0).Count() > 0),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Monovia"),
+            s => s.SetProperty(e => e.Name, "Monovia"),
             rowsAffectedCount: 1);
 
     [ConditionalTheory]
@@ -155,7 +155,7 @@ public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture> : BulkUpda
                 async,
                 ss => ss.Set<EagleQuery>().Where(e => e.CountryId > 0),
                 e => e,
-                s => s.SetProperty(e => e.Name, e => "Eagle"),
+                s => s.SetProperty(e => e.Name, "Eagle"),
                 rowsAffectedCount: 1));
 
     protected abstract void ClearLog();

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesTestBase.cs
@@ -102,7 +102,7 @@ public abstract class InheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTest
             async,
             ss => ss.Set<Animal>().Where(e => e.Name == "Great spotted kiwi"),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Animal"),
+            s => s.SetProperty(e => e.Name, "Animal"),
             rowsAffectedCount: 1,
             (b, a) => a.ForEach(e => Assert.Equal("Animal", e.Name)));
 
@@ -113,7 +113,7 @@ public abstract class InheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTest
             async,
             ss => ss.Set<Animal>().Where(e => e.Name == "Great spotted kiwi").OrderBy(e => e.Name).Skip(0).Take(3),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Animal"),
+            s => s.SetProperty(e => e.Name, "Animal"),
             rowsAffectedCount: 1);
 
     [ConditionalTheory]
@@ -123,7 +123,7 @@ public abstract class InheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTest
             async,
             ss => ss.Set<Kiwi>().Where(e => e.Name == "Great spotted kiwi"),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Kiwi"),
+            s => s.SetProperty(e => e.Name, "Kiwi"),
             rowsAffectedCount: 1);
 
     [ConditionalTheory]
@@ -133,7 +133,7 @@ public abstract class InheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTest
             async,
             ss => ss.Set<Country>().Where(e => e.Animals.Where(a => a.CountryId > 0).Count() > 0),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Monovia"),
+            s => s.SetProperty(e => e.Name, "Monovia"),
             rowsAffectedCount: 2);
 
     [ConditionalTheory]
@@ -143,7 +143,7 @@ public abstract class InheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTest
             async,
             ss => ss.Set<Country>().Where(e => e.Animals.OfType<Kiwi>().Where(a => a.CountryId > 0).Count() > 0),
             e => e,
-            s => s.SetProperty(e => e.Name, e => "Monovia"),
+            s => s.SetProperty(e => e.Name, "Monovia"),
             rowsAffectedCount: 1);
 
     [ConditionalTheory]
@@ -155,7 +155,7 @@ public abstract class InheritanceBulkUpdatesTestBase<TFixture> : BulkUpdatesTest
                 async,
                 ss => ss.Set<EagleQuery>().Where(e => e.CountryId > 0),
                 e => e,
-                s => s.SetProperty(e => e.Name, e => "Eagle"),
+                s => s.SetProperty(e => e.Name, "Eagle"),
                 rowsAffectedCount: 1));
 
     protected abstract void ClearLog();

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
@@ -371,7 +371,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).TagWith("MyUpdate"),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -382,7 +382,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -395,7 +395,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID == customer),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 1,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -404,7 +404,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID == customer),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 0,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
     }
@@ -418,9 +418,59 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => value),
+            s => s.SetProperty(c => c.ContactName, value),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Abc", c.ContactName)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_Where_set_parameter_from_closure_array(bool async)
+    {
+        var array = new[] { "Abc", "Def" };
+        return AssertUpdate(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
+            e => e,
+            s => s.SetProperty(c => c.ContactName, array[0]),
+            rowsAffectedCount: 8,
+            (b, a) => Assert.All(a, c => Assert.Equal("Abc", c.ContactName)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_Where_set_parameter_from_inline_list(bool async)
+        => AssertUpdate(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
+            e => e,
+            s => s.SetProperty(c => c.ContactName, new List<string> { "Abc", "Def" }[0]),
+            rowsAffectedCount: 8,
+            (b, a) => Assert.All(a, c => Assert.Equal("Abc", c.ContactName)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Update_Where_set_parameter_from_multilevel_property_access(bool async)
+    {
+        var container = new Container { Containee = new() { Property = "Abc" } };
+
+        return AssertUpdate(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
+            e => e,
+            s => s.SetProperty(c => c.ContactName, container.Containee.Property),
+            rowsAffectedCount: 8,
+            (b, a) => Assert.All(a, c => Assert.Equal("Abc", c.ContactName)));
+    }
+
+    class Container
+    {
+        public Containee Containee { get; set; }
+    }
+
+    class Containee
+    {
+        public string Property { get; set; }
     }
 
     [ConditionalTheory]
@@ -430,7 +480,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).Skip(4),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 4,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -441,7 +491,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).Take(4),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 4,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -452,7 +502,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).Skip(2).Take(4),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 4,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -463,7 +513,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.City),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -474,7 +524,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.City).Skip(4),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 4,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -485,7 +535,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.City).Take(4),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 4,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -496,7 +546,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.City).Skip(2).Take(4),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 4,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -507,7 +557,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.City).Skip(2).Take(6).Skip(2).Take(2),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 2,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -522,7 +572,7 @@ WHERE [OrderID] < 10300"))
                         == ss.Set<Order>()
                             .GroupBy(e => e.CustomerID).Where(g => g.Count() > 11).Select(e => e.Key).FirstOrDefault()),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 1,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -537,7 +587,7 @@ WHERE [OrderID] < 10300"))
                         == ss.Set<Order>()
                             .GroupBy(e => e.CustomerID).Where(g => g.Count() > 11).Select(e => e.First().CustomerID).FirstOrDefault()),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 1,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -552,7 +602,7 @@ WHERE [OrderID] < 10300"))
                         == ss.Set<Order>()
                             .GroupBy(e => e.CustomerID).Where(g => g.Count() > 11).Select(e => e.First().Customer).FirstOrDefault()),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 1,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -566,7 +616,7 @@ WHERE [OrderID] < 10300"))
                     c => ss.Set<Order>()
                         .GroupBy(e => e.CustomerID).Where(g => g.Count() > 11).Select(e => e.First().Customer).Contains(c)),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 24,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -577,7 +627,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).Distinct(),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -588,7 +638,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Order>().Where(o => o.Customer.City == "Seattle"),
             e => e,
-            s => s.SetProperty(c => c.OrderDate, c => null),
+            s => s.SetProperty(c => c.OrderDate, (DateTime?)null),
             rowsAffectedCount: 14,
             (b, a) => Assert.All(a, c => Assert.Null(c.OrderDate)));
 
@@ -599,7 +649,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<OrderDetail>().Where(od => od.Order.Customer.City == "Seattle"),
             e => e,
-            s => s.SetProperty(c => c.Quantity, c => 1),
+            s => s.SetProperty(c => c.Quantity, 1),
             rowsAffectedCount: 40,
             (b, a) => Assert.All(a, c => Assert.Equal(1, c.Quantity)));
 
@@ -610,7 +660,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).SelectMany(c => c.Orders),
             e => e,
-            s => s.SetProperty(c => c.OrderDate, c => null),
+            s => s.SetProperty(c => c.OrderDate, (DateTime?)null),
             rowsAffectedCount: 63,
             (b, a) => Assert.All(a, c => Assert.Null(c.OrderDate)));
 
@@ -657,7 +707,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
             e => e,
-            s => s.SetProperty(c => EF.Property<string>(c, "ContactName"), c => "Updated"),
+            s => s.SetProperty(c => EF.Property<string>(c, "ContactName"), "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -668,7 +718,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => null),
+            s => s.SetProperty(c => c.ContactName, (string)null),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Null(c.ContactName)));
 
@@ -705,7 +755,7 @@ WHERE [OrderID] < 10300"))
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => value).SetProperty(c => c.City, c => "Seattle"),
+            s => s.SetProperty(c => c.ContactName, c => value).SetProperty(c => c.City, "Seattle"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(
                 a, c =>
@@ -724,7 +774,7 @@ WHERE [OrderID] < 10300"))
                 async,
                 ss => ss.Set<OrderDetail>().Where(od => od.OrderID < 10250),
                 e => e,
-                s => s.SetProperty(e => e.MaybeScalar(e => e.OrderID), e => 10300),
+                s => s.SetProperty(e => e.MaybeScalar(e => e.OrderID), 10300),
                 rowsAffectedCount: 0));
 
     [ConditionalTheory]
@@ -737,7 +787,7 @@ WHERE [OrderID] < 10300"))
                 ss => ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F"))
                     .Select(e => new { e, e.Customer }),
                 e => e.Customer,
-                s => s.SetProperty(c => c.Customer.ContactName, c => "Name").SetProperty(c => c.e.OrderDate, e => new DateTime(2020, 1, 1)),
+                s => s.SetProperty(c => c.Customer.ContactName, "Name").SetProperty(c => c.e.OrderDate, new DateTime(2020, 1, 1)),
                 rowsAffectedCount: 0));
 
     [ConditionalTheory]
@@ -745,13 +795,13 @@ WHERE [OrderID] < 10300"))
     public virtual Task Update_unmapped_property_throws(bool async)
         => AssertTranslationFailed(
             RelationalStrings.UnableToTranslateSetProperty(
-                "c => c.IsLondon", "c => True",
+                "c => c.IsLondon", "True",
                 CoreStrings.QueryUnableToTranslateMember("IsLondon", "Customer")),
             () => AssertUpdate(
                 async,
                 ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
                 e => e,
-                s => s.SetProperty(c => c.IsLondon, c => true),
+                s => s.SetProperty(c => c.IsLondon, true),
                 rowsAffectedCount: 0));
 
     [ConditionalTheory]
@@ -762,7 +812,7 @@ WHERE [OrderID] < 10300"))
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
                 .Union(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 12,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -774,7 +824,7 @@ WHERE [OrderID] < 10300"))
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
                 .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 12,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -786,7 +836,7 @@ WHERE [OrderID] < 10300"))
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
                 .Except(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -798,7 +848,7 @@ WHERE [OrderID] < 10300"))
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
                 .Intersect(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))),
             e => e,
-            s => s.SetProperty(c => c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.ContactName, "Updated"),
             rowsAffectedCount: 0,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -812,7 +862,7 @@ WHERE [OrderID] < 10300"))
                       on c.CustomerID equals o.CustomerID
                   select new { c, o },
             e => e.c,
-            s => s.SetProperty(c => c.c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.c.ContactName, "Updated"),
             rowsAffectedCount: 2,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -827,7 +877,7 @@ WHERE [OrderID] < 10300"))
                   from o in grouping.DefaultIfEmpty()
                   select new { c, o },
             e => e.c,
-            s => s.SetProperty(c => c.c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -840,7 +890,7 @@ WHERE [OrderID] < 10300"))
                   from o in ss.Set<Order>().Where(o => o.OrderID < 10300)
                   select new { c, o },
             e => e.c,
-            s => s.SetProperty(c => c.c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -853,7 +903,7 @@ WHERE [OrderID] < 10300"))
                   from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate.Value.Year < c.ContactName.Length)
                   select new { c, o },
             e => e.c,
-            s => s.SetProperty(c => c.c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.c.ContactName, "Updated"),
             rowsAffectedCount: 0,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -866,7 +916,7 @@ WHERE [OrderID] < 10300"))
                   from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate.Value.Year < c.ContactName.Length).DefaultIfEmpty()
                   select new { c, o },
             e => e.c,
-            s => s.SetProperty(c => c.c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -887,7 +937,7 @@ WHERE [OrderID] < 10300"))
                       o
                   },
             e => e.c,
-            s => s.SetProperty(c => c.c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -901,7 +951,7 @@ WHERE [OrderID] < 10300"))
                   from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate.Value.Year < c.ContactName.Length)
                   select new { c, o },
             e => e.c,
-            s => s.SetProperty(c => c.c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.c.ContactName, "Updated"),
             rowsAffectedCount: 0,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -920,7 +970,7 @@ WHERE [OrderID] < 10300"))
                       o
                   },
             e => e.c,
-            s => s.SetProperty(c => c.c.ContactName, c => "Updated"),
+            s => s.SetProperty(c => c.c.ContactName, "Updated"),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Equal("Updated", c.ContactName)));
 
@@ -938,7 +988,7 @@ WHERE [OrderID] < 10300"))
                             @"SELECT [Region], [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address]
 FROM [Customers]
 WHERE [CustomerID] LIKE 'A%'"))
-                    .ExecuteUpdateAsync(s => s.SetProperty(c => c.ContactName, c => "Updated")));
+                    .ExecuteUpdateAsync(s => s.SetProperty(c => c.ContactName, "Updated")));
         }
         else
         {
@@ -950,7 +1000,7 @@ WHERE [CustomerID] LIKE 'A%'"))
                             @"SELECT [Region], [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address]
 FROM [Customers]
 WHERE [CustomerID] LIKE 'A%'"))
-                    .ExecuteUpdate(s => s.SetProperty(c => c.ContactName, c => "Updated")));
+                    .ExecuteUpdate(s => s.SetProperty(c => c.ContactName, "Updated")));
         }
     }
 
@@ -962,7 +1012,7 @@ WHERE [CustomerID] LIKE 'A%'"))
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
                 .SelectMany(c => c.Orders.Where(o => o.OrderDate.Value.Year == 1997)),
             e => e,
-            s => s.SetProperty(c => c.OrderDate, c => null),
+            s => s.SetProperty(c => c.OrderDate, (DateTime?)null),
             rowsAffectedCount: 35,
             (b, a) => Assert.All(a, c => Assert.Null(c.OrderDate)));
 

--- a/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/EntitySplittingTestBase.cs
@@ -82,7 +82,7 @@ public abstract class EntitySplittingTestBase : NonSharedModelTestBase
                     RelationalStrings.NonQueryTranslationFailedWithDetails(
                         "", RelationalStrings.ExecuteOperationOnEntitySplitting("ExecuteUpdate", "MeterReading"))[21..],
                     (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => context.MeterReadings.ExecuteUpdateAsync(s => s.SetProperty(m => m.CurrentRead, m => "Value")))).Message));
+                        () => context.MeterReadings.ExecuteUpdateAsync(s => s.SetProperty(m => m.CurrentRead, "Value")))).Message));
         }
         else
         {
@@ -93,7 +93,7 @@ public abstract class EntitySplittingTestBase : NonSharedModelTestBase
                     RelationalStrings.NonQueryTranslationFailedWithDetails(
                         "", RelationalStrings.ExecuteOperationOnEntitySplitting("ExecuteUpdate", "MeterReading"))[21..],
                     Assert.Throws<InvalidOperationException>(
-                        () => context.MeterReadings.ExecuteUpdate(s => s.SetProperty(m => m.CurrentRead, m => "Value"))).Message));
+                        () => context.MeterReadings.ExecuteUpdate(s => s.SetProperty(m => m.CurrentRead, "Value"))).Message));
         }
     }
 

--- a/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
@@ -657,7 +657,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
             await TestHelpers.ExecuteWithStrategyInTransactionAsync(
                 CreateContext,
                 UseTransaction,
-                async context => await context.Set<Vehicle>().ExecuteUpdateAsync(s => s.SetProperty(e => e.SeatingCapacity, e => 1)),
+                async context => await context.Set<Vehicle>().ExecuteUpdateAsync(s => s.SetProperty(e => e.SeatingCapacity, 1)),
                 context =>
                 {
                     Assert.True(context.Set<Vehicle>().All(e => e.SeatingCapacity == 1));
@@ -670,7 +670,7 @@ public abstract class TableSplittingTestBase : NonSharedModelTestBase
             TestHelpers.ExecuteWithStrategyInTransaction(
                 CreateContext,
                 UseTransaction,
-                context => context.Set<Vehicle>().ExecuteUpdate(s => s.SetProperty(e => e.SeatingCapacity, e => 1)),
+                context => context.Set<Vehicle>().ExecuteUpdate(s => s.SetProperty(e => e.SeatingCapacity, 1)),
                 context => Assert.True(context.Set<Vehicle>().All(e => e.SeatingCapacity == 1)));
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -5,9 +5,13 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 public class NorthwindBulkUpdatesSqlServerTest : NorthwindBulkUpdatesTestBase<NorthwindBulkUpdatesSqlServerFixture<NoopModelCustomizer>>
 {
-    public NorthwindBulkUpdatesSqlServerTest(NorthwindBulkUpdatesSqlServerFixture<NoopModelCustomizer> fixture)
+    public NorthwindBulkUpdatesSqlServerTest(
+        NorthwindBulkUpdatesSqlServerFixture<NoopModelCustomizer> fixture,
+        ITestOutputHelper testOutputHelper)
         : base(fixture)
     {
+        ClearLog();
+        // Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
     [ConditionalFact]
@@ -605,6 +609,43 @@ WHERE 0 = 1");
 
 UPDATE [c]
 SET [c].[ContactName] = @__value_0
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'");
+    }
+
+    public override async Task Update_Where_set_parameter_from_closure_array(bool async)
+    {
+        await base.Update_Where_set_parameter_from_closure_array(async);
+
+        AssertExecuteUpdateSql(
+            @"@__p_0='Abc' (Size = 4000)
+
+UPDATE [c]
+SET [c].[ContactName] = @__p_0
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'");
+    }
+
+    public override async Task Update_Where_set_parameter_from_inline_list(bool async)
+    {
+        await base.Update_Where_set_parameter_from_inline_list(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE [c]
+SET [c].[ContactName] = N'Abc'
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'");
+    }
+
+    public override async Task Update_Where_set_parameter_from_multilevel_property_access(bool async)
+    {
+        await base.Update_Where_set_parameter_from_multilevel_property_access(async);
+
+        AssertExecuteUpdateSql(
+            @"@__container_Containee_Property_0='Abc' (Size = 4000)
+
+UPDATE [c]
+SET [c].[ContactName] = @__container_Containee_Property_0
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'F%'");
     }

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -7,9 +7,13 @@ namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
 public class NorthwindBulkUpdatesSqliteTest : NorthwindBulkUpdatesTestBase<NorthwindBulkUpdatesSqliteFixture<NoopModelCustomizer>>
 {
-    public NorthwindBulkUpdatesSqliteTest(NorthwindBulkUpdatesSqliteFixture<NoopModelCustomizer> fixture)
+    public NorthwindBulkUpdatesSqliteTest(
+        NorthwindBulkUpdatesSqliteFixture<NoopModelCustomizer> fixture,
+        ITestOutputHelper testOutputHelper)
         : base(fixture)
     {
+        ClearLog();
+        // Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
     [ConditionalFact]
@@ -584,6 +588,40 @@ WHERE 0");
 
 UPDATE ""Customers"" AS ""c""
 SET ""ContactName"" = @__value_0
+WHERE ""c"".""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_Where_set_parameter_from_closure_array(bool async)
+    {
+        await base.Update_Where_set_parameter_from_closure_array(async);
+
+        AssertExecuteUpdateSql(
+            @"@__p_0='Abc' (Size = 3)
+
+UPDATE ""Customers"" AS ""c""
+SET ""ContactName"" = @__p_0
+WHERE ""c"".""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_Where_set_parameter_from_inline_list(bool async)
+    {
+        await base.Update_Where_set_parameter_from_inline_list(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Customers"" AS ""c""
+SET ""ContactName"" = 'Abc'
+WHERE ""c"".""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_Where_set_parameter_from_multilevel_property_access(bool async)
+    {
+        await base.Update_Where_set_parameter_from_multilevel_property_access(async);
+
+        AssertExecuteUpdateSql(
+            @"@__container_Containee_Property_0='Abc' (Size = 3)
+
+UPDATE ""Customers"" AS ""c""
+SET ""ContactName"" = @__container_Containee_Property_0
 WHERE ""c"".""CustomerID"" LIKE 'F%'");
     }
 


### PR DESCRIPTION
Fixes #28968

**Description**

This is a non-breaking tweak to a new API introduced in EF7. It allows a simpler form to be used for `ExecuteUpdate`. Specifcally,

```C#
.SetProperty(p => p.Name, "Shay")
```

can be used instead of

```C#
.SetProperty(p => p.Name, _ => "Shay")
```

There may be many calls to `SetProperty` and setting to a value that does not depend on any other values in the entity is a very common case.

**Customer impact**

Shorter, more readable code for a frequently used common case.

**How found**

Customer suggestion.

**Regression**

No. New API, and this is non-breaking for existing use of that API in RC1.

**Testing**

New tests added.

**Risk**

Low; non-breaking tweak to new API.

----

@smitpatel as discussed offline. Added various closure tests, funcletizer seems to be humming along with 100% efficiency.

AFAICT, switching from Expression to regular non-Expression doesn't seem to create particular difficulties for dynamic expression construction. Here's a sample:

```c#
await ctx.Blogs.ExecuteUpdateAsync(sp => sp
    .SetProperty(b => b.Name, "Hello"));

// Same thing dynamically:
var setPropertyMethodInfo = typeof(SetPropertyCalls<>).MakeGenericType(typeof(Blog))
    .GetMethods()
    .Single(m => m.Name == nameof(SetPropertyCalls<Blog>.SetProperty)
                 && m.GetParameters()[0].ParameterType.IsGenericType
                 && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>)
                 && !m.GetParameters()[1].ParameterType.IsGenericType)
    .MakeGenericMethod(typeof(string));

var setPropertyCallsParam = Expression.Parameter(typeof(SetPropertyCalls<Blog>), "sp");
var blogParam1 = Expression.Parameter(typeof(Blog), "b");

Expression<Func<SetPropertyCalls<Blog>, SetPropertyCalls<Blog>>> setProperties =
    Expression.Lambda<Func<SetPropertyCalls<Blog>, SetPropertyCalls<Blog>>>(
        Expression.Call(
            setPropertyCallsParam,
            setPropertyMethodInfo,
            Expression.Lambda<Func<Blog, string>>(Expression.Property(blogParam1, nameof(Blog.Name)), blogParam1),
            Expression.Constant("Hello")),
        setPropertyCallsParam);

await ctx.Blogs.ExecuteUpdateAsync(setProperties);
```

What do you think?

Closes #28968