### PR TITLE
Fix to #28648 - Json/Query: translate element access of a json array

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1408,6 +1408,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("PendingAmbientTransaction");
 
         /// <summary>
+        ///     The query projects an entity mapped to JSON and accesses a JSON collection element. Such queries require 'AsNoTracking' option, even when the parent entity is projected.
+        /// </summary>
+        public static string ProjectingJsonCollectionElementRequiresNoTracking
+            => GetString("ProjectingJsonCollectionElementRequiresNoTracking");
+
+        /// <summary>
         ///     Unable to translate set operations when both sides don't assign values to the same properties in the nominal type. Please make sure that the same properties are included on both sides, and consider assigning default values if a property doesn't require a specific value.
         /// </summary>
         public static string ProjectionMappingCountMismatch

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -950,6 +950,9 @@
   <data name="PendingAmbientTransaction" xml:space="preserve">
     <value>This connection was used with an ambient transaction. The original ambient transaction needs to be completed before this connection can be used outside of it.</value>
   </data>
+  <data name="ProjectingJsonCollectionElementRequiresNoTracking" xml:space="preserve">
+    <value>The query projects an entity mapped to JSON and accesses a JSON collection element. Such queries require 'AsNoTracking' option, even when the parent entity is projected.</value>
+  </data>
   <data name="ProjectionMappingCountMismatch" xml:space="preserve">
     <value>Unable to translate set operations when both sides don't assign values to the same properties in the nominal type. Please make sure that the same properties are included on both sides, and consider assigning default values if a property doesn't require a specific value.</value>
   </data>

--- a/src/EFCore.Relational/Query/Internal/CollectionIndexerToElementAtNormalizingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/CollectionIndexerToElementAtNormalizingExpressionVisitor.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class CollectionIndexerToElementAtNormalizingExpressionVisitor : ExpressionVisitor
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        // Convert list[x] to list.ElementAt(x)
+        if (methodCallExpression.Method is { Name: "get_Item", IsStatic: false, DeclaringType: { IsGenericType: true } declaringType }
+            && declaringType.GetGenericTypeDefinition() == typeof(List<>))
+        {
+            var source = Visit(methodCallExpression.Object!);
+            var index = Visit(methodCallExpression.Arguments[0]);
+            var sourceTypeArgument = source.Type.GetSequenceType();
+
+            return Expression.Call(
+                QueryableMethods.ElementAt.MakeGenericMethod(sourceTypeArgument),
+                    Expression.Call(
+                        QueryableMethods.AsQueryable.MakeGenericMethod(sourceTypeArgument),
+                        source),
+                    index);
+        }
+
+        return base.VisitMethodCall(methodCallExpression);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitBinary(BinaryExpression binaryExpression)
+    {
+        // Convert array[x] to array.ElementAt(x)
+        if (binaryExpression.NodeType == ExpressionType.ArrayIndex)
+        {
+            var source = Visit(binaryExpression.Left);
+            var index = Visit(binaryExpression.Right);
+            var sourceTypeArgument = source.Type.GetSequenceType();
+
+            return Expression.Call(
+                QueryableMethods.ElementAt.MakeGenericMethod(sourceTypeArgument),
+                    Expression.Call(
+                        QueryableMethods.AsQueryable.MakeGenericMethod(sourceTypeArgument),
+                        source),
+                    index);
+        }
+
+        return base.VisitBinary(binaryExpression);
+    }
+}

--- a/src/EFCore.Relational/Query/JsonQueryExpression.cs
+++ b/src/EFCore.Relational/Query/JsonQueryExpression.cs
@@ -162,6 +162,33 @@ public class JsonQueryExpression : Expression, IPrintableExpression
     }
 
     /// <summary>
+    ///     Binds a collection element access with this JSON query expression to get the SQL representation.
+    /// </summary>
+    /// <param name="collectionIndexExpression">The collection index to bind.</param>
+    public virtual JsonQueryExpression BindCollectionElement(SqlExpression collectionIndexExpression)
+    {
+        // this needs to be changed IF JsonQueryExpression will also be used for collection of primitives
+        // see issue #28688
+        Debug.Assert(
+            Path.Last().ArrayIndex == null,
+            "Already accessing JSON array element.");
+
+        var newPath = Path.ToList();
+        newPath.Add(new PathSegment(collectionIndexExpression));
+
+        return new JsonQueryExpression(
+            EntityType,
+            JsonColumn,
+            _keyPropertyMap,
+            newPath,
+            EntityType.ClrType,
+            collection: false,
+            // TODO: computing nullability might be more complicated when we allow strict mode
+            // see issue #28656
+            nullable: true);
+    }
+
+    /// <summary>
     ///     Makes this JSON query expression nullable.
     /// </summary>
     /// <returns>A new expression which has <see cref="IsNullable" /> property set to true.</returns>

--- a/src/EFCore.Relational/Query/RelationalQueryTranslationPreprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryTranslationPreprocessor.cs
@@ -37,6 +37,7 @@ public class RelationalQueryTranslationPreprocessor : QueryTranslationPreprocess
         expression = new RelationalQueryMetadataExtractingExpressionVisitor(_relationalQueryCompilationContext).Visit(expression);
         expression = base.NormalizeQueryableMethod(expression);
         expression = new TableValuedFunctionToQueryRootConvertingExpressionVisitor(QueryCompilationContext.Model).Visit(expression);
+        expression = new CollectionIndexerToElementAtNormalizingExpressionVisitor().Visit(expression);
 
         return expression;
     }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
@@ -68,28 +69,10 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
         if (binaryExpression.NodeType == ExpressionType.ArrayIndex
             && binaryExpression.Left.Type == typeof(byte[]))
         {
-            var left = Visit(binaryExpression.Left);
-            var right = Visit(binaryExpression.Right);
-
-            if (left is SqlExpression leftSql
-                && right is SqlExpression rightSql)
-            {
-                return Dependencies.SqlExpressionFactory.Convert(
-                    Dependencies.SqlExpressionFactory.Function(
-                        "SUBSTRING",
-                        new[]
-                        {
-                            leftSql,
-                            Dependencies.SqlExpressionFactory.Add(
-                                Dependencies.SqlExpressionFactory.ApplyDefaultTypeMapping(rightSql),
-                                Dependencies.SqlExpressionFactory.Constant(1)),
-                            Dependencies.SqlExpressionFactory.Constant(1)
-                        },
-                        nullable: true,
-                        argumentsPropagateNullability: new[] { true, true, true },
-                        typeof(byte[])),
-                    binaryExpression.Type);
-            }
+            return TranslateByteArrayElementAccess(
+                binaryExpression.Left,
+                binaryExpression.Right,
+                binaryExpression.Type);
         }
 
         var visitedExpression = base.VisitBinary(binaryExpression);
@@ -150,6 +133,52 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
         }
 
         return base.VisitUnary(unaryExpression);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        if (methodCallExpression is MethodCallExpression { Method: MethodInfo { IsGenericMethod: true } } genericMethodCall
+            && genericMethodCall.Method.GetGenericMethodDefinition() == EnumerableMethods.ElementAt
+            && genericMethodCall.Arguments[0].Type == typeof(byte[]))
+        {
+            return TranslateByteArrayElementAccess(
+                genericMethodCall.Arguments[0],
+                genericMethodCall.Arguments[1],
+                methodCallExpression.Type);
+        }
+
+        return base.VisitMethodCall(methodCallExpression);
+    }
+
+    private Expression TranslateByteArrayElementAccess(Expression array, Expression index, Type resultType)
+    {
+        var visitedArray = Visit(array);
+        var visitedIndex = Visit(index);
+
+        return visitedArray is SqlExpression sqlArray
+            && visitedIndex is SqlExpression sqlIndex
+            ? Dependencies.SqlExpressionFactory.Convert(
+                    Dependencies.SqlExpressionFactory.Function(
+                        "SUBSTRING",
+                        new[]
+                        {
+                            sqlArray,
+                            Dependencies.SqlExpressionFactory.Add(
+                                Dependencies.SqlExpressionFactory.ApplyDefaultTypeMapping(sqlIndex),
+                                Dependencies.SqlExpressionFactory.Constant(1)),
+                            Dependencies.SqlExpressionFactory.Constant(1)
+                        },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true, true, true },
+                        typeof(byte[])),
+                    resultType)
+            : QueryCompilationContext.NotTranslatedExpression;
     }
 
     private static string? GetProviderType(SqlExpression expression)

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
@@ -13,6 +13,8 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     protected override string StoreName
         => "JsonQueryAdHocTest";
 
+    #region 29219
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Optional_json_properties_materialized_as_null_when_the_element_in_json_is_not_present(bool async)
@@ -83,4 +85,189 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
         public int NonNullableScalar { get; set; }
         public int? NullableScalar { get; set; }
     }
+
+    #endregion
+
+    #region ArrayOfPrimitives
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Project_json_array_of_primitives_on_reference(bool async)
+    {
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        using (var context = contextFactory.CreateContext())
+        {
+            var query = context.Entities.OrderBy(x => x.Id).Select(x => new { x.Reference.IntArray, x.Reference.ListOfString });
+
+            var result = async
+                ? await query.ToListAsync()
+                : query.ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(3, result[0].IntArray.Length);
+            Assert.Equal(3, result[0].ListOfString.Count);
+            Assert.Equal(3, result[1].IntArray.Length);
+            Assert.Equal(3, result[1].ListOfString.Count);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Project_json_array_of_primitives_on_collection(bool async)
+    {
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        using (var context = contextFactory.CreateContext())
+        {
+            var query = context.Entities.OrderBy(x => x.Id).Select(x => new { x.Collection[0].IntArray, x.Collection[1].ListOfString });
+
+            var result = async
+                ? await query.ToListAsync()
+                : query.ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(3, result[0].IntArray.Length);
+            Assert.Equal(2, result[0].ListOfString.Count);
+            Assert.Equal(3, result[1].IntArray.Length);
+            Assert.Equal(2, result[1].ListOfString.Count);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Project_element_of_json_array_of_primitives(bool async)
+    {
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        using (var context = contextFactory.CreateContext())
+        {
+            var query = context.Entities.OrderBy(x => x.Id).Select(x => new
+            {
+                ArrayElement = x.Reference.IntArray[0],
+                ListElement = x.Reference.ListOfString[1]
+            });
+
+            var result = async
+                ? await query.ToListAsync()
+                : query.ToList();
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Predicate_based_on_element_of_json_array_of_primitives1(bool async)
+    {
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        using (var context = contextFactory.CreateContext())
+        {
+            var query = context.Entities.Where(x => x.Reference.IntArray[0] == 1);
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync());
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => query.ToList());
+            }    
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Predicate_based_on_element_of_json_array_of_primitives2(bool async)
+    {
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        using (var context = contextFactory.CreateContext())
+        {
+            var query = context.Entities.Where(x => x.Reference.ListOfString[1] == "Bar");
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync());
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => query.ToList());
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Predicate_based_on_element_of_json_array_of_primitives3(bool async)
+    {
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        using (var context = contextFactory.CreateContext())
+        {
+            var query = context.Entities.Where(x => x.Reference.IntArray.AsQueryable().ElementAt(0) == 1
+                || x.Reference.ListOfString.AsQueryable().ElementAt(1) == "Bar");
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToListAsync());
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => query.ToList());
+            }
+        }
+    }
+
+
+    protected abstract void SeedArrayOfPrimitives(MyContextArrayOfPrimitives ctx);
+
+    protected class MyContextArrayOfPrimitives : DbContext
+    {
+        public MyContextArrayOfPrimitives(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<MyEntityArrayOfPrimitives> Entities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<MyEntityArrayOfPrimitives>().Property(x => x.Id).ValueGeneratedNever();
+            modelBuilder.Entity<MyEntityArrayOfPrimitives>().OwnsOne(x => x.Reference, b =>
+            {
+                b.ToJson();
+                b.Property(x => x.IntArray).HasConversion(
+                     x => string.Join(" ", x),
+                     x => x.Split(" ", StringSplitOptions.None).Select(v => int.Parse(v)).ToArray(),
+                     new ValueComparer<int[]>(true));
+
+                b.Property(x => x.ListOfString).HasConversion(
+                    x => string.Join(" ", x),
+                    x => x.Split(" ", StringSplitOptions.None).ToList(),
+                    new ValueComparer<List<string>>(true));
+            });
+
+            modelBuilder.Entity<MyEntityArrayOfPrimitives>().OwnsMany(x => x.Collection, b =>
+            {
+                b.ToJson();
+                b.Property(x => x.IntArray).HasConversion(
+                     x => string.Join(" ", x),
+                     x => x.Split(" ", StringSplitOptions.None).Select(v => int.Parse(v)).ToArray(),
+                     new ValueComparer<int[]>(true));
+                b.Property(x => x.ListOfString).HasConversion(
+                    x => string.Join(" ", x),
+                    x => x.Split(" ", StringSplitOptions.None).ToList(),
+                    new ValueComparer<List<string>>(true));
+            });
+        }
+    }
+
+    public class MyEntityArrayOfPrimitives
+    {
+        public int Id { get; set; }
+        public MyJsonEntityArrayOfPrimitives Reference { get; set; }
+        public List<MyJsonEntityArrayOfPrimitives> Collection { get; set; }
+    }
+
+    public class MyJsonEntityArrayOfPrimitives
+    {
+        public int[] IntArray { get; set; }
+        public List<string> ListOfString { get; set; }
+    }
+
+    #endregion
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -112,7 +112,8 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
             ss => ss.Set<JsonEntityBasic>().Select(
                 x => new
                 {
-                    x.Id, x.OwnedReferenceRoot.OwnedReferenceBranch.Enum,
+                    x.Id,
+                    x.OwnedReferenceRoot.OwnedReferenceBranch.Enum,
                 }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -632,14 +633,481 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Json_collection_element_access_in_projection_basic(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[0]).AsNoTracking());
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[1]).AsNoTracking());
 
-    [ConditionalTheory(Skip = "issue #28648")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Json_collection_element_access_in_predicate(bool async)
+    public virtual Task Json_collection_element_access_in_projection_using_ElementAt(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot.AsQueryable().ElementAt(1)).AsNoTracking());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_using_ElementAtOrDefault(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot.AsQueryable().ElementAtOrDefault(1)).AsNoTracking());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_project_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[1].OwnedCollectionBranch).AsNoTracking(),
+            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_using_ElementAt_project_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .Select(x => x.OwnedCollectionRoot.AsQueryable().ElementAt(1).OwnedCollectionBranch)
+                .AsNoTracking(),
+            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_using_ElementAtOrDefault_project_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .Select(x => x.OwnedCollectionRoot.AsQueryable().ElementAtOrDefault(1).OwnedCollectionBranch)
+                .AsNoTracking(),
+            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_using_parameter(bool async)
+    {
+        var prm = 0;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[prm]).AsNoTracking());
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_using_column(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[x.Id]).AsNoTracking());
+
+    private static int MyMethod(int value)
+        => value;
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_in_projection_using_untranslatable_client_method(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[MyMethod(x.Id)]).AsNoTracking()))).Message;
+
+        Assert.Equal(
+            CoreStrings.TranslationFailed("JsonQueryExpression(j.OwnedCollectionRoot, $)"),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_in_projection_using_untranslatable_client_method2(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[0].OwnedReferenceBranch.OwnedCollectionLeaf[MyMethod(x.Id)]).AsNoTracking()))).Message;
+
+        Assert.Equal(
+            CoreStrings.TranslationFailed("JsonQueryExpression(j.OwnedCollectionRoot, $.[0].OwnedReferenceBranch.OwnedCollectionLeaf)"),
+            message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_outside_bounds(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[25]).AsNoTracking(),
+            ss => ss.Set<JsonEntityBasic>().Select(x => (JsonOwnedRoot)null));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_outside_bounds_with_property_access(bool async)
+        => AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityBasic>().OrderBy(x => x.Id).Select(x => (int?)x.OwnedCollectionRoot[25].Number),
+            ss => ss.Set<JsonEntityBasic>().Select(x => (int?)null));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_nested(bool async)
+    {
+        var prm = 1;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[0].OwnedCollectionBranch[prm]).AsNoTracking());
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_nested_project_scalar(bool async)
+    {
+        var prm = 1;
+
+        return AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[0].OwnedCollectionBranch[prm].Date));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_nested_project_reference(bool async)
+    {
+        var prm = 1;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[0].OwnedCollectionBranch[prm].OwnedReferenceLeaf).AsNoTracking());
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_nested_project_collection(bool async)
+    {
+        var prm = 1;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .OrderBy(x => x.Id)
+                .Select(x => x.OwnedCollectionRoot[0].OwnedCollectionBranch[prm].OwnedCollectionLeaf)
+                .AsNoTracking(),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_projection_nested_project_collection_anonymous_projection(bool async)
+    {
+        var prm = 1;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .Select(x => new { x.Id, x.OwnedCollectionRoot[0].OwnedCollectionBranch[prm].OwnedCollectionLeaf })
+                .AsNoTracking(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Id, a.Id);
+                AssertCollection(e.OwnedCollectionLeaf, a.OwnedCollectionLeaf, ordered: true);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_predicate_using_constant(bool async)
         => AssertQueryScalar(
             async,
             ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedCollectionRoot[0].Name != "Foo").Select(x => x.Id));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_predicate_using_variable(bool async)
+    {
+        var prm = 1;
+
+        return AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedCollectionRoot[prm].Name != "Foo").Select(x => x.Id));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_predicate_using_column(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedCollectionRoot[x.Id].Name == "e1_c2").Select(x => new { x.Id, x }),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Id, a.Id);
+                AssertEqual(e.x, a.x);
+            },
+            entryCount: 40);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_predicate_using_complex_expression1(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedCollectionRoot[x.Id == 1 ? 0 : 1].Name == "e1_c1").Select(x => new { x.Id, x }),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Id, a.Id);
+                AssertEqual(e.x, a.x);
+            },
+            entryCount: 40);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_predicate_using_complex_expression2(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedCollectionRoot[ss.Set<JsonEntityBasic>().Max(x => x.Id)].Name == "e1_c2").Select(x => new { x.Id, x }),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Id, a.Id);
+                AssertEqual(e.x, a.x);
+            },
+            entryCount: 40);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_predicate_using_ElementAt(bool async)
+        => AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedCollectionRoot.AsQueryable().ElementAt(1).Name != "Foo").Select(x => x.Id));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_in_predicate_nested_mix(bool async)
+    {
+        var prm = 0;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedCollectionRoot[1].OwnedCollectionBranch[prm].OwnedCollectionLeaf[x.Id - 1].SomethingSomething == "e1_c2_c1_c1"),
+            entryCount: 40);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_collection_element_access_manual_Element_at_and_pushdown(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => new
+            {
+                x.Id,
+                CollectionElement = x.OwnedCollectionRoot.Select(xx => xx.Number).ElementAt(0)
+            }));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative(bool async)
+    {
+        var prm = 0;
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(x => new
+                {
+                    x.Id,
+                    CollectionElement = x.OwnedCollectionRoot[prm].OwnedCollectionBranch.Select(xx => "Foo").ElementAt(0)
+                })))).Message;
+
+        Assert.Equal(CoreStrings.TranslationFailed("JsonQueryExpression(j.OwnedCollectionRoot, $.[__prm_0].OwnedCollectionBranch)"), message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative2(bool async)
+    {
+        var prm = 0;
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(x => new
+                {
+                    x.Id,
+                    CollectionElement = x.OwnedCollectionRoot[prm + x.Id].OwnedCollectionBranch.Select(xx => x.Id).ElementAt(0)
+                })))).Message;
+
+        Assert.Equal(CoreStrings.TranslationFailed("JsonQueryExpression(j.OwnedCollectionRoot, $.[(...)].OwnedCollectionBranch)"), message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative3(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(x => new
+                {
+                    x.Id,
+                    CollectionElement = x.OwnedCollectionRoot.Select(xx => x.OwnedReferenceRoot).ElementAt(0)
+                })))).Message;
+
+        Assert.Equal(CoreStrings.TranslationFailed("JsonQueryExpression(j.OwnedCollectionRoot, $)"), message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative4(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(x => new
+                {
+                    x.Id,
+                    CollectionElement = x.OwnedCollectionRoot.Select(xx => x.OwnedCollectionRoot).ElementAt(0)
+                })))).Message;
+
+        Assert.Equal(CoreStrings.TranslationFailed("JsonQueryExpression(j.OwnedCollectionRoot, $)"), message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative5(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(x => new
+                {
+                    x.Id,
+                    CollectionElement = x.OwnedCollectionRoot.Select(xx => new { xx.OwnedReferenceBranch }).ElementAt(0)
+                })))).Message;
+
+        Assert.Equal(CoreStrings.TranslationFailed("JsonQueryExpression(j.OwnedCollectionRoot, $)"), message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative6(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(x => new
+                {
+                    x.Id,
+                    CollectionElement = x.OwnedCollectionRoot.Select(xx => new JsonEntityBasic { Id = x.Id }).ElementAt(0)
+                })))).Message;
+
+        Assert.Equal(CoreStrings.TranslationFailed("JsonQueryExpression(j.OwnedCollectionRoot, $)"), message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_deduplication_with_collection_indexer_in_original(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => new
+            {
+                x.Id,
+                Duplicate1 = x.OwnedCollectionRoot[0].OwnedReferenceBranch,
+                Original = x.OwnedCollectionRoot[0],
+                Duplicate2 = x.OwnedCollectionRoot[0].OwnedReferenceBranch.OwnedCollectionLeaf
+            }).AsNoTracking(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Original, a.Original);
+                AssertEqual(e.Duplicate1, a.Duplicate1);
+                AssertCollection(e.Duplicate2, a.Duplicate2, ordered: true);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_deduplication_with_collection_indexer_in_target(bool async)
+    {
+        var prm = 1;
+
+        // issue #29513
+        return AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => new
+            {
+                x.Id,
+                Duplicate1 = x.OwnedReferenceRoot.OwnedCollectionBranch[1],
+                Original = x.OwnedReferenceRoot,
+                Duplicate2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[prm]
+            }).AsNoTracking(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertEqual(e.Original, a.Original);
+                AssertEqual(e.Duplicate1, a.Duplicate1);
+                AssertEqual(e.Duplicate2, a.Duplicate2);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_projection_deduplication_with_collection_in_original_and_collection_indexer_in_target(bool async)
+        // issue #29513
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => new
+            {
+                x.Id,
+                Original = x.OwnedReferenceRoot.OwnedCollectionBranch,
+                Duplicate = x.OwnedReferenceRoot.OwnedCollectionBranch[1],
+            }).AsNoTracking(),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Id, a.Id);
+                AssertCollection(e.Original, a.Original, ordered: true);
+                AssertEqual(e.Duplicate, a.Duplicate);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_in_projection_requires_NoTracking_even_if_owner_is_present(bool async)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(x => new
+                {
+                    x,
+                    CollectionElement = x.OwnedCollectionRoot[1]
+                }),
+                elementSorter: e => e.x.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.x, a.x);
+                    AssertEqual(e.CollectionElement, a.CollectionElement);
+                }));
+
+        Assert.Equal(RelationalStrings.ProjectingJsonCollectionElementRequiresNoTracking, exception.Message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Json_collection_element_access_in_projection_requires_NoTracking_even_if_owner_is_present2(bool async)
+    {
+        var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AssertQuery(
+                async,
+                ss => ss.Set<JsonEntityBasic>().Select(x => new
+                {
+                    x,
+                    CollectionElement = x.OwnedCollectionRoot[1].OwnedReferenceBranch
+                }),
+                elementSorter: e => e.x.Id,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.x, a.x);
+                    AssertEqual(e.CollectionElement, a.CollectionElement);
+                }))).Message;
+
+        Assert.Equal(RelationalStrings.ProjectingJsonCollectionElementRequiresNoTracking, message);
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -666,6 +1134,15 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
             async,
             ss => ss.Set<JsonEntityBasic>()
                 .GroupBy(x => x.OwnedReferenceRoot.Name).Select(x => new { x.Key, Count = x.Count() }));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Group_by_on_json_scalar_using_collection_indexer(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .GroupBy(x => x.OwnedCollectionRoot[0].Name).Select(x => new { x.Key, Count = x.Count() }));
+
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -8224,6 +8224,20 @@ public abstract class GearsOfWarQueryTestBase<TFixture> : QueryTestBase<TFixture
             ss => ss.Set<Squad>().Where(s => s.Members.OrderBy(m => m.Nickname).ElementAt(s.Id).Nickname == "Cole Train"),
             ss => ss.Set<Squad>().Where(s => s.Members.OrderBy(m => m.Nickname).ElementAtOrDefault(s.Id).Nickname == "Cole Train"));
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Using_indexer_on_byte_array_and_string_in_projection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Squad>().Select(x => new { x.Id, ByteArray = x.Banner[0], String = x.Name[1] }),
+            elementSorter: e => e.Id,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Id, a.Id);
+                Assert.Equal(e.ByteArray, a.ByteArray);
+                Assert.Equal(e.String, a.String);
+            });
+
     protected GearsOfWarContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -10032,6 +10032,17 @@ WHERE (
 """);
     }
 
+    public override async Task Using_indexer_on_byte_array_and_string_in_projection(bool async)
+    {
+        await base.Using_indexer_on_byte_array_and_string_in_projection(async);
+
+        AssertSql(
+"""
+SELECT [s].[Id], CAST(SUBSTRING([s].[Banner], 0 + 1, 1) AS tinyint), [s].[Name]
+FROM [Squads] AS [s]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryAdHocSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryAdHocSqlServerTest.cs
@@ -43,4 +43,56 @@ public class JsonQueryAdHocSqlServerTest : JsonQueryAdHocTestBase
         ctx.Database.ExecuteSqlRaw(@"INSERT INTO [Entities] ([Id], [Reference], [Collection])
 VALUES(3, N'{{ ""NonNullableScalar"" : 30 }}', N'[{{ ""NonNullableScalar"" : 10001 }}]')");
     }
+
+    protected override void SeedArrayOfPrimitives(MyContextArrayOfPrimitives ctx)
+    {
+        var entity1 = new MyEntityArrayOfPrimitives
+        {
+            Id = 1,
+            Reference = new MyJsonEntityArrayOfPrimitives
+            {
+                IntArray = new int[] { 1, 2, 3 },
+                ListOfString = new List<string> { "Foo", "Bar", "Baz" }
+            },
+            Collection = new List<MyJsonEntityArrayOfPrimitives>
+            {
+                new MyJsonEntityArrayOfPrimitives
+                {
+                    IntArray = new int[] { 111, 112, 113 },
+                    ListOfString = new List<string> { "Foo11", "Bar11" }
+                },
+                new MyJsonEntityArrayOfPrimitives
+                {
+                    IntArray = new int[] { 211, 212, 213 },
+                    ListOfString = new List<string> { "Foo12", "Bar12" }
+                },
+            }
+        };
+
+        var entity2 = new MyEntityArrayOfPrimitives
+        {
+            Id = 2,
+            Reference = new MyJsonEntityArrayOfPrimitives
+            {
+                IntArray = new int[] { 10, 20, 30 },
+                ListOfString = new List<string> { "A", "B", "C" }
+            },
+            Collection = new List<MyJsonEntityArrayOfPrimitives>
+            {
+                new MyJsonEntityArrayOfPrimitives
+                {
+                    IntArray = new int[] { 110, 120, 130 },
+                    ListOfString = new List<string> { "A1", "Z1" }
+                },
+                new MyJsonEntityArrayOfPrimitives
+                {
+                    IntArray = new int[] { 210, 220, 230 },
+                    ListOfString = new List<string> { "A2", "Z2" }
+                },
+            }
+        };
+
+        ctx.Entities.AddRange(entity1, entity2);
+        ctx.SaveChanges();
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -584,20 +584,401 @@ WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
     {
         await base.Json_collection_element_access_in_projection_basic(async);
 
-        // array element access in projection is currently done on the client - issue 28648
         AssertSql(
 """
-SELECT [j].[OwnedCollectionRoot], [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Json_collection_element_access_in_predicate(bool async)
+    public override async Task Json_collection_element_access_in_projection_using_ElementAt(bool async)
     {
-        await base.Json_collection_element_access_in_predicate(async);
+        await base.Json_collection_element_access_in_projection_using_ElementAt(async);
 
         AssertSql(
-            @"");
+"""
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1]'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_in_projection_using_ElementAtOrDefault(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_using_ElementAtOrDefault(async);
+
+        AssertSql(
+"""
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1]'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_in_projection_project_collection(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_project_collection(async);
+
+        AssertSql(
+"""
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_in_projection_using_ElementAt_project_collection(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_using_ElementAt_project_collection(async);
+
+        AssertSql(
+"""
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_in_projection_using_ElementAtOrDefault_project_collection(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_using_ElementAtOrDefault_project_collection(async);
+
+        AssertSql(
+"""
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_projection_using_parameter(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_using_parameter(async);
+
+        AssertSql(
+"""
+@__prm_0='0'
+
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_projection_using_column(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_using_column(async);
+
+        AssertSql(
+"""
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[' + CAST([j].[Id] AS nvarchar(max)) + ']'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_in_projection_using_untranslatable_client_method(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_using_untranslatable_client_method(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_collection_element_access_in_projection_using_untranslatable_client_method2(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_using_untranslatable_client_method2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_collection_element_access_outside_bounds(bool async)
+    {
+        await base.Json_collection_element_access_outside_bounds(async);
+
+        AssertSql(
+"""
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[25]'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_outside_bounds_with_property_access(bool async)
+    {
+        await base.Json_collection_element_access_outside_bounds_with_property_access(async);
+
+        AssertSql(
+"""
+SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot],'$[25].Number') AS int)
+FROM [JsonEntitiesBasic] AS [j]
+ORDER BY [j].[Id]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_projection_nested(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_nested(async);
+
+        AssertSql(
+"""
+@__prm_0='1'
+
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_projection_nested_project_scalar(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_nested_project_scalar(async);
+
+        AssertSql(
+"""
+@__prm_0='1'
+
+SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].Date') AS datetime2)
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_projection_nested_project_reference(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_nested_project_reference(async);
+
+        AssertSql(
+"""
+@__prm_0='1'
+
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceLeaf'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_projection_nested_project_collection(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_nested_project_collection(async);
+
+        AssertSql(
+"""
+@__prm_0='1'
+
+SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+ORDER BY [j].[Id]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_projection_nested_project_collection_anonymous_projection(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_nested_project_collection_anonymous_projection(async);
+
+        AssertSql(
+"""
+@__prm_0='1'
+
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_in_predicate_using_constant(bool async)
+    {
+        await base.Json_collection_element_access_in_predicate_using_constant(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Name') IS NULL)
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_predicate_using_variable(bool async)
+    {
+        await base.Json_collection_element_access_in_predicate_using_variable(async);
+
+        AssertSql(
+"""
+@__prm_0='1'
+
+SELECT [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') IS NULL)
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_predicate_using_column(bool async)
+    {
+        await base.Json_collection_element_access_in_predicate_using_column(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST([j].[Id] AS nvarchar(max)) + '].Name') = N'e1_c2'
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_predicate_using_complex_expression1(bool async)
+    {
+        await base.Json_collection_element_access_in_predicate_using_complex_expression1(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST(CASE
+    WHEN [j].[Id] = 1 THEN 0
+    ELSE 1
+END AS nvarchar(max)) + '].Name') = N'e1_c1'
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_predicate_using_complex_expression2(bool async)
+    {
+        await base.Json_collection_element_access_in_predicate_using_complex_expression2(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST((
+    SELECT MAX([j].[Id])
+    FROM [JsonEntitiesBasic] AS [j]) AS nvarchar(max)) + '].Name') = N'e1_c2'
+""");
+    }
+
+    public override async Task Json_collection_element_access_in_predicate_using_ElementAt(bool async)
+    {
+        await base.Json_collection_element_access_in_predicate_using_ElementAt(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id]
+FROM [JsonEntitiesBasic] AS [j]
+WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[1].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot],'$[1].Name') IS NULL)
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_collection_element_access_in_predicate_nested_mix(bool async)
+    {
+        await base.Json_collection_element_access_in_predicate_nested_mix(async);
+
+        AssertSql(
+"""
+@__prm_0='0'
+
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST([j].[Id] - 1 AS nvarchar(max)) + '].SomethingSomething') = N'e1_c2_c1_c1'
+""");
+    }
+
+    public override async Task Json_collection_element_access_manual_Element_at_and_pushdown(bool async)
+    {
+        await base.Json_collection_element_access_manual_Element_at_and_pushdown(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], CAST(JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Number') AS int) AS [CollectionElement]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative(bool async)
+    {
+        await base.Json_collection_element_access_manual_Element_at_and_pushdown_negative(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative2(bool async)
+    {
+        await base.Json_collection_element_access_manual_Element_at_and_pushdown_negative2(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative3(bool async)
+    {
+        await base.Json_collection_element_access_manual_Element_at_and_pushdown_negative3(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative4(bool async)
+    {
+        await base.Json_collection_element_access_manual_Element_at_and_pushdown_negative4(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative5(bool async)
+    {
+        await base.Json_collection_element_access_manual_Element_at_and_pushdown_negative5(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_collection_element_access_manual_Element_at_and_pushdown_negative6(bool async)
+    {
+        await base.Json_collection_element_access_manual_Element_at_and_pushdown_negative6(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_projection_deduplication_with_collection_indexer_in_original(bool async)
+    {
+        await base.Json_projection_deduplication_with_collection_indexer_in_original(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot],'$[0]')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
+    public override async Task Json_projection_deduplication_with_collection_indexer_in_target(bool async)
+    {
+        await base.Json_projection_deduplication_with_collection_indexer_in_target(async);
+
+        AssertSql(
+"""
+@__prm_0='1'
+
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedCollectionBranch[1]'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_projection_deduplication_with_collection_in_original_and_collection_indexer_in_target(bool async)
+    {
+        await base.Json_projection_deduplication_with_collection_in_original_and_collection_indexer_in_target(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedCollectionBranch'), JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedCollectionBranch[1]')
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Json_collection_element_access_in_projection_requires_NoTracking_even_if_owner_is_present(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_requires_NoTracking_even_if_owner_is_present(async);
+
+        AssertSql();
+    }
+
+    public override async Task Json_collection_element_access_in_projection_requires_NoTracking_even_if_owner_is_present2(bool async)
+    {
+        await base.Json_collection_element_access_in_projection_requires_NoTracking_even_if_owner_is_present2(async);
+
+        AssertSql();
     }
 
     public override async Task Json_scalar_required_null_semantics(bool async)
@@ -633,6 +1014,21 @@ WHERE JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') = JSON_VALUE([j].[OwnedRefer
 SELECT [t].[Key], COUNT(*) AS [Count]
 FROM (
     SELECT JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS [Key]
+    FROM [JsonEntitiesBasic] AS [j]
+) AS [t]
+GROUP BY [t].[Key]
+""");
+    }
+
+    public override async Task Group_by_on_json_scalar_using_collection_indexer(bool async)
+    {
+        await base.Group_by_on_json_scalar_using_collection_indexer(async);
+
+        AssertSql(
+"""
+SELECT [t].[Key], COUNT(*) AS [Count]
+FROM (
+    SELECT JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Name') AS [Key]
     FROM [JsonEntitiesBasic] AS [j]
 ) AS [t]
 GROUP BY [t].[Key]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -387,7 +387,9 @@ WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] =
 
     public override void MakeBinary_does_not_throw_for_unsupported_operator()
         => Assert.Equal(
-            CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == (string)(__parameters[0]))"),
+            CoreStrings.TranslationFailedWithDetails(
+                "DbSet<Customer>()    .Where(c => c.CustomerID == (string)__parameters        .ElementAt(0))",
+                CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
             Assert.Throws<InvalidOperationException>(
                 () => base.MakeBinary_does_not_throw_for_unsupported_operator()).Message.Replace("\r", "").Replace("\n", ""));
 
@@ -400,7 +402,9 @@ WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] =
         using (var context = CreateContext())
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                CoreStrings.TranslationFailedWithDetails(
+                    "DbSet<Customer>()    .Where(c => c.CustomerID == __args        .ElementAt(0))",
+                    CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
                 Assert.Throws<InvalidOperationException>(
                     () => query(context, new[] { "ALFKI" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
         }
@@ -408,7 +412,9 @@ WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] =
         using (var context = CreateContext())
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                CoreStrings.TranslationFailedWithDetails(
+                    "DbSet<Customer>()    .Where(c => c.CustomerID == __args        .ElementAt(0))",
+                    CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
                 Assert.Throws<InvalidOperationException>(
                     () => query(context, new[] { "ANATR" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
         }
@@ -423,7 +429,9 @@ WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] =
         using (var context = CreateContext())
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                CoreStrings.TranslationFailedWithDetails(
+                    "DbSet<Customer>()    .Where(c => c.CustomerID == __args        .ElementAt(0))",
+                    CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => Enumerate(query(context, new[] { "ALFKI" })))).Message.Replace("\r", "").Replace("\n", ""));
         }
@@ -431,7 +439,9 @@ WHERE [c].[CustomerID] = @__s1 OR [c].[CustomerID] = @__s2 OR [c].[CustomerID] =
         using (var context = CreateContext())
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                CoreStrings.TranslationFailedWithDetails(
+                    "DbSet<Customer>()    .Where(c => c.CustomerID == __args        .ElementAt(0))",
+                    CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => Enumerate(query(context, new[] { "ANATR" })))).Message.Replace("\r", "").Replace("\n", ""));
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -13126,6 +13126,17 @@ WHERE (
 """);
     }
 
+    public override async Task Using_indexer_on_byte_array_and_string_in_projection(bool async)
+    {
+        await base.Using_indexer_on_byte_array_and_string_in_projection(async);
+
+        AssertSql(
+"""
+SELECT [s].[Id], CAST(SUBSTRING([s].[Banner], 0 + 1, 1) AS tinyint), [s].[Name]
+FROM [Squads] AS [s]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -11288,6 +11288,17 @@ WHERE (
 """);
     }
 
+    public override async Task Using_indexer_on_byte_array_and_string_in_projection(bool async)
+    {
+        await base.Using_indexer_on_byte_array_and_string_in_projection(async);
+
+        AssertSql(
+"""
+SELECT [s].[Id], CAST(SUBSTRING([s].[Banner], 0 + 1, 1) AS tinyint), [s].[Name]
+FROM [Squads] AS [s]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -9862,6 +9862,17 @@ WHERE (
 """);
     }
 
+    public override async Task Using_indexer_on_byte_array_and_string_in_projection(bool async)
+    {
+        await base.Using_indexer_on_byte_array_and_string_in_projection(async);
+
+        AssertSql(
+"""
+SELECT [s].[Id], CAST(SUBSTRING([s].[Banner], 0 + 1, 1) AS tinyint), [s].[Name]
+FROM [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
@@ -17,5 +17,6 @@ public enum SqlServerCondition
     SupportsTemporalTablesCascadeDelete = 1 << 8,
     SupportsUtf8 = 1 << 9,
     SupportsFunctions2019 = 1 << 10,
-    SupportsFunctions2017 = 1 << 11
+    SupportsFunctions2017 = 1 << 11,
+    SupportsJsonPathExpressions = 1 << 12,
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
@@ -82,6 +82,11 @@ public sealed class SqlServerConditionAttribute : Attribute, ITestCondition
             isMet &= TestEnvironment.IsFunctions2017Supported;
         }
 
+        if (Conditions.HasFlag(SqlServerCondition.SupportsJsonPathExpressions))
+        {
+            isMet &= TestEnvironment.SupportsJsonPathExpressions;
+        }
+
         return new ValueTask<bool>(isMet);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -43,6 +43,8 @@ public static class TestEnvironment
 
     private static bool? _supportsFunctions2019;
 
+    private static bool? _supportsJsonPathExpressions;
+
     private static byte? _productMajorVersion;
 
     private static int? _engineEdition;
@@ -324,6 +326,35 @@ public static class TestEnvironment
             }
 
             return _supportsFunctions2019.Value;
+        }
+    }
+
+    public static bool SupportsJsonPathExpressions
+    {
+        get
+        {
+            if (!IsConfigured)
+            {
+                return false;
+            }
+
+            if (_supportsJsonPathExpressions.HasValue)
+            {
+                return _supportsJsonPathExpressions.Value;
+            }
+
+            try
+            {
+                _productMajorVersion = GetProductMajorVersion();
+
+                _supportsJsonPathExpressions = _productMajorVersion >= 14 || IsSqlAzure;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                _supportsJsonPathExpressions = false;
+            }
+
+            return _supportsJsonPathExpressions.Value;
         }
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -9433,6 +9433,17 @@ WHERE (
 """);
     }
 
+    public override async Task Using_indexer_on_byte_array_and_string_in_projection(bool async)
+    {
+        await base.Using_indexer_on_byte_array_and_string_in_projection(async);
+
+        AssertSql(
+"""
+SELECT "s"."Id", "s"."Banner", "s"."Name"
+FROM "Squads" AS "s"
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindCompiledQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindCompiledQuerySqliteTest.cs
@@ -14,7 +14,9 @@ public class NorthwindCompiledQuerySqliteTest : NorthwindCompiledQueryTestBase<N
 
     public override void MakeBinary_does_not_throw_for_unsupported_operator()
         => Assert.Equal(
-            CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == (string)(__parameters[0]))"),
+            CoreStrings.TranslationFailedWithDetails(
+                "DbSet<Customer>()    .Where(c => c.CustomerID == (string)__parameters        .ElementAt(0))",
+                CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
             Assert.Throws<InvalidOperationException>(
                 () => base.MakeBinary_does_not_throw_for_unsupported_operator()).Message.Replace("\r", "").Replace("\n", ""));
 
@@ -27,7 +29,9 @@ public class NorthwindCompiledQuerySqliteTest : NorthwindCompiledQueryTestBase<N
         using (var context = CreateContext())
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                CoreStrings.TranslationFailedWithDetails(
+                    "DbSet<Customer>()    .Where(c => c.CustomerID == __args        .ElementAt(0))",
+                    CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
                 Assert.Throws<InvalidOperationException>(
                     () => query(context, new[] { "ALFKI" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
         }
@@ -35,7 +39,9 @@ public class NorthwindCompiledQuerySqliteTest : NorthwindCompiledQueryTestBase<N
         using (var context = CreateContext())
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                CoreStrings.TranslationFailedWithDetails(
+                    "DbSet<Customer>()    .Where(c => c.CustomerID == __args        .ElementAt(0))",
+                    CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
                 Assert.Throws<InvalidOperationException>(
                     () => query(context, new[] { "ANATR" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
         }
@@ -50,7 +56,9 @@ public class NorthwindCompiledQuerySqliteTest : NorthwindCompiledQueryTestBase<N
         using (var context = CreateContext())
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                CoreStrings.TranslationFailedWithDetails(
+                    "DbSet<Customer>()    .Where(c => c.CustomerID == __args        .ElementAt(0))",
+                    CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => Enumerate(query(context, new[] { "ALFKI" })))).Message.Replace("\r", "").Replace("\n", ""));
         }
@@ -58,7 +66,9 @@ public class NorthwindCompiledQuerySqliteTest : NorthwindCompiledQueryTestBase<N
         using (var context = CreateContext())
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                CoreStrings.TranslationFailedWithDetails(
+                    "DbSet<Customer>()    .Where(c => c.CustomerID == __args        .ElementAt(0))",
+                    CoreStrings.QueryUnableToTranslateMethod("System.Linq.Enumerable", nameof(Enumerable.ElementAt))),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => Enumerate(query(context, new[] { "ANATR" })))).Message.Replace("\r", "").Replace("\n", ""));
         }


### PR DESCRIPTION
Converting indexer over list/array into ElementAt, so that nav expansion understands it and can perform pushown and inject MaterializeCollectionNavigation expression where necessary. In translation phase we recognize the pattern that nav expansion creates and if the root is JsonQueryExpression, we apply collection index over it. JsonQueryExpression path segment now consists of two components - string representing JSON property name and SqlExpression representing collection index (it can be constant, parameter or any arbitrary expression that resolves to int)

Deduplication is heavily restricted currently - we only de-duplicate projections whose additional path consists of JSON property accesses only (no collection indexes allowed). All queries projecting entities that need JSON array access must be set to NoTracking (for now). This is because we don't flow those collection index values into shaper. Instead, the ordinal keys are filled with dummy values, which prohibits us from doing proper change tracking.

Fixes #28648