### PR TITLE
[release/7.0] Query: Don't fail translation of aggregate when owned navigations

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -441,6 +441,14 @@ WHERE c[""Discriminator""] IN (""OwnedPerson"", ""Branch"", ""LeafB"", ""LeafA""
         AssertSql(" ");
     }
 
+    [ConditionalTheory(Skip = "GroupBy #17314")]
+    public override async Task GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(async);
+
+        AssertSql();
+    }
+
     public override async Task Filter_on_indexer_using_closure(bool async)
     {
         await base.Filter_on_indexer_using_closure(async);

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -881,6 +881,25 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 AssertEqual(e.sub.c2, a.sub.c2);
             });
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                    .GroupBy(e => e.Id)
+                    .Select(e => new
+                    {
+                        e.Key,
+                        Sum = e.Sum(i => i.PersonAddress.Country.PlanetId)
+                    }),
+            elementSorter: e => e.Key,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Key, a.Key);
+                AssertEqual(e.Sum, a.Sum);
+            });
+
     protected virtual DbContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -1236,6 +1236,19 @@ LEFT JOIN (
 ORDER BY [p].[Id], [t].[Id], [t].[Id0], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
     }
 
+    public override async Task GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(async);
+
+        AssertSql(
+            @"SELECT [o].[Id] AS [Key], (
+    SELECT COALESCE(SUM([o0].[PersonAddress_Country_PlanetId]), 0)
+    FROM [OwnedPerson] AS [o0]
+    WHERE [o].[Id] = [o0].[Id]) AS [Sum]
+FROM [OwnedPerson] AS [o]
+GROUP BY [o].[Id]");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
@@ -1224,6 +1224,19 @@ LEFT JOIN (
 ORDER BY [p].[Id], [t].[Id], [t].[Id0], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
     }
 
+    public override async Task GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(async);
+
+        AssertSql(
+            @"SELECT [o].[Id] AS [Key], (
+    SELECT COALESCE(SUM([o0].[PersonAddress_Country_PlanetId]), 0)
+    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o0]
+    WHERE [o].[Id] = [o0].[Id]) AS [Sum]
+FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+GROUP BY [o].[Id]");
+    }
+
     // not AssertQuery so original (non-temporal) query gets executed, but data is modified
     // so results don't match expectations
     public override Task Owned_entity_without_owner_does_not_throw_for_identity_resolution(bool async, bool useAsTracking)


### PR DESCRIPTION
Resolves #29201

### Description

Regression in a relatively important case where aggregate functions are used over owned type mapped to the same table as the owner. For example:

```C#
var query = context.Books
    .GroupBy(post => post.Author.Id)
    .Select(grouping => new
    {
        Author = grouping.Key,
        TotalCost = grouping.Sum(post => post.Detail.Price),
    });
```

This was due to a significant change in the design for aggregate functions, enabling a lot of new functionality in EF7. We were missing test cases for this.

### Customer impact

Exception in a relatively common query case that worked in EF Core 6.0.

### How found

Found writing docs for new features.

### Regression

Yes. from 6.0.

### Testing

New testing added; will also investigate additional testing in this area.

### Risk

Low, since the test removes an incorrect check when looking for errors.
