### PR TITLE
[release/7.0] Reset query tracking behavior correctly if set on DbContextOptions

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -882,8 +882,12 @@ public class DbContext :
             || _configurationSnapshot.HasChangeTrackerConfiguration)
         {
             var changeTracker = ChangeTracker;
+            ((IResettableService)changeTracker).ResetState();
             changeTracker.AutoDetectChangesEnabled = _configurationSnapshot.AutoDetectChangesEnabled;
-            changeTracker.QueryTrackingBehavior = _configurationSnapshot.QueryTrackingBehavior;
+            if (_configurationSnapshot.QueryTrackingBehavior.HasValue)
+            {
+                changeTracker.QueryTrackingBehavior = _configurationSnapshot.QueryTrackingBehavior.Value;
+            }
             changeTracker.LazyLoadingEnabled = _configurationSnapshot.LazyLoadingEnabled;
             changeTracker.CascadeDeleteTiming = _configurationSnapshot.CascadeDeleteTiming;
             changeTracker.DeleteOrphansTiming = _configurationSnapshot.DeleteOrphansTiming;
@@ -940,7 +944,7 @@ public class DbContext :
             _changeTracker != null,
             changeDetectorEvents != null,
             _changeTracker?.AutoDetectChangesEnabled ?? true,
-            _changeTracker?.QueryTrackingBehavior ?? QueryTrackingBehavior.TrackAll,
+            _changeTracker?.QueryTrackingBehavior,
             _database?.AutoTransactionBehavior ?? AutoTransactionBehavior.WhenNeeded,
             _database?.AutoSavepointsEnabled ?? true,
             _changeTracker?.LazyLoadingEnabled ?? true,

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -52,6 +52,9 @@ public class DbContext :
     IDbSetCache,
     IDbContextPoolable
 {
+    private static readonly bool QuirkEnabled29733
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29733", out var enabled) && enabled;
+
     private readonly DbContextOptions _options;
 
     private IDictionary<(Type Type, string? Name), object>? _sets;
@@ -882,12 +885,20 @@ public class DbContext :
             || _configurationSnapshot.HasChangeTrackerConfiguration)
         {
             var changeTracker = ChangeTracker;
-            ((IResettableService)changeTracker).ResetState();
-            changeTracker.AutoDetectChangesEnabled = _configurationSnapshot.AutoDetectChangesEnabled;
-            if (_configurationSnapshot.QueryTrackingBehavior.HasValue)
+            if (QuirkEnabled29733
+                && _configurationSnapshot.QueryTrackingBehavior.HasValue)
             {
                 changeTracker.QueryTrackingBehavior = _configurationSnapshot.QueryTrackingBehavior.Value;
             }
+            else
+            {
+                ((IResettableService)changeTracker).ResetState();
+                if (_configurationSnapshot.QueryTrackingBehavior.HasValue)
+                {
+                    changeTracker.QueryTrackingBehavior = _configurationSnapshot.QueryTrackingBehavior.Value;
+                }
+            }
+            changeTracker.AutoDetectChangesEnabled = _configurationSnapshot.AutoDetectChangesEnabled;
             changeTracker.LazyLoadingEnabled = _configurationSnapshot.LazyLoadingEnabled;
             changeTracker.CascadeDeleteTiming = _configurationSnapshot.CascadeDeleteTiming;
             changeTracker.DeleteOrphansTiming = _configurationSnapshot.DeleteOrphansTiming;
@@ -944,7 +955,9 @@ public class DbContext :
             _changeTracker != null,
             changeDetectorEvents != null,
             _changeTracker?.AutoDetectChangesEnabled ?? true,
-            _changeTracker?.QueryTrackingBehavior,
+            QuirkEnabled29733
+                ? _changeTracker?.QueryTrackingBehavior ?? QueryTrackingBehavior.TrackAll
+                : _changeTracker?.QueryTrackingBehavior,
             _database?.AutoTransactionBehavior ?? AutoTransactionBehavior.WhenNeeded,
             _database?.AutoSavepointsEnabled ?? true,
             _changeTracker?.LazyLoadingEnabled ?? true,

--- a/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
+++ b/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
@@ -23,7 +23,7 @@ public sealed class DbContextPoolConfigurationSnapshot
         bool hasChangeTrackerConfiguration,
         bool hasChangeDetectorConfiguration,
         bool autoDetectChangesEnabled,
-        QueryTrackingBehavior queryTrackingBehavior,
+        QueryTrackingBehavior? queryTrackingBehavior,
         AutoTransactionBehavior autoTransactionBehavior,
         bool autoSavepointsEnabled,
         bool lazyLoadingEnabled,
@@ -135,7 +135,7 @@ public sealed class DbContextPoolConfigurationSnapshot
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public QueryTrackingBehavior QueryTrackingBehavior { get; }
+    public QueryTrackingBehavior? QueryTrackingBehavior { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to


### PR DESCRIPTION
Port of #29766
Fixes #29733

**Description**

When using DbContext pooling, a query tracking behavior of NoTracking could be changed to TrackAll after the context has been returned to the pool and retrieved again.

**Customer impact**

Queries running with the wrong tracking behavior could result in application crashes, incorrect data, and reduced performance. 

**How found**

Customer reported on 7.0

**Regression**

Yes, from 6.0.

**Testing**

Added a tests around this area where the tracking behavior is specified on the options builder.

**Risk**

Low; simple code change, and a quirk was added to revert back to older behavior.