### PR TITLE
[SMALL] Fix to #29572 - Json: predicate on json bool property generates incorrect sql

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -764,5 +764,5 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override Expression VisitJsonScalar(JsonScalarExpression jsonScalarExpression)
-        => jsonScalarExpression;
+        => ApplyConversion(jsonScalarExpression, condition: false);
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -806,6 +806,36 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_boolean_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestBoolean),
+            entryCount: 6);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_boolean_predicate_negated(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => !x.Reference.TestBoolean),
+            entryCount: 0);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_boolean_projection(bool async)
+        => AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityAllTypes>().Select(x => x.Reference.TestBoolean));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_boolean_projection_negated(bool async)
+        => AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityAllTypes>().Select(x => !x.Reference.TestBoolean));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task FromSql_on_entity_with_json_basic(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -841,6 +841,55 @@ FROM [JsonEntitiesAllTypes] AS [j]
 """);
     }
 
+    public override async Task Json_boolean_predicate(bool async)
+    {
+        await base.Json_boolean_predicate(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(1 AS bit)
+""");
+    }
+
+    public override async Task Json_boolean_predicate_negated(bool async)
+    {
+        await base.Json_boolean_predicate_negated(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(0 AS bit)
+""");
+    }
+
+    public override async Task Json_boolean_projection(bool async)
+    {
+        await base.Json_boolean_projection(async);
+
+        AssertSql(
+"""
+SELECT CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit)
+FROM [JsonEntitiesAllTypes] AS [j]
+""");
+    }
+
+    public override async Task Json_boolean_projection_negated(bool async)
+    {
+        await base.Json_boolean_projection_negated(async);
+
+        AssertSql(
+"""
+SELECT CASE
+    WHEN CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(0 AS bit) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [JsonEntitiesAllTypes] AS [j]
+""");
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_on_entity_with_json_basic(bool async)


### PR DESCRIPTION
Search condition visitor wasn't handling json scalar expressions properly - we should convert them into search conditions/values just like we do with regular columns

Fixes #29572