### PR TITLE
Handle row-version columns in owned types with conversions

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/F1RelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/F1RelationalFixture.cs
@@ -25,5 +25,62 @@ public abstract class F1RelationalFixture<TRowVersion> : F1FixtureBase<TRowVersi
         modelBuilder.Entity<EngineSupplier>().ToTable("EngineSuppliers");
         modelBuilder.Entity<Gearbox>().ToTable("Gearboxes");
         modelBuilder.Entity<Sponsor>().ToTable("Sponsors");
+
+        modelBuilder.Entity<FanTpt>().UseTptMappingStrategy();
+        modelBuilder.Entity<FanTpc>().UseTpcMappingStrategy();
+
+        modelBuilder.Entity<Circuit>(
+            b =>
+            {
+                b.ToTable("Circuits");
+                b.Property(e => e.Name).HasColumnName("Name");
+            });
+
+        modelBuilder.Entity<City>(
+            b =>
+            {
+                b.ToTable("Circuits");
+                b.Property(e => e.Name).HasColumnName("Name");
+            });
+
+        modelBuilder.Entity<CircuitTpt>(
+            b =>
+            {
+                b.UseTptMappingStrategy();
+                b.Property(e => e.Name).HasColumnName("Name");
+            });
+
+        modelBuilder.Entity<StreetCircuitTpt>(
+            b =>
+            {
+                b.ToTable("StreetCircuitsTpt");
+            });
+
+        modelBuilder.Entity<CityTpt>(
+            b =>
+            {
+                b.ToTable("StreetCircuitsTpt");
+                b.Property(e => e.Name).HasColumnName("Name");
+            });
+
+        modelBuilder.Entity<CircuitTpc>(
+            b =>
+            {
+                b.UseTpcMappingStrategy();
+                b.Property(e => e.Name).HasColumnName("Name");
+            });
+
+        modelBuilder.Entity<StreetCircuitTpc>(
+            b =>
+            {
+                b.ToTable("StreetCircuitsTpc");
+            });
+
+        modelBuilder.Entity<CityTpc>(
+            b =>
+            {
+                b.ToTable("StreetCircuitsTpc");
+                b.Property(e => e.Name).HasColumnName("Name");
+            });
     }
 }

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -1834,7 +1834,7 @@ public partial class RelationalModelValidatorTest : ModelValidatorTest
         var personType = model.FindEntityType(typeof(Person))!;
         var concurrencyProperty = personType.GetDeclaredProperties().Single(p => p.IsConcurrencyToken);
         Assert.Equal("Version", concurrencyProperty.GetColumnName());
-        Assert.Equal(typeof(byte[]), concurrencyProperty.ClrType);
+        Assert.Equal(typeof(ulong), concurrencyProperty.ClrType);
     }
 
     [ConditionalFact]

--- a/test/EFCore.Specification.Tests/F1FixtureBase.cs
+++ b/test/EFCore.Specification.Tests/F1FixtureBase.cs
@@ -192,6 +192,33 @@ public abstract class F1FixtureBase<TRowVersion> : SharedStoreFixtureBase<F1Cont
                     eb.Property<TRowVersion>("Version").IsRowVersion();
                     eb.Property<int?>(Sponsor.ClientTokenPropertyName).IsConcurrencyToken();
                 });
+
+        modelBuilder.Entity<Fan>();
+        modelBuilder.Entity<SuperFan>();
+        modelBuilder.Entity<MegaFan>();
+
+        modelBuilder.Entity<FanTpt>();
+        modelBuilder.Entity<SuperFanTpt>();
+        modelBuilder.Entity<MegaFanTpt>();
+
+        modelBuilder.Entity<FanTpc>();
+        modelBuilder.Entity<SuperFanTpc>();
+        modelBuilder.Entity<MegaFanTpc>();
+
+        modelBuilder.Entity<Circuit>();
+        modelBuilder.Entity<StreetCircuit>().HasOne(e => e.City).WithOne().HasForeignKey<City>(e => e.Id);
+        modelBuilder.Entity<OvalCircuit>();
+        modelBuilder.Entity<City>();
+
+        modelBuilder.Entity<CircuitTpt>();
+        modelBuilder.Entity<StreetCircuitTpt>().HasOne(e => e.City).WithOne().HasForeignKey<CityTpt>(e => e.Id);
+        modelBuilder.Entity<OvalCircuitTpt>();
+        modelBuilder.Entity<CityTpt>();
+
+        modelBuilder.Entity<CircuitTpc>();
+        modelBuilder.Entity<StreetCircuitTpc>().HasOne(e => e.City).WithOne().HasForeignKey<CityTpc>(e => e.Id);
+        modelBuilder.Entity<OvalCircuitTpc>();
+        modelBuilder.Entity<CityTpc>();
     }
 
     private static void ConfigureConstructorBinding<TEntity>(IMutableEntityType mutableEntityType, params string[] propertyNames)

--- a/test/EFCore.Specification.Tests/F1MaterializationInterceptor.cs
+++ b/test/EFCore.Specification.Tests/F1MaterializationInterceptor.cs
@@ -84,6 +84,38 @@ public class F1MaterializationInterceptor : IMaterializationInterceptor
             nameof(TitleSponsor) => InterceptionResult<object>.SuppressWithResult(
                 new TitleSponsor.TitleSponsorProxy(
                     materializationData.GetPropertyValue<ILazyLoader>("_loader"))),
+            nameof(SuperFan) => InterceptionResult<object>.SuppressWithResult(
+                new SuperFan.SuperFanProxy()),
+            nameof(MegaFan) => InterceptionResult<object>.SuppressWithResult(
+                new MegaFan.MegaFanProxy()),
+            nameof(SuperFanTpt) => InterceptionResult<object>.SuppressWithResult(
+                new SuperFanTpt.SuperFanTptProxy()),
+            nameof(MegaFanTpt) => InterceptionResult<object>.SuppressWithResult(
+                new MegaFanTpt.MegaFanTptProxy()),
+            nameof(SuperFanTpc) => InterceptionResult<object>.SuppressWithResult(
+                new SuperFanTpc.SuperFanTpcProxy()),
+            nameof(MegaFanTpc) => InterceptionResult<object>.SuppressWithResult(
+                new MegaFanTpc.MegaFanTpcProxy()),
+            nameof(SwagBag) => InterceptionResult<object>.SuppressWithResult(
+                new SwagBag.SwagBagProxy()),
+            nameof(StreetCircuit) => InterceptionResult<object>.SuppressWithResult(
+                new StreetCircuit.StreetCircuitProxy()),
+            nameof(OvalCircuit) => InterceptionResult<object>.SuppressWithResult(
+                new OvalCircuit.OvalCircuitProxy()),
+            nameof(City) => InterceptionResult<object>.SuppressWithResult(
+                new City.CityProxy()),
+            nameof(StreetCircuitTpt) => InterceptionResult<object>.SuppressWithResult(
+                new StreetCircuitTpt.StreetCircuitTptProxy()),
+            nameof(OvalCircuitTpt) => InterceptionResult<object>.SuppressWithResult(
+                new OvalCircuitTpt.OvalCircuitTptProxy()),
+            nameof(CityTpt) => InterceptionResult<object>.SuppressWithResult(
+                new CityTpt.CityTptProxy()),
+            nameof(StreetCircuitTpc) => InterceptionResult<object>.SuppressWithResult(
+                new StreetCircuitTpc.StreetCircuitTpcProxy()),
+            nameof(OvalCircuitTpc) => InterceptionResult<object>.SuppressWithResult(
+                new OvalCircuit.OvalCircuitProxy()),
+            nameof(CityTpc) => InterceptionResult<object>.SuppressWithResult(
+                new CityTpc.CityTpcProxy()),
             _ => result
         };
 

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Circuit.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Circuit.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+
+public interface IStreetCircuit<TCity>
+{
+    string Name { get; set; }
+    public TCity City { get; set; }
+}
+
+public abstract class Circuit
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public ulong ULongVersion { get; init; }
+
+    [NotMapped]
+    public List<byte> BinaryVersion { get; init; }
+}
+
+public class StreetCircuit : Circuit, IStreetCircuit<City>
+{
+    public class StreetCircuitProxy : StreetCircuit, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public int Length { get; set; }
+
+    [Required]
+    public City City { get; set; }
+}
+
+public class OvalCircuit : Circuit
+{
+    public class OvalCircuitProxy : OvalCircuit, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public double Banking { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/CircuitTpc.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/CircuitTpc.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+
+public abstract class CircuitTpc
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public ulong ULongVersion { get; init; }
+
+    [NotMapped]
+    public List<byte> BinaryVersion { get; init; }
+}
+
+public class StreetCircuitTpc : CircuitTpc, IStreetCircuit<CityTpc>
+{
+    public class StreetCircuitTpcProxy : StreetCircuitTpc, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public int Length { get; set; }
+
+    [Required]
+    public CityTpc City { get; set; }
+}
+
+public class OvalCircuitTpc : CircuitTpc
+{
+    public class OvalCircuitTpcProxy : OvalCircuitTpc, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public double Banking { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/CircuitTpt.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/CircuitTpt.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+
+public abstract class CircuitTpt
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public ulong ULongVersion { get; init; }
+
+    [NotMapped]
+    public List<byte> BinaryVersion { get; init; }
+}
+
+public class StreetCircuitTpt : CircuitTpt, IStreetCircuit<CityTpt>
+{
+    public class StreetCircuitTptProxy : StreetCircuitTpt, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public int Length { get; set; }
+
+    [Required]
+    public CityTpt City { get; set; }
+}
+
+public class OvalCircuitTpt : CircuitTpt
+{
+    public class OvalCircuitTptProxy : OvalCircuitTpt, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public double Banking { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/City.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/City.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+
+public interface ICity
+{
+    public string Name { get; set; }
+}
+
+public class City : ICity
+{
+    public class CityProxy : City, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; }
+}
+
+public class CityTpt : ICity
+{
+    public class CityTptProxy : CityTpt, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; }
+}
+
+public class CityTpc : ICity
+{
+    public class CityTpcProxy : CityTpc, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/F1Context.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/F1Context.cs
@@ -15,6 +15,11 @@ public class F1Context : PoolableDbContext
     public DbSet<Sponsor> Sponsors { get; set; }
     public DbSet<Engine> Engines { get; set; }
     public DbSet<EngineSupplier> EngineSuppliers { get; set; }
+    public DbSet<Fan> Fans { get; set; }
+    public DbSet<FanTpt> FanTpts { get; set; }
+    public DbSet<FanTpc> FanTpcs { get; set; }
+
+    public DbSet<Circuit> Circuits { get; set; }
 
     public static void Seed(F1Context context)
     {
@@ -864,5 +869,22 @@ public class F1Context : PoolableDbContext
 
         teams.Single(t => t.Id == Team.McLaren).Sponsors.Add(vodafone);
         teams.Single(t => t.Id == Team.Ferrari).Sponsors.Add(shell);
+
+        context.AddRange(
+            new SuperFan { Id = 1, Name = "Alice", Swag = new() { Stuff = "SuperStuff" }},
+            new MegaFan { Id = 2, Name = "Toast", Swag = new() { Stuff = "MegaStuff" } },
+            new SuperFanTpt { Id = 1, Name = "Alice", Swag = new() { Stuff = "SuperStuff" }},
+            new MegaFanTpt { Id = 2, Name = "Toast", Swag = new() { Stuff = "MegaStuff" } },
+            new SuperFanTpc { Id = 1, Name = "Alice", Swag = new() { Stuff = "SuperStuff" }},
+            new MegaFanTpc { Id = 2, Name = "Toast", Swag = new() { Stuff = "MegaStuff" } },
+            new StreetCircuit { Id = 1, Name = "Monaco" },
+            new City { Id = 1, Name = "Monaco" },
+            new OvalCircuit { Id = 2, Name = "Indy" },
+            new StreetCircuitTpt { Id = 1, Name = "Monaco" },
+            new CityTpt { Id = 1, Name = "Monaco" },
+            new OvalCircuitTpt { Id = 2, Name = "Indy" },
+            new StreetCircuitTpc { Id = 1, Name = "Monaco" },
+            new CityTpc { Id = 1, Name = "Monaco" },
+            new OvalCircuitTpc { Id = 2, Name = "Indy" });
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Fan.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Fan.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+
+public interface ISuperFan
+{
+    string Name { get; set; }
+    SwagBag Swag { get; set; }
+}
+
+public abstract class Fan
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public ulong ULongVersion { get; init; }
+
+    [NotMapped]
+    public List<byte> BinaryVersion { get; init; }
+}
+
+public class MegaFan : Fan
+{
+    public class MegaFanProxy : MegaFan, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public string MegaStatus { get; set; }
+    public SwagBag Swag { get; set; }
+}
+
+public class SuperFan : Fan, ISuperFan
+{
+    public class SuperFanProxy : SuperFan, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public string SuperStatus { get; set; }
+    public SwagBag Swag { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/FanTpc.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/FanTpc.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+
+public abstract class FanTpc
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public ulong ULongVersion { get; init; }
+
+    [NotMapped]
+    public List<byte> BinaryVersion { get; init; }
+}
+
+public class MegaFanTpc : FanTpc
+{
+    public class MegaFanTpcProxy : MegaFanTpc, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public string MegaStatus { get; set; }
+    public SwagBag Swag { get; set; }
+}
+
+public class SuperFanTpc : FanTpc, ISuperFan
+{
+    public class SuperFanTpcProxy : SuperFanTpc, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public string SuperStatus { get; set; }
+    public SwagBag Swag { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/FanTpt.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/FanTpt.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+
+public abstract class FanTpt
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public ulong ULongVersion { get; init; }
+
+    [NotMapped]
+    public List<byte> BinaryVersion { get; init; }
+}
+
+public class MegaFanTpt : FanTpt
+{
+    public class MegaFanTptProxy : MegaFanTpt, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public string MegaStatus { get; set; }
+    public SwagBag Swag { get; set; }
+}
+
+public class SuperFanTpt : FanTpt, ISuperFan
+{
+    public class SuperFanTptProxy : SuperFanTpt, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    public string SuperStatus { get; set; }
+    public SwagBag Swag { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/SwagBag.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/SwagBag.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+
+[Owned]
+public class SwagBag
+{
+    public class SwagBagProxy : SwagBag, IF1Proxy
+    {
+        public bool CreatedCalled { get; set; }
+        public bool InitializingCalled { get; set; }
+        public bool InitializedCalled { get; set; }
+    }
+
+    [Required]
+    public string Stuff { get; set; }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -36,6 +36,42 @@ public class F1ULongSqlServerFixture : F1SqlServerFixtureBase<ulong>
             .HasData(
                 new OptimisticParent { Id = new Guid("AF8451C3-61CB-4EDA-8282-92250D85EF03"), }
             );
+
+        modelBuilder
+            .Entity<Fan>()
+            .Property(e => e.ULongVersion)
+            .IsRowVersion()
+            .HasConversion<byte[]>();
+
+        modelBuilder
+            .Entity<FanTpt>()
+            .Property(e => e.ULongVersion)
+            .IsRowVersion()
+            .HasConversion<byte[]>();
+
+        modelBuilder
+            .Entity<FanTpc>()
+            .Property(e => e.ULongVersion)
+            .IsRowVersion()
+            .HasConversion<byte[]>();
+
+        modelBuilder
+            .Entity<Circuit>()
+            .Property(e => e.ULongVersion)
+            .IsRowVersion()
+            .HasConversion<byte[]>();
+
+        modelBuilder
+            .Entity<CircuitTpt>()
+            .Property(e => e.ULongVersion)
+            .IsRowVersion()
+            .HasConversion<byte[]>();
+
+        modelBuilder
+            .Entity<CircuitTpc>()
+            .Property(e => e.ULongVersion)
+            .IsRowVersion()
+            .HasConversion<byte[]>();
     }
 
     public class OptimisticOptionalChild
@@ -54,6 +90,87 @@ public class F1ULongSqlServerFixture : F1SqlServerFixtureBase<ulong>
 
 public class F1SqlServerFixture : F1SqlServerFixtureBase<byte[]>
 {
+    protected override void BuildModelExternal(ModelBuilder modelBuilder)
+    {
+        base.BuildModelExternal(modelBuilder);
+
+        var converter = new BinaryVersionConverter();
+        var comparer = new BinaryVersionComparer();
+
+        modelBuilder
+            .Entity<Fan>()
+            .Property(e => e.BinaryVersion)
+            .HasConversion(converter, comparer)
+            .IsRowVersion();
+
+        modelBuilder
+            .Entity<FanTpt>()
+            .Property(e => e.BinaryVersion)
+            .HasConversion(converter, comparer)
+            .IsRowVersion();
+
+        modelBuilder
+            .Entity<FanTpc>()
+            .Property(e => e.BinaryVersion)
+            .HasConversion(converter, comparer)
+            .IsRowVersion();
+
+        modelBuilder
+            .Entity<Circuit>()
+            .Property(e => e.BinaryVersion)
+            .HasConversion(converter, comparer)
+            .IsRowVersion();
+
+        modelBuilder
+            .Entity<CircuitTpt>()
+            .Property(e => e.BinaryVersion)
+            .HasConversion(converter, comparer)
+            .IsRowVersion();
+
+        modelBuilder
+            .Entity<CircuitTpc>()
+            .Property(e => e.BinaryVersion)
+            .HasConversion(converter, comparer)
+            .IsRowVersion();
+    }
+
+    private class BinaryVersionConverter : ValueConverter<List<byte>, byte[]>
+    {
+        public BinaryVersionConverter()
+            : base(
+                v => v == null ? null : v.ToArray(),
+                v => v == null ? null : v.ToList())
+        {
+        }
+    }
+
+    private class BinaryVersionComparer : ValueComparer<List<byte>>
+    {
+        public BinaryVersionComparer()
+            : base(
+                (l, r) => (l == null && r == null) || (l != null && r != null && l.SequenceEqual(r)),
+                v => CalculateHashCode(v),
+                v => v == null ? null : v.ToList())
+        {
+        }
+
+        private static int CalculateHashCode(List<byte> source)
+        {
+            if (source == null)
+            {
+                return 0;
+            }
+
+            var hash = new HashCode();
+            foreach (var el in source)
+            {
+                hash.Add(el);
+            }
+
+            return hash.ToHashCode();
+        }
+
+    }
 }
 
 public abstract class F1SqlServerFixtureBase<TRowVersion> : F1RelationalFixture<TRowVersion>

--- a/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
@@ -36,38 +36,38 @@ public class OptimisticConcurrencyULongSqlServerTest : OptimisticConcurrencySqlS
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPH_and_owned_types(bool updateOwned)
-        => Row_version_with_owned_types<SuperFan, ulong>(updateOwned, Mapping.Tph, "ULongVersion");
+    public Task Ulong_row_version_with_TPH_and_owned_types(bool updateOwnedFirst)
+        => Row_version_with_owned_types<SuperFan, ulong>(updateOwnedFirst, Mapping.Tph, "ULongVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPT_and_owned_types(bool updateOwned)
-        => Row_version_with_owned_types<SuperFanTpt, ulong>(updateOwned, Mapping.Tpt, "ULongVersion");
+    public Task Ulong_row_version_with_TPT_and_owned_types(bool updateOwnedFirst)
+        => Row_version_with_owned_types<SuperFanTpt, ulong>(updateOwnedFirst, Mapping.Tpt, "ULongVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPC_and_owned_types(bool updateOwned)
-        => Row_version_with_owned_types<SuperFanTpc, ulong>(updateOwned, Mapping.Tpc, "ULongVersion");
+    public Task Ulong_row_version_with_TPC_and_owned_types(bool updateOwnedFirst)
+        => Row_version_with_owned_types<SuperFanTpc, ulong>(updateOwnedFirst, Mapping.Tpc, "ULongVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPH_and_table_splitting(bool updateDependent)
-        => Row_version_with_table_splitting<StreetCircuit, City, ulong>(updateDependent, Mapping.Tph, "ULongVersion");
+    public Task Ulong_row_version_with_TPH_and_table_splitting(bool updateDependentFirst)
+        => Row_version_with_table_splitting<StreetCircuit, City, ulong>(updateDependentFirst, Mapping.Tph, "ULongVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPT_and_table_splitting(bool updateDependent)
-        => Row_version_with_table_splitting<StreetCircuitTpt, CityTpt, ulong>(updateDependent, Mapping.Tpt, "ULongVersion");
+    public Task Ulong_row_version_with_TPT_and_table_splitting(bool updateDependentFirst)
+        => Row_version_with_table_splitting<StreetCircuitTpt, CityTpt, ulong>(updateDependentFirst, Mapping.Tpt, "ULongVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPC_and_table_splitting(bool updateDependent)
-        => Row_version_with_table_splitting<StreetCircuitTpc, CityTpc, ulong>(updateDependent, Mapping.Tpc, "ULongVersion");
+    public Task Ulong_row_version_with_TPC_and_table_splitting(bool updateDependentFirst)
+        => Row_version_with_table_splitting<StreetCircuitTpc, CityTpc, ulong>(updateDependentFirst, Mapping.Tpc, "ULongVersion");
 }
 
 public class OptimisticConcurrencySqlServerTest : OptimisticConcurrencySqlServerTestBase<F1SqlServerFixture, byte[]>
@@ -80,38 +80,38 @@ public class OptimisticConcurrencySqlServerTest : OptimisticConcurrencySqlServer
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Row_version_with_TPH_and_owned_types(bool updateOwned)
-        => Row_version_with_owned_types<SuperFan, List<byte>>(updateOwned, Mapping.Tph, "BinaryVersion");
+    public Task Row_version_with_TPH_and_owned_types(bool updateOwnedFirst)
+        => Row_version_with_owned_types<SuperFan, List<byte>>(updateOwnedFirst, Mapping.Tph, "BinaryVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Row_version_with_TPT_and_owned_types(bool updateOwned)
-        => Row_version_with_owned_types<SuperFanTpt, List<byte>>(updateOwned, Mapping.Tpt, "BinaryVersion");
+    public Task Row_version_with_TPT_and_owned_types(bool updateOwnedFirst)
+        => Row_version_with_owned_types<SuperFanTpt, List<byte>>(updateOwnedFirst, Mapping.Tpt, "BinaryVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Row_version_with_TPC_and_owned_types(bool updateOwned)
-        => Row_version_with_owned_types<SuperFanTpc, List<byte>>(updateOwned, Mapping.Tpc, "BinaryVersion");
+    public Task Row_version_with_TPC_and_owned_types(bool updateOwnedFirst)
+        => Row_version_with_owned_types<SuperFanTpc, List<byte>>(updateOwnedFirst, Mapping.Tpc, "BinaryVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPH_and_table_splitting(bool updateDependent)
-        => Row_version_with_table_splitting<StreetCircuit, City, List<byte>>(updateDependent, Mapping.Tph, "BinaryVersion");
+    public Task Ulong_row_version_with_TPH_and_table_splitting(bool updateDependentFirst)
+        => Row_version_with_table_splitting<StreetCircuit, City, List<byte>>(updateDependentFirst, Mapping.Tph, "BinaryVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPT_and_table_splitting(bool updateDependent)
-        => Row_version_with_table_splitting<StreetCircuitTpt, CityTpt, List<byte>>(updateDependent, Mapping.Tpt, "BinaryVersion");
+    public Task Ulong_row_version_with_TPT_and_table_splitting(bool updateDependentFirst)
+        => Row_version_with_table_splitting<StreetCircuitTpt, CityTpt, List<byte>>(updateDependentFirst, Mapping.Tpt, "BinaryVersion");
 
     [ConditionalTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public Task Ulong_row_version_with_TPC_and_table_splitting(bool updateDependent)
-        => Row_version_with_table_splitting<StreetCircuitTpc, CityTpc, List<byte>>(updateDependent, Mapping.Tpc, "BinaryVersion");
+    public Task Ulong_row_version_with_TPC_and_table_splitting(bool updateDependentFirst)
+        => Row_version_with_table_splitting<StreetCircuitTpc, CityTpc, List<byte>>(updateDependentFirst, Mapping.Tpc, "BinaryVersion");
 }
 
 public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersion>
@@ -130,7 +130,7 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
         Tpc
     }
 
-    protected async Task Row_version_with_owned_types<TEntity, TVersion>(bool updateOwned, Mapping mapping, string propertyName)
+    protected async Task Row_version_with_owned_types<TEntity, TVersion>(bool updateOwnedFirst, Mapping mapping, string propertyName)
         where TEntity : class, ISuperFan
     {
         await using var c = CreateF1Context();
@@ -146,69 +146,100 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
 
                 var fanEntry = c.Entry(fan);
                 var swagEntry = fanEntry.Reference(s => s.Swag).TargetEntry!;
-                var originalFanVersion = fanEntry.Property<TVersion>(propertyName).CurrentValue;
-                var originalSwagVersion = default(TVersion);
+                var fanVersion1 = fanEntry.Property<TVersion>(propertyName).CurrentValue;
+                var swagVersion1 = default(TVersion);
 
-                if (mapping == Mapping.Tph)
+                if (mapping == Mapping.Tph) // Issue #29750
                 {
-                    originalSwagVersion
-                        = swagEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
+                    swagVersion1 = swagEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
 
-                    Assert.Equal(originalFanVersion, originalSwagVersion);
-                }
-
-                if (updateOwned)
-                {
-                    fan.Swag.Stuff += "+";
-                }
-                else
-                {
-                    fan.Name += "+";
+                    Assert.Equal(fanVersion1, swagVersion1);
                 }
 
                 await using var innerContext = CreateF1Context();
                 UseTransaction(innerContext.Database, transaction);
                 var fanInner = innerContext.Set<TEntity>().Single(e => e.Name == "Alice");
 
-                if (updateOwned)
+                if (updateOwnedFirst)
                 {
+                    fan.Swag.Stuff += "+";
                     fanInner.Swag.Stuff += "-";
                 }
                 else
                 {
                     fanInner.Name += "-";
+                    fan.Name += "+";
                 }
 
                 await innerContext.SaveChangesAsync();
 
-                if (!updateOwned || mapping != Mapping.Tpt) // Issue #22060
+                if (updateOwnedFirst && mapping == Mapping.Tpt) // Issue #22060
                 {
-                    await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
-
-                    await fanEntry.ReloadAsync();
-                    await swagEntry.ReloadAsync();
-
                     await context.SaveChangesAsync();
+                    return;
+                }
 
-                    var fanVersion = fanEntry.Property<TVersion>(propertyName).CurrentValue;
-                    Assert.NotEqual(originalFanVersion, fanVersion);
+                await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
 
-                    if (mapping == Mapping.Tph)
-                    {
-                        var swagVersion = swagEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
-                        Assert.Equal(fanVersion, swagVersion);
-                        Assert.NotEqual(originalSwagVersion, swagVersion);
-                    }
+                await fanEntry.ReloadAsync();
+                await swagEntry.ReloadAsync();
+
+                await context.SaveChangesAsync();
+
+                var fanVersion2 = fanEntry.Property<TVersion>(propertyName).CurrentValue;
+                Assert.NotEqual(fanVersion1, fanVersion2);
+
+                var swagVersion2 = default(TVersion);
+                if (mapping == Mapping.Tph) // Issue #29750
+                {
+                    swagVersion2 = swagEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
+                    Assert.Equal(fanVersion2, swagVersion2);
+                    Assert.NotEqual(swagVersion1, swagVersion2);
+                }
+
+                await innerContext.Entry(fanInner).ReloadAsync();
+                await innerContext.Entry(fanInner.Swag).ReloadAsync();
+
+                if (updateOwnedFirst)
+                {
+                    fanInner.Name += "-";
+                    fan.Name += "+";
                 }
                 else
                 {
+                    fan.Swag.Stuff += "+";
+                    fanInner.Swag.Stuff += "-";
+                }
+
+                await innerContext.SaveChangesAsync();
+
+                if (!updateOwnedFirst && mapping == Mapping.Tpt) // Issue #22060
+                {
                     await context.SaveChangesAsync();
+                    return;
+                }
+
+                await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
+
+                await fanEntry.ReloadAsync();
+                await swagEntry.ReloadAsync();
+
+                await context.SaveChangesAsync();
+
+                var fanVersion3 = fanEntry.Property<TVersion>(propertyName).CurrentValue;
+                Assert.NotEqual(fanVersion2, fanVersion3);
+
+                if (mapping == Mapping.Tph) // Issue #29750
+                {
+                    var swagVersion3 = swagEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
+                    Assert.Equal(fanVersion3, swagVersion3);
+                    Assert.NotEqual(swagVersion2, swagVersion3);
                 }
             });
     }
 
     protected async Task Row_version_with_table_splitting<TEntity, TCity, TVersion>(
-        bool updateDependent,
+        bool updateDependentFirst,
         Mapping mapping,
         string propertyName)
         where TEntity : class, IStreetCircuit<TCity>
@@ -227,71 +258,100 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
 
                 var circuitEntry = c.Entry(circuit);
                 var cityEntry = circuitEntry.Reference(s => s.City).TargetEntry!;
-                var originalCircuitVersion = circuitEntry.Property<TVersion>(propertyName).CurrentValue;
-                var originalCityVersion = default(TVersion);
+                var circuitVersion1 = circuitEntry.Property<TVersion>(propertyName).CurrentValue;
+                var cityVersion1 = default(TVersion);
 
-                if (mapping == Mapping.Tph)
+                if (mapping == Mapping.Tph) // Issue #29750
                 {
-                    originalCityVersion
-                        = cityEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
+                    cityVersion1 = cityEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
 
-                    Assert.Equal(originalCircuitVersion, originalCityVersion);
-                }
-
-                if (updateDependent)
-                {
-                    circuit.City.Name += "+";
-                }
-                else
-                {
-                    circuit.Name += "+";
+                    Assert.Equal(circuitVersion1, cityVersion1);
                 }
 
                 await using var innerContext = CreateF1Context();
                 UseTransaction(innerContext.Database, transaction);
-                var fanInner = innerContext.Set<TEntity>().Include(e => e.City).Single(e => e.Name == "Monaco");
+                var circuitInner = innerContext.Set<TEntity>().Include(e => e.City).Single(e => e.Name == "Monaco");
 
-                if (updateDependent)
+                if (updateDependentFirst)
                 {
-                    fanInner.City.Name += "-";
+                    circuit.City.Name += "+";
+                    circuitInner.City.Name += "-";
                 }
                 else
                 {
-                    fanInner.Name += "-";
+                    circuit.Name += "+";
+                    circuitInner.Name += "-";
                 }
 
-                if (mapping == Mapping.Tpc)
+                if (mapping == Mapping.Tpc) // Issue #29751.
                 {
                     await Assert.ThrowsAsync<InvalidOperationException>(() => innerContext.SaveChangesAsync());
+                    return;
+                }
 
+                await innerContext.SaveChangesAsync();
+
+                if (updateDependentFirst && mapping == Mapping.Tpt) // Issue #22060
+                {
+                    await context.SaveChangesAsync();
+                    return;
+                }
+
+                await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
+
+                await circuitEntry.ReloadAsync();
+                await cityEntry.ReloadAsync();
+
+                await context.SaveChangesAsync();
+
+                var circuitVersion2 = circuitEntry.Property<TVersion>(propertyName).CurrentValue;
+                Assert.NotEqual(circuitVersion1, circuitVersion2);
+
+                var cityVersion2 = default(TVersion);
+                if (mapping == Mapping.Tph) // Issue #29750
+                {
+                    cityVersion2 = cityEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
+                    Assert.Equal(circuitVersion2, cityVersion2);
+                    Assert.NotEqual(cityVersion1, cityVersion2);
+                }
+
+                await innerContext.Entry(circuitInner).ReloadAsync();
+                await innerContext.Entry(circuitInner.City).ReloadAsync();
+
+                if (updateDependentFirst)
+                {
+                    circuit.Name += "+";
+                    circuitInner.Name += "-";
                 }
                 else
                 {
-                    await innerContext.SaveChangesAsync();
+                    circuit.City.Name += "+";
+                    circuitInner.City.Name += "-";
+                }
 
-                    if (!updateDependent || mapping != Mapping.Tpt) // Issue #22060
-                    {
-                        await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
+                await innerContext.SaveChangesAsync();
 
-                        await circuitEntry.ReloadAsync();
-                        await cityEntry.ReloadAsync();
+                if (!updateDependentFirst && mapping == Mapping.Tpt) // Issue #22060
+                {
+                    await context.SaveChangesAsync();
+                    return;
+                }
 
-                        await context.SaveChangesAsync();
+                await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
 
-                        var circuitVersion = circuitEntry.Property<TVersion>(propertyName).CurrentValue;
-                        Assert.NotEqual(originalCircuitVersion, circuitVersion);
+                await circuitEntry.ReloadAsync();
+                await cityEntry.ReloadAsync();
 
-                        if (mapping == Mapping.Tph)
-                        {
-                            var cityVersion = cityEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
-                            Assert.Equal(circuitVersion, cityVersion);
-                            Assert.NotEqual(originalCityVersion, cityVersion);
-                        }
-                    }
-                    else
-                    {
-                        await context.SaveChangesAsync();
-                    }
+                await context.SaveChangesAsync();
+
+                var circuitVersion3 = circuitEntry.Property<TVersion>(propertyName).CurrentValue;
+                Assert.NotEqual(circuitVersion2, circuitVersion3);
+
+                if (mapping == Mapping.Tph) // Issue #29750
+                {
+                    var cityVersion3 = cityEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
+                    Assert.Equal(circuitVersion3, cityVersion3);
+                    Assert.NotEqual(cityVersion2, cityVersion3);
                 }
             });
     }


### PR DESCRIPTION
Fixes #29689

Also add more end-to-end tests for optimistic concurrency, converters, owned types, inheritance, and table sharing.
