### PR TITLE
Fix result mapping string size in SQL Server string aggregate translator

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerStringAggregateMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerStringAggregateMethodTranslator.cs
@@ -61,21 +61,21 @@ public class SqlServerStringAggregateMethodTranslator : IAggregateMethodCallTran
         var resultTypeMapping = sqlExpression.TypeMapping;
         if (resultTypeMapping?.Size != null)
         {
-            if (resultTypeMapping.IsUnicode && resultTypeMapping.Size < 8000)
+            if (resultTypeMapping.IsUnicode && resultTypeMapping.Size < 4000)
             {
                 resultTypeMapping = _typeMappingSource.FindMapping(
                     typeof(string),
                     resultTypeMapping.StoreTypeNameBase,
                     unicode: true,
-                    size: 8000);
+                    size: 4000);
             }
-            else if (!resultTypeMapping.IsUnicode && resultTypeMapping.Size < 4000)
+            else if (!resultTypeMapping.IsUnicode && resultTypeMapping.Size < 8000)
             {
                 resultTypeMapping = _typeMappingSource.FindMapping(
                     typeof(string),
                     resultTypeMapping.StoreTypeNameBase,
                     unicode: false,
-                    size: 4000);
+                    size: 8000);
             }
         }
 


### PR DESCRIPTION
Fixes #29229

**Description**

When translating SQL Server aggregate string methods (string.Join, string.Concat), the maximum size for unicode/non-unicode strings is reversed, leading to an incorrect type mapping for the result

**Customer impact**

Reproducing an observable bug here isn't trivial (and may not be possible), since SqlServerStringTypeMapping has checks and doesn't take the incorrect size into account. However, the fix is trivial and ensures the correctness of the type mapping.

**How found**

Customer reported.

**Regression**

No, new feature (aggregate string function translation.

**Testing**

New testing added.

**Risk**

Very low; small self-evident fix in new code introduced for a new 7.0 feature only.
