### PR TITLE
Fix passing property and entity type names to ValueGenerated messages

### DIFF
--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -2785,8 +2785,8 @@ public static class CoreLoggerExtensions
             definition.Log(
                 diagnostics,
                 internalEntityEntry.Context.GetType().ShortDisplayName(),
-                property.Name,
-                internalEntityEntry.EntityType.ShortName());
+                internalEntityEntry.EntityType.ShortName(),
+                property.Name);
         }
 
         if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -2808,8 +2808,8 @@ public static class CoreLoggerExtensions
         var p = (PropertyValueEventData)payload;
         return d.GenerateMessage(
             p.EntityEntry.Context.GetType().ShortDisplayName(),
-            p.Property.Name,
-            p.EntityEntry.Metadata.ShortName());
+            p.EntityEntry.Metadata.ShortName(),
+            p.Property.Name);
     }
 
     /// <summary>
@@ -2837,8 +2837,8 @@ public static class CoreLoggerExtensions
                 diagnostics,
                 internalEntityEntry.Context.GetType().ShortDisplayName(),
                 value,
-                property.Name,
-                internalEntityEntry.EntityType.ShortName());
+                internalEntityEntry.EntityType.ShortName(),
+                property.Name);
         }
 
         if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -2861,8 +2861,8 @@ public static class CoreLoggerExtensions
         return d.GenerateMessage(
             p.EntityEntry.Context.GetType().ShortDisplayName(),
             p.Value,
-            p.Property.Name,
-            p.EntityEntry.Metadata.ShortName());
+            p.EntityEntry.Metadata.ShortName(),
+            p.Property.Name);
     }
 
     /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -4593,7 +4593,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     '{contextType}' generated a temporary value for the property '{2_entityType}.{1_property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+        ///     '{contextType}' generated a temporary value for the property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
         /// </summary>
         public static EventDefinition<string, string, string> LogTempValueGenerated(IDiagnosticsLogger logger)
         {
@@ -4618,7 +4618,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     '{contextType}' generated temporary value '{keyValue}' for the property '{3_entityType}.{2_property}'.
+        ///     '{contextType}' generated temporary value '{keyValue}' for the property '{entityType}.{property}'.
         /// </summary>
         public static EventDefinition<string, object?, string, string> LogTempValueGeneratedSensitive(IDiagnosticsLogger logger)
         {
@@ -4643,7 +4643,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     '{contextType}' generated a value for the property '{2_entityType}.{1_property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+        ///     '{contextType}' generated a value for the property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
         /// </summary>
         public static EventDefinition<string, string, string> LogValueGenerated(IDiagnosticsLogger logger)
         {
@@ -4668,7 +4668,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     '{contextType}' generated value '{keyValue}' for the property '{3_entityType}.{2_property}'.
+        ///     '{contextType}' generated value '{keyValue}' for the property '{entityType}.{property}'.
         /// </summary>
         public static EventDefinition<string, object?, string, string> LogValueGeneratedSensitive(IDiagnosticsLogger logger)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -965,19 +965,19 @@
     <comment>Debug CoreEventId.StateChanged string string string EntityState EntityState</comment>
   </data>
   <data name="LogTempValueGenerated" xml:space="preserve">
-    <value>'{contextType}' generated a temporary value for the property '{2_entityType}.{1_property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
+    <value>'{contextType}' generated a temporary value for the property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
     <comment>Debug CoreEventId.ValueGenerated string string string</comment>
   </data>
   <data name="LogTempValueGeneratedSensitive" xml:space="preserve">
-    <value>'{contextType}' generated temporary value '{keyValue}' for the property '{3_entityType}.{2_property}'.</value>
+    <value>'{contextType}' generated temporary value '{keyValue}' for the property '{entityType}.{property}'.</value>
     <comment>Debug CoreEventId.ValueGenerated string object? string string</comment>
   </data>
   <data name="LogValueGenerated" xml:space="preserve">
-    <value>'{contextType}' generated a value for the property '{2_entityType}.{1_property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
+    <value>'{contextType}' generated a value for the property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
     <comment>Debug CoreEventId.ValueGenerated string string string</comment>
   </data>
   <data name="LogValueGeneratedSensitive" xml:space="preserve">
-    <value>'{contextType}' generated value '{keyValue}' for the property '{3_entityType}.{2_property}'.</value>
+    <value>'{contextType}' generated value '{keyValue}' for the property '{entityType}.{property}'.</value>
     <comment>Debug CoreEventId.ValueGenerated string object? string string</comment>
   </data>
   <data name="ManyToManyOneNav" xml:space="preserve">

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -868,9 +868,9 @@ public class ChangeTrackerTest
             Assert.Equal(
                 sensitive
                     ? CoreResources.LogTempValueGeneratedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
-                        nameof(LikeAZooContextSensitive), 1, nameof(Hat.Id), nameof(Hat))
+                        nameof(LikeAZooContextSensitive), 1, nameof(Hat), nameof(Hat.Id))
                     : CoreResources.LogTempValueGenerated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
-                        nameof(LikeAZooContext), nameof(Hat.Id), nameof(Hat)),
+                        nameof(LikeAZooContext), nameof(Hat), nameof(Hat.Id)),
                 message);
         }
         else
@@ -878,9 +878,9 @@ public class ChangeTrackerTest
             Assert.Equal(
                 sensitive
                     ? CoreResources.LogValueGeneratedSensitive(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
-                        nameof(LikeAZooContextSensitive), 1, nameof(Hat.Id), nameof(Hat))
+                        nameof(LikeAZooContextSensitive), 1, nameof(Hat), nameof(Hat.Id))
                     : CoreResources.LogValueGenerated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
-                        nameof(LikeAZooContext), nameof(Hat.Id), nameof(Hat)),
+                        nameof(LikeAZooContext), nameof(Hat), nameof(Hat.Id)),
                 message);
         }
     }


### PR DESCRIPTION
Fixes #29517

Parameter-reordering works for exception messages, but doesn't work for log messages. Also checked there are no other cases of this.


