### PR TITLE
Validate that the main fragment of optional dependents that use table sharing have at least one required non-shared property

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -654,6 +654,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, storeObject);
 
         /// <summary>
+        ///     Entity type '{entityType}' has a split mapping and is an optional dependent sharing a store object, but it doesn't map any required non-shared property to the main store object. Keep at least one required non-shared property mapped to a column on '{storeObject}' or mark '{entityType}' as a required dependent by calling '{requiredDependentConfig}'.
+        /// </summary>
+        public static string EntitySplittingMissingRequiredPropertiesOptionalDependent(object? entityType, object? storeObject, object? requiredDependentConfig)
+            => string.Format(
+                GetString("EntitySplittingMissingRequiredPropertiesOptionalDependent", nameof(entityType), nameof(storeObject), nameof(requiredDependentConfig)),
+                entityType, storeObject, requiredDependentConfig);
+
+        /// <summary>
         ///     Entity type '{entityType}' has a split mapping for '{storeObject}', but it doesn't have a main mapping of the same type. Map '{entityType}' to '{storeObjectType}'.
         /// </summary>
         public static string EntitySplittingUnmappedMainFragment(object? entityType, object? storeObject, object? storeObjectType)
@@ -1740,7 +1748,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     The foreign key column '{fkColumnName}' has '{fkColumnType}' values which cannot be compared to the '{pkColumnType}' values of the associated principal key column '{pkColumnName}'. Foreign key column types must be comparable with principal key column types.
+        ///     The foreign key column '{fkColumnName}' has '{fkColumnType}' values which cannot be compared to the '{pkColumnType}' values of the associated principal key column '{pkColumnName}'. To use 'SaveChanges` or 'SaveChangesAsync', foreign key column types must be comparable with principal key column types.
         /// </summary>
         public static string StoredKeyTypesNotConvertable(object? fkColumnName, object? fkColumnType, object? pkColumnType, object? pkColumnName)
             => string.Format(
@@ -3757,7 +3765,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                         logger.Options,
                         RelationalEventId.UnexpectedTrailingResultSetWhenSaving,
                         LogLevel.Warning,
-                        "CoreEventId.UnexpectedTrailingResultSetWhenSaving",
+                        "RelationalEventId.UnexpectedTrailingResultSetWhenSaving",
                         level => LoggerMessage.Define(
                             level,
                             RelationalEventId.UnexpectedTrailingResultSetWhenSaving,

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -358,6 +358,9 @@
   <data name="EntitySplittingMissingPropertiesMainFragment" xml:space="preserve">
     <value>Entity type '{entityType}' has a split mapping, but it doesn't map any non-primary key property to the main store object. Keep at least one non-primary key property mapped to a column on '{storeObject}'.</value>
   </data>
+  <data name="EntitySplittingMissingRequiredPropertiesOptionalDependent" xml:space="preserve">
+    <value>Entity type '{entityType}' has a split mapping and is an optional dependent sharing a store object, but it doesn't map any required non-shared property to the main store object. Keep at least one required non-shared property mapped to a column on '{storeObject}' or mark '{entityType}' as a required dependent by calling '{requiredDependentConfig}'.</value>
+  </data>
   <data name="EntitySplittingUnmappedMainFragment" xml:space="preserve">
     <value>Entity type '{entityType}' has a split mapping for '{storeObject}', but it doesn't have a main mapping of the same type. Map '{entityType}' to '{storeObjectType}'.</value>
   </data>
@@ -769,10 +772,6 @@
     <value>The entity type '{entityType}' is an optional dependent using table sharing without any required non shared property that could be used to identify whether the entity exists. If all nullable properties contain a null value in database then an object instance won't be created in the query. Add a required property to create instances with null values for other properties or mark the incoming navigation as required to always create an instance.</value>
     <comment>Warning RelationalEventId.OptionalDependentWithoutIdentifyingPropertyWarning string</comment>
   </data>
-  <data name="LogStoredProcedureConcurrencyTokenNotMapped" xml:space="preserve">
-    <value>The entity type '{entityType}' is mapped to the stored procedure '{sproc}', but the concurrency token '{token}' is not mapped to any original value parameter.</value>
-    <comment>Warning RelationalEventId.StoredProcedureConcurrencyTokenNotMapped string string string</comment>
-  </data>
   <data name="LogPossibleUnintendedUseOfEquals" xml:space="preserve">
     <value>Possible unintended use of method 'Equals' for arguments '{left}' and '{right}' of different types in a query. This comparison will always return false.</value>
     <comment>Warning RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning string string</comment>
@@ -805,6 +804,10 @@
     <value>Rolling back transaction.</value>
     <comment>Debug RelationalEventId.TransactionRollingBack</comment>
   </data>
+  <data name="LogStoredProcedureConcurrencyTokenNotMapped" xml:space="preserve">
+    <value>The entity type '{entityType}' is mapped to the stored procedure '{sproc}', but the concurrency token '{token}' is not mapped to any original value parameter.</value>
+    <comment>Warning RelationalEventId.StoredProcedureConcurrencyTokenNotMapped string string string</comment>
+  </data>
   <data name="LogTpcStoreGeneratedIdentity" xml:space="preserve">
     <value>The entity type '{entityType}' is using the table per concrete type mapping strategy, but property '{property}' is configured with an incompatible database-generated default. Configure a compatible value generation strategy if available, or use non-generated key values.</value>
     <comment>Warning RelationalEventId.TpcStoreGeneratedIdentityWarning string string</comment>
@@ -815,7 +818,7 @@
   </data>
   <data name="LogUnexpectedTrailingResultSetWhenSaving" xml:space="preserve">
     <value>An unexpected trailing result set was found when reading the results of a SaveChanges operation; this may indicate that a stored procedure returned a result set without being configured for it in the EF model. Check your stored procedure definitions.</value>
-    <comment>Warning CoreEventId.UnexpectedTrailingResultSetWhenSaving</comment>
+    <comment>Warning RelationalEventId.UnexpectedTrailingResultSetWhenSaving</comment>
   </data>
   <data name="LogUnnamedIndexAllPropertiesNotToMappedToAnyTable" xml:space="preserve">
     <value>The unnamed index on the entity type '{entityType}' specifies properties {indexProperties}, but none of these properties are mapped to a column in any table. This index will not be created in the database.</value>
@@ -980,6 +983,9 @@
   <data name="SqlQueryUnmappedType" xml:space="preserve">
     <value>The element type '{elementType}' used in 'SqlQuery' method is not natively supported by your database provider. Either use a supported element type, or use ModelConfigurationBuilder.DefaultTypeMapping to define a mapping for your type.</value>
   </data>
+  <data name="StoredKeyTypesNotConvertable" xml:space="preserve">
+    <value>The foreign key column '{fkColumnName}' has '{fkColumnType}' values which cannot be compared to the '{pkColumnType}' values of the associated principal key column '{pkColumnName}'. To use 'SaveChanges` or 'SaveChangesAsync', foreign key column types must be comparable with principal key column types.</value>
+  </data>
   <data name="StoredProcedureCurrentValueParameterOnDelete" xml:space="preserve">
     <value>Current value parameter '{parameter}' is not allowed on delete stored procedure '{sproc}'. Use HasOriginalValueParameter() instead.</value>
   </data>
@@ -1058,11 +1064,11 @@
   <data name="StoredProcedureResultColumnParameterConflict" xml:space="preserve">
     <value>The property '{entityType}.{property}' is mapped to a result column of the stored procedure '{sproc}', but it is also mapped to an output parameter. A store-generated property can only be mapped to one of these.</value>
   </data>
-  <data name="StoredProcedureRowsAffectedNotPopulated" xml:space="preserve">
-    <value>Stored procedure '{sproc}' was configured with a rows affected output parameter or return value, but a valid value was not found when executing the procedure.</value>
-  </data>
   <data name="StoredProcedureRowsAffectedForInsert" xml:space="preserve">
     <value>A rows affected parameter, result column or return value cannot be configured on stored procedure '{sproc}' because it is used for insertion. Rows affected values are only allowed on stored procedures performing updating or deletion.</value>
+  </data>
+  <data name="StoredProcedureRowsAffectedNotPopulated" xml:space="preserve">
+    <value>Stored procedure '{sproc}' was configured with a rows affected output parameter or return value, but a valid value was not found when executing the procedure.</value>
   </data>
   <data name="StoredProcedureRowsAffectedReturnConflictingParameter" xml:space="preserve">
     <value>The stored procedure '{sproc}' cannot be configured to return the rows affected because a rows affected parameter or a rows affected result column for this stored procedure already exists.</value>
@@ -1078,9 +1084,6 @@
   </data>
   <data name="StoredProcedureUnmapped" xml:space="preserve">
     <value>The entity type '{entityType}' was configured to use some stored procedures and is not mapped to any table. An entity type that isn't mapped to a table must be mapped to insert, update and delete stored procedures.</value>
-  </data>
-  <data name="StoredKeyTypesNotConvertable" xml:space="preserve">
-    <value>The foreign key column '{fkColumnName}' has '{fkColumnType}' values which cannot be compared to the '{pkColumnType}' values of the associated principal key column '{pkColumnName}'. To use 'SaveChanges` or 'SaveChangesAsync', foreign key column types must be comparable with principal key column types.</value>
   </data>
   <data name="TableNotMappedEntityType" xml:space="preserve">
     <value>The entity type '{entityType}' is not mapped to the store object '{table}'.</value>


### PR DESCRIPTION
Fixes #29079

### Customer Impact

When querying optional dependents using table sharing normally EF determines whether they exist by checking all required non-shared columns for NULLs. However, if they are also using entity splitting EF would need to check all table fragments which would be suboptimal from a perf standpoint. Currently EF will only check the properties on the main fragment and the added validation will throw for models that could produce invalid results.

### Regression?

No. Entity splitting is a new feature.

### Risk

Low. This change is constrained to model validation.

### Verification

Added a test for the affected scenario.

