### PR TITLE
[release/7.0] Fix making column required on SQL Server with idempotent migrations

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
@@ -750,6 +750,9 @@ public abstract class MigrationsSqlGeneratorTestBase
         ContextOptions = options;
     }
 
+    protected virtual void Generate(MigrationOperation operation, MigrationsSqlGenerationOptions options)
+        => Generate(null, new[] { operation }, options);
+
     protected virtual void Generate(params MigrationOperation[] operation)
         => Generate(null, operation);
 


### PR DESCRIPTION
Fixes #29530, backports #29619

**Description**

Before EF 7.0, making a column non-nullable which contained nulls would fail. EF 7.0 added an UPDATE statement to convert nulls to a default value, but the SQL wasn't properly escaped.

**Customer impact**

Making a column non-nullable can cause the migration to fail in certain scenarios (when the column is renamed).

**How found**

Customer reported on 7.0

**Regression**

Partial; this scenario used to work correctly as long as the column contained no nulls. When nulls were present, this already caused a failure (null constraint violation).

**Testing**

Added a test for the affected scenario.

**Risk**

Very low; the fix is trivial and affects migrations only (no runtime impact). A quirk was added to revert back to older behavior.