### PR TITLE
[release/7.0] Fix to #29279 - EF7 - GroupBy on Json column property + First/FirstOrDefault generates incorrect SQL

### DIFF
--- a/src/EFCore.Relational/Query/JsonQueryExpression.cs
+++ b/src/EFCore.Relational/Query/JsonQueryExpression.cs
@@ -195,9 +195,13 @@ public class JsonQueryExpression : Expression, IPrintableExpression
     protected override Expression VisitChildren(ExpressionVisitor visitor)
     {
         var jsonColumn = (ColumnExpression)visitor.Visit(JsonColumn);
+        var newKeyPropertyMap = new Dictionary<IProperty, ColumnExpression>();
+        foreach (var (property, column) in _keyPropertyMap)
+        {
+            newKeyPropertyMap[property] = (ColumnExpression)visitor.Visit(column);
+        }
 
-        // TODO: also visit columns in the _keyPropertyMap?
-        return Update(jsonColumn, _keyPropertyMap);
+        return Update(jsonColumn, newKeyPropertyMap);
     }
 
     /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -669,6 +669,49 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Group_by_First_on_json_scalar(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .GroupBy(x => x.OwnedReferenceRoot.Name).Select(g => g.OrderBy(x => x.Id).First()),
+            entryCount: 40);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Group_by_FirstOrDefault_on_json_scalar(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .GroupBy(x => x.OwnedReferenceRoot.Name).Select(g => g.OrderBy(x => x.Id).FirstOrDefault()),
+            entryCount: 40);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Group_by_Skip_Take_on_json_scalar(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .GroupBy(x => x.OwnedReferenceRoot.Name).Select(g => g.OrderBy(x => x.Id).Skip(1).Take(5)));
+
+    [ConditionalTheory(Skip = "issue #29287")]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Group_by_json_scalar_Orderby_json_scalar_FirstOrDefault(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .GroupBy(x => x.OwnedReferenceRoot.OwnedReferenceBranch.Enum).Select(g => g.OrderBy(x => x.OwnedReferenceRoot.Number).FirstOrDefault()),
+            entryCount: 40);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Group_by_json_scalar_Skip_First_project_json_scalar(bool async)
+        => AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .GroupBy(x => x.OwnedReferenceRoot.Name).Select(g => g.First().OwnedReferenceRoot.OwnedReferenceBranch.Enum));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Json_with_include_on_json_entity(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -550,6 +550,115 @@ FROM (
 GROUP BY [t].[Key]");
     }
 
+    public override async Task Group_by_First_on_json_scalar(bool async)
+    {
+        await base.Group_by_First_on_json_scalar(async);
+
+        AssertSql(
+            @"SELECT [t1].[Id], [t1].[EntityBasicId], [t1].[Name], JSON_QUERY([t1].[c],'$'), JSON_QUERY([t1].[c0],'$')
+FROM (
+    SELECT [t].[Key]
+    FROM (
+        SELECT CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS nvarchar(max)) AS [Key]
+        FROM [JsonEntitiesBasic] AS [j]
+    ) AS [t]
+    GROUP BY [t].[Key]
+) AS [t0]
+LEFT JOIN (
+    SELECT [t2].[Id], [t2].[EntityBasicId], [t2].[Name], JSON_QUERY([t2].[c],'$') AS [c], JSON_QUERY([t2].[c0],'$') AS [c0], [t2].[Key]
+    FROM (
+        SELECT [t3].[Id], [t3].[EntityBasicId], [t3].[Name], JSON_QUERY([t3].[c],'$') AS [c], JSON_QUERY([t3].[c0],'$') AS [c0], [t3].[Key], ROW_NUMBER() OVER(PARTITION BY [t3].[Key] ORDER BY [t3].[Id]) AS [row]
+        FROM (
+            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], JSON_QUERY([j0].[OwnedCollectionRoot],'$') AS [c], JSON_QUERY([j0].[OwnedReferenceRoot],'$') AS [c0], CAST(JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS nvarchar(max)) AS [Key]
+            FROM [JsonEntitiesBasic] AS [j0]
+        ) AS [t3]
+    ) AS [t2]
+    WHERE [t2].[row] <= 1
+) AS [t1] ON [t0].[Key] = [t1].[Key]");
+    }
+
+    public override async Task Group_by_FirstOrDefault_on_json_scalar(bool async)
+    {
+        await base.Group_by_FirstOrDefault_on_json_scalar(async);
+
+        AssertSql(
+            @"SELECT [t1].[Id], [t1].[EntityBasicId], [t1].[Name], JSON_QUERY([t1].[c],'$'), JSON_QUERY([t1].[c0],'$')
+FROM (
+    SELECT [t].[Key]
+    FROM (
+        SELECT CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS nvarchar(max)) AS [Key]
+        FROM [JsonEntitiesBasic] AS [j]
+    ) AS [t]
+    GROUP BY [t].[Key]
+) AS [t0]
+LEFT JOIN (
+    SELECT [t2].[Id], [t2].[EntityBasicId], [t2].[Name], JSON_QUERY([t2].[c],'$') AS [c], JSON_QUERY([t2].[c0],'$') AS [c0], [t2].[Key]
+    FROM (
+        SELECT [t3].[Id], [t3].[EntityBasicId], [t3].[Name], JSON_QUERY([t3].[c],'$') AS [c], JSON_QUERY([t3].[c0],'$') AS [c0], [t3].[Key], ROW_NUMBER() OVER(PARTITION BY [t3].[Key] ORDER BY [t3].[Id]) AS [row]
+        FROM (
+            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], JSON_QUERY([j0].[OwnedCollectionRoot],'$') AS [c], JSON_QUERY([j0].[OwnedReferenceRoot],'$') AS [c0], CAST(JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS nvarchar(max)) AS [Key]
+            FROM [JsonEntitiesBasic] AS [j0]
+        ) AS [t3]
+    ) AS [t2]
+    WHERE [t2].[row] <= 1
+) AS [t1] ON [t0].[Key] = [t1].[Key]");
+    }
+
+    public override async Task Group_by_Skip_Take_on_json_scalar(bool async)
+    {
+        await base.Group_by_Skip_Take_on_json_scalar(async);
+
+        AssertSql(
+            @"SELECT [t0].[Key], [t1].[Id], [t1].[EntityBasicId], [t1].[Name], [t1].[c], [t1].[c0]
+FROM (
+    SELECT [t].[Key]
+    FROM (
+        SELECT CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS nvarchar(max)) AS [Key]
+        FROM [JsonEntitiesBasic] AS [j]
+    ) AS [t]
+    GROUP BY [t].[Key]
+) AS [t0]
+LEFT JOIN (
+    SELECT [t2].[Id], [t2].[EntityBasicId], [t2].[Name], [t2].[c], [t2].[c0], [t2].[Key]
+    FROM (
+        SELECT [t3].[Id], [t3].[EntityBasicId], [t3].[Name], JSON_QUERY([t3].[c],'$') AS [c], JSON_QUERY([t3].[c0],'$') AS [c0], [t3].[Key], ROW_NUMBER() OVER(PARTITION BY [t3].[Key] ORDER BY [t3].[Id]) AS [row]
+        FROM (
+            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], JSON_QUERY([j0].[OwnedCollectionRoot],'$') AS [c], JSON_QUERY([j0].[OwnedReferenceRoot],'$') AS [c0], CAST(JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS nvarchar(max)) AS [Key]
+            FROM [JsonEntitiesBasic] AS [j0]
+        ) AS [t3]
+    ) AS [t2]
+    WHERE 1 < [t2].[row] AND [t2].[row] <= 6
+) AS [t1] ON [t0].[Key] = [t1].[Key]
+ORDER BY [t0].[Key], [t1].[Key], [t1].[Id]");
+    }
+
+    public override async Task Group_by_json_scalar_Orderby_json_scalar_FirstOrDefault(bool async)
+    {
+        await base.Group_by_json_scalar_Orderby_json_scalar_FirstOrDefault(async);
+
+        AssertSql(
+            @"");
+    }
+
+    public override async Task Group_by_json_scalar_Skip_First_project_json_scalar(bool async)
+    {
+        await base.Group_by_json_scalar_Skip_First_project_json_scalar(async);
+
+        AssertSql(
+            @"SELECT (
+    SELECT TOP(1) CAST(JSON_VALUE([t0].[c0],'$.OwnedReferenceBranch.Enum') AS nvarchar(max))
+    FROM (
+        SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], JSON_QUERY([j0].[OwnedCollectionRoot],'$') AS [c], JSON_QUERY([j0].[OwnedReferenceRoot],'$') AS [c0], CAST(JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS nvarchar(max)) AS [Key]
+        FROM [JsonEntitiesBasic] AS [j0]
+    ) AS [t0]
+    WHERE [t].[Key] = [t0].[Key] OR (([t].[Key] IS NULL) AND ([t0].[Key] IS NULL)))
+FROM (
+    SELECT CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS nvarchar(max)) AS [Key]
+    FROM [JsonEntitiesBasic] AS [j]
+) AS [t]
+GROUP BY [t].[Key]");
+    }
+
     public override async Task Json_with_include_on_json_entity(bool async)
     {
         await base.Json_with_include_on_json_entity(async);


### PR DESCRIPTION
Problem was that in VisitChildren for JsonQueryExpression we were not passing key columns stored in _keyPropertyMap thru the visitor, so the aliases got out of sync. Fix is to process these key columns also and then update the JsonQueryExpression with new map if any of the columns have been modified by the visitor.

Fixes #29279

### Customer impact

Exception in a relatively simple GroupBy + paging scenario involving new JSON mapping feature.

### How found

Found by a customer testing EF7 bits.

### Regression

No, this is in the new feature.

### Testing

New testing added for the reported scenario and additional cases around it.

### Risk

Low, only affects JSON scenarios (code change is in the new class that only gets created to traverse JSON expressions). It should be safe to pass key columns through the visitor - we already do that for the JSON column. Could be unnecessary work, but safe.