### PR TITLE
[release/7.0] Scaffolding: Fix code for EF6 many-to-many pattern

### DIFF
--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -401,7 +401,8 @@ public static class ScaffoldingModelExtensions
         var toTableArguments = new List<object?>();
 
         if (explicitSchema
-            || tableName != null && tableName != entityType.GetDbSetName())
+            || tableName != null && (tableName != entityType.GetDbSetName()
+                || (entityType.IsSimpleManyToManyJoinEntityType() && tableName != entityType.ShortName())))
         {
             toTableHandledByConventions = false;
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -347,6 +347,26 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             }
 
+            foreach (var property in joinEntityType.GetProperties())
+            {
+                var propertyFluentApiCalls = property.GetFluentApiCalls(annotationCodeGenerator);
+                if (propertyFluentApiCalls == null)
+                {
+                    continue;
+                }
+
+                usings.AddRange(propertyFluentApiCalls.GetRequiredUsings());
+
+            this.Write("                        j.IndexerProperty<");
+            this.Write(this.ToStringHelper.ToStringWithCulture(code.Reference(property.ClrType)));
+            this.Write(">(");
+            this.Write(this.ToStringHelper.ToStringWithCulture(code.Literal(property.Name)));
+            this.Write(")");
+            this.Write(this.ToStringHelper.ToStringWithCulture(code.Fragment(propertyFluentApiCalls, indent: 7)));
+            this.Write(";\r\n");
+
+            }
+
             this.Write("                    });\r\n");
 
             anyEntityTypeConfiguration = true;

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.tt
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.tt
@@ -276,6 +276,20 @@ public partial class <#= Options.ContextName #> : DbContext
                         j.HasIndex(<#= code.Literal(index.Properties.Select(e => e.Name).ToArray()) #>, <#= code.Literal(index.GetDatabaseName()) #>)<#= code.Fragment(indexFluentApiCalls, indent: 7) #>;
 <#
             }
+
+            foreach (var property in joinEntityType.GetProperties())
+            {
+                var propertyFluentApiCalls = property.GetFluentApiCalls(annotationCodeGenerator);
+                if (propertyFluentApiCalls == null)
+                {
+                    continue;
+                }
+
+                usings.AddRange(propertyFluentApiCalls.GetRequiredUsings());
+#>
+                        j.IndexerProperty<<#= code.Reference(property.ClrType) #>>(<#= code.Literal(property.Name) #>)<#= code.Fragment(propertyFluentApiCalls, indent: 7) #>;
+<#
+            }
 #>
                     });
 <#

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -2287,6 +2287,119 @@ public class RelationalScaffoldingModelFactoryTest
     }
 
     [ConditionalFact]
+    public void Scaffold_skip_navigation_for_many_to_many_join_table_ef6()
+    {
+        var database = new DatabaseModel
+        {
+            Tables =
+            {
+                new DatabaseTable
+                {
+                    Name = "Blogs",
+                    Columns =
+                    {
+                        new DatabaseColumn { Name = "Id", StoreType = "int"  }
+                    },
+                    PrimaryKey = new DatabasePrimaryKey { Columns = { new DatabaseColumnRef("Id") } }
+                },
+                new DatabaseTable
+                {
+                    Name = "Posts",
+                    Columns =
+                    {
+                        new DatabaseColumn { Name = "Id", StoreType = "int"  }
+                    },
+                    PrimaryKey = new DatabasePrimaryKey { Columns = { new DatabaseColumnRef("Id") } }
+                },
+                new DatabaseTable
+                {
+                    Name = "PostBlogs",
+                    Columns =
+                    {
+                        new DatabaseColumn { Name = "Post_Id", StoreType = "int"  },
+                        new DatabaseColumn { Name = "Blog_Id", StoreType = "int"  }
+                    },
+                    PrimaryKey = new DatabasePrimaryKey
+                    {
+                        Columns = { new DatabaseColumnRef("Post_Id"), new DatabaseColumnRef("Blog_Id") }
+                    },
+                    ForeignKeys =
+                    {
+                        new DatabaseForeignKey
+                        {
+                            Name = "Post_Blogs_Source",
+                            Columns ={ new DatabaseColumnRef("Post_Id") },
+                            PrincipalTable = new DatabaseTableRef("Posts"),
+                            PrincipalColumns = { new DatabaseColumnRef("Id") },
+                            OnDelete = ReferentialAction.Cascade
+                        },
+                        new DatabaseForeignKey
+                        {
+                            Name = "Post_Blogs_Target",
+                            Columns ={ new DatabaseColumnRef("Blog_Id") },
+                            PrincipalTable = new DatabaseTableRef("Blogs"),
+                            PrincipalColumns = { new DatabaseColumnRef("Id") },
+                            OnDelete = ReferentialAction.Cascade
+                        }
+                    }
+                }
+            }
+        };
+
+        var model = _factory.Create(database, new ModelReverseEngineerOptions());
+
+        Assert.Collection(
+            model.GetEntityTypes().OrderBy(e => e.Name),
+            t1 =>
+            {
+                Assert.Equal("Blog", t1.Name);
+                Assert.Equal("Blogs", t1.GetTableName());
+                Assert.Empty(t1.GetDeclaredForeignKeys());
+                var skipNavigation = Assert.Single(t1.GetSkipNavigations());
+                Assert.Equal("Posts", skipNavigation.Name);
+                Assert.Equal("Blogs", skipNavigation.Inverse.Name);
+                Assert.Equal("PostBlog", skipNavigation.JoinEntityType.Name);
+                Assert.Equal("Post_Blogs_Target", skipNavigation.ForeignKey.GetConstraintName());
+            },
+            t2 =>
+            {
+                Assert.Equal("Post", t2.Name);
+                Assert.Equal("Posts", t2.GetTableName());
+                Assert.Empty(t2.GetDeclaredForeignKeys());
+                var skipNavigation = Assert.Single(t2.GetSkipNavigations());
+                Assert.Equal("Blogs", skipNavigation.Name);
+                Assert.Equal("Posts", skipNavigation.Inverse.Name);
+                Assert.Equal("PostBlog", skipNavigation.JoinEntityType.Name);
+                Assert.Equal("Post_Blogs_Source", skipNavigation.ForeignKey.GetConstraintName());
+            },
+            t3 =>
+            {
+                Assert.Equal("PostBlog", t3.Name);
+                Assert.Equal("PostBlogs", t3.GetTableName());
+                Assert.Collection(
+                    t3.GetForeignKeys().OrderBy(fk => fk.GetConstraintName()),
+                    fk1 =>
+                    {
+                        Assert.Equal("Post_Blogs_Source", fk1.GetConstraintName());
+                        var property = Assert.Single(fk1.Properties);
+                        Assert.Equal("PostId", property.Name);
+                        Assert.Equal("Post_Id", property.GetColumnName(StoreObjectIdentifier.Table(t3.GetTableName())));
+                        Assert.Equal("Post", fk1.PrincipalEntityType.Name);
+                        Assert.Equal(DeleteBehavior.Cascade, fk1.DeleteBehavior);
+                    },
+                    fk2 =>
+                    {
+                        Assert.Equal("Post_Blogs_Target", fk2.GetConstraintName());
+                        var property = Assert.Single(fk2.Properties);
+                        Assert.Equal("BlogId", property.Name);
+                        Assert.Equal("Blog_Id", property.GetColumnName(StoreObjectIdentifier.Table(t3.GetTableName())));
+                        Assert.Equal("Blog", fk2.PrincipalEntityType.Name);
+                        Assert.Equal(DeleteBehavior.Cascade, fk2.DeleteBehavior);
+                    });
+            });
+    }
+
+    [ConditionalFact]
     public void Scaffold_skip_navigation_for_many_to_many_join_table_basic()
     {
         var database = new DatabaseModel


### PR DESCRIPTION
Certain patterns of many-to-many join tables that don't follow the EF Core conventions--most notably ones generated by EF6--result in an incomplete model when scaffolding. This fix adds additional handling for these patterns.

Fixes #29544, fixes #29634

### Customer impact

Multiple users have reported issues in this area. Some issues can be worked around by applying the fix to custom scaffolding templates. Others require manually updating the code after it's scaffolded. The incorrect models result in runtime exceptions about missing tables and columns.

### Regression

Yes. Correct models were scaffolded in EF Core 6.

### Testing

Added automated tests covering more unconventional many-to-many join tables.

### Risk

Low. Adds back code that I neglected to port as part of the custom templates feature.