### PR TITLE
[release/7.0] Reset LocalView when returning context to the pool

### DIFF
--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -51,8 +51,7 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
     INotifyCollectionChanged,
     INotifyPropertyChanged,
     INotifyPropertyChanging,
-    IListSource,
-    IResettableService
+    IListSource
     where TEntity : class
 {
     private ObservableBackedBindingList<TEntity>? _bindingList;
@@ -502,13 +501,11 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
         => false;
 
     /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     Resets this view, clearing any <see cref="IBindingList" /> created with <see cref="ToBindingList" /> and
+    ///     any <see cref="ObservableCollection{T}" /> created with <see cref="ToObservableCollection" />, and clearing any
+    ///     events registered on <see cref="PropertyChanged" />, <see cref="PropertyChanging" />, or <see cref="CollectionChanged" />.
     /// </summary>
-    [EntityFrameworkInternal]
-    void IResettableService.ResetState()
+    public virtual void Reset()
     {
         _bindingList = null;
         _observable = null;
@@ -517,18 +514,8 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
         _triggeringStateManagerChange = false;
         _triggeringObservableChange = false;
         _triggeringLocalViewChange = false;
-    }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
-    {
-        ((IResettableService)this).ResetState();
-        return Task.CompletedTask;
+        PropertyChanged = null;
+        PropertyChanging = null;
+        CollectionChanged = null;
     }
 }

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -51,7 +51,8 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
     INotifyCollectionChanged,
     INotifyPropertyChanged,
     INotifyPropertyChanging,
-    IListSource
+    IListSource,
+    IResettableService
     where TEntity : class
 {
     private ObservableBackedBindingList<TEntity>? _bindingList;
@@ -499,4 +500,35 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
     /// </summary>
     bool IListSource.ContainsListCollection
         => false;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    void IResettableService.ResetState()
+    {
+        _bindingList = null;
+        _observable = null;
+        _countChanges = 0;
+        _count = 0;
+        _triggeringStateManagerChange = false;
+        _triggeringObservableChange = false;
+        _triggeringLocalViewChange = false;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
+    {
+        ((IResettableService)this).ResetState();
+        return Task.CompletedTask;
+    }
 }

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -520,7 +520,7 @@ public class InternalDbSet<[DynamicallyAccessedMembers(IEntityType.DynamicallyAc
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     void IResettableService.ResetState()
-        => ((IResettableService?)_localView)?.ResetState();
+        => _localView?.Reset();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -528,12 +528,11 @@ public class InternalDbSet<[DynamicallyAccessedMembers(IEntityType.DynamicallyAc
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    async Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
+    Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
     {
-        if (_localView != null)
-        {
-            await ((IResettableService)_localView).ResetStateAsync(cancellationToken).ConfigureAwait(false);
-        }
+        ((IResettableService)this).ResetState();
+
+        return Task.CompletedTask;
     }
 
     private EntityEntry<TEntity> EntryWithoutDetectChanges(TEntity entity)

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -520,7 +520,7 @@ public class InternalDbSet<[DynamicallyAccessedMembers(IEntityType.DynamicallyAc
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     void IResettableService.ResetState()
-        => _localView = null;
+        => ((IResettableService?)_localView)?.ResetState();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -528,13 +528,12 @@ public class InternalDbSet<[DynamicallyAccessedMembers(IEntityType.DynamicallyAc
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
+    async Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
     {
-        ((IResettableService)this).ResetState();
-
-        return Task.CompletedTask;
+        if (_localView != null)
+        {
+            await ((IResettableService)_localView).ResetStateAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private EntityEntry<TEntity> EntryWithoutDetectChanges(TEntity entity)

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -768,6 +768,9 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
 
         Assert.Null(context1!.Database.GetCommandTimeout());
 
+        var set = context1.Customers;
+        var localView = set.Local;
+
         context1.ChangeTracker.AutoDetectChangesEnabled = true;
         context1.ChangeTracker.LazyLoadingEnabled = true;
         context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
@@ -826,6 +829,9 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         Assert.False(_context_OnSavedChanges);
         Assert.False(_context_OnSavingChanges);
         Assert.False(_context_OnSaveChangesFailed);
+
+        Assert.Same(set, context2!.Customers);
+        Assert.Same(localView, context2!.Customers.Local);
     }
 
     [ConditionalTheory]
@@ -865,6 +871,8 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         var factory = BuildFactory<PooledContext>(withDependencyInjection);
 
         var context1 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
+        var set = context1.Customers;
+        var localView = set.Local;
 
         context1.ChangeTracker.AutoDetectChangesEnabled = true;
         context1.ChangeTracker.LazyLoadingEnabled = true;
@@ -909,6 +917,9 @@ public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture
         Assert.False(_context_OnSavedChanges);
         Assert.False(_context_OnSavingChanges);
         Assert.False(_context_OnSaveChangesFailed);
+
+        Assert.Same(set, context2!.Customers);
+        Assert.Same(localView, context2!.Customers.Local);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Fixes #29164


**Description**

Fix memory leak when using context pooling by not continually registering a listener every time a context is obtained from the pool and a `DbSet.Local` is used.

**Customer impact**

Fixes memory leak when using context pooling, which is becoming more common.

**How found**

Customer reported.

**Regression**

No.

**Testing**

New testing added.

**Risk**

Low; small change.

---

This change treats the LocalView as one of the resettable services and resets it rather than severing when the context is returned to the pool. This fixes a memory leak because the view was previously recreated and re-registered with _the same StateManager_ every time the context was re-used, these registrations were never cleared. But since the StateManager is reused, the local views can also be reused, meaning that the registration is retained rather than repeated across uses of the context instance.