### PR TITLE
[release/7.0] Scaffolding: Handle FK on keyless entity type

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -255,8 +255,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             this.Write(this.ToStringHelper.ToStringWithCulture(foreignKey.DependentToPrincipal.Name));
             this.Write(").");
             this.Write(this.ToStringHelper.ToStringWithCulture(foreignKey.IsUnique ? "WithOne" : "WithMany"));
-            this.Write("(p => p.");
-            this.Write(this.ToStringHelper.ToStringWithCulture(foreignKey.PrincipalToDependent.Name));
+            this.Write("(");
+            this.Write(this.ToStringHelper.ToStringWithCulture(foreignKey.PrincipalToDependent != null ? $"p => p.{foreignKey.PrincipalToDependent.Name}" : ""));
             this.Write(")");
             this.Write(this.ToStringHelper.ToStringWithCulture(code.Fragment(foreignKeyFluentApiCalls, indent: 4)));
             this.Write(";\r\n");
@@ -803,7 +803,7 @@ if ((NamespaceHintValueAcquired == false))
             {
                 get
                 {
-                    return this.formatProviderField;
+                    return this.formatProviderField ;
                 }
                 set
                 {

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.tt
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.tt
@@ -210,7 +210,7 @@ public partial class <#= Options.ContextName #> : DbContext
                 WriteLine("");
             }
 #>
-            entity.HasOne(d => d.<#= foreignKey.DependentToPrincipal.Name #>).<#= foreignKey.IsUnique ? "WithOne" : "WithMany" #>(p => p.<#= foreignKey.PrincipalToDependent.Name #>)<#= code.Fragment(foreignKeyFluentApiCalls, indent: 4) #>;
+            entity.HasOne(d => d.<#= foreignKey.DependentToPrincipal.Name #>).<#= foreignKey.IsUnique ? "WithOne" : "WithMany" #>(<#= foreignKey.PrincipalToDependent != null ? $"p => p.{foreignKey.PrincipalToDependent.Name}" : "" #>)<#= code.Fragment(foreignKeyFluentApiCalls, indent: 4) #>;
 <#
             anyEntityTypeConfiguration = true;
         }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -621,7 +621,7 @@ if ((NamespaceHintValueAcquired == false))
             {
                 get
                 {
-                    return this.formatProviderField;
+                    return this.formatProviderField ;
                 }
                 set
                 {


### PR DESCRIPTION
The scaffolding code currently assumes that all relationships have bidirectional navigation properties. However, this isn't true for foreign keys constraints on keyless tables where only a one-directional relationship is allowed. This fix updates the scaffolding code to handle this case.

Fixes #29516

### Customer impact

Multiple customers have reported this. They can work around it by adding custom scaffolding templates to their project and applying the fix locally. Without a fix, scaffolding will fail with a NullReferenceException.

### Regression

Yes. This worked in EF Core 6.

### Testing

Added an automated test covering this scenario.

### Risk

Low. This just adds null handling to the existing code.