### PR TITLE
[release/7.0] Add CodeQL3000 run to efcore-ci-official

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,12 @@
+{
+  "areaPath": "DevDiv\\Entity Framework",
+  "codebaseName": "efcore",
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "iterationPath": "DevDiv",
+  "notificationAliases": [
+    "aspnetcore-build@microsoft.com"
+  ],
+  "projectName": "DEVDIV",
+  "repositoryName": "efcore",
+  "template": "TFSDEVDIV"
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,24 @@
+schedules:
+- cron: 0 9 * * 1
+  displayName: "Run CodeQL3000 weekly, Monday at 2:00 AM PDT"
+  branches:
+    include:
+    - release/2.1
+    - release/6.0
+    - release/7.0
+    - main
+  always: true
+
+parameters:
+  # Parameter below is ignored in public builds.
+  #
+  # Choose whether to run the CodeQL3000 tasks.
+  # Manual builds align w/ official builds unless this parameter is true.
+  - name: runCodeQL3000
+    default: false
+    displayName: Run CodeQL3000 tasks
+    type: boolean
+
 variables:
   - name: _BuildConfig
     value: Release
@@ -33,6 +54,8 @@ variables:
     value: 'en_US.UTF-8'
   - name: LANGUAGE
     value: 'en_US.UTF-8'
+  - name: runCodeQL3000
+    value: ${{ and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true')))) }}
 
 trigger:
   batch: true
@@ -51,16 +74,15 @@ stages:
   jobs:
     - template: eng/common/templates/jobs/jobs.yml
       parameters:
-        enableMicrobuild: true
+        enableMicrobuild: ${{ ne(variables.runCodeQL3000, 'true') }}
         enablePublishBuildArtifacts: true
-        enablePublishBuildAssets: true
+        enablePublishBuildAssets: ${{ ne(variables.runCodeQL3000, 'true') }}
         enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
         enableTelemetry: true
         helixRepo: dotnet/efcore
         jobs:
           - job: Windows
-            timeoutInMinutes: 90
-            enablePublishTestResults: true
+            enablePublishTestResults: ${{ ne(variables.runCodeQL3000, 'true') }}
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: NetCore-Svc-Public
@@ -68,11 +90,35 @@ stages:
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Svc-Internal
                 demands: ImageOverride -equals 1es-windows-2019
+            ${{ if eq(variables.runCodeQL3000, 'true') }}:
+              # Component governance and SBOM creation are not needed here. Disable what Arcade would inject.
+              disableComponentGovernance: true
+              enableSbom: false
+              # CodeQL3000 extends build duration.
+              timeoutInMinutes: 180
+            ${{ else }}:
+              timeoutInMinutes: 90
             variables:
               - _InternalBuildArgs: ''
+              # Rely on task Arcade injects, not auto-injected build step.
+              - skipComponentGovernanceDetection: true
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 - _SignType: real
                 - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines) /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+              - ${{ if eq(variables.runCodeQL3000, 'true') }}:
+                - _AdditionalBuildArgs: /p:Test=false /p:Sign=false /p:Pack=false /p:Publish=false /p:UseSharedCompilation=false
+                # Security analysis is included in normal runs. Disable its auto-injection.
+                - skipNugetSecurityAnalysis: true
+                # Do not let CodeQL3000 Extension gate scan frequency.
+                - Codeql.Cadence: 0
+                # Enable CodeQL3000 unconditionally so it may be run on any branch.
+                - Codeql.Enabled: true
+                # Ignore test and infrastructure code.
+                - Codeql.SourceRoot: src
+                # CodeQL3000 needs this plumbed along as a variable to enable TSA.
+                - Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+                # Default expects tsaoptions.json under SourceRoot.
+                - Codeql.TSAOptionsPath: '$(Build.SourcesDirectory)/.config/tsaoptions.json'
             steps:
               - task: NuGetCommand@2
                 displayName: 'Clear NuGet caches'
@@ -96,147 +142,166 @@ stages:
                     arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
                   env:
                     Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs) $(_InternalRuntimeDownloadArgs)
+              - ${{ if eq(variables.runCodeQL3000, 'true') }}:
+                - task: CodeQL3000Init@0
+                  displayName: CodeQL Initialize
+                - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+                  displayName: 'Set CI CodeQL3000 tag'
+                  condition: ne(variables.CODEQL_DIST,'')
+              - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs)
+                  $(_InternalRuntimeDownloadArgs) $(_AdditionalBuildArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
                 name: Build
-              - script: |
-                    .dotnet\dotnet publish --configuration $(_BuildConfig) --runtime win-x64 --self-contained test\EFCore.Trimming.Tests
-                    artifacts\bin\EFCore.Trimming.Tests\$(_BuildConfig)\net7.0\win-x64\publish\EFCore.Trimming.Tests.exe
-                displayName: Test trimming
-              - task: PublishBuildArtifacts@1
-                displayName: Upload TestResults
-                condition: always()
-                continueOnError: true
-                inputs:
-                  pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-                  artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-                  artifactType: Container
-                  parallel: true
-
-          - job: macOS
-            enablePublishTestResults: true
-            pool:
-              vmImage: macOS-11
-            steps:
-              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                - task: Bash@3
-                  displayName: Setup Private Feeds Credentials
+              - ${{ if eq(variables.runCodeQL3000, 'true') }}:
+                - task: CodeQL3000Finalize@0
+                  displayName: CodeQL Finalize
+              - ${{ else }}:
+                - script: |
+                      .dotnet\dotnet publish --configuration $(_BuildConfig) --runtime win-x64 --self-contained test\EFCore.Trimming.Tests
+                      artifacts\bin\EFCore.Trimming.Tests\$(_BuildConfig)\net7.0\win-x64\publish\EFCore.Trimming.Tests.exe
+                  displayName: Test trimming
+                - task: PublishBuildArtifacts@1
+                  displayName: Upload TestResults
+                  condition: always()
+                  continueOnError: true
                   inputs:
-                    filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                    arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-                  env:
-                    Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine $(_InternalRuntimeDownloadArgs)
-                env:
-                  Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
-                  COMPlus_EnableWriteXorExecute: 0 # Work-around for https://github.com/dotnet/runtime/issues/70758
-                name: Build
-              - task: PublishBuildArtifacts@1
-                displayName: Upload TestResults
-                condition: always()
-                continueOnError: true
-                inputs:
-                  pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-                  artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-                  artifactType: Container
-                  parallel: true
+                    pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+                    artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+                    artifactType: Container
+                    parallel: true
 
-          - job: Linux
-            timeoutInMinutes: 120
-            enablePublishTestResults: true
-            pool:
-              ${{ if or(ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
-                vmImage: ubuntu-22.04
-              ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
-                name: NetCore1ESPool-Svc-Internal
-                demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
-            variables:
-              - _runCounter: $[counter(variables['Build.Reason'], 0)]
-              - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest', 'Schedule')) }}:
-                - _CosmosConnectionUrl: 'true'
-            steps:
-              - bash: |
-                    echo "##vso[task.setvariable variable=_CosmosConnectionUrl]https://ef-nightly-test.documents.azure.com:443/"
-                    echo "##vso[task.setvariable variable=_CosmosToken]$(ef-nightly-cosmos-key)"
-                displayName: Prepare to run Cosmos tests on ef-nightly-test
-                condition: and(eq(variables['_CosmosConnectionUrl'], 'true'), or(endsWith(variables['_runCounter'], '0'), endsWith(variables['_runCounter'], '2'), endsWith(variables['_runCounter'], '4'), endsWith(variables['_runCounter'], '6'), endsWith(variables['_runCounter'], '8')))
-              - bash: |
-                    echo "##vso[task.setvariable variable=_CosmosConnectionUrl]https://ef-pr-test.documents.azure.com:443/"
-                    echo "##vso[task.setvariable variable=_CosmosToken]$(ef-pr-cosmos-test)"
-                displayName: Prepare to run Cosmos tests on ef-pr-test
-                condition: and(eq(variables['_CosmosConnectionUrl'], 'true'), or(endsWith(variables['_runCounter'], '1'), endsWith(variables['_runCounter'], '3'), endsWith(variables['_runCounter'], '5'), endsWith(variables['_runCounter'], '7'), endsWith(variables['_runCounter'], '9')))
-              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                - task: Bash@3
-                  displayName: Setup Private Feeds Credentials
+          - ${{ if ne(variables.runCodeQL3000, 'true') }}:
+            - job: macOS
+              enablePublishTestResults: true
+              pool:
+                vmImage: macOS-11
+              variables:
+                # Rely on task Arcade injects, not auto-injected build step.
+                - skipComponentGovernanceDetection: true
+              steps:
+                - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                  - task: Bash@3
+                    displayName: Setup Private Feeds Credentials
+                    inputs:
+                      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+                      arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+                    env:
+                      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+                - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine $(_InternalRuntimeDownloadArgs)
+                  env:
+                    Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
+                    COMPlus_EnableWriteXorExecute: 0 # Work-around for https://github.com/dotnet/runtime/issues/70758
+                  name: Build
+                - task: PublishBuildArtifacts@1
+                  displayName: Upload TestResults
+                  condition: always()
+                  continueOnError: true
                   inputs:
-                    filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                    arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-                  env:
-                    Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine $(_InternalRuntimeDownloadArgs)
-                env:
-                  Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
-                  Test__Cosmos__AuthToken: $(_CosmosToken)
-                name: Build
-              - task: PublishBuildArtifacts@1
-                displayName: Upload TestResults
-                condition: always()
-                continueOnError: true
-                inputs:
-                  pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-                  artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-                  artifactType: Container
-                  parallel: true
+                    pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+                    artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+                    artifactType: Container
+                    parallel: true
 
-          - job: Helix
-            timeoutInMinutes: 180
-            pool:
-              ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCore-Svc-Public
-                demands: ImageOverride -equals 1es-windows-2019-open
-              ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                name: NetCore1ESPool-Svc-Internal
-                demands: ImageOverride -equals 1es-windows-2019
-            variables:
-              - name: _HelixBuildConfig
-                value: $(_BuildConfig)
-              - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                - name: HelixTargetQueues
-                  value: OSX.1100.Amd64.Open;(Ubuntu.2204.Amd64.SqlServer)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20220131172221-d5c5072
-                - name: _HelixAccessToken
-                  value: '' # Needed for public queues
-              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                - name: HelixTargetQueues
-                  value: OSX.1100.Amd64;(Ubuntu.2204.Amd64.SqlServer)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20220131172221-d5c5072
-                - name: _HelixAccessToken
-                  value: $(HelixApiAccessToken) # Needed for internal queues
-            steps:
-              - task: NuGetCommand@2
-                displayName: 'Clear NuGet caches'
-                condition: succeeded()
-                inputs:
-                  command: custom
-                  arguments: 'locals all -clear'
-              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                - task: PowerShell@2
-                  displayName: Setup Private Feeds Credentials
+            - job: Linux
+              timeoutInMinutes: 120
+              enablePublishTestResults: true
+              pool:
+                ${{ if or(ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
+                  vmImage: ubuntu-22.04
+                ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
+                  name: NetCore1ESPool-Svc-Internal
+                  demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
+              variables:
+                - _runCounter: $[counter(variables['Build.Reason'], 0)]
+                # Rely on task Arcade injects, not auto-injected build step.
+                - skipComponentGovernanceDetection: true
+                - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest', 'Schedule')) }}:
+                  - _CosmosConnectionUrl: 'true'
+              steps:
+                - bash: |
+                      echo "##vso[task.setvariable variable=_CosmosConnectionUrl]https://ef-nightly-test.documents.azure.com:443/"
+                      echo "##vso[task.setvariable variable=_CosmosToken]$(ef-nightly-cosmos-key)"
+                  displayName: Prepare to run Cosmos tests on ef-nightly-test
+                  condition: and(eq(variables['_CosmosConnectionUrl'], 'true'), or(endsWith(variables['_runCounter'], '0'), endsWith(variables['_runCounter'], '2'), endsWith(variables['_runCounter'], '4'), endsWith(variables['_runCounter'], '6'), endsWith(variables['_runCounter'], '8')))
+                - bash: |
+                      echo "##vso[task.setvariable variable=_CosmosConnectionUrl]https://ef-pr-test.documents.azure.com:443/"
+                      echo "##vso[task.setvariable variable=_CosmosToken]$(ef-pr-cosmos-test)"
+                  displayName: Prepare to run Cosmos tests on ef-pr-test
+                  condition: and(eq(variables['_CosmosConnectionUrl'], 'true'), or(endsWith(variables['_runCounter'], '1'), endsWith(variables['_runCounter'], '3'), endsWith(variables['_runCounter'], '5'), endsWith(variables['_runCounter'], '7'), endsWith(variables['_runCounter'], '9')))
+                - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                  - task: Bash@3
+                    displayName: Setup Private Feeds Credentials
+                    inputs:
+                      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+                      arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+                    env:
+                      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+                - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine $(_InternalRuntimeDownloadArgs)
+                  env:
+                    Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
+                    Test__Cosmos__AuthToken: $(_CosmosToken)
+                  name: Build
+                - task: PublishBuildArtifacts@1
+                  displayName: Upload TestResults
+                  condition: always()
+                  continueOnError: true
                   inputs:
-                    filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                    arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-                  env:
-                    Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - script: restore.cmd -ci /p:configuration=$(_BuildConfig)
-                displayName: Restore packages
-              - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
-                displayName: Send job to helix
-                env:
-                  HelixAccessToken: $(_HelixAccessToken)
-                  SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-                  MSSQL_SA_PASSWORD: "Password12!"
-                  COMPlus_EnableWriteXorExecute: 0 # Work-around for https://github.com/dotnet/runtime/issues/70758
+                    pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+                    artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+                    artifactType: Container
+                    parallel: true
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            - job: Helix
+              timeoutInMinutes: 180
+              pool:
+                ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                  name: NetCore-Svc-Public
+                  demands: ImageOverride -equals 1es-windows-2019-open
+                ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                  name: NetCore1ESPool-Svc-Internal
+                  demands: ImageOverride -equals 1es-windows-2019
+              variables:
+                # Rely on task Arcade injects, not auto-injected build step.
+                - skipComponentGovernanceDetection: true
+                - name: _HelixBuildConfig
+                  value: $(_BuildConfig)
+                - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                  - name: HelixTargetQueues
+                    value: OSX.1100.Amd64.Open;(Ubuntu.2204.Amd64.SqlServer)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20220131172221-d5c5072
+                  - name: _HelixAccessToken
+                    value: '' # Needed for public queues
+                - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                  - name: HelixTargetQueues
+                    value: OSX.1100.Amd64;(Ubuntu.2204.Amd64.SqlServer)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64-20220131172221-d5c5072
+                  - name: _HelixAccessToken
+                    value: $(HelixApiAccessToken) # Needed for internal queues
+              steps:
+                - task: NuGetCommand@2
+                  displayName: 'Clear NuGet caches'
+                  condition: succeeded()
+                  inputs:
+                    command: custom
+                    arguments: 'locals all -clear'
+                - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                  - task: PowerShell@2
+                    displayName: Setup Private Feeds Credentials
+                    inputs:
+                      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+                      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+                    env:
+                      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+                - script: restore.cmd -ci /p:configuration=$(_BuildConfig)
+                  displayName: Restore packages
+                - script: .dotnet\dotnet build eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
+                  displayName: Send job to helix
+                  env:
+                    HelixAccessToken: $(_HelixAccessToken)
+                    SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+                    MSSQL_SA_PASSWORD: "Password12!"
+                    COMPlus_EnableWriteXorExecute: 0 # Work-around for https://github.com/dotnet/runtime/issues/70758
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables.runCodeQL3000, 'true')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       publishingInfraVersion: 3


### PR DESCRIPTION
- backport of #29425
- add new schedule for a weekly run
- add top-level parameter enabling CodeQL3000 in manual builds
- mix CodeQL3000 tasks into regular build; avoid large duplications
  - skip other jobs in CodeQL3000 runs
  - set `$(UseSharedCompilation)` to `false` to ease analysis
- tag CodeQL3000 runs
- add a tsaoptions.json file
  - cribbed values from our eng/sdl-tsa-vars.config file