### PR TITLE
[release/6.0] Query: Use type mapping from IDbFunction while translating (#27995)

### DIFF
--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -99,14 +99,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                         arguments,
                         dbFunction.IsNullable,
                         argumentsPropagateNullability,
-                        method.ReturnType.UnwrapNullableType())
+                        method.ReturnType.UnwrapNullableType(),
+                        dbFunction.TypeMapping)
                     : _sqlExpressionFactory.Function(
                         dbFunction.Schema,
                         dbFunction.Name,
                         arguments,
                         dbFunction.IsNullable,
                         argumentsPropagateNullability,
-                        method.ReturnType.UnwrapNullableType());
+                        method.ReturnType.UnwrapNullableType(),
+                        dbFunction.TypeMapping);
             }
 
             return _plugins.Concat(_translators)

--- a/test/EFCore.Relational.Specification.Tests/Query/SimpleQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SimpleQueryRelationalTestBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -50,6 +51,56 @@ namespace Microsoft.EntityFrameworkCore.Query
                 mb.HasNoKey();
                 mb.ToTable((string)null);
             }
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task StoreType_for_UDF_used(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context27954>();
+            using var context = contextFactory.CreateContext();
+
+            var date = new DateTime(2012, 12, 12);
+            var query1 = context.Set<MyEntity>().Where(x => x.SomeDate == date);
+            var query2 = context.Set<MyEntity>().Where(x => MyEntity.Modify(x.SomeDate) == date);
+
+            if (async)
+            {
+                await query1.ToListAsync();
+                await Assert.ThrowsAnyAsync<Exception>(() => query2.ToListAsync());
+            }
+            else
+            {
+                query1.ToList();
+                Assert.ThrowsAny<Exception>(() => query2.ToList());
+            }
+        }
+
+        protected class Context27954 : DbContext
+        {
+            public Context27954(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<MyEntity> MyEntities { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder
+                    .HasDbFunction(typeof(MyEntity).GetMethod(nameof(MyEntity.Modify)))
+                    .HasName("ModifyDate")
+                    .HasStoreType("datetime")
+                    .HasSchema("dbo");
+            }
+        }
+
+        protected class MyEntity
+        {
+            public int Id { get; set; }
+            [Column(TypeName = "datetime")]
+            public DateTime SomeDate { get; set; }
+            public static DateTime Modify(DateTime date) => throw new NotSupportedException();
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -321,6 +321,24 @@ WHERE [t].[TableId] = 123
 ORDER BY [t].[ParcelNumber]");
         }
 
+        public override async Task StoreType_for_UDF_used(bool async)
+        {
+            await base.StoreType_for_UDF_used(async);
+
+            AssertSql(
+                @"@__date_0='2012-12-12T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [m].[Id], [m].[SomeDate]
+FROM [MyEntities] AS [m]
+WHERE [m].[SomeDate] = @__date_0",
+                    //
+                    @"@__date_0='2012-12-12T00:00:00.0000000' (DbType = DateTime)
+
+SELECT [m].[Id], [m].[SomeDate]
+FROM [MyEntities] AS [m]
+WHERE [dbo].[ModifyDate]([m].[SomeDate]) = @__date_0");
+        }
+
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Muliple_occurrences_of_FromSql_in_group_by_aggregate(bool async)


### PR DESCRIPTION
Resolves #27954
Resolves #27524
Resolves #29204

### Description

Custom mappings to database functions are not using the correct type mappings for parameters of the functions. This makes it impossible to map these database functions. These issues have been fixed and tested in EF7, and this change brings the fixes back to LTS EF Core 6.0, since there are no workarounds.

### Customer impact

Impossible to map database functions where the type mapping for parameters is important. There is no known workaround.

### How found

Multiple customer reports.

### Regression

No.

### Testing

These issues have been fixed and tested in EF7.

### Risk

Low; correct type mappings now used.
