### PR TITLE
[release/6.0] Microsoft.Data.Sqlite: Avoid re-sending PRAGMA key on pooled connections

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -197,27 +197,6 @@ namespace Microsoft.Data.Sqlite
             _state = ConnectionState.Open;
             try
             {
-                if (ConnectionOptions.Password.Length != 0)
-                {
-                    if (SQLitePCLExtensions.EncryptionSupported(out var libraryName) == false)
-                    {
-                        throw new InvalidOperationException(Resources.EncryptionNotSupported(libraryName));
-                    }
-
-                    // NB: SQLite doesn't support parameters in PRAGMA statements, so we escape the value using the
-                    //     quote function before concatenating.
-                    var quotedPassword = this.ExecuteScalar<string>(
-                        "SELECT quote($password);",
-                        new SqliteParameter("$password", ConnectionOptions.Password));
-                    this.ExecuteNonQuery("PRAGMA key = " + quotedPassword + ";");
-
-                    if (SQLitePCLExtensions.EncryptionSupported() != false)
-                    {
-                        // NB: Forces decryption. Throws when the key is incorrect.
-                        this.ExecuteNonQuery("SELECT COUNT(*) FROM sqlite_master;");
-                    }
-                }
-
                 if (ConnectionOptions.ForeignKeys.HasValue)
                 {
                     this.ExecuteNonQuery(

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionInternal.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionInternal.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
+using Microsoft.Data.Sqlite.Properties;
 using SQLitePCL;
 
 using static SQLitePCL.raw;
@@ -94,6 +96,32 @@ namespace Microsoft.Data.Sqlite
             var rc = sqlite3_open_v2(filename, out _db, flags, vfs: null);
             SqliteException.ThrowExceptionForRC(rc, _db);
 
+            if (connectionOptions.Password.Length != 0)
+            {
+                if (SQLitePCLExtensions.EncryptionSupported(out var libraryName) == false)
+                {
+                    throw new InvalidOperationException(Resources.EncryptionNotSupported(libraryName));
+                }
+
+                // NB: SQLite doesn't support parameters in PRAGMA statements, so we escape the value using the
+                //     quote function before concatenating.
+                var quotedPassword = ExecuteScalar(
+                    "SELECT quote($password);",
+                    connectionOptions.Password,
+                    connectionOptions.DefaultTimeout);
+                ExecuteNonQuery(
+                    "PRAGMA key = " + quotedPassword + ";",
+                    connectionOptions.DefaultTimeout);
+
+                if (SQLitePCLExtensions.EncryptionSupported() != false)
+                {
+                    // NB: Forces decryption. Throws when the key is incorrect.
+                    ExecuteNonQuery(
+                        "SELECT COUNT(*) FROM sqlite_master;",
+                        connectionOptions.DefaultTimeout);
+                }
+            }
+
             _pool = pool;
         }
 
@@ -143,5 +171,56 @@ namespace Microsoft.Data.Sqlite
             _db.Dispose();
             _pool = null;
         }
+
+        private void ExecuteNonQuery(string sql, int timeout)
+            => RetryWhileBusy(() => sqlite3_exec(_db, sql), timeout);
+
+        private string ExecuteScalar(string sql, string p1, int timeout)
+        {
+            var timer = Stopwatch.StartNew();
+            sqlite3_stmt stmt = null!;
+            RetryWhileBusy(() => sqlite3_prepare_v2(_db, sql, out stmt), timeout, timer);
+            try
+            {
+                sqlite3_bind_text(stmt, 1, p1);
+
+                RetryWhileBusy(() => sqlite3_step(stmt), () => sqlite3_reset(stmt), timeout, timer);
+
+                return sqlite3_column_text(stmt, 0).utf8_to_string();
+            }
+            finally
+            {
+                stmt.Dispose();
+            }
+        }
+
+        private void RetryWhileBusy(Func<int> action, int timeout, Stopwatch? timer = null)
+            => RetryWhileBusy(action, () => { }, timeout, timer);
+
+        private void RetryWhileBusy(Func<int> action, Action reset, int timeout, Stopwatch? timer = null)
+        {
+            int rc;
+            timer ??= Stopwatch.StartNew();
+
+            while (IsBusy(rc = action()))
+            {
+                if (timeout != 0
+                    && timer.ElapsedMilliseconds >= timeout * 1000L)
+                {
+                    break;
+                }
+
+                reset();
+
+                Thread.Sleep(150);
+            }
+
+            SqliteException.ThrowExceptionForRC(rc, _db);
+        }
+
+        private static bool IsBusy(int rc)
+            => rc == SQLITE_LOCKED
+                || rc == SQLITE_BUSY
+                || rc == SQLITE_LOCKED_SHAREDCACHE;
     }
 }


### PR DESCRIPTION
Fixes #28967

### Customer Impact

Connection pooling was designed to improve throughput in both high-traffic web scenarios and when using encryption. However, customers reported that when using encryption via SQLCipher, performance had not improved--it was still deriving the encryption key every time a connection was opened. This PR avoids that behavior and ensures the key is only derived once per pooled connection.

### Regression?

No.

### Risk

Low. This just moves the logic to a place where it will only be executed once per pooled connection instead of every time an ADO.NET connection is opened. The logic will continue to be skipped when not using encryption.

### Verification

Manually verified the new perf characteristics. This simple benchmark goes from 5078 ms to 124.

```cs
using Dapper;
using Microsoft.Data.Sqlite;

using var connection = new SqliteConnection(
    "Data Source=test.db;Password=Password12!");

connection.Execute(
    "CREATE TABLE IF NOT EXISTS Data(Value)");

for (var i = 0; i < 10; i++)
{
    connection.Execute(
        "INSERT INTO Data VALUES (@Value)",
        new { Value = Random.Shared.Next() });
}
```
