### PR TITLE
Make DbUpdateException.Entries contain all entries when we can't populate it

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Update/NonSharedModelUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/NonSharedModelUpdatesTestBase.cs
@@ -110,6 +110,41 @@ public abstract class NonSharedModelUpdatesTestBase : NonSharedModelTestBase
         public Author? Author { get; set; }
     }
 
+    [ConditionalTheory] // Issue #29379
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task DbUpdateException_Entries_is_correct_with_multiple_inserts(bool async)
+    {
+        var contextFactory = await InitializeAsync<DbContext>(onModelCreating: mb => mb.Entity<Blog>().HasIndex(b => b.Name).IsUnique());
+
+        await ExecuteWithStrategyInTransactionAsync(
+            contextFactory,
+            async context =>
+            {
+                context.Add(new Blog { Name = "Blog2" });
+                await context.SaveChangesAsync();
+            },
+            async context =>
+            {
+                context.Add(new Blog { Name = "Blog1" });
+                context.Add(new Blog { Name = "Blog2" });
+                context.Add(new Blog { Name = "Blog3" });
+
+                var exception = async
+                    ? await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync())
+                    : Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+
+                var entry = Assert.Single(exception.Entries);
+
+                Assert.Equal("Blog2", ((Blog)entry.Entity).Name);
+            });
+    }
+
+    public class Blog
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+    }
+
     protected virtual void ExecuteWithStrategyInTransaction(
         ContextFactory<DbContext> contextFactory,
         Action<DbContext> testOperation,

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -1234,12 +1234,7 @@ END");
         // inner exception for details.
         // SqlException : Cannot insert explicit value for identity column in table
         // 'Blog' when IDENTITY_INSERT is set to OFF.
-        context.Database.CreateExecutionStrategy().Execute(
-            context, c =>
-            {
-                var updateException = Assert.Throws<DbUpdateException>(() => c.SaveChanges());
-                Assert.Single(updateException.Entries);
-            });
+        context.Database.CreateExecutionStrategy().Execute(context, c => Assert.Throws<DbUpdateException>(() => c.SaveChanges()));
     }
 
     [ConditionalFact]

--- a/test/EFCore.Sqlite.FunctionalTests/Update/NonSharedModelUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/NonSharedModelUpdatesSqliteTest.cs
@@ -78,6 +78,36 @@ RETURNING 1;
 """);
     }
 
+    public override async Task DbUpdateException_Entries_is_correct_with_multiple_inserts(bool async)
+    {
+        await base.DbUpdateException_Entries_is_correct_with_multiple_inserts(async);
+
+        AssertSql(
+"""
+@p0='Blog2' (Size = 5)
+
+INSERT INTO "Blog" ("Name")
+VALUES (@p0)
+RETURNING "Id";
+""",
+            //
+"""
+@p0='Blog1' (Size = 5)
+
+INSERT INTO "Blog" ("Name")
+VALUES (@p0)
+RETURNING "Id";
+""",
+            //
+"""
+@p0='Blog2' (Size = 5)
+
+INSERT INTO "Blog" ("Name")
+VALUES (@p0)
+RETURNING "Id";
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Closes #29379

