### PR TITLE
[release/7.0] Allow underscores in identifiers again

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -1455,10 +1455,11 @@ public class CSharpHelper : ICSharpHelper
     {
         if (ch < 'a')
         {
-            return ch < 'A'
+            return (ch < 'A'
                 ? ch >= '0'
                 && ch <= '9'
-                : ch <= 'Z';
+                : ch <= 'Z')
+                || ch == '_';
         }
 
         if (ch <= 'z')

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -2520,12 +2520,12 @@ namespace TestNamespace
                 afterSaveBehavior: PropertySaveBehavior.Throw);
 
             var overrides = new StoreObjectDictionary<RuntimeRelationalPropertyOverrides>();
-            var idDerivedInsert = new RuntimeRelationalPropertyOverrides(
+            var idDerived_Insert = new RuntimeRelationalPropertyOverrides(
                 id,
                 StoreObjectIdentifier.InsertStoredProcedure(""Derived_Insert"", ""TPC""),
                 true,
                 ""DerivedId"");
-            overrides.Add(StoreObjectIdentifier.InsertStoredProcedure(""Derived_Insert"", ""TPC""), idDerivedInsert);
+            overrides.Add(StoreObjectIdentifier.InsertStoredProcedure(""Derived_Insert"", ""TPC""), idDerived_Insert);
             var idPrincipalBaseView = new RuntimeRelationalPropertyOverrides(
                 id,
                 StoreObjectIdentifier.View(""PrincipalBaseView"", ""TPC""),
@@ -4579,23 +4579,23 @@ namespace TestNamespace
                 nullable: true);
             blob.AddAnnotation(""Cosmos:PropertyName"", ""JsonBlob"");
 
-            var id0 = runtimeEntityType.AddProperty(
+            var __id = runtimeEntityType.AddProperty(
                 ""__id"",
                 typeof(string),
                 afterSaveBehavior: PropertySaveBehavior.Throw,
                 valueGeneratorFactory: new IdValueGeneratorFactory().Create);
-            id0.AddAnnotation(""Cosmos:PropertyName"", ""id"");
+            __id.AddAnnotation(""Cosmos:PropertyName"", ""id"");
 
-            var jObject = runtimeEntityType.AddProperty(
+            var __jObject = runtimeEntityType.AddProperty(
                 ""__jObject"",
                 typeof(JObject),
                 nullable: true,
                 valueGenerated: ValueGenerated.OnAddOrUpdate,
                 beforeSaveBehavior: PropertySaveBehavior.Ignore,
                 afterSaveBehavior: PropertySaveBehavior.Ignore);
-            jObject.AddAnnotation(""Cosmos:PropertyName"", """");
+            __jObject.AddAnnotation(""Cosmos:PropertyName"", """");
 
-            var etag = runtimeEntityType.AddProperty(
+            var _etag = runtimeEntityType.AddProperty(
                 ""_etag"",
                 typeof(string),
                 nullable: true,
@@ -4609,7 +4609,7 @@ namespace TestNamespace
             runtimeEntityType.SetPrimaryKey(key);
 
             var key0 = runtimeEntityType.AddKey(
-                new[] { id0, partitionId });
+                new[] { __id, partitionId });
 
             return runtimeEntityType;
         }


### PR DESCRIPTION
Port of #29821
Fixes #29450

**Description**

A change in the validation of identifier names resulted in an unintentional breaking change.

**Customer impact**

If the generated files would contain underscores the customer needs to add them manually to allow them to compile against existing code.

**How found**

Customer reported on 7.0

**Regression**

Yes.

**Testing**

Adjusted the tests for the affected scenario

**Risk**

Low; the fix reverts the affected code to the 6.0 version.