### PR TITLE
[release/7.0] Avoid infinite loop during foreign key discovery

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -50,6 +50,9 @@ public class ForeignKeyPropertyDiscoveryConvention :
     IPropertyFieldChangedConvention,
     IModelFinalizingConvention
 {
+    private static readonly bool QuirkEnabled29826
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29826", out var enabled) && enabled;
+
     /// <summary>
     ///     Creates a new instance of <see cref="ForeignKeyPropertyDiscoveryConvention" />.
     /// </summary>
@@ -309,7 +312,8 @@ public class ForeignKeyPropertyDiscoveryConvention :
                 : relationshipBuilder;
         }
 
-        if (conflictingFKCount == 0)
+        if ((!QuirkEnabled29826 && conflictingFKCount >= 0)
+            || (QuirkEnabled29826 && conflictingFKCount == 0))
         {
             return ((ForeignKey)foreignKey).Builder.ReuniquifyImplicitProperties(false);
         }

--- a/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -812,6 +812,44 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     }
 
     [ConditionalFact]
+    public void Does_not_match_if_a_foreign_key_on_the_best_candidate_property_already_configured_explicitly()
+    {
+        var dependentTypeBuilder = DependentType.Builder;
+        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavPeEKaYProperty, ConfigurationSource.Convention).Metadata;
+        dependentTypeBuilder.Property(DependentEntity.PrincipalEntityIDProperty, ConfigurationSource.Convention);
+        dependentTypeBuilder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention);
+        dependentTypeBuilder.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
+
+        var derivedTypeBuilder = _model.Entity(typeof(DerivedPrincipalEntity), ConfigurationSource.Convention);
+        derivedTypeBuilder.HasBaseType(PrincipalType, ConfigurationSource.Convention);
+
+        var relationshipBuilder = dependentTypeBuilder
+            .HasRelationship(derivedTypeBuilder.Metadata, new[] { fkProperty }, ConfigurationSource.Explicit);
+        var compositeRelationshipBuilder = dependentTypeBuilder
+            .HasRelationship(PrincipalTypeWithCompositeKey, new[] { fkProperty }, ConfigurationSource.Explicit);
+
+        var newRelationshipBuilder = dependentTypeBuilder.HasRelationship(
+            PrincipalType, "SomeNav", null, ConfigurationSource.Convention);
+
+        Assert.Equal(
+            "SomeNav" + nameof(PrincipalEntity.PeeKay),
+            newRelationshipBuilder.Metadata.Properties.Single().Name);
+
+        newRelationshipBuilder = RunConvention(newRelationshipBuilder);
+
+        var fk = (IReadOnlyForeignKey)relationshipBuilder.Metadata;
+        Assert.Same(fkProperty, fk.Properties.Single());
+        Assert.False(fk.IsUnique);
+
+        var newFk = newRelationshipBuilder.Metadata;
+        Assert.Equal(3, DependentType.GetForeignKeys().Count());
+        Assert.Equal("SomeNav" + nameof(PrincipalEntity.PeeKay), newFk.Properties.Single().Name);
+        Assert.Null(newFk.GetPropertiesConfigurationSource());
+
+        ValidateModel();
+    }
+
+    [ConditionalFact]
     public void Logs_warning_if_foreign_key_property_names_are_order_dependent()
     {
         var relationshipBuilder = DependentType.Builder.HasRelationship(


### PR DESCRIPTION
This is a port of #29849
Fixes #29826

**Description**

When there are already two foreign keys using a property the convention erroneously tries to reconfigure another foreign key to use the same property, fails and repeats.

**Customer impact**

An app with an affected model will hang in an infinite loop. There is no workaround other than removing this convention.

**How found**

Customer reported on 7.0

**Regression**

Yes.

**Testing**

Added a test for this scenario

**Risk**

Low; the fix has limited scope and a quirk mode was added.
