### PR TITLE
[release/7.0] Use correct parameter in query based on type mapping

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -41,6 +41,9 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     private IRelationalCommandBuilder _relationalCommandBuilder;
     private Dictionary<string, int>? _repeatedParameterCounts;
 
+    private static readonly bool QuirkEnabled29646
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29646", out var enabled) && enabled;
+
     /// <summary>
     ///     Creates a new instance of the <see cref="QuerySqlGenerator" /> class.
     /// </summary>
@@ -598,20 +601,53 @@ public class QuerySqlGenerator : SqlExpressionVisitor
         var invariantName = sqlParameterExpression.Name;
         var parameterName = sqlParameterExpression.Name;
 
-        if (_relationalCommandBuilder.Parameters
-            .All(
-                p => p.InvariantName != parameterName
-                    || (p is TypeMappedRelationalParameter typeMappedRelationalParameter
-                        && (typeMappedRelationalParameter.RelationalTypeMapping.StoreType != sqlParameterExpression.TypeMapping!.StoreType
-                            || typeMappedRelationalParameter.RelationalTypeMapping.Converter
-                            != sqlParameterExpression.TypeMapping!.Converter))))
+        if (QuirkEnabled29646)
         {
-            parameterName = GetUniqueParameterName(parameterName);
-            _relationalCommandBuilder.AddParameter(
-                invariantName,
-                _sqlGenerationHelper.GenerateParameterName(parameterName),
-                sqlParameterExpression.TypeMapping!,
-                sqlParameterExpression.IsNullable);
+            if (_relationalCommandBuilder.Parameters
+                .All(
+                    p => p.InvariantName != parameterName
+                        || (p is TypeMappedRelationalParameter typeMappedRelationalParameter
+                            && (typeMappedRelationalParameter.RelationalTypeMapping.StoreType != sqlParameterExpression.TypeMapping!.StoreType
+                                || typeMappedRelationalParameter.RelationalTypeMapping.Converter
+                                != sqlParameterExpression.TypeMapping!.Converter))))
+            {
+                parameterName = GetUniqueParameterName(parameterName);
+                _relationalCommandBuilder.AddParameter(
+                    invariantName,
+                    _sqlGenerationHelper.GenerateParameterName(parameterName),
+                    sqlParameterExpression.TypeMapping!,
+                    sqlParameterExpression.IsNullable);
+            }
+        }
+        else
+        {
+            // Try to see if a parameter already exists - if so, just integrate the same placeholder into the SQL instead of sending the same
+            // data twice.
+            // Note that if the type mapping differs, we do send the same data twice (e.g. the same string may be sent once as Unicode, once as
+            // non-Unicode).
+            var parameter = _relationalCommandBuilder.Parameters.FirstOrDefault(
+                p =>
+                    p.InvariantName == parameterName
+                    && p is TypeMappedRelationalParameter typeMappedRelationalParameter
+                    && string.Equals(
+                        typeMappedRelationalParameter.RelationalTypeMapping.StoreType, sqlParameterExpression.TypeMapping!.StoreType,
+                        StringComparison.OrdinalIgnoreCase)
+                    && typeMappedRelationalParameter.RelationalTypeMapping.Converter == sqlParameterExpression.TypeMapping!.Converter);
+
+            if (parameter is null)
+            {
+                parameterName = GetUniqueParameterName(parameterName);
+
+                _relationalCommandBuilder.AddParameter(
+                    invariantName,
+                    _sqlGenerationHelper.GenerateParameterName(parameterName),
+                    sqlParameterExpression.TypeMapping!,
+                    sqlParameterExpression.IsNullable);
+            }
+            else
+            {
+                parameterName = ((TypeMappedRelationalParameter)parameter).Name;
+            }
         }
 
         _relationalCommandBuilder

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
@@ -21,7 +21,7 @@ public abstract class GearsOfWarQueryRelationalTestBase<TFixture> : GearsOfWarQu
         var place = "Seattle";
         return AssertQuery(
             async,
-            ss => ss.Set<City>().Where(e => e.Nation == place || e.Location == place));
+            ss => ss.Set<City>().Where(e => e.Nation == place || e.Location == place || e.Location == place));
     }
 
     public override async Task Correlated_collection_with_distinct_not_projecting_identifier_column_also_projecting_complex_expressions(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -9401,7 +9401,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (CAST(0 AS b
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1
+WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Location] = @__place_0_1
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -4791,7 +4791,7 @@ FROM (
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__prefix_0 = N'' OR LEFT([c].[CustomerID], LEN(@__prefix_0_1)) = @__prefix_0
+WHERE @__prefix_0 = N'' OR LEFT([c].[CustomerID], LEN(@__prefix_0_1)) = @__prefix_0_1
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -32,7 +32,7 @@ public class NorthwindQueryFiltersQuerySqlServerTest : NorthwindQueryFiltersQuer
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 """);
     }
 
@@ -47,7 +47,7 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 """);
     }
 
@@ -63,7 +63,7 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)) AND [c].[CustomerID] = @__p_0
+WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)) AND [c].[CustomerID] = @__p_0
 """);
     }
 
@@ -78,7 +78,7 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AN
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 """);
     }
 
@@ -93,7 +93,7 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 """,
             //
 """
@@ -102,7 +102,7 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 """);
     }
 
@@ -117,7 +117,7 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 """);
     }
 
@@ -132,7 +132,7 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 """);
     }
 
@@ -153,11 +153,11 @@ LEFT JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c0].[CompanyName] IS NOT NULL) AND LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+        WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c0].[CompanyName] IS NOT NULL) AND LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 ORDER BY [c].[CustomerID], [t0].[OrderID]
 """);
     }
@@ -189,7 +189,7 @@ FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+    WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 """);
@@ -213,7 +213,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c].[CustomerID], [c].[CompanyName]
         FROM [Customers] AS [c]
-        WHERE @__ef_filter__TenantPrefix_1 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1_1)) = @__ef_filter__TenantPrefix_1)
+        WHERE @__ef_filter__TenantPrefix_1 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1_1)) = @__ef_filter__TenantPrefix_1_1)
     ) AS [t] ON [o0].[CustomerID] = [t].[CustomerID]
     WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 ) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
@@ -239,7 +239,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c0].[CompanyName] IS NOT NULL) AND LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+        WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c0].[CompanyName] IS NOT NULL) AND LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
@@ -252,13 +252,13 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [c1].[CustomerID], [c1].[CompanyName]
             FROM [Customers] AS [c1]
-            WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c1].[CompanyName] IS NOT NULL) AND LEFT([c1].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)
+            WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c1].[CompanyName] IS NOT NULL) AND LEFT([c1].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
         ) AS [t3] ON [o1].[CustomerID] = [t3].[CustomerID]
         WHERE ([t3].[CustomerID] IS NOT NULL) AND ([t3].[CompanyName] IS NOT NULL)
     ) AS [t2] ON [o0].[OrderID] = [t2].[OrderID]
     WHERE [o0].[Quantity] > @__ef_filter___quantity_1
 ) AS [t1] ON [t0].[OrderID] = [t1].[OrderID]
-WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) AND [t1].[Discount] < CAST(10 AS real)
+WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)) AND [t1].[Discount] < CAST(10 AS real)
 """);
     }
 
@@ -281,7 +281,7 @@ SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[Cont
 FROM (
     select * from Customers
 ) AS [m]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([m].[CompanyName] IS NOT NULL) AND LEFT([m].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([m].[CompanyName] IS NOT NULL) AND LEFT([m].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 """);
     }
 
@@ -307,7 +307,7 @@ FROM (
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+    WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 ) AS [t] ON [m].[CustomerID] = [t].[CustomerID]
 WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 """);
@@ -325,7 +325,7 @@ WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)) AND [c].[CustomerID] = @__customerID
+WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)) AND [c].[CustomerID] = @__customerID
 """,
             //
 """
@@ -335,7 +335,7 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AN
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)) AND [c].[CustomerID] = @__customerID
+WHERE (@__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)) AND [c].[CustomerID] = @__customerID
 """);
     }
 
@@ -353,7 +353,7 @@ FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+    WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 """);
@@ -380,7 +380,7 @@ FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0)
+    WHERE @__ef_filter__TenantPrefix_0 = N'' OR (([c].[CompanyName] IS NOT NULL) AND LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1)
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE ([t].[CustomerID] IS NOT NULL) AND ([t].[CompanyName] IS NOT NULL)
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -11939,7 +11939,7 @@ WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t].[HasSoulPatch] IN (CAST(0 AS b
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1
+WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Location] = @__place_0_1
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -10225,7 +10225,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (CAST(0 AS b
 
 SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1
+WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Location] = @__place_0_1
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -3250,7 +3250,7 @@ FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 
 SELECT [c].[Name], [c].[Location], [c].[Nation], [c].[PeriodEnd], [c].[PeriodStart]
 FROM [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c]
-WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1
+WHERE [c].[Nation] = @__place_0 OR [c].[Location] = @__place_0_1 OR [c].[Location] = @__place_0_1
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -2902,7 +2902,7 @@ WHERE "m"."Timeline" = '1902-01-02 10:00:00.1234567+01:30'
 
 SELECT "c"."Name", "c"."Location", "c"."Nation"
 FROM "Cities" AS "c"
-WHERE "c"."Nation" = @__place_0 OR "c"."Location" = @__place_0
+WHERE "c"."Nation" = @__place_0 OR "c"."Location" = @__place_0 OR "c"."Location" = @__place_0
 """);
     }
 


### PR DESCRIPTION
Fixes #29646, backports #29650

**Description**

When the same parameter is used in a query in contexts which require different type mappings, we sometimes use the incorrect type mapping in the incorrect context.

**Customer impact**

Since the incorrect SQL representation or parameter may be sent to the server, LINQ queries may return incorrect data. For example, if the same .NET string is compared against both Unicode and non-Unicode database columns in a query, that could yield wrong results.

**How found**

Customer reported on 7.0

**Regression**

Yes.

**Testing**

Added a test for the affected scenario.

**Risk**

Low; the fix is quite trivial, and a quirk was added to revert back to older behavior.

