### PR TITLE
[release/7.0] Fix bug where a non-sproc command comes before a sproc command

### DIFF
--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -17,6 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Update;
 /// </remarks>
 public abstract class AffectedCountModificationCommandBatch : ReaderModificationCommandBatch
 {
+    private static readonly bool QuirkEnabled29643
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29643", out var enabled) && enabled;
+
     /// <summary>
     ///     Creates a new <see cref="AffectedCountModificationCommandBatch" /> instance.
     /// </summary>
@@ -91,11 +94,13 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 var parameterCounter = 0;
                 IReadOnlyModificationCommand command;
 
-                for (commandIndex = 0;
-                     commandIndex < ResultSetMappings.Count;
-                     commandIndex++, parameterCounter += command.StoreStoredProcedure!.Parameters.Count)
+                for (commandIndex = 0; commandIndex < ResultSetMappings.Count; commandIndex++, parameterCounter += ParameterCount(command))
                 {
                     command = ModificationCommands[commandIndex];
+
+                    Check.DebugAssert(
+                        command.ColumnModifications.All(c => c.UseParameter),
+                        "This code assumes all column modifications involve a DbParameter (see counting above)");
 
                     if (!ResultSetMappings[commandIndex].HasFlag(ResultSetMapping.HasOutputParameters))
                     {
@@ -210,11 +215,13 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
                 var parameterCounter = 0;
                 IReadOnlyModificationCommand command;
 
-                for (commandIndex = 0;
-                     commandIndex < ResultSetMappings.Count;
-                     commandIndex++, parameterCounter += command.StoreStoredProcedure!.Parameters.Count)
+                for (commandIndex = 0; commandIndex < ResultSetMappings.Count; commandIndex++, parameterCounter += ParameterCount(command))
                 {
                     command = ModificationCommands[commandIndex];
+
+                    Check.DebugAssert(
+                        command.ColumnModifications.All(c => c.UseParameter),
+                        "This code assumes all column modifications involve a DbParameter (see counting above)");
 
                     if (!ResultSetMappings[commandIndex].HasFlag(ResultSetMapping.HasOutputParameters))
                     {
@@ -446,6 +453,40 @@ public abstract class AffectedCountModificationCommandBatch : ReaderModification
         }
 
         return commandIndex - 1;
+    }
+
+    private static int ParameterCount(IReadOnlyModificationCommand command)
+    {
+        if (QuirkEnabled29643)
+        {
+            return command.StoreStoredProcedure!.Parameters.Count;
+        }
+
+        // As a shortcut, if the command uses a stored procedure, return the number of parameters directly from it.
+        if (command.StoreStoredProcedure is { } storedProcedure)
+        {
+            return storedProcedure.Parameters.Count;
+        }
+
+        // Otherwise we need to count the total parameters used by all column modifications
+        var parameterCount = 0;
+
+        for (var i = 0; i < command.ColumnModifications.Count; i++)
+        {
+            var columnModification = command.ColumnModifications[i];
+
+            if (columnModification.UseCurrentValueParameter)
+            {
+                parameterCount++;
+            }
+
+            if (columnModification.UseOriginalValueParameter)
+            {
+                parameterCount++;
+            }
+        }
+
+        return parameterCount;
     }
 
     private IReadOnlyList<IUpdateEntry> AggregateEntries(int endIndex, int commandCount)

--- a/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/StoredProcedureUpdateTestBase.cs
@@ -1028,6 +1028,48 @@ public abstract class StoredProcedureUpdateTestBase : NonSharedModelTestBase
         }
     }
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public abstract Task Non_sproc_followed_by_sproc_commands_in_the_same_batch(bool async);
+
+    protected async Task Non_sproc_followed_by_sproc_commands_in_the_same_batch(bool async, string createSprocSql)
+    {
+        var contextFactory = await InitializeAsync<DbContext>(
+            modelBuilder => modelBuilder.Entity<EntityWithAdditionalProperty>()
+                .InsertUsingStoredProcedure(
+                    nameof(EntityWithAdditionalProperty) + "_Insert",
+                    spb => spb
+                        .HasParameter(w => w.Name)
+                        .HasParameter(w => w.Id, pb => pb.IsOutput())
+                        .HasParameter(w => w.AdditionalProperty))
+                .Property(e => e.AdditionalProperty).IsConcurrencyToken(),
+            seed: ctx => CreateStoredProcedures(ctx, createSprocSql));
+
+        await using var context = contextFactory.CreateContext();
+
+        // Prepare by adding an entity
+        var entity1 = new EntityWithAdditionalProperty { Name = "Entity1", AdditionalProperty = 1 };
+        context.Set<EntityWithAdditionalProperty>().Add(entity1);
+
+        using (TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            await SaveChanges(context, async);
+        }
+
+        // Now add a second entity and update the first one. The update gets ordered first, and doesn't use a sproc, and then the insertion
+        // does.
+        var entity2 = new EntityWithAdditionalProperty { Name = "Entity2" };
+        context.Set<EntityWithAdditionalProperty>().Add(entity2);
+        entity1.Name = "Entity1_Modified";
+        entity1.AdditionalProperty = 2;
+        await SaveChanges(context, async);
+
+        using (TestSqlLoggerFactory.SuspendRecordingEvents())
+        {
+            Assert.Equal("Entity2", context.Set<EntityWithAdditionalProperty>().Single(b => b.Id == entity2.Id).Name);
+        }
+    }
+
     /// <summary>
     ///     A method to be implement by the provider, to set up a store-generated concurrency token shadow property with the given name.
     /// </summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/StoredProcedureUpdateSqlServerTest.cs
@@ -665,6 +665,36 @@ EXEC [Child1_Insert] @p0 OUTPUT, @p1, @p2;
 """);
     }
 
+    public override async Task Non_sproc_followed_by_sproc_commands_in_the_same_batch(bool async)
+    {
+        await base.Non_sproc_followed_by_sproc_commands_in_the_same_batch(
+            async,
+"""
+CREATE PROCEDURE EntityWithAdditionalProperty_Insert(@Name varchar(max), @Id int OUT, @AdditionalProperty int)
+AS BEGIN
+    INSERT INTO [EntityWithAdditionalProperty] ([Name], [AdditionalProperty]) VALUES (@Name, @AdditionalProperty);
+    SET @Id = SCOPE_IDENTITY();
+END
+""");
+
+        AssertSql(
+"""
+@p2='1'
+@p0='2'
+@p3='1'
+@p1='Entity1_Modified' (Size = 4000)
+@p4='Entity2' (Size = 4000)
+@p5=NULL (Nullable = false) (Direction = Output) (DbType = Int32)
+@p6='0'
+
+SET NOCOUNT ON;
+UPDATE [EntityWithAdditionalProperty] SET [AdditionalProperty] = @p0, [Name] = @p1
+OUTPUT 1
+WHERE [Id] = @p2 AND [AdditionalProperty] = @p3;
+EXEC [EntityWithAdditionalProperty_Insert] @p4, @p5 OUTPUT, @p6;
+""");
+    }
+
     protected override void ConfigureStoreGeneratedConcurrencyToken(EntityTypeBuilder entityTypeBuilder, string propertyName)
         => entityTypeBuilder.Property<byte[]>(propertyName).IsRowVersion();
 


### PR DESCRIPTION
Fixes #29643, #29680

**Description**

In the new stored procedure mapping support, the logic to count parameters for the purpose of propagating sproc output variables incorrectly assumed all commands in the batch use a sproc. This causes us to propagate the wrong database-generated value into the wrong entity property.

**Customer impact**

When mixing both stored procedure and non-stored procedure updates in the same SaveChanges batch, database-generated values may cause an exception, or even get assigned to the wrong entity property (bad data).

**How found**

Customer reported on 7.0

**Regression**

No.

**Testing**

Added a test for the affected scenario.

**Risk**

Low; the fix is quite trivial, and a quirk was added to revert back to older behavior.
