### PR TITLE
Update SqlClient to 5.0.1

### DIFF
--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a patch update of our SqlClient dependency from 5.0.0 to 5.0.1 (see https://github.com/dotnet/SqlClient/pull/1794). We should do this for 7.0, so doing this manually rather than waiting for dependabot.