### PR TITLE
[release/7.0] Include table name for overrides in snapshot.

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -845,9 +845,6 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
         annotations.TryGetAndRemove(RelationalAnnotationNames.TableName, out IAnnotation tableNameAnnotation);
         var table = StoreObjectIdentifier.Create(entityType, StoreObjectType.Table);
         var tableName = (string?)tableNameAnnotation?.Value ?? table?.Name;
-        var explicitName = tableNameAnnotation != null
-            || entityType.BaseType == null
-            || entityType.BaseType.GetTableName() != tableName;
 
         annotations.TryGetAndRemove(RelationalAnnotationNames.Schema, out IAnnotation schemaAnnotation);
         var schema = (string?)schemaAnnotation?.Value ?? table?.Schema;
@@ -861,6 +858,12 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
         var hasTriggers = entityType.GetDeclaredTriggers().Any(t => t.GetTableName() == tableName! && t.GetTableSchema() == schema);
         var hasOverrides = table != null
             && entityType.GetProperties().Select(p => p.FindOverrides(table.Value)).Any(o => o != null);
+
+        var explicitName = tableNameAnnotation != null
+            || entityType.BaseType == null
+            || entityType.BaseType.GetTableName() != tableName
+            || hasOverrides;
+
         var requiresTableBuilder = isExcludedFromMigrations
             || comment != null
             || hasTriggers


### PR DESCRIPTION
This is a port of #29819
Fixes #29534

**Description**

The model snapshot generated for a migration that includes types in a TPH hierarchy with table-specific configuration doesn't include the table name for derived classes.

**Customer impact**

The generated migration will not compile until the customer fixes it manually.

**How found**

Multiple customer reports on 7.0

**Regression**

Yes.

**Testing**

Added tests for the affected scenario

**Risk**

Low; the fix only impacts design-time tooling.