### PR TITLE
Query: Make ExtractJsonProperty generic on return type and resilient …

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -125,12 +125,12 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 exception);
         }
 
-        private static object? ExtractJsonProperty(JsonElement element, string propertyName, Type returnType)
-        {
-            var jsonElementProperty = element.GetProperty(propertyName);
-
-            return jsonElementProperty.Deserialize(returnType);
-        }
+        private static T? ExtractJsonProperty<T>(JsonElement element, string propertyName, bool nullable)
+            => nullable
+                ? element.TryGetProperty(propertyName, out var jsonValue)
+                    ? jsonValue.Deserialize<T>()
+                    : default
+                : element.GetProperty(propertyName).Deserialize<T>();
 
         private static void IncludeReference<TEntity, TIncludingEntity, TIncludedEntity>(
             QueryContext queryContext,


### PR DESCRIPTION
…with missing properties

Resolves #29219

This should improve perf slightly by removing boxing for non-nullable value types