### PR TITLE
[release/7.0] Scaffolding: Fix missing HasForeignKey when principal key is an alternate key

### DIFF
--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -720,6 +720,11 @@ public static class ScaffoldingModelExtensions
         var hasForeignKey =
             new FluentApiCodeFragment(nameof(ReferenceReferenceBuilder.HasForeignKey)) { IsHandledByDataAnnotations = true };
 
+        if (!foreignKey.PrincipalKey.IsPrimaryKey())
+        {
+            hasForeignKey.IsHandledByDataAnnotations = false;
+        }
+
         if (foreignKey.IsUnique)
         {
             hasForeignKey.TypeArguments.Add(foreignKey.DeclaringEntityType.Name);


### PR DESCRIPTION
When scaffolding an EF model from a database schema and using data annotations, incomplete code is generated for foreign key constraints referencing non-primary keys. This fix enables the missing code to be scaffolded.

Fixes #29418

### Customer impact

Multiple customers have reported this. The only workaround is to update the scaffolded code once you discover it's incomplete.

The only indication that the code is incomplete is a runtime exception that will occur when querying data using the foreign key:

> SqlException: Invalid column name '{wrong-foreign-key-column}'.

### Regression

Yes. EF Core 6 generated the correct code.

### Testing

Added automated scaffolding tests covering several scenarios involving alternate principal keys.

### Risk

Low. This just causes the same code to be generated whether or not you're using data annotations.