### PR TITLE
[8.0] Fix to #29260 - Sqlite: AddTicks translation gives incorrect results

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeAddTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeAddTranslator.cs
@@ -84,7 +84,7 @@ public class SqliteDateTimeAddTranslator : IMethodCallTranslator
                 _sqlExpressionFactory.Convert(
                     _sqlExpressionFactory.Divide(
                         arguments[0],
-                        _sqlExpressionFactory.Constant((double)TimeSpan.TicksPerDay)),
+                        _sqlExpressionFactory.Constant((double)TimeSpan.TicksPerSecond)),
                     typeof(string)),
                 _sqlExpressionFactory.Constant(" seconds"));
         }


### PR DESCRIPTION
We were using TimeSpan.TicksPerDay rather than TicksPerSecond in the translation. Fixing the typo and correcting the test.

Fixes #29260