### PR TITLE
Most of explicit and lazy loading for no-tracking queries

### DIFF
--- a/src/EFCore.Abstractions/Infrastructure/ILazyLoader.cs
+++ b/src/EFCore.Abstractions/Infrastructure/ILazyLoader.cs
@@ -35,6 +35,17 @@ public interface ILazyLoader : IDisposable
         bool loaded = true);
 
     /// <summary>
+    ///     Gets whether or not the given navigation as known to be completely loaded or known to be
+    ///     no longer completely loaded.
+    /// </summary>
+    /// <param name="entity">The entity on which the navigation property is located.</param>
+    /// <param name="navigationName">The navigation property name.</param>
+    /// <returns><see langword="true" />if the navigation is known to be loaded.</returns>
+    bool IsLoaded(
+        object entity,
+        [CallerMemberName] string navigationName = "");
+
+    /// <summary>
     ///     Loads a navigation property if it has not already been loaded.
     /// </summary>
     /// <param name="entity">The entity on which the navigation property is located.</param>

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -1108,7 +1108,7 @@ public static class CoreLoggerExtensions
     /// <param name="navigationName">The name of the navigation property.</param>
     public static void LazyLoadOnDisposedContextWarning(
         this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
-        DbContext context,
+        DbContext? context,
         object entityType,
         string navigationName)
     {
@@ -1188,7 +1188,7 @@ public static class CoreLoggerExtensions
     /// <param name="navigationName">The name of the navigation property.</param>
     public static void DetachedLazyLoadingWarning(
         this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
-        DbContext context,
+        DbContext? context,
         object entityType,
         string navigationName)
     {

--- a/src/EFCore/Diagnostics/LazyLoadingEventData.cs
+++ b/src/EFCore/Diagnostics/LazyLoadingEventData.cs
@@ -16,13 +16,13 @@ public class LazyLoadingEventData : DbContextEventData
     /// </summary>
     /// <param name="eventDefinition">The event definition.</param>
     /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
-    /// <param name="context">The current <see cref="DbContext" />.</param>
+    /// <param name="context">The current <see cref="DbContext" />, or <see langword="null" /> if it is no longer available.</param>
     /// <param name="entity">The entity instance on which lazy loading was initiated.</param>
     /// <param name="navigationPropertyName">The navigation property name of the relationship to be loaded.</param>
     public LazyLoadingEventData(
         EventDefinitionBase eventDefinition,
         Func<EventDefinitionBase, EventData, string> messageGenerator,
-        DbContext context,
+        DbContext? context,
         object entity,
         string navigationPropertyName)
         : base(eventDefinition, messageGenerator, context)

--- a/src/EFCore/Infrastructure/Internal/LazyLoader.cs
+++ b/src/EFCore/Infrastructure/Internal/LazyLoader.cs
@@ -95,6 +95,7 @@ public class LazyLoader : ILazyLoader, IInjectableService
             try
             {
                 _isLoading!.Add(navEntry);
+                // ShouldLoad is called after _isLoading.Add because it could attempt to load the property. See #13138.
                 if (ShouldLoad(entity, navigationName, out var entry))
                 {
                     try
@@ -135,6 +136,7 @@ public class LazyLoader : ILazyLoader, IInjectableService
             try
             {
                 _isLoading!.Add(navEntry);
+                // ShouldLoad is called after _isLoading.Add because it could attempt to load the property. See #13138.
                 if (ShouldLoad(entity, navigationName, out var entry))
                 {
                     try

--- a/src/EFCore/Internal/IInjectableService.cs
+++ b/src/EFCore/Internal/IInjectableService.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Internal;
+
+/// <summary>
+///     <para>
+///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+///         any release. You should only use it directly in your code with extreme caution and knowing that
+///         doing so can result in application failures when updating to a new Entity Framework Core release.
+///     </para>
+///     <para>
+///         Implemented by service property types to notify services instances of lifecycle changes.
+///     </para>
+/// </summary>
+public interface IInjectableService
+{
+    /// <summary>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    ///     <para>
+    ///         Called when the entity holding this service is being detached from a DbContext.
+    ///     </para>
+    /// </summary>
+    /// <param name="context">The <see cref="DbContext"/> instance.</param>
+    /// <param name="entity">The entity instance that is being detached.</param>
+    /// <returns><see langword="true" /> if the service property should be set to <see langword="null" />. </returns>
+    bool Detaching(DbContext context, object entity);
+
+    /// <summary>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    ///     <para>
+    ///         Called when an entity that needs this is being attached to a DbContext.
+    ///     </para>
+    /// </summary>
+    /// <param name="context">The <see cref="DbContext"/> instance.</param>
+    /// <param name="entity">The entity instance that is being attached.</param>
+    /// <param name="existingService">
+    ///     The existing instance of this service being held by the entity instance, or <see langword="null" /> if there
+    ///     is no existing instance.
+    /// </param>
+    /// <returns>The service instance to use, or <see langword="null" /> if a new instance should be created.</returns>
+    IInjectableService? Attaching(DbContext context, object entity, IInjectableService? existingService);
+}

--- a/src/EFCore/Metadata/Internal/IMemberClassifier.cs
+++ b/src/EFCore/Metadata/Internal/IMemberClassifier.cs
@@ -56,5 +56,5 @@ public interface IMemberClassifier
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IParameterBindingFactory? FindServicePropertyCandidateBindingFactory(PropertyInfo propertyInfo, IConventionModel model);
+    IParameterBindingFactory? FindServicePropertyCandidateBindingFactory(MemberInfo memberInfo, IConventionModel model);
 }

--- a/src/EFCore/Metadata/Internal/MemberClassifier.cs
+++ b/src/EFCore/Metadata/Internal/MemberClassifier.cs
@@ -186,15 +186,15 @@ public class MemberClassifier : IMemberClassifier
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual IParameterBindingFactory? FindServicePropertyCandidateBindingFactory(
-        PropertyInfo propertyInfo,
+        MemberInfo memberInfo,
         IConventionModel model)
     {
-        if (!propertyInfo.IsCandidateProperty(publicOnly: false))
+        if (!memberInfo.IsCandidateProperty(publicOnly: false))
         {
             return null;
         }
 
-        var type = propertyInfo.PropertyType;
+        var type = memberInfo.GetMemberType();
         var configurationType = ((Model)model).Configuration?.GetConfigurationType(type);
         if (configurationType != TypeConfigurationType.ServiceProperty)
         {
@@ -203,13 +203,13 @@ public class MemberClassifier : IMemberClassifier
                 return null;
             }
 
-            if (propertyInfo.IsCandidateProperty()
-                && _typeMappingSource.FindMapping(propertyInfo.GetMemberType(), (IModel)model) != null)
+            if (memberInfo.IsCandidateProperty()
+                && _typeMappingSource.FindMapping(memberInfo.GetMemberType(), (IModel)model) != null)
             {
                 return null;
             }
         }
 
-        return _parameterBindingFactories.FindFactory(type, propertyInfo.GetSimpleMemberName());
+        return _parameterBindingFactories.FindFactory(type, memberInfo.GetSimpleMemberName());
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -257,11 +257,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 generatorType, method);
 
         /// <summary>
-        ///     The navigation '{1_entityType}.{0_navigation}' cannot be loaded because the entity is not being tracked. Navigations can only be loaded for tracked entities.
+        ///     The navigation '{1_entityType}.{0_navigation}' cannot be loaded because one or more of the key or foreign key properties are shadow properties and the entity is not being tracked. Relationships using shadow values can only be loaded for tracked entities.
         /// </summary>
-        public static string CannotLoadDetached(object? navigation, object? entityType)
+        public static string CannotLoadDetachedShadow(object? navigation, object? entityType)
             => string.Format(
-                GetString("CannotLoadDetached", "0_navigation", "1_entityType"),
+                GetString("CannotLoadDetachedShadow", "0_navigation", "1_entityType"),
                 navigation, entityType);
 
         /// <summary>
@@ -3600,7 +3600,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     An attempt was made to lazy-load navigation '{entityType}.{navigation}' after the associated DbContext was disposed.
+        ///     An attempt was made to lazy-load navigation '{entityType}.{navigation}' after the associated DbContext was disposed or returned to the pool, or the entity was explicitly detached from the context.
         /// </summary>
         public static EventDefinition<string, string> LogLazyLoadOnDisposedContext(IDiagnosticsLogger logger)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -204,8 +204,8 @@
   <data name="CannotCreateValueGenerator" xml:space="preserve">
     <value>Cannot create an instance of value generator type '{generatorType}'. Ensure that the type can be instantiated and has a parameterless constructor, or use the overload of '{method}' that accepts a delegate.</value>
   </data>
-  <data name="CannotLoadDetached" xml:space="preserve">
-    <value>The navigation '{1_entityType}.{0_navigation}' cannot be loaded because the entity is not being tracked. Navigations can only be loaded for tracked entities.</value>
+  <data name="CannotLoadDetachedShadow" xml:space="preserve">
+    <value>The navigation '{1_entityType}.{0_navigation}' cannot be loaded because one or more of the key or foreign key properties are shadow properties and the entity is not being tracked. Relationships using shadow values can only be loaded for tracked entities.</value>
   </data>
   <data name="CannotMarkNonShared" xml:space="preserve">
     <value>The type '{type}' cannot be marked as a non-shared type since a shared type entity type with this CLR type exists in the model.</value>
@@ -810,7 +810,7 @@
     <comment>Error CoreEventId.InvalidIncludePathError object object</comment>
   </data>
   <data name="LogLazyLoadOnDisposedContext" xml:space="preserve">
-    <value>An attempt was made to lazy-load navigation '{entityType}.{navigation}' after the associated DbContext was disposed.</value>
+    <value>An attempt was made to lazy-load navigation '{entityType}.{navigation}' after the associated DbContext was disposed or returned to the pool, or the entity was explicitly detached from the context.</value>
     <comment>Warning CoreEventId.LazyLoadOnDisposedContextWarning string string</comment>
   </data>
   <data name="LogManyServiceProvidersCreated" xml:space="preserve">

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -15,13 +15,16 @@ internal static class PropertyInfoExtensions
     public static bool IsStatic(this PropertyInfo property)
         => (property.GetMethod ?? property.SetMethod)!.IsStatic;
 
-    public static bool IsCandidateProperty(this PropertyInfo propertyInfo, bool needsWrite = true, bool publicOnly = true)
-        => !propertyInfo.IsStatic()
+    public static bool IsCandidateProperty(this MemberInfo memberInfo, bool needsWrite = true, bool publicOnly = true)
+        => memberInfo is PropertyInfo propertyInfo
+            ? !propertyInfo.IsStatic()
             && propertyInfo.CanRead
             && (!needsWrite || propertyInfo.FindSetterProperty() != null)
             && propertyInfo.GetMethod != null
             && (!publicOnly || propertyInfo.GetMethod.IsPublic)
-            && propertyInfo.GetIndexParameters().Length == 0;
+            && propertyInfo.GetIndexParameters().Length == 0
+            : memberInfo is FieldInfo { IsStatic: false } fieldInfo
+            && (!publicOnly || fieldInfo.IsPublic);
 
     public static bool IsIndexerProperty(this PropertyInfo propertyInfo)
     {

--- a/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
@@ -208,7 +208,7 @@ public class WarningsTest
                 loggerFactory.Log.Select(l => l.Message));
 
             var entityEntry = context.Entry(entity);
-            var loaded = entityEntry.Navigation("Nav").IsLoaded;
+            Assert.True(entityEntry.Navigation("Nav").IsLoaded);
             loggerFactory.Clear();
             Assert.NotNull(entity.Nav);
             Assert.DoesNotContain(

--- a/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
@@ -207,6 +207,8 @@ public class WarningsTest
                     .GenerateMessage("WarningAsErrorEntity", "Nav"),
                 loggerFactory.Log.Select(l => l.Message));
 
+            var entityEntry = context.Entry(entity);
+            var loaded = entityEntry.Navigation("Nav").IsLoaded;
             loggerFactory.Clear();
             Assert.NotNull(entity.Nav);
             Assert.DoesNotContain(

--- a/test/EFCore.Specification.Tests/F1FixtureBase.cs
+++ b/test/EFCore.Specification.Tests/F1FixtureBase.cs
@@ -234,10 +234,7 @@ public abstract class F1FixtureBase<TRowVersion> : SharedStoreFixtureBase<F1Cont
 
         if (loaderField != null)
         {
-            var loaderProperty = typeof(TLoaderEntity) == typeof(TEntity)
-                ? entityType.AddServiceProperty(loaderField!, ConfigurationSource.Explicit)
-                : entityType.FindServiceProperty(loaderField.Name)!;
-
+            var loaderProperty = entityType.FindServiceProperty(loaderField.Name)!;
             parameterBindings.Add(new DependencyInjectionParameterBinding(typeof(ILazyLoader), typeof(ILazyLoader), loaderProperty));
         }
 

--- a/test/EFCore.Specification.Tests/FieldsOnlyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldsOnlyLoadTestBase.cs
@@ -3517,8 +3517,8 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
     public virtual async Task Load_many_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state, bool async)
     {
         using var context = CreateContext();
-        var child = context.Attach(
-            new ChildShadowFk { Id = 767 }).Entity;
+        var child = context.Attach(new ChildShadowFk { Id = 767 }).Entity;
+        context.Entry(child).Property("ParentId").CurrentValue = null;
 
         ClearLog();
 
@@ -3555,8 +3555,8 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
     public virtual async Task Load_one_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state, bool async)
     {
         using var context = CreateContext();
-        var single = context.Attach(
-            new SingleShadowFk { Id = 767 }).Entity;
+        var single = context.Attach(new SingleShadowFk { Id = 767 }).Entity;
+        context.Entry(single).Property("ParentId").CurrentValue = null;
 
         ClearLog();
 
@@ -3594,8 +3594,8 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
     public virtual async Task Load_many_to_one_reference_to_principal_using_Query_null_FK_shadow_fk(EntityState state, bool async)
     {
         using var context = CreateContext();
-        var child = context.Attach(
-            new ChildShadowFk { Id = 767 }).Entity;
+        var child = context.Attach(new ChildShadowFk { Id = 767 }).Entity;
+        context.Entry(child).Property("ParentId").CurrentValue = null;
 
         ClearLog();
 
@@ -3629,8 +3629,8 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
     public virtual async Task Load_one_to_one_reference_to_principal_using_Query_null_FK_shadow_fk(EntityState state, bool async)
     {
         using var context = CreateContext();
-        var single = context.Attach(
-            new SingleShadowFk { Id = 767 }).Entity;
+        var single = context.Attach(new SingleShadowFk { Id = 767 }).Entity;
+        context.Entry(single).Property("ParentId").CurrentValue = null;
 
         ClearLog();
 
@@ -4224,20 +4224,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Children), nameof(Parent)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await collectionEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        collectionEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await collectionEntry.LoadAsync();
+        }
+        else
+        {
+            collectionEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4257,20 +4251,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Children), nameof(Parent)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await collectionEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        collectionEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await collectionEntry.LoadAsync();
+        }
+        else
+        {
+            collectionEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4290,20 +4278,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Children), nameof(Parent)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await collectionEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        collectionEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await collectionEntry.LoadAsync();
+        }
+        else
+        {
+            collectionEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4323,20 +4305,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(child).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Child.Parent), nameof(Child)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await referenceEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        referenceEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await referenceEntry.LoadAsync();
+        }
+        else
+        {
+            referenceEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4356,20 +4332,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(child).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Child.Parent), nameof(Child)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await referenceEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        referenceEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await referenceEntry.LoadAsync();
+        }
+        else
+        {
+            referenceEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4389,20 +4359,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(child).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Child.Parent), nameof(Child)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await referenceEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        referenceEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await referenceEntry.LoadAsync();
+        }
+        else
+        {
+            referenceEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4422,20 +4386,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Single), nameof(Parent)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await referenceEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        referenceEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await referenceEntry.LoadAsync();
+        }
+        else
+        {
+            referenceEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4455,20 +4413,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Single), nameof(Parent)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await referenceEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        referenceEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await referenceEntry.LoadAsync();
+        }
+        else
+        {
+            referenceEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4488,20 +4440,14 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Single), nameof(Parent)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await referenceEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        referenceEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await referenceEntry.LoadAsync();
+        }
+        else
+        {
+            referenceEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -4519,9 +4465,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Children), nameof(Parent)),
-            Assert.Throws<InvalidOperationException>(() => collectionEntry.Query()).Message);
+        var query = collectionEntry.Query();
     }
 
     [ConditionalTheory]
@@ -4539,9 +4483,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Children), nameof(Parent)),
-            Assert.Throws<InvalidOperationException>(() => collectionEntry.Query()).Message);
+        var query = collectionEntry.Query();
     }
 
     [ConditionalTheory]
@@ -4559,9 +4501,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Children), nameof(Parent)),
-            Assert.Throws<InvalidOperationException>(() => collectionEntry.Query()).Message);
+        var query = collectionEntry.Query();
     }
 
     [ConditionalTheory]
@@ -4579,9 +4519,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(child).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Child.Parent), nameof(Child)),
-            Assert.Throws<InvalidOperationException>(() => referenceEntry.Query()).Message);
+        var query = referenceEntry.Query();
     }
 
     [ConditionalTheory]
@@ -4599,9 +4537,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(child).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Child.Parent), nameof(Child)),
-            Assert.Throws<InvalidOperationException>(() => referenceEntry.Query()).Message);
+        var query = referenceEntry.Query();
     }
 
     [ConditionalTheory]
@@ -4619,9 +4555,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(child).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Child.Parent), nameof(Child)),
-            Assert.Throws<InvalidOperationException>(() => referenceEntry.Query()).Message);
+        var query = referenceEntry.Query();
     }
 
     [ConditionalTheory]
@@ -4639,9 +4573,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Single), nameof(Parent)),
-            Assert.Throws<InvalidOperationException>(() => referenceEntry.Query()).Message);
+        var query = referenceEntry.Query();
     }
 
     [ConditionalTheory]
@@ -4659,9 +4591,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Single), nameof(Parent)),
-            Assert.Throws<InvalidOperationException>(() => referenceEntry.Query()).Message);
+        var query = referenceEntry.Query();
     }
 
     [ConditionalTheory]
@@ -4679,9 +4609,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture> : IClassFixture<TFixture>
             context.Entry(parent).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(Parent.Single), nameof(Parent)),
-            Assert.Throws<InvalidOperationException>(() => referenceEntry.Query()).Message);
+        var query = referenceEntry.Query();
     }
 
     protected class Parent

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -3064,6 +3064,12 @@ public abstract class LazyLoadProxyTestBase<TFixture> : IClassFixture<TFixture>
             }
             set => _backing = value;
         }
+
+        public override bool Equals(object obj)
+            => throw new InvalidOperationException();
+
+        public override int GetHashCode()
+            => throw new InvalidOperationException();
     }
 
     public class Child

--- a/test/EFCore.Specification.Tests/ManyToManyFieldsLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyFieldsLoadTestBase.cs
@@ -643,20 +643,14 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture> : IClassFixture<TFi
             context.Entry(left).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(left.TwoSkip), nameof(EntityOne)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await collectionEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        collectionEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await collectionEntry.LoadAsync();
+        }
+        else
+        {
+            collectionEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -676,9 +670,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture> : IClassFixture<TFi
             context.Entry(left).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(left.TwoSkip), nameof(EntityOne)),
-            Assert.Throws<InvalidOperationException>(() => collectionEntry.Query()).Message);
+        var query = collectionEntry.Query();
     }
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
@@ -17,90 +17,116 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
     [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
     [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
     [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
     [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
     [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
     [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
     [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
     [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
     [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
     [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
     [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
     [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
     [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
     public virtual async Task Load_collection(EntityState state, QueryTrackingBehavior queryTrackingBehavior, bool async)
     {
         using var context = Fixture.CreateContext();
 
-        context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
         var collectionEntry = context.Entry(left).Collection(e => e.TwoSkip);
 
-        context.Entry(left).State = state;
+        SetState(context, left, state, queryTrackingBehavior);
 
         Assert.False(collectionEntry.IsLoaded);
 
-        if (ExpectLazyLoading)
+        if (ExpectLazyLoading
+            && state == EntityState.Detached
+            && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
         {
-            Assert.Equal(7, left.TwoSkip.Count);
+            Assert.Null(left.TwoSkip);
         }
         else
         {
-            if (async)
+            if (ExpectLazyLoading)
             {
-                await collectionEntry.LoadAsync();
+                Assert.Equal(7, left.TwoSkip.Count);
             }
             else
             {
-                collectionEntry.Load();
+                if (async)
+                {
+                    await collectionEntry.LoadAsync();
+                }
+                else
+                {
+                    collectionEntry.Load();
+                }
+            }
+
+            Assert.True(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkip)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkip).IsLoaded);
+            }
+
+            RecordLog();
+
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(7, left.TwoSkip.Count);
+            foreach (var right in left.TwoSkip)
+            {
+                Assert.Contains(left, right.OneSkip);
             }
         }
 
-        Assert.True(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkip)
-        {
-            Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkip).IsLoaded);
-        }
-
-        RecordLog();
-        context.ChangeTracker.LazyLoadingEnabled = false;
-
-        Assert.Equal(7, left.TwoSkip.Count);
-        foreach (var right in left.TwoSkip)
-        {
-            Assert.Contains(left, right.OneSkip);
-        }
-
-        Assert.Equal(1 + 7 + 7, context.ChangeTracker.Entries().Count());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 7 + 7, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_using_Query(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
         var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
 
-        context.Entry(left).State = state;
+        SetState(context, left, state);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -117,15 +143,18 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         RecordLog();
         context.ChangeTracker.LazyLoadingEnabled = false;
 
-        Assert.Equal(3, left.TwoSkipShared.Count);
-        foreach (var right in left.TwoSkipShared)
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 3 + 3, context.ChangeTracker.Entries().Count());
+
+        if (state != EntityState.Detached)
         {
-            Assert.Contains(left, right.OneSkipShared);
+            Assert.Equal(3, left.TwoSkipShared.Count);
+            foreach (var right in left.TwoSkipShared)
+            {
+                Assert.Contains(left, right.OneSkipShared);
+            }
+
+            Assert.Equal(children, left.TwoSkipShared.ToList());
         }
-
-        Assert.Equal(children, left.TwoSkipShared.ToList());
-
-        Assert.Equal(1 + 3 + 3, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
@@ -199,10 +228,14 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_already_loaded(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
@@ -213,7 +246,12 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
 
         var collectionEntry = context.Entry(left).Collection(e => e.ThreeSkipPayloadFull);
 
-        context.Entry(left).State = state;
+        foreach (var two in left.ThreeSkipPayloadFull)
+        {
+            SetState(context, two, state);
+        }
+
+        SetState(context, left, state);
 
         Assert.True(collectionEntry.IsLoaded);
 
@@ -248,16 +286,20 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             Assert.Contains(left, right.OneSkipPayloadFull);
         }
 
-        Assert.Equal(1 + 4 + 4, context.ChangeTracker.Entries().Count());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 4 + 4, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_using_Query_already_loaded(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
@@ -268,7 +310,12 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
 
         var collectionEntry = context.Entry(left).Collection(e => e.TwoSkip);
 
-        context.Entry(left).State = state;
+        foreach (var two in left.TwoSkip)
+        {
+            SetState(context, two, state);
+        }
+
+        SetState(context, left, state);
 
         Assert.True(collectionEntry.IsLoaded);
 
@@ -291,84 +338,106 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             Assert.Contains(left, right.OneSkip);
         }
 
-        Assert.Equal(children, left.TwoSkip.ToList());
+        if (state == EntityState.Detached)
+        {
+            Assert.NotEqual(children, left.TwoSkip.ToList());
+        }
+        else
+        {
+            Assert.Equal(children, left.TwoSkip.ToList());
+        }
 
-        Assert.Equal(1 + 7 + 7, context.ChangeTracker.Entries().Count());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 7 + 7, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_untyped(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
         var navigationEntry = context.Entry(left).Navigation("TwoSkip");
 
-        context.Entry(left).State = state;
+        SetState(context, left, state);
 
         Assert.False(navigationEntry.IsLoaded);
 
-        if (ExpectLazyLoading)
+        if (ExpectLazyLoading && state == EntityState.Detached)
         {
-            Assert.Equal(7, left.TwoSkip.Count);
+            Assert.Null(left.TwoSkip);
         }
         else
         {
-            if (async)
+            if (ExpectLazyLoading)
             {
-                await navigationEntry.LoadAsync();
+                Assert.Equal(7, left.TwoSkip.Count);
             }
             else
             {
-                navigationEntry.Load();
+                if (async)
+                {
+                    await navigationEntry.LoadAsync();
+                }
+                else
+                {
+                    navigationEntry.Load();
+                }
+            }
+
+            Assert.True(navigationEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkip)
+            {
+                Assert.False(context.Entry((object)entityTwo).Collection("OneSkip").IsLoaded);
+            }
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(7, left.TwoSkip.Count);
+            foreach (var right in left.TwoSkip)
+            {
+                Assert.Contains(left, right.OneSkip);
             }
         }
 
-        Assert.True(navigationEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkip)
-        {
-            Assert.False(context.Entry((object)entityTwo).Collection("OneSkip").IsLoaded);
-        }
-
-        RecordLog();
-        context.ChangeTracker.LazyLoadingEnabled = false;
-
-        Assert.Equal(7, left.TwoSkip.Count);
-        foreach (var right in left.TwoSkip)
-        {
-            Assert.Contains(left, right.OneSkip);
-        }
-
-        Assert.Equal(1 + 7 + 7, context.ChangeTracker.Entries().Count());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 7 + 7, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_using_Query_untyped(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
         var collectionEntry = context.Entry(left).Navigation("TwoSkipShared");
 
-        context.Entry(left).State = state;
+        SetState(context, left, state);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -385,24 +454,31 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         RecordLog();
         context.ChangeTracker.LazyLoadingEnabled = false;
 
-        Assert.Equal(3, left.TwoSkipShared.Count);
-        foreach (var right in left.TwoSkipShared)
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 3 + 3, context.ChangeTracker.Entries().Count());
+
+        if (state != EntityState.Detached)
         {
-            Assert.Contains(left, right.OneSkipShared);
+            Assert.Equal(3, left.TwoSkipShared.Count);
+            foreach (var right in left.TwoSkipShared)
+            {
+                Assert.Contains(left, right.OneSkipShared);
+            }
+
+            Assert.Equal(children, left.TwoSkipShared.ToList());
         }
-
-        Assert.Equal(children, left.TwoSkipShared.ToList());
-
-        Assert.Equal(1 + 3 + 3, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_not_found_untyped(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
@@ -416,42 +492,54 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
 
         var navigationEntry = context.Entry(left).Navigation("TwoSkip");
 
-        context.Entry(left).State = state;
+        SetState(context, left, state);
 
         Assert.False(navigationEntry.IsLoaded);
 
-        if (ExpectLazyLoading)
+        if (ExpectLazyLoading && state == EntityState.Detached)
         {
-            Assert.Equal(0, left.TwoSkip.Count);
+            Assert.Null(left.TwoSkip);
         }
         else
         {
-            if (async)
+            if (ExpectLazyLoading)
             {
-                await navigationEntry.LoadAsync();
+                Assert.Equal(0, left.TwoSkip.Count);
             }
             else
             {
-                navigationEntry.Load();
+                if (async)
+                {
+                    await navigationEntry.LoadAsync();
+                }
+                else
+                {
+                    navigationEntry.Load();
+                }
             }
+
+            Assert.True(navigationEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Empty(left.TwoSkip);
         }
 
-        Assert.True(navigationEntry.IsLoaded);
-
-        RecordLog();
-        context.ChangeTracker.LazyLoadingEnabled = false;
-
-        Assert.Empty(left.TwoSkip);
-        Assert.Single(context.ChangeTracker.Entries());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_using_Query_not_found_untyped(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
@@ -465,7 +553,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
 
         var navigationEntry = context.Entry(left).Navigation("TwoSkip");
 
-        context.Entry(left).State = state;
+        SetState(context, left, state);
 
         Assert.False(navigationEntry.IsLoaded);
 
@@ -481,22 +569,30 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         Assert.Empty(children);
         Assert.Empty(left.TwoSkip);
 
-        Assert.Single(context.ChangeTracker.Entries());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true, CascadeTiming.Immediate)]
     [InlineData(EntityState.Unchanged, false, CascadeTiming.Immediate)]
+    [InlineData(EntityState.Added, true, CascadeTiming.Immediate)]
+    [InlineData(EntityState.Added, false, CascadeTiming.Immediate)]
     [InlineData(EntityState.Modified, true, CascadeTiming.Immediate)]
     [InlineData(EntityState.Modified, false, CascadeTiming.Immediate)]
     [InlineData(EntityState.Deleted, true, CascadeTiming.Immediate)]
     [InlineData(EntityState.Deleted, false, CascadeTiming.Immediate)]
+    [InlineData(EntityState.Detached, true, CascadeTiming.Immediate)]
+    [InlineData(EntityState.Detached, false, CascadeTiming.Immediate)]
     [InlineData(EntityState.Unchanged, true, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Unchanged, false, CascadeTiming.OnSaveChanges)]
+    [InlineData(EntityState.Added, true, CascadeTiming.OnSaveChanges)]
+    [InlineData(EntityState.Added, false, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Modified, true, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Modified, false, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Deleted, true, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Deleted, false, CascadeTiming.OnSaveChanges)]
+    [InlineData(EntityState.Detached, true, CascadeTiming.OnSaveChanges)]
+    [InlineData(EntityState.Detached, false, CascadeTiming.OnSaveChanges)]
     public virtual async Task Load_collection_already_loaded_untyped(EntityState state, bool async, CascadeTiming deleteOrphansTiming)
     {
         using var context = Fixture.CreateContext();
@@ -509,7 +605,12 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
 
         var navigationEntry = context.Entry(left).Navigation("ThreeSkipPayloadFull");
 
-        context.Entry(left).State = state;
+        foreach (var two in left.ThreeSkipPayloadFull)
+        {
+            SetState(context, two, state);
+        }
+
+        SetState(context, left, state);
 
         Assert.True(navigationEntry.IsLoaded);
 
@@ -544,22 +645,30 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             Assert.Contains(left, right.OneSkipPayloadFull);
         }
 
-        Assert.Equal(1 + 4 + 4, context.ChangeTracker.Entries().Count());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 4 + 4, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true, CascadeTiming.Immediate)]
     [InlineData(EntityState.Unchanged, false, CascadeTiming.Immediate)]
+    [InlineData(EntityState.Added, true, CascadeTiming.Immediate)]
+    [InlineData(EntityState.Added, false, CascadeTiming.Immediate)]
     [InlineData(EntityState.Modified, true, CascadeTiming.Immediate)]
     [InlineData(EntityState.Modified, false, CascadeTiming.Immediate)]
     [InlineData(EntityState.Deleted, true, CascadeTiming.Immediate)]
     [InlineData(EntityState.Deleted, false, CascadeTiming.Immediate)]
+    [InlineData(EntityState.Detached, true, CascadeTiming.Immediate)]
+    [InlineData(EntityState.Detached, false, CascadeTiming.Immediate)]
     [InlineData(EntityState.Unchanged, true, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Unchanged, false, CascadeTiming.OnSaveChanges)]
+    [InlineData(EntityState.Added, true, CascadeTiming.OnSaveChanges)]
+    [InlineData(EntityState.Added, false, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Modified, true, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Modified, false, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Deleted, true, CascadeTiming.OnSaveChanges)]
     [InlineData(EntityState.Deleted, false, CascadeTiming.OnSaveChanges)]
+    [InlineData(EntityState.Detached, true, CascadeTiming.OnSaveChanges)]
+    [InlineData(EntityState.Detached, false, CascadeTiming.OnSaveChanges)]
     public virtual async Task Load_collection_using_Query_already_loaded_untyped(
         EntityState state,
         bool async,
@@ -575,7 +684,12 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
 
         var navigationEntry = context.Entry(left).Navigation("TwoSkip");
 
-        context.Entry(left).State = state;
+        foreach (var two in left.TwoSkip)
+        {
+            SetState(context, two, state);
+        }
+
+        SetState(context, left, state);
 
         Assert.True(navigationEntry.IsLoaded);
 
@@ -599,84 +713,106 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             Assert.Contains(left, right.OneSkip);
         }
 
-        Assert.Equal(children, left.TwoSkip.ToList());
+        if (state == EntityState.Detached)
+        {
+            Assert.NotEqual(children, left.TwoSkip.ToList());
+        }
+        else
+        {
+            Assert.Equal(children, left.TwoSkip.ToList());
+        }
 
-        Assert.Equal(1 + 7 + 7, context.ChangeTracker.Entries().Count());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 7 + 7, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_composite_key(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityCompositeKey>().Find(7, "7_2", new DateTime(2007, 2, 1));
+        var left = context.Set<EntityCompositeKey>().Find(7, "7_2", new DateTime(2007, 2, 1))!;
 
         ClearLog();
 
         var collectionEntry = context.Entry(left).Collection(e => e.ThreeSkipFull);
 
-        context.Entry(left).State = state;
+        SetState(context, left, state);
 
         Assert.False(collectionEntry.IsLoaded);
 
-        if (ExpectLazyLoading)
+        if (ExpectLazyLoading && state == EntityState.Detached)
         {
-            Assert.Equal(2, left.ThreeSkipFull.Count);
+            Assert.Null(left.ThreeSkipFull);
         }
         else
         {
-            if (async)
+            if (ExpectLazyLoading)
             {
-                await collectionEntry.LoadAsync();
+                Assert.Equal(2, left.ThreeSkipFull.Count);
             }
             else
             {
-                collectionEntry.Load();
+                if (async)
+                {
+                    await collectionEntry.LoadAsync();
+                }
+                else
+                {
+                    collectionEntry.Load();
+                }
+            }
+
+            Assert.True(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.ThreeSkipFull)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.CompositeKeySkipFull).IsLoaded);
+            }
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, left.ThreeSkipFull.Count);
+            foreach (var right in left.ThreeSkipFull)
+            {
+                Assert.Contains(left, right.CompositeKeySkipFull);
             }
         }
 
-        Assert.True(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.ThreeSkipFull)
-        {
-            Assert.False(context.Entry(entityTwo).Collection(e => e.CompositeKeySkipFull).IsLoaded);
-        }
-
-        RecordLog();
-        context.ChangeTracker.LazyLoadingEnabled = false;
-
-        Assert.Equal(2, left.ThreeSkipFull.Count);
-        foreach (var right in left.ThreeSkipFull)
-        {
-            Assert.Contains(left, right.CompositeKeySkipFull);
-        }
-
-        Assert.Equal(1 + 2 + 2, context.ChangeTracker.Entries().Count());
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 2 + 2, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
     [InlineData(EntityState.Unchanged, true)]
     [InlineData(EntityState.Unchanged, false)]
+    [InlineData(EntityState.Added, true)]
+    [InlineData(EntityState.Added, false)]
     [InlineData(EntityState.Modified, true)]
     [InlineData(EntityState.Modified, false)]
     [InlineData(EntityState.Deleted, true)]
     [InlineData(EntityState.Deleted, false)]
+    [InlineData(EntityState.Detached, true)]
+    [InlineData(EntityState.Detached, false)]
     public virtual async Task Load_collection_using_Query_composite_key(EntityState state, bool async)
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityCompositeKey>().Find(7, "7_2", new DateTime(2007, 2, 1));
+        var left = context.Set<EntityCompositeKey>().Find(7, "7_2", new DateTime(2007, 2, 1))!;
 
         ClearLog();
 
         var collectionEntry = context.Entry(left).Collection(e => e.ThreeSkipFull);
 
-        context.Entry(left).State = state;
+        SetState(context, left, state);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -693,15 +829,18 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         RecordLog();
         context.ChangeTracker.LazyLoadingEnabled = false;
 
-        Assert.Equal(2, left.ThreeSkipFull.Count);
-        foreach (var right in left.ThreeSkipFull)
+        Assert.Equal(state == EntityState.Detached ? 0 : 1 + 2 + 2, context.ChangeTracker.Entries().Count());
+
+        if (state != EntityState.Detached)
         {
-            Assert.Contains(left, right.CompositeKeySkipFull);
+            Assert.Equal(2, left.ThreeSkipFull.Count);
+            foreach (var right in left.ThreeSkipFull)
+            {
+                Assert.Contains(left, right.CompositeKeySkipFull);
+            }
+
+            Assert.Equal(children, left.ThreeSkipFull.ToList());
         }
-
-        Assert.Equal(children, left.ThreeSkipFull.ToList());
-
-        Assert.Equal(1 + 2 + 2, context.ChangeTracker.Entries().Count());
     }
 
     [ConditionalTheory]
@@ -724,20 +863,14 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             context.Entry(left).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(left.TwoSkip), nameof(EntityOne)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await collectionEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        collectionEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await collectionEntry.LoadAsync();
+        }
+        else
+        {
+            collectionEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -757,9 +890,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             context.Entry(left).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(left.TwoSkip), nameof(EntityOne)),
-            Assert.Throws<InvalidOperationException>(() => collectionEntry.Query()).Message);
+        var query = collectionEntry.Query();
     }
 
     [ConditionalTheory]
@@ -769,7 +900,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
@@ -818,7 +949,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
@@ -857,7 +988,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
@@ -896,7 +1027,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
@@ -946,7 +1077,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
@@ -1002,7 +1133,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
     {
         using var context = Fixture.CreateContext();
 
-        var left = context.Set<EntityOne>().Find(3);
+        var left = context.Set<EntityOne>().Find(3)!;
 
         ClearLog();
 
@@ -1078,6 +1209,18 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         {
             Assert.False(context.Entry(right).Collection(e => e.OneSkip).IsLoaded);
             Assert.Same(left, right.OneSkip.Single());
+        }
+    }
+
+    private static void SetState(
+        DbContext context,
+        object entity,
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
+    {
+        if (state != (queryTrackingBehavior == QueryTrackingBehavior.TrackAll ? EntityState.Unchanged : EntityState.Detached))
+        {
+            context.Entry(entity).State = state;
         }
     }
 

--- a/test/EFCore.Specification.Tests/UnidirectionalManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/UnidirectionalManyToManyLoadTestBase.cs
@@ -31,7 +31,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
     {
         using var context = Fixture.CreateContext();
 
-        context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
 
         var left = context.Set<UnidirectionalEntityOne>().Find(3);
 
@@ -721,20 +721,14 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
             context.Entry(left).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(left.TwoSkip), nameof(UnidirectionalEntityOne)),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    if (async)
-                    {
-                        await collectionEntry.LoadAsync();
-                    }
-                    else
-                    {
-                        collectionEntry.Load();
-                    }
-                })).Message);
+        if (async)
+        {
+            await collectionEntry.LoadAsync();
+        }
+        else
+        {
+            collectionEntry.Load();
+        }
     }
 
     [ConditionalTheory]
@@ -754,9 +748,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
             context.Entry(left).State = EntityState.Detached;
         }
 
-        Assert.Equal(
-            CoreStrings.CannotLoadDetached(nameof(left.TwoSkip), nameof(UnidirectionalEntityOne)),
-            Assert.Throws<InvalidOperationException>(() => collectionEntry.Query()).Message);
+        var query = collectionEntry.Query();
     }
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -486,22 +486,17 @@ public abstract class WithConstructorsTestBase<TFixture> : IClassFixture<TFixtur
         using (var context = CreateContext())
         {
             post = context.Set<LazyPropertyPost>().OrderBy(e => e.Id).First();
-
             Assert.NotNull(post.GetLoader());
-
             context.Entry(post).State = EntityState.Detached;
-
-            Assert.Null(post.GetLoader());
         }
 
+        Assert.NotNull(post.GetLoader());
         Assert.Null(post.LazyPropertyBlog);
 
         using (var context = CreateContext())
         {
             context.Attach(post);
-
             Assert.NotNull(post.GetLoader());
-
             Assert.NotNull(post.LazyPropertyBlog);
             Assert.Contains(post, post.LazyPropertyBlog.LazyPropertyPosts);
         }
@@ -560,22 +555,17 @@ public abstract class WithConstructorsTestBase<TFixture> : IClassFixture<TFixtur
         using (var context = CreateContext())
         {
             post = context.Set<LazyFieldPost>().OrderBy(e => e.Id).First();
-
             Assert.NotNull(post.GetLoader());
-
             context.Entry(post).State = EntityState.Detached;
-
-            Assert.Null(post.GetLoader());
         }
 
+        Assert.NotNull(post.GetLoader());
         Assert.Null(post.LazyFieldBlog);
 
         using (var context = CreateContext())
         {
             context.Attach(post);
-
             Assert.NotNull(post.GetLoader());
-
             Assert.NotNull(post.LazyFieldBlog);
             Assert.Contains(post, post.LazyFieldBlog.LazyFieldPosts);
         }
@@ -1665,26 +1655,9 @@ public abstract class WithConstructorsTestBase<TFixture> : IClassFixture<TFixtur
             modelBuilder.Entity<LazyPsBlog>();
             modelBuilder.Entity<LazyAsyncPsBlog>();
             modelBuilder.Entity<LazyPcsBlog>();
-
             modelBuilder.Entity<BlogAsImmutableRecord>();
-
-            // Manually configure service fields since there is no public API yet
-
-            var bindingFactories = context.GetService<IParameterBindingFactories>();
-
-            var blogServiceProperty = modelBuilder.Entity<LazyFieldBlog>().Metadata.AddServiceProperty(
-                typeof(LazyFieldBlog).GetRuntimeFields().Single(f => f.Name == "_loader"));
-
-            blogServiceProperty.ParameterBinding =
-                (ServiceParameterBinding)bindingFactories.FindFactory(typeof(ILazyLoader), "_loader")
-                    .Bind(blogServiceProperty.DeclaringEntityType, typeof(ILazyLoader), "_loader");
-
-            var postServiceProperty = modelBuilder.Entity<LazyFieldPost>().Metadata.AddServiceProperty(
-                typeof(LazyFieldPost).GetRuntimeFields().Single(f => f.Name == "_loader"));
-
-            postServiceProperty.ParameterBinding =
-                (ServiceParameterBinding)bindingFactories.FindFactory(typeof(ILazyLoader), "_loader")
-                    .Bind(postServiceProperty.DeclaringEntityType, typeof(ILazyLoader), "_loader");
+            modelBuilder.Entity<LazyFieldBlog>();
+            modelBuilder.Entity<LazyFieldPost>();
         }
 
         protected override void Seed(WithConstructorsContext context)

--- a/test/EFCore.Specification.Tests/test/EFCore.Specification.Tests/LazyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/test/EFCore.Specification.Tests/LazyLoadTestBase.cs
@@ -1,0 +1,5425 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public abstract partial class LoadTestBase<TFixture>
+{
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_collection(EntityState state, QueryTrackingBehavior queryTrackingBehavior, bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<Parent>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(await parent.LazyLoadChildren(async)); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.Children);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(collectionEntry.IsLoaded);
+
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, parent.Children.Count());
+        }
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 3, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_many_to_one_reference_to_principal(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<Child>().Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(await child.LazyLoadParent(async)); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(await child.LazyLoadParent(async));
+            }
+            else
+            {
+                Assert.NotNull(await child.LazyLoadParent(async));
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(child, child.Parent!.Children.Single());
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(child.Parent);
+                    Assert.Null(parent.Children);
+                }
+                else
+                {
+                    Assert.Same(parent, child.Parent);
+                    Assert.Same(child, parent.Children.Single());
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_principal(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<Single>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(await single.LazyLoadParent(async)); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(await single.LazyLoadParent(async));
+            }
+            else
+            {
+                Assert.NotNull(await single.LazyLoadParent(async));
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(single, single.Parent!.Single);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(single.Parent);
+                    Assert.Null(parent.Single);
+                }
+                else
+                {
+                    Assert.Same(parent, single.Parent);
+                    Assert.Same(single, parent.Single);
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_dependent(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<Parent>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(await parent.LazyLoadSingle(async)); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(await parent.LazyLoadSingle(async));
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(parent, parent.Single.Parent);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var single = context.ChangeTracker.Entries<Single>().Single().Entity;
+
+                Assert.Same(single, parent.Single);
+                Assert.Same(parent, single.Parent);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_PK_to_PK_reference_to_principal(EntityState state, QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SinglePkToPk>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(single.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(single.Parent);
+            }
+            else
+            {
+                Assert.NotNull(single.Parent);
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(single, single.Parent!.SinglePkToPk);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(single.Parent);
+                    Assert.Null(parent.SinglePkToPk);
+                }
+                else
+                {
+                    Assert.Same(parent, single.Parent);
+                    Assert.Same(single, parent.SinglePkToPk);
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(EntityState state, QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<Parent>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.SinglePkToPk);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.SinglePkToPk); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.SinglePkToPk);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(parent, parent.SinglePkToPk.Parent);
+
+            if (state != EntityState.Detached)
+            {
+                var single = context.ChangeTracker.Entries<SinglePkToPk>().Single().Entity;
+
+                Assert.Same(single, parent.SinglePkToPk);
+                Assert.Same(parent, single.Parent);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_many_to_one_reference_to_principal_null_FK(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new Child { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await child.LazyLoadParent(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_principal_null_FK(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new Single { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await single.LazyLoadParent(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_collection_not_found(EntityState state, QueryTrackingBehavior queryTrackingBehavior, bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new Parent { Id = 767, AlternateId = "NewRoot" }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached)
+        {
+            Assert.Null(await parent.LazyLoadChildren(async)); // Explicitly detached
+        }
+        else
+        {
+            Assert.Empty(await parent.LazyLoadChildren(async));
+            Assert.False(changeDetector.DetectChangesCalled);
+            Assert.True(collectionEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Single(context.ChangeTracker.Entries());
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_many_to_one_reference_to_principal_not_found(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new Child { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await child.LazyLoadParent(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_principal_not_found(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new Single { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await single.LazyLoadParent(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_dependent_not_found(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new Parent { Id = 767, AlternateId = "NewRoot" }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await parent.LazyLoadSingle(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Null(parent.Single);
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_collection_already_loaded(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<Parent>().Include(e => e.Children).Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.True(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(await parent.LazyLoadChildren(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(collectionEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(2, parent.Children.Count());
+
+        if (queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+            && state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Null(c));
+        }
+        else
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_collection_already_partially_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        var child = context.Set<Child>().OrderBy(e => e.Id).First();
+        var parent = context.Set<Parent>().Single();
+        if (parent.Children == null)
+        {
+            parent.Children = new List<Child> { child };
+            child.Parent = parent;
+        }
+
+        context.ChangeTracker.LazyLoadingEnabled = true;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(await parent.LazyLoadChildren(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        RecordLog();
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(collectionEntry.IsLoaded); // Explicitly detached
+            Assert.Equal(1, parent.Children.Count());
+
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+        }
+        else
+        {
+            Assert.True(collectionEntry.IsLoaded);
+
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            // Note that when detached there is no identity resolution, so loading results in duplicates
+            Assert.Equal(state == EntityState.Detached ? 3 : 2, parent.Children.Count());
+
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_many_to_one_reference_to_principal_already_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<Child>().Include(e => e.Parent).Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child.Parent, state, queryTrackingBehavior);
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(await child.LazyLoadParent(async));
+        }
+        else
+        {
+            Assert.True(referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(await child.LazyLoadParent(async));
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(child, child.Parent.Children.Single());
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                Assert.Same(parent, child.Parent);
+                Assert.Same(child, parent.Children.Single());
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_principal_already_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<Single>().Include(e => e.Parent).Single();
+
+        ClearLog();
+
+        SetState(context, single.Parent, state, queryTrackingBehavior);
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(await single.LazyLoadParent(async));
+        }
+        else
+        {
+            Assert.True(referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(await single.LazyLoadParent(async));
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(single, single.Parent.Single);
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                Assert.Same(parent, single.Parent);
+                Assert.Same(single, parent.Single);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_dependent_already_loaded(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<Parent>().Include(e => e.Single).Single();
+
+        ClearLog();
+
+        SetState(context, parent.Single, state, queryTrackingBehavior);
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(await parent.LazyLoadSingle(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        if (state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.Same(parent, parent.Single.Parent);
+        }
+
+        if (state != EntityState.Detached)
+        {
+            var single = context.ChangeTracker.Entries<Single>().Single().Entity;
+
+            Assert.Same(single, parent.Single);
+            Assert.Same(parent, single.Parent);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SinglePkToPk>().Include(e => e.Parent).Single();
+
+        ClearLog();
+
+        SetState(context, single.Parent, state, queryTrackingBehavior);
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(single.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        Assert.Same(single, single.Parent.SinglePkToPk);
+
+        if (state != EntityState.Detached)
+        {
+            var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+            Assert.Same(parent, single.Parent);
+            Assert.Same(single, parent.SinglePkToPk);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<Parent>().Include(e => e.SinglePkToPk).Single();
+
+        ClearLog();
+
+        SetState(context, parent.SinglePkToPk, state, queryTrackingBehavior);
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.SinglePkToPk);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.SinglePkToPk);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        Assert.Same(parent, parent.SinglePkToPk.Parent);
+
+        if (state != EntityState.Detached)
+        {
+            var single = context.ChangeTracker.Entries<SinglePkToPk>().Single().Entity;
+
+            Assert.Same(single, parent.SinglePkToPk);
+            Assert.Same(parent, single.Parent);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var child = context.Set<ChildAk>().Single(e => e.Id == 32);
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(child.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(child.Parent);
+            }
+            else
+            {
+                Assert.NotNull(child.Parent);
+            }
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(child, child.Parent!.ChildrenAk.Single());
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(child.Parent);
+                    Assert.Null(parent.ChildrenAk);
+                }
+                else
+                {
+                    Assert.Same(parent, child.Parent);
+                    Assert.Same(child, parent.ChildrenAk.Single());
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var single = context.Set<SingleAk>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(single.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(single.Parent);
+            }
+            else
+            {
+                Assert.NotNull(single.Parent);
+            }
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(single, single.Parent!.SingleAk);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(single.Parent);
+                    Assert.Null(parent.SingleAk);
+                }
+                else
+                {
+                    Assert.Same(parent, single.Parent);
+                    Assert.Same(single, parent.SingleAk);
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var parent = context.Set<Parent>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.SingleAk);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.SingleAk); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.SingleAk);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(parent, parent.SingleAk.Parent);
+
+            if (state != EntityState.Detached)
+            {
+                var single = context.ChangeTracker.Entries<SingleAk>().Single().Entity;
+
+                Assert.Same(single, parent.SingleAk);
+                Assert.Same(parent, single.Parent);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_null_FK_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var child = context.Attach(new ChildAk { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        Assert.Null(child.Parent);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_null_FK_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var single = context.Attach(new SingleAk { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        Assert.Null(single.Parent);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_shadow_fk(EntityState state, QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var parent = context.Set<Parent>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.ChildrenShadowFk);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.ChildrenShadowFk); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.ChildrenShadowFk);
+
+            Assert.True(collectionEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, parent.ChildrenShadowFk.Count());
+            Assert.All(parent.ChildrenShadowFk.Select(e => e.Parent), c => Assert.Same(parent, c));
+        }
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 3, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var child = context.Set<ChildShadowFk>().Single(e => e.Id == 52);
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(child.Parent); // Explicitly detached
+        }
+        else if (state == EntityState.Detached || queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Equal(
+                CoreStrings.CannotLoadDetachedShadow("Parent", "ChildShadowFk"),
+                Assert.Throws<InvalidOperationException>(() => child.Parent).Message);
+        }
+        else
+        {
+            var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+            Assert.False(referenceEntry.IsLoaded);
+
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(child.Parent);
+            }
+            else
+            {
+                Assert.NotNull(child.Parent);
+            }
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(child, child.Parent!.ChildrenShadowFk.Single());
+            }
+
+            var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(child.Parent);
+                Assert.Null(parent.ChildrenShadowFk);
+            }
+            else
+            {
+                Assert.Same(parent, child.Parent);
+                Assert.Same(child, parent.ChildrenShadowFk.Single());
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var single = context.Set<SingleShadowFk>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(single.Parent); // Explicitly detached
+        }
+        else if (state == EntityState.Detached || queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Equal(
+                CoreStrings.CannotLoadDetachedShadow("Parent", "SingleShadowFk"),
+                Assert.Throws<InvalidOperationException>(() => single.Parent).Message);
+        }
+        else
+        {
+            var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+            Assert.False(referenceEntry.IsLoaded);
+
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(single.Parent);
+            }
+            else
+            {
+                Assert.NotNull(single.Parent);
+            }
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(single, single.Parent!.SingleShadowFk);
+            }
+
+            var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(single.Parent);
+                Assert.Null(parent.SingleShadowFk);
+            }
+            else
+            {
+                Assert.Same(parent, single.Parent);
+                Assert.Same(single, parent.SingleShadowFk);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var parent = context.Set<Parent>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.SingleShadowFk);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.SingleShadowFk); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.SingleShadowFk);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(parent, parent.SingleShadowFk.Parent);
+
+            if (state != EntityState.Detached)
+            {
+                var single = context.ChangeTracker.Entries<SingleShadowFk>().Single().Entity;
+
+                Assert.Same(single, parent.SingleShadowFk);
+                Assert.Same(parent, single.Parent);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_null_FK_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var child = context.Attach(new ChildShadowFk { Id = 767 }).Entity;
+
+        if (queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            context.Entry(child).Property("ParentId").CurrentValue = null;
+        }
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        if (state == EntityState.Detached)
+        {
+            Assert.Null(child.Parent); // Explicitly detached
+        }
+        else if (queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Equal(
+                CoreStrings.CannotLoadDetachedShadow("Parent", "ChildShadowFk"),
+                Assert.Throws<InvalidOperationException>(() => child.Parent).Message);
+        }
+        else
+        {
+            var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+            Assert.False(referenceEntry.IsLoaded);
+
+            Assert.Null(child.Parent);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Single(context.ChangeTracker.Entries());
+            Assert.Null(child.Parent);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_null_FK_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var single = context.Attach(new SingleShadowFk { Id = 767 }).Entity;
+
+        if (queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            context.Entry(single).Property("ParentId").CurrentValue = null;
+        }
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        if (state == EntityState.Detached)
+        {
+            Assert.Null(single.Parent);
+        }
+        else if (queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Equal(
+                CoreStrings.CannotLoadDetachedShadow("Parent", "SingleShadowFk"),
+                Assert.Throws<InvalidOperationException>(() => single.Parent).Message);
+        }
+        else
+        {
+            var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+            Assert.False(referenceEntry.IsLoaded);
+
+            Assert.Null(single.Parent);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Single(context.ChangeTracker.Entries());
+
+            Assert.Null(single.Parent);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_composite_key(EntityState state, QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var parent = context.Set<Parent>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.ChildrenCompositeKey);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.ChildrenCompositeKey); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.ChildrenCompositeKey);
+
+            Assert.True(collectionEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, parent.ChildrenCompositeKey.Count());
+            Assert.All(parent.ChildrenCompositeKey.Select(e => e.Parent), c => Assert.Same(parent, c));
+        }
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 3, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var child = context.Set<ChildCompositeKey>().Single(e => e.Id == 52);
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(child.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(child.Parent);
+            }
+            else
+            {
+                Assert.NotNull(child.Parent);
+            }
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(child, child.Parent!.ChildrenCompositeKey.Single());
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(child.Parent);
+                    Assert.Null(parent.ChildrenCompositeKey);
+                }
+                else
+                {
+                    Assert.Same(parent, child.Parent);
+                    Assert.Same(child, parent.ChildrenCompositeKey.Single());
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var single = context.Set<SingleCompositeKey>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(single.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(single.Parent);
+            }
+            else
+            {
+                Assert.NotNull(single.Parent);
+            }
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(single, single.Parent!.SingleCompositeKey);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<Parent>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(single.Parent);
+                    Assert.Null(parent.SingleCompositeKey);
+                }
+                else
+                {
+                    Assert.Same(parent, single.Parent);
+                    Assert.Same(single, parent.SingleCompositeKey);
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var parent = context.Set<Parent>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.SingleCompositeKey);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.SingleCompositeKey); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.SingleCompositeKey);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(parent, parent.SingleCompositeKey.Parent);
+
+            if (state != EntityState.Detached)
+            {
+                var single = context.ChangeTracker.Entries<SingleCompositeKey>().Single().Entity;
+
+                Assert.Same(single, parent.SingleCompositeKey);
+                Assert.Same(parent, single.Parent);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_null_FK_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var child = context.Attach(new ChildCompositeKey { Id = 767, ParentId = 567 }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        Assert.Null(child.Parent);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_null_FK_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var single = context.Attach(new SingleCompositeKey { Id = 767, ParentAlternateId = "Boot" }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        Assert.Null(single.Parent);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_collection_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentFullLoaderByConstructor>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(await parent.LazyLoadChildren(async)); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(await parent.LazyLoadChildren(async));
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(collectionEntry.IsLoaded);
+
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, parent.Children.Count());
+        }
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 3, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_many_to_one_reference_to_principal_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<ChildFullLoaderByConstructor>().Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(await child.LazyLoadParent(async)); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(await child.LazyLoadParent(async));
+            }
+            else
+            {
+                Assert.NotNull(await child.LazyLoadParent(async));
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(child, child.Parent!.Children.Single());
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentFullLoaderByConstructor>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(child.Parent);
+                    Assert.Null(parent.Children);
+                }
+                else
+                {
+                    Assert.Same(parent, child.Parent);
+                    Assert.Same(child, parent.Children.Single());
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_principal_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SingleFullLoaderByConstructor>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(await single.LazyLoadParent(async)); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(await single.LazyLoadParent(async));
+            }
+            else
+            {
+                Assert.NotNull(await single.LazyLoadParent(async));
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(single, single.Parent!.Single);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentFullLoaderByConstructor>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(single.Parent);
+                    Assert.Null(parent.Single);
+                }
+                else
+                {
+                    Assert.Same(parent, single.Parent);
+                    Assert.Same(single, parent.Single);
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_dependent_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentFullLoaderByConstructor>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(await parent.LazyLoadSingle(async)); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(await parent.LazyLoadSingle(async));
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(parent, parent.Single.Parent);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var single = context.ChangeTracker.Entries<SingleFullLoaderByConstructor>().Single().Entity;
+
+                Assert.Same(single, parent.Single);
+                Assert.Same(parent, single.Parent);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_many_to_one_reference_to_principal_null_FK_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new ChildFullLoaderByConstructor { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await child.LazyLoadParent(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_principal_null_FK_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new SingleFullLoaderByConstructor { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await single.LazyLoadParent(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_collection_not_found_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new ParentFullLoaderByConstructor { Id = 767 }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached)
+        {
+            Assert.Null(await parent.LazyLoadChildren(async)); // Explicitly detached
+        }
+        else
+        {
+            Assert.Empty(await parent.LazyLoadChildren(async));
+            Assert.False(changeDetector.DetectChangesCalled);
+            Assert.True(collectionEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Single(context.ChangeTracker.Entries());
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_many_to_one_reference_to_principal_not_found_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new ChildFullLoaderByConstructor { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await child.LazyLoadParent(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_principal_not_found_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new SingleFullLoaderByConstructor { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await single.LazyLoadParent(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_dependent_not_found_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new ParentFullLoaderByConstructor { Id = 767 }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(await parent.LazyLoadSingle(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Null(parent.Single);
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_collection_already_loaded_full_loader_constructor_injection(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentFullLoaderByConstructor>().Include(e => e.Children).Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.True(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(await parent.LazyLoadChildren(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(collectionEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(2, parent.Children.Count());
+
+        if (queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+            && state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Null(c));
+        }
+        else
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_many_to_one_reference_to_principal_already_loaded_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<ChildFullLoaderByConstructor>().Include(e => e.Parent).Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child.Parent, state, queryTrackingBehavior);
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(await child.LazyLoadParent(async));
+        }
+        else
+        {
+            Assert.True(referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(await child.LazyLoadParent(async));
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(child, child.Parent.Children.Single());
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentFullLoaderByConstructor>().Single().Entity;
+
+                Assert.Same(parent, child.Parent);
+                Assert.Same(child, parent.Children.Single());
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_principal_already_loaded_full_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SingleFullLoaderByConstructor>().Include(e => e.Parent).Single();
+
+        ClearLog();
+
+        SetState(context, single.Parent, state, queryTrackingBehavior);
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(await single.LazyLoadParent(async));
+        }
+        else
+        {
+            Assert.True(referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(await single.LazyLoadParent(async));
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(single, single.Parent.Single);
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentFullLoaderByConstructor>().Single().Entity;
+
+                Assert.Same(parent, single.Parent);
+                Assert.Same(single, parent.Single);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, true)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution, false)]
+    public virtual async Task Lazy_load_one_to_one_reference_to_dependent_already_loaded_full_loader_constructor_injection(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentFullLoaderByConstructor>().Include(e => e.Single).Single();
+
+        ClearLog();
+
+        SetState(context, parent.Single, state, queryTrackingBehavior);
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(await parent.LazyLoadSingle(async));
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        if (state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.Same(parent, parent.Single.Parent);
+        }
+
+        if (state != EntityState.Detached)
+        {
+            var single = context.ChangeTracker.Entries<SingleFullLoaderByConstructor>().Single().Entity;
+
+            Assert.Same(single, parent.Single);
+            Assert.Same(parent, single.Parent);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderByConstructor>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Children);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(collectionEntry.IsLoaded);
+
+        Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(2, parent.Children.Count());
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 3, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<ChildDelegateLoaderByConstructor>().Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Deleted)
+        {
+            Assert.Null(child.Parent);
+        }
+        else
+        {
+            Assert.NotNull(child.Parent);
+        }
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        if (state != EntityState.Deleted)
+        {
+            Assert.Same(child, child.Parent!.Children.Single());
+        }
+
+        if (state != EntityState.Detached)
+        {
+            var parent = context.ChangeTracker.Entries<ParentDelegateLoaderByConstructor>().Single().Entity;
+
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(child.Parent);
+                Assert.Null(parent.Children);
+            }
+            else
+            {
+                Assert.Same(parent, child.Parent);
+                Assert.Same(child, parent.Children.Single());
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SingleDelegateLoaderByConstructor>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Deleted)
+        {
+            Assert.Null(single.Parent);
+        }
+        else
+        {
+            Assert.NotNull(single.Parent);
+        }
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        if (state != EntityState.Deleted)
+        {
+            Assert.Same(single, single.Parent!.Single);
+        }
+
+        if (state != EntityState.Detached)
+        {
+            var parent = context.ChangeTracker.Entries<ParentDelegateLoaderByConstructor>().Single().Entity;
+
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(single.Parent);
+                Assert.Null(parent.Single);
+            }
+            else
+            {
+                Assert.Same(parent, single.Parent);
+                Assert.Same(single, parent.Single);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderByConstructor>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Single);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        if (state != EntityState.Deleted)
+        {
+            Assert.Same(parent, parent.Single.Parent);
+        }
+
+        if (state != EntityState.Detached)
+        {
+            var single = context.ChangeTracker.Entries<SingleDelegateLoaderByConstructor>().Single().Entity;
+
+            Assert.Same(single, parent.Single);
+            Assert.Same(parent, single.Parent);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_null_FK_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new ChildDelegateLoaderByConstructor { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(child.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_null_FK_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new SingleDelegateLoaderByConstructor { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(single.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_not_found_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new ParentDelegateLoaderByConstructor { Id = 767 }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        // Delegate not set because delegate constructor not called
+        Assert.Null(parent.Children);
+        Assert.False(changeDetector.DetectChangesCalled);
+        Assert.False(collectionEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_not_found_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new ChildDelegateLoaderByConstructor { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(child.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_not_found_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new SingleDelegateLoaderByConstructor { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(single.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_not_found_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new ParentDelegateLoaderByConstructor { Id = 767 }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(parent.Single);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Null(parent.Single);
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_already_loaded_delegate_loader_constructor_injection(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderByConstructor>().Include(e => e.Children).Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Children);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        // Loader delegate has no way of recording loader state for untracked queries or detached entities
+        Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, collectionEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(2, parent.Children.Count());
+
+        if (queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+            && state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Null(c));
+        }
+        else
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_already_loaded_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<ChildDelegateLoaderByConstructor>().Include(e => e.Parent).Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child.Parent, state, queryTrackingBehavior);
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(child.Parent);
+        }
+        else
+        {
+            // Delegate loader cannot influence IsLoader flag
+            Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(child.Parent);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            // Delegate loader cannot influence IsLoader flag
+            Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(child, child.Parent.Children.Single());
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderByConstructor>().Single().Entity;
+
+                Assert.Same(parent, child.Parent);
+                Assert.Same(child, parent.Children.Single());
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_already_loaded_delegate_loader_constructor_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SingleDelegateLoaderByConstructor>().Include(e => e.Parent).Single();
+
+        ClearLog();
+
+        SetState(context, single.Parent, state, queryTrackingBehavior);
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(single.Parent);
+        }
+        else
+        {
+            Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(single.Parent);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(single, single.Parent.Single);
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderByConstructor>().Single().Entity;
+
+                Assert.Same(parent, single.Parent);
+                Assert.Same(single, parent.Single);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_already_loaded_delegate_loader_constructor_injection(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderByConstructor>().Include(e => e.Single).Single();
+
+        ClearLog();
+
+        SetState(context, parent.Single, state, queryTrackingBehavior);
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Single);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        if (state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.Same(parent, parent.Single.Parent);
+        }
+
+        if (state != EntityState.Detached)
+        {
+            var single = context.ChangeTracker.Entries<SingleDelegateLoaderByConstructor>().Single().Entity;
+
+            Assert.Same(single, parent.Single);
+            Assert.Same(parent, single.Parent);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderByProperty>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.Children); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.Children);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(collectionEntry.IsLoaded);
+
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, parent.Children.Count());
+        }
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 3, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<ChildDelegateLoaderByProperty>().Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(child.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(child.Parent);
+            }
+            else
+            {
+                Assert.NotNull(child.Parent);
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(child, child.Parent!.Children.Single());
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderByProperty>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(child.Parent);
+                    Assert.Null(parent.Children);
+                }
+                else
+                {
+                    Assert.Same(parent, child.Parent);
+                    Assert.Same(child, parent.Children.Single());
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SingleDelegateLoaderByProperty>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(single.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(single.Parent);
+            }
+            else
+            {
+                Assert.NotNull(single.Parent);
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(single, single.Parent!.Single);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderByProperty>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(single.Parent);
+                    Assert.Null(parent.Single);
+                }
+                else
+                {
+                    Assert.Same(parent, single.Parent);
+                    Assert.Same(single, parent.Single);
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderByProperty>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.Single); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.Single);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(parent, parent.Single.Parent);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var single = context.ChangeTracker.Entries<SingleDelegateLoaderByProperty>().Single().Entity;
+
+                Assert.Same(single, parent.Single);
+                Assert.Same(parent, single.Parent);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_null_FK_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new ChildDelegateLoaderByProperty { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(child.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_null_FK_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new SingleDelegateLoaderByProperty { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(single.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_not_found_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new ParentDelegateLoaderByProperty { Id = 767 }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached)
+        {
+            Assert.Null(parent.Children); // Explicitly detached
+        }
+        else
+        {
+            Assert.Empty(parent.Children);
+            Assert.False(changeDetector.DetectChangesCalled);
+            Assert.True(collectionEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Single(context.ChangeTracker.Entries());
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_not_found_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new ChildDelegateLoaderByProperty { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(child.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_not_found_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new SingleDelegateLoaderByProperty { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(single.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_not_found_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new ParentDelegateLoaderByProperty { Id = 767 }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(parent.Single);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Null(parent.Single);
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_already_loaded_delegate_loader_property_injection(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderByProperty>().Include(e => e.Children).Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        // Loader delegate has no way of recording loader state for untracked queries or detached entities
+        Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Children);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        // Loader delegate has no way of recording loader state for untracked queries or detached entities
+        Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, collectionEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(2, parent.Children.Count());
+
+        if (queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+            && state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Null(c));
+        }
+        else
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_already_loaded_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<ChildDelegateLoaderByProperty>().Include(e => e.Parent).Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child.Parent, state, queryTrackingBehavior);
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(child.Parent);
+        }
+        else
+        {
+            Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(child.Parent);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(child, child.Parent.Children.Single());
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderByProperty>().Single().Entity;
+
+                Assert.Same(parent, child.Parent);
+                Assert.Same(child, parent.Children.Single());
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_already_loaded_delegate_loader_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SingleDelegateLoaderByProperty>().Include(e => e.Parent).Single();
+
+        ClearLog();
+
+        SetState(context, single.Parent, state, queryTrackingBehavior);
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(single.Parent);
+        }
+        else
+        {
+            Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(single.Parent);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(single, single.Parent.Single);
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderByProperty>().Single().Entity;
+
+                Assert.Same(parent, single.Parent);
+                Assert.Same(single, parent.Single);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_already_loaded_delegate_loader_property_injection(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderByProperty>().Include(e => e.Single).Single();
+
+        ClearLog();
+
+        SetState(context, parent.Single, state, queryTrackingBehavior);
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Single);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(queryTrackingBehavior == QueryTrackingBehavior.TrackAll && state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        if (state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.Same(parent, parent.Single.Parent);
+        }
+
+        if (state != EntityState.Detached)
+        {
+            var single = context.ChangeTracker.Entries<SingleDelegateLoaderByProperty>().Single().Entity;
+
+            Assert.Same(single, parent.Single);
+            Assert.Same(parent, single.Parent);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual void Lazy_loading_uses_field_access_when_abstract_base_class_navigation()
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        var product = context.Set<SimpleProduct>().Single();
+        var deposit = product.Deposit;
+
+        Assert.NotNull(deposit);
+        Assert.Same(deposit, product.Deposit);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
@@ -16,7 +16,9 @@ public class LazyLoadProxySqlServerTest : LazyLoadProxyTestBase<LazyLoadProxySql
         base.Lazy_load_collection(state, useAttach, useDetach);
 
         AssertSql(
-"""
+            state == EntityState.Detached && useAttach
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -30,10 +32,12 @@ WHERE [c].[ParentId] = @__p_0
         base.Lazy_load_many_to_one_reference_to_principal(state, useAttach, useDetach);
 
         AssertSql(
-"""
+            state == EntityState.Detached && useAttach
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -44,10 +48,12 @@ WHERE [p].[Id] = @__p_0
         base.Lazy_load_one_to_one_reference_to_principal(state, useAttach, useDetach);
 
         AssertSql(
-"""
+            state == EntityState.Detached && useAttach
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -58,10 +64,12 @@ WHERE [p].[Id] = @__p_0
         base.Lazy_load_one_to_one_reference_to_dependent(state, useAttach, useDetach);
 
         AssertSql(
-"""
+            state == EntityState.Detached && useAttach
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -72,10 +80,10 @@ WHERE [s].[ParentId] = @__p_0
         base.Lazy_load_one_to_one_PK_to_PK_reference_to_principal(state);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -86,10 +94,10 @@ WHERE [p].[Id] = @__p_0
         base.Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(state);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
-SELECT [s].[Id]
+SELECT TOP(1) [s].[Id]
 FROM [SinglePkToPk] AS [s]
 WHERE [s].[Id] = @__p_0
 """);
@@ -114,7 +122,7 @@ WHERE [s].[Id] = @__p_0
         base.Lazy_load_collection_not_found(state);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -128,10 +136,10 @@ WHERE [c].[ParentId] = @__p_0
         base.Lazy_load_many_to_one_reference_to_principal_not_found(state);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -142,10 +150,10 @@ WHERE [p].[Id] = @__p_0
         base.Lazy_load_one_to_one_reference_to_principal_not_found(state);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -156,10 +164,10 @@ WHERE [p].[Id] = @__p_0
         base.Lazy_load_one_to_one_reference_to_dependent_not_found(state);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -216,10 +224,10 @@ WHERE [s].[ParentId] = @__p_0
         base.Lazy_load_many_to_one_reference_to_principal_alternate_key(state);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0
 """);
@@ -230,10 +238,10 @@ WHERE [p].[AlternateId] = @__p_0
         base.Lazy_load_one_to_one_reference_to_principal_alternate_key(state);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0
 """);
@@ -244,10 +252,10 @@ WHERE [p].[AlternateId] = @__p_0
         base.Lazy_load_one_to_one_reference_to_dependent_alternate_key(state);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -272,7 +280,7 @@ WHERE [s].[ParentId] = @__p_0
         base.Lazy_load_collection_shadow_fk(state);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -286,10 +294,12 @@ WHERE [c].[ParentId] = @__p_0
         base.Lazy_load_many_to_one_reference_to_principal_shadow_fk(state);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -300,10 +310,12 @@ WHERE [p].[Id] = @__p_0
         base.Lazy_load_one_to_one_reference_to_principal_shadow_fk(state);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -314,10 +326,10 @@ WHERE [p].[Id] = @__p_0
         base.Lazy_load_one_to_one_reference_to_dependent_shadow_fk(state);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -342,7 +354,7 @@ WHERE [s].[ParentId] = @__p_0
         base.Lazy_load_collection_composite_key(state);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707' (Nullable = true)
 
@@ -357,11 +369,11 @@ WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
         base.Lazy_load_many_to_one_reference_to_principal_composite_key(state);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 """);
@@ -372,11 +384,11 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
         base.Lazy_load_one_to_one_reference_to_principal_composite_key(state);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707'
 
-SELECT [p].[Id], [p].[AlternateId], [p].[Discriminator]
+SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 """);
@@ -387,11 +399,11 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
         base.Lazy_load_one_to_one_reference_to_dependent_composite_key(state);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
 WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
 """);
@@ -418,7 +430,7 @@ WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
         if (!async)
         {
             AssertSql(
-"""
+                """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -434,14 +446,14 @@ WHERE [c].[ParentId] = @__p_0
         base.Top_level_projection_track_entities_before_passing_to_client_method();
 
         AssertSql(
-"""
+            """
 SELECT TOP(1) [p].[Id], [p].[AlternateId], [p].[Discriminator]
 FROM [Parent] AS [p]
 ORDER BY [p].[Id]
 
 @__p_0='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -452,7 +464,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Entity_equality_with_proxy_parameter(async);
 
         AssertSql(
-"""
+            """
 @__entity_equality_called_0_Id='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -473,10 +485,12 @@ WHERE [p].[Id] = @__entity_equality_called_0_Id
 
     private void AssertSql(string expected)
     {
+        expected ??= "";
+        var sql = Sql ?? "";
         try
         {
             Assert.Equal(
-                expected, Sql, ignoreLineEndingDifferences: true);
+                expected, sql, ignoreLineEndingDifferences: true);
         }
         catch
         {
@@ -501,7 +515,7 @@ WHERE [p].[Id] = @__entity_equality_called_0_Id
 
             var testInfo = testName + " : " + lineNumber + FileNewLine;
             var newBaseLine = $@"            AssertSql(
-                {"@\"" + Sql.Replace("\"", "\"\"") + "\""});
+                {"@\"" + sql.Replace("\"", "\"\"") + "\""});
 
 ";
 

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -11,12 +11,14 @@ public class LoadSqlServerTest : LoadTestBase<LoadSqlServerTest.LoadSqlServerFix
         fixture.TestSqlLoggerFactory.Clear();
     }
 
-    public override void Lazy_load_collection(EntityState state)
+    public override async Task Lazy_load_collection(EntityState state, QueryTrackingBehavior queryTrackingBehavior, bool async)
     {
-        base.Lazy_load_collection(state);
+        await base.Lazy_load_collection(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -25,96 +27,127 @@ WHERE [c].[ParentId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal(EntityState state)
+    public override async Task Lazy_load_many_to_one_reference_to_principal(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_many_to_one_reference_to_principal(state);
+        await base.Lazy_load_many_to_one_reference_to_principal(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal(EntityState state)
+    public override async Task Lazy_load_one_to_one_reference_to_principal(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_one_to_one_reference_to_principal(state);
+        await base.Lazy_load_one_to_one_reference_to_principal(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_dependent(EntityState state)
+    public override async Task Lazy_load_one_to_one_reference_to_dependent(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_one_to_one_reference_to_dependent(state);
+        await base.Lazy_load_one_to_one_reference_to_dependent(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_PK_to_PK_reference_to_principal(EntityState state)
+    public override void Lazy_load_one_to_one_PK_to_PK_reference_to_principal(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_PK_to_PK_reference_to_principal(state);
+        base.Lazy_load_one_to_one_PK_to_PK_reference_to_principal(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(EntityState state)
+    public override void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(state);
+        base.Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [s].[Id]
+SELECT TOP(1) [s].[Id]
 FROM [SinglePkToPk] AS [s]
 WHERE [s].[Id] = @__p_0
 """);
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal_null_FK(EntityState state)
+    public override async Task Lazy_load_many_to_one_reference_to_principal_null_FK(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_many_to_one_reference_to_principal_null_FK(state);
+        await base.Lazy_load_many_to_one_reference_to_principal_null_FK(state, queryTrackingBehavior, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal_null_FK(EntityState state)
+    public override async Task Lazy_load_one_to_one_reference_to_principal_null_FK(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_one_to_one_reference_to_principal_null_FK(state);
+        await base.Lazy_load_one_to_one_reference_to_principal_null_FK(state, queryTrackingBehavior, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_collection_not_found(EntityState state)
+    public override async Task Lazy_load_collection_not_found(EntityState state, QueryTrackingBehavior queryTrackingBehavior, bool async)
     {
-        base.Lazy_load_collection_not_found(state);
+        await base.Lazy_load_collection_not_found(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -123,154 +156,203 @@ WHERE [c].[ParentId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal_not_found(EntityState state)
+    public override async Task Lazy_load_many_to_one_reference_to_principal_not_found(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_many_to_one_reference_to_principal_not_found(state);
+        await base.Lazy_load_many_to_one_reference_to_principal_not_found(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='787'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal_not_found(EntityState state)
+    public override async Task Lazy_load_one_to_one_reference_to_principal_not_found(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_one_to_one_reference_to_principal_not_found(state);
+        await base.Lazy_load_one_to_one_reference_to_principal_not_found(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='787'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_dependent_not_found(EntityState state)
+    public override async Task Lazy_load_one_to_one_reference_to_dependent_not_found(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_one_to_one_reference_to_dependent_not_found(state);
+        await base.Lazy_load_one_to_one_reference_to_dependent_not_found(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='767' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_collection_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
-    {
-        base.Lazy_load_collection_already_loaded(state, cascadeDeleteTiming);
-
-        AssertSql(@"");
-    }
-
-    public override void Lazy_load_many_to_one_reference_to_principal_already_loaded(EntityState state)
-    {
-        base.Lazy_load_many_to_one_reference_to_principal_already_loaded(state);
-
-        AssertSql(@"");
-    }
-
-    public override void Lazy_load_one_to_one_reference_to_principal_already_loaded(EntityState state)
-    {
-        base.Lazy_load_one_to_one_reference_to_principal_already_loaded(state);
-
-        AssertSql(@"");
-    }
-
-    public override void Lazy_load_one_to_one_reference_to_dependent_already_loaded(
+    public override async Task Lazy_load_collection_already_loaded(
         EntityState state,
-        CascadeTiming cascadeDeleteTiming)
+        CascadeTiming cascadeDeleteTiming,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_one_to_one_reference_to_dependent_already_loaded(state, cascadeDeleteTiming);
+        await base.Lazy_load_collection_already_loaded(state, cascadeDeleteTiming, queryTrackingBehavior, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(EntityState state)
+    public override async Task Lazy_load_many_to_one_reference_to_principal_already_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(state);
+        await base.Lazy_load_many_to_one_reference_to_principal_already_loaded(state, queryTrackingBehavior, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(EntityState state)
+    public override async Task Lazy_load_one_to_one_reference_to_principal_already_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(state);
+        await base.Lazy_load_one_to_one_reference_to_principal_already_loaded(state, queryTrackingBehavior, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal_alternate_key(EntityState state)
+    public override async Task Lazy_load_one_to_one_reference_to_dependent_already_loaded(
+        EntityState state,
+        CascadeTiming cascadeDeleteTiming,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        base.Lazy_load_many_to_one_reference_to_principal_alternate_key(state);
+        await base.Lazy_load_one_to_one_reference_to_dependent_already_loaded(state, cascadeDeleteTiming, queryTrackingBehavior, async);
+
+        AssertSql();
+    }
+
+    public override void Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        base.Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(state, queryTrackingBehavior);
+
+        AssertSql();
+    }
+
+    public override void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        base.Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(state, queryTrackingBehavior);
+
+        AssertSql();
+    }
+
+    public override void Lazy_load_many_to_one_reference_to_principal_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        base.Lazy_load_many_to_one_reference_to_principal_alternate_key(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal_alternate_key(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_principal_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_principal_alternate_key(state);
+        base.Lazy_load_one_to_one_reference_to_principal_alternate_key(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_dependent_alternate_key(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_dependent_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_dependent_alternate_key(state);
+        base.Lazy_load_one_to_one_reference_to_dependent_alternate_key(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal_null_FK_alternate_key(EntityState state)
+    public override void Lazy_load_many_to_one_reference_to_principal_null_FK_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_many_to_one_reference_to_principal_null_FK_alternate_key(state);
+        base.Lazy_load_many_to_one_reference_to_principal_null_FK_alternate_key(state, queryTrackingBehavior);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal_null_FK_alternate_key(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_principal_null_FK_alternate_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_principal_null_FK_alternate_key(state);
+        base.Lazy_load_one_to_one_reference_to_principal_null_FK_alternate_key(state, queryTrackingBehavior);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_collection_shadow_fk(EntityState state)
+    public override void Lazy_load_collection_shadow_fk(EntityState state, QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_collection_shadow_fk(state);
+        base.Lazy_load_collection_shadow_fk(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -279,68 +361,86 @@ WHERE [c].[ParentId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal_shadow_fk(EntityState state)
+    public override void Lazy_load_many_to_one_reference_to_principal_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_many_to_one_reference_to_principal_shadow_fk(state);
+        base.Lazy_load_many_to_one_reference_to_principal_shadow_fk(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached || queryTrackingBehavior != QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal_shadow_fk(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_principal_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_principal_shadow_fk(state);
+        base.Lazy_load_one_to_one_reference_to_principal_shadow_fk(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached || queryTrackingBehavior != QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_dependent_shadow_fk(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_dependent_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_dependent_shadow_fk(state);
+        base.Lazy_load_one_to_one_reference_to_dependent_shadow_fk(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state)
+    public override void Lazy_load_many_to_one_reference_to_principal_null_FK_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_many_to_one_reference_to_principal_null_FK_shadow_fk(state);
+        base.Lazy_load_many_to_one_reference_to_principal_null_FK_shadow_fk(state, queryTrackingBehavior);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_principal_null_FK_shadow_fk(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_principal_null_FK_shadow_fk(state);
+        base.Lazy_load_one_to_one_reference_to_principal_null_FK_shadow_fk(state, queryTrackingBehavior);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_collection_composite_key(EntityState state)
+    public override void Lazy_load_collection_composite_key(EntityState state, QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_collection_composite_key(state);
+        base.Lazy_load_collection_composite_key(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 @__p_1='707' (Nullable = true)
 
@@ -350,63 +450,79 @@ WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
 """);
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal_composite_key(EntityState state)
+    public override void Lazy_load_many_to_one_reference_to_principal_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_many_to_one_reference_to_principal_composite_key(state);
+        base.Lazy_load_many_to_one_reference_to_principal_composite_key(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 @__p_1='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal_composite_key(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_principal_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_principal_composite_key(state);
+        base.Lazy_load_one_to_one_reference_to_principal_composite_key(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 @__p_1='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 """);
     }
 
-    public override void Lazy_load_one_to_one_reference_to_dependent_composite_key(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_dependent_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_dependent_composite_key(state);
+        base.Lazy_load_one_to_one_reference_to_dependent_composite_key(state, queryTrackingBehavior);
 
         AssertSql(
-"""
+            state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 @__p_1='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
 WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
 """);
     }
 
-    public override void Lazy_load_many_to_one_reference_to_principal_null_FK_composite_key(EntityState state)
+    public override void Lazy_load_many_to_one_reference_to_principal_null_FK_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_many_to_one_reference_to_principal_null_FK_composite_key(state);
+        base.Lazy_load_many_to_one_reference_to_principal_null_FK_composite_key(state, queryTrackingBehavior);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
-    public override void Lazy_load_one_to_one_reference_to_principal_null_FK_composite_key(EntityState state)
+    public override void Lazy_load_one_to_one_reference_to_principal_null_FK_composite_key(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
     {
-        base.Lazy_load_one_to_one_reference_to_principal_null_FK_composite_key(state);
+        base.Lazy_load_one_to_one_reference_to_principal_null_FK_composite_key(state, queryTrackingBehavior);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_collection(EntityState state, QueryTrackingBehavior queryTrackingBehavior, bool async)
@@ -414,7 +530,7 @@ WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
         await base.Load_collection(state, queryTrackingBehavior, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -428,10 +544,10 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -442,10 +558,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -456,10 +572,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -470,10 +586,10 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_one_to_one_PK_to_PK_reference_to_principal(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -484,10 +600,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_PK_to_PK_reference_to_dependent(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
-SELECT [s].[Id]
+SELECT TOP(1) [s].[Id]
 FROM [SinglePkToPk] AS [s]
 WHERE [s].[Id] = @__p_0
 """);
@@ -498,7 +614,7 @@ WHERE [s].[Id] = @__p_0
         await base.Load_collection_using_Query(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -512,7 +628,7 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -526,7 +642,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_using_Query(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -540,7 +656,9 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_using_Query(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
@@ -554,7 +672,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_one_to_one_PK_to_PK_reference_to_principal_using_Query(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -568,7 +686,9 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_PK_to_PK_reference_to_dependent_using_Query(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707'
 
 SELECT TOP(2) [s].[Id]
@@ -581,14 +701,14 @@ WHERE [s].[Id] = @__p_0
     {
         await base.Load_many_to_one_reference_to_principal_null_FK(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_reference_to_principal_null_FK(EntityState state, bool async)
     {
         await base.Load_one_to_one_reference_to_principal_null_FK(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_many_to_one_reference_to_principal_using_Query_null_FK(EntityState state, bool async)
@@ -596,7 +716,7 @@ WHERE [s].[Id] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_null_FK(state, async);
 
         AssertSql(
-"""
+            """
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE 0 = 1
@@ -608,7 +728,7 @@ WHERE 0 = 1
         await base.Load_one_to_one_reference_to_principal_using_Query_null_FK(state, async);
 
         AssertSql(
-"""
+            """
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE 0 = 1
@@ -620,7 +740,7 @@ WHERE 0 = 1
         await base.Load_collection_not_found(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -634,10 +754,10 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_not_found(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -648,10 +768,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_not_found(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -662,10 +782,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_not_found(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -676,7 +796,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_using_Query_not_found(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -690,7 +810,7 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_not_found(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -704,7 +824,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_using_Query_not_found(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -718,7 +838,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_using_Query_not_found(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
@@ -731,14 +851,14 @@ WHERE [s].[ParentId] = @__p_0
     {
         await base.Load_collection_already_loaded(state, async, cascadeDeleteTiming);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_many_to_one_reference_to_principal_already_loaded(EntityState state, bool async)
     {
         await base.Load_many_to_one_reference_to_principal_already_loaded(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_reference_to_principal_already_loaded(
@@ -748,7 +868,7 @@ WHERE [s].[ParentId] = @__p_0
     {
         await base.Load_one_to_one_reference_to_principal_already_loaded(state, async, cascadeDeleteTiming);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_reference_to_dependent_already_loaded(
@@ -758,21 +878,21 @@ WHERE [s].[ParentId] = @__p_0
     {
         await base.Load_one_to_one_reference_to_dependent_already_loaded(state, async, cascadeDeleteTiming);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(EntityState state, bool async)
     {
         await base.Load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(EntityState state, bool async)
     {
         await base.Load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_collection_using_Query_already_loaded(
@@ -783,7 +903,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_using_Query_already_loaded(state, async, cascadeDeleteTiming);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -797,7 +917,9 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_already_loaded(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Deleted
+                ? ""
+                : """
 @__p_0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -811,7 +933,9 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_using_Query_already_loaded(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Deleted
+                ? ""
+                : """
 @__p_0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -828,7 +952,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_using_Query_already_loaded(state, async, cascadeDeleteTiming);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
@@ -842,7 +966,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_one_to_one_PK_to_PK_reference_to_principal_using_Query_already_loaded(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -856,7 +980,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_PK_to_PK_reference_to_dependent_using_Query_already_loaded(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
 SELECT TOP(2) [s].[Id]
@@ -870,7 +994,7 @@ WHERE [s].[Id] = @__p_0
         await base.Load_collection_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -884,10 +1008,10 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -898,10 +1022,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -912,10 +1036,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -926,7 +1050,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_using_Query_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -940,7 +1064,7 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
 SELECT [p].[Id], [p].[AlternateId]
@@ -954,7 +1078,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_using_Query_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707'
 
 SELECT [p].[Id], [p].[AlternateId]
@@ -968,7 +1092,9 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_using_Query_untyped(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
 SELECT [s].[Id], [s].[ParentId]
@@ -982,7 +1108,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_not_found_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -996,10 +1122,10 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_not_found_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -1010,10 +1136,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_not_found_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -1024,10 +1150,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_not_found_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [Single] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -1038,7 +1164,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_using_Query_not_found_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -1052,7 +1178,7 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_not_found_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
 SELECT [p].[Id], [p].[AlternateId]
@@ -1066,7 +1192,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_using_Query_not_found_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='787'
 
 SELECT [p].[Id], [p].[AlternateId]
@@ -1080,7 +1206,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_using_Query_not_found_untyped(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='767' (Nullable = true)
 
 SELECT [s].[Id], [s].[ParentId]
@@ -1093,21 +1219,21 @@ WHERE [s].[ParentId] = @__p_0
     {
         await base.Load_collection_already_loaded_untyped(state, async, cascadeDeleteTiming);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_many_to_one_reference_to_principal_already_loaded_untyped(EntityState state, bool async)
     {
         await base.Load_many_to_one_reference_to_principal_already_loaded_untyped(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_reference_to_principal_already_loaded_untyped(EntityState state, bool async)
     {
         await base.Load_one_to_one_reference_to_principal_already_loaded_untyped(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_reference_to_dependent_already_loaded_untyped(
@@ -1117,7 +1243,7 @@ WHERE [s].[ParentId] = @__p_0
     {
         await base.Load_one_to_one_reference_to_dependent_already_loaded_untyped(state, async, cascadeDeleteTiming);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_collection_using_Query_already_loaded_untyped(
@@ -1128,7 +1254,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_using_Query_already_loaded_untyped(state, async, cascadeDeleteTiming);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -1142,7 +1268,9 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_already_loaded_untyped(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Deleted
+                ? ""
+                : """
 @__p_0='707'
 
 SELECT [p].[Id], [p].[AlternateId]
@@ -1156,7 +1284,9 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_using_Query_already_loaded_untyped(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Deleted
+                ? ""
+                : """
 @__p_0='707'
 
 SELECT [p].[Id], [p].[AlternateId]
@@ -1173,7 +1303,7 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_using_Query_already_loaded_untyped(state, async, cascadeDeleteTiming);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [s].[Id], [s].[ParentId]
@@ -1187,7 +1317,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -1201,10 +1331,10 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0
 """);
@@ -1215,10 +1345,10 @@ WHERE [p].[AlternateId] = @__p_0
         await base.Load_one_to_one_reference_to_principal_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0
 """);
@@ -1229,10 +1359,10 @@ WHERE [p].[AlternateId] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleAk] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -1243,7 +1373,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_using_Query_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -1257,7 +1387,7 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -1271,7 +1401,7 @@ WHERE [p].[AlternateId] = @__p_0
         await base.Load_one_to_one_reference_to_principal_using_Query_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -1285,7 +1415,9 @@ WHERE [p].[AlternateId] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_using_Query_alternate_key(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
@@ -1298,14 +1430,14 @@ WHERE [s].[ParentId] = @__p_0
     {
         await base.Load_many_to_one_reference_to_principal_null_FK_alternate_key(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_reference_to_principal_null_FK_alternate_key(EntityState state, bool async)
     {
         await base.Load_one_to_one_reference_to_principal_null_FK_alternate_key(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_many_to_one_reference_to_principal_using_Query_null_FK_alternate_key(EntityState state, bool async)
@@ -1313,7 +1445,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_null_FK_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE 0 = 1
@@ -1325,7 +1457,7 @@ WHERE 0 = 1
         await base.Load_one_to_one_reference_to_principal_using_Query_null_FK_alternate_key(state, async);
 
         AssertSql(
-"""
+            """
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE 0 = 1
@@ -1337,7 +1469,7 @@ WHERE 0 = 1
         await base.Load_collection_shadow_fk(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -1351,10 +1483,12 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_shadow_fk(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -1365,10 +1499,12 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_shadow_fk(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[Id] = @__p_0
 """);
@@ -1379,10 +1515,10 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_shadow_fk(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentId]
 FROM [SingleShadowFk] AS [s]
 WHERE [s].[ParentId] = @__p_0
 """);
@@ -1393,7 +1529,7 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_collection_using_Query_shadow_fk(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='707' (Nullable = true)
 
 SELECT [c].[Id], [c].[ParentId]
@@ -1407,7 +1543,9 @@ WHERE [c].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_shadow_fk(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -1421,7 +1559,9 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_principal_using_Query_shadow_fk(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707'
 
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
@@ -1435,7 +1575,9 @@ WHERE [p].[Id] = @__p_0
         await base.Load_one_to_one_reference_to_dependent_using_Query_shadow_fk(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='707' (Nullable = true)
 
 SELECT TOP(2) [s].[Id], [s].[ParentId]
@@ -1448,14 +1590,14 @@ WHERE [s].[ParentId] = @__p_0
     {
         await base.Load_many_to_one_reference_to_principal_null_FK_shadow_fk(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state, bool async)
     {
         await base.Load_one_to_one_reference_to_principal_null_FK_shadow_fk(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_many_to_one_reference_to_principal_using_Query_null_FK_shadow_fk(EntityState state, bool async)
@@ -1463,7 +1605,9 @@ WHERE [s].[ParentId] = @__p_0
         await base.Load_many_to_one_reference_to_principal_using_Query_null_FK_shadow_fk(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE 0 = 1
@@ -1475,7 +1619,9 @@ WHERE 0 = 1
         await base.Load_one_to_one_reference_to_principal_using_Query_null_FK_shadow_fk(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE 0 = 1
@@ -1487,7 +1633,7 @@ WHERE 0 = 1
         await base.Load_collection_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707' (Nullable = true)
 
@@ -1502,11 +1648,11 @@ WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
         await base.Load_many_to_one_reference_to_principal_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 """);
@@ -1517,11 +1663,11 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
         await base.Load_one_to_one_reference_to_principal_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707'
 
-SELECT [p].[Id], [p].[AlternateId]
+SELECT TOP(1) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
 """);
@@ -1532,11 +1678,11 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
         await base.Load_one_to_one_reference_to_dependent_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707' (Nullable = true)
 
-SELECT [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
+SELECT TOP(1) [s].[Id], [s].[ParentAlternateId], [s].[ParentId]
 FROM [SingleCompositeKey] AS [s]
 WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
 """);
@@ -1547,7 +1693,7 @@ WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
         await base.Load_collection_using_Query_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707' (Nullable = true)
 
@@ -1562,7 +1708,7 @@ WHERE [c].[ParentAlternateId] = @__p_0 AND [c].[ParentId] = @__p_1
         await base.Load_many_to_one_reference_to_principal_using_Query_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707'
 
@@ -1577,7 +1723,7 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
         await base.Load_one_to_one_reference_to_principal_using_Query_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 @__p_0='Root' (Size = 450)
 @__p_1='707'
 
@@ -1592,7 +1738,9 @@ WHERE [p].[AlternateId] = @__p_0 AND [p].[Id] = @__p_1
         await base.Load_one_to_one_reference_to_dependent_using_Query_composite_key(state, async);
 
         AssertSql(
-"""
+            state == EntityState.Detached
+                ? ""
+                : """
 @__p_0='Root' (Size = 450)
 @__p_1='707' (Nullable = true)
 
@@ -1606,14 +1754,14 @@ WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
     {
         await base.Load_many_to_one_reference_to_principal_null_FK_composite_key(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_one_to_one_reference_to_principal_null_FK_composite_key(EntityState state, bool async)
     {
         await base.Load_one_to_one_reference_to_principal_null_FK_composite_key(state, async);
 
-        AssertSql(@"");
+        AssertSql();
     }
 
     public override async Task Load_many_to_one_reference_to_principal_using_Query_null_FK_composite_key(EntityState state, bool async)
@@ -1621,7 +1769,7 @@ WHERE [s].[ParentAlternateId] = @__p_0 AND [s].[ParentId] = @__p_1
         await base.Load_many_to_one_reference_to_principal_using_Query_null_FK_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE 0 = 1
@@ -1633,7 +1781,7 @@ WHERE 0 = 1
         await base.Load_one_to_one_reference_to_principal_using_Query_null_FK_composite_key(state, async);
 
         AssertSql(
-"""
+            """
 SELECT TOP(2) [p].[Id], [p].[AlternateId]
 FROM [Parent] AS [p]
 WHERE 0 = 1
@@ -1649,12 +1797,14 @@ WHERE 0 = 1
     private const string FileNewLine = @"
 ";
 
-    private void AssertSql(string expected)
+    private void AssertSql(string expected = null)
     {
+        var sql = Sql ?? "";
+        expected ??= "";
         try
         {
             Assert.Equal(
-                expected, Sql, ignoreLineEndingDifferences: true);
+                expected, sql, ignoreLineEndingDifferences: true);
         }
         catch
         {
@@ -1679,7 +1829,7 @@ WHERE 0 = 1
 
             var testInfo = testName + " : " + lineNumber + FileNewLine;
             var newBaseLine = $@"            AssertSql(
-                {"@\"" + Sql.Replace("\"", "\"\"") + "\""});
+                {"@\"" + sql.Replace("\"", "\"\"") + "\""});
 
 ";
 

--- a/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
@@ -28,11 +28,8 @@ public class ServicePropertyDiscoveryConventionTest
             foreach (var entityType in entityTypes)
             {
                 ValidateServiceProperty<DbContext, DbContext>(entityType, "Context");
-                ValidateServiceProperty<DbContext, DbContext>(entityType, "Context2");
                 ValidateServiceProperty<IEntityType, IEntityType>(entityType, "EntityType");
-                ValidateServiceProperty<IEntityType, IEntityType>(entityType, "EntityType2");
                 ValidateServiceProperty<ILazyLoader, ILazyLoader>(entityType, "ALazyLoader");
-                ValidateServiceProperty<ILazyLoader, ILazyLoader>(entityType, "ALazyLoader2");
                 ValidateServiceProperty<Action<object, string>, ILazyLoader>(entityType, "LazyLoader");
 
                 var clrType = entityType.ClrType;
@@ -42,31 +39,22 @@ public class ServicePropertyDiscoveryConventionTest
                 }
 
                 var contextProperty = clrType.GetAnyProperty("Context");
-                var context2Property = clrType.GetAnyProperty("Context2");
                 var entityTypeProperty = clrType.GetAnyProperty("EntityType");
-                var entityType2Property = clrType.GetAnyProperty("EntityType2");
                 var lazyLoaderProperty = clrType.GetAnyProperty("ALazyLoader");
-                var lazyLoader2Property = clrType.GetAnyProperty("ALazyLoader2");
                 var lazyLoaderServiceProperty = clrType.GetAnyProperty("LazyLoader");
 
                 var entity = Activator.CreateInstance(entityType.ClrType);
 
                 Assert.Null(contextProperty!.GetValue(entity));
-                Assert.Null(context2Property!.GetValue(entity));
                 Assert.Null(entityTypeProperty!.GetValue(entity));
-                Assert.Null(entityType2Property!.GetValue(entity));
                 Assert.Null(lazyLoaderProperty!.GetValue(entity));
-                Assert.Null(lazyLoader2Property!.GetValue(entity));
                 Assert.Null(lazyLoaderServiceProperty!.GetValue(entity));
 
                 context.Add(entity!);
 
                 Assert.Same(context, contextProperty!.GetValue(entity));
-                Assert.Same(context, context2Property!.GetValue(entity));
                 Assert.Same(entityType, entityTypeProperty!.GetValue(entity));
-                Assert.Same(entityType, entityType2Property!.GetValue(entity));
                 Assert.NotNull(lazyLoaderProperty!.GetValue(entity));
-                Assert.NotNull(lazyLoader2Property!.GetValue(entity));
                 Assert.NotNull(lazyLoaderServiceProperty!.GetValue(entity));
             }
 
@@ -100,11 +88,8 @@ public class ServicePropertyDiscoveryConventionTest
                 }
 
                 Assert.Same(context, clrType.GetAnyProperty("Context")!.GetValue(entry.Entity));
-                Assert.Same(context, clrType.GetAnyProperty("Context2")!.GetValue(entry.Entity));
                 Assert.Same(entry.Metadata, clrType.GetAnyProperty("EntityType")!.GetValue(entry.Entity));
-                Assert.Same(entry.Metadata, clrType.GetAnyProperty("EntityType2")!.GetValue(entry.Entity));
                 Assert.NotNull(clrType.GetAnyProperty("ALazyLoader")!.GetValue(entry.Entity));
-                Assert.NotNull(clrType.GetAnyProperty("ALazyLoader2")!.GetValue(entry.Entity));
                 Assert.NotNull(clrType.GetAnyProperty("LazyLoader")!.GetValue(entry.Entity));
             }
         }
@@ -255,11 +240,8 @@ public class ServicePropertyDiscoveryConventionTest
                 {
                     // Because private properties on un-mapped base types are not found by convention
                     b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("Context")!);
-                    b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("Context2")!);
                     b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("EntityType")!);
-                    b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("EntityType2")!);
                     b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("ALazyLoader")!);
-                    b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("ALazyLoader2")!);
                     b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("LazyLoader")!);
                 });
     }
@@ -268,11 +250,8 @@ public class ServicePropertyDiscoveryConventionTest
     {
         public int Id { get; set; }
         private DbContext? Context { get; set; }
-        private DbContext? Context2 { get; set; }
         private IEntityType? EntityType { get; set; }
-        private IEntityType? EntityType2 { get; set; }
         private ILazyLoader? ALazyLoader { get; set; }
-        private ILazyLoader? ALazyLoader2 { get; set; }
         private Action<object, string>? LazyLoader { get; set; }
     }
 
@@ -288,11 +267,8 @@ public class ServicePropertyDiscoveryConventionTest
     {
         public int Id { get; set; }
         private DbContext? Context { get; set; }
-        private DbContext? Context2 { get; set; }
         private IEntityType? EntityType { get; set; }
-        private IEntityType? EntityType2 { get; set; }
         private ILazyLoader? ALazyLoader { get; set; }
-        private ILazyLoader? ALazyLoader2 { get; set; }
         private Action<object, string>? LazyLoader { get; set; }
     }
 
@@ -313,28 +289,19 @@ public class ServicePropertyDiscoveryConventionTest
         public PublicUnmappedBase(
             int id,
             DbContext? context,
-            DbContext? context2,
             IEntityType? entityType,
-            IEntityType? entityType2,
             ILazyLoader? aLazyLoader,
-            ILazyLoader? aLazyLoader2,
             Action<object, string>? lazyLoader)
         {
             Id = id;
             Context = context;
-            Context2 = context2;
             EntityType = entityType;
-            EntityType2 = entityType2;
             ALazyLoader = aLazyLoader;
-            ALazyLoader2 = aLazyLoader2;
             LazyLoader = lazyLoader;
 
             Assert.NotNull(context);
-            Assert.NotNull(context2);
             Assert.NotNull(entityType);
-            Assert.NotNull(entityType2);
             Assert.NotNull(aLazyLoader);
-            Assert.NotNull(aLazyLoader2);
             Assert.NotNull(lazyLoader);
 
             ConstructorCalled = true;
@@ -342,11 +309,8 @@ public class ServicePropertyDiscoveryConventionTest
 
         public int Id { get; set; }
         public DbContext? Context { get; set; }
-        public DbContext? Context2 { get; set; }
         public IEntityType? EntityType { get; set; }
-        public IEntityType? EntityType2 { get; set; }
         public ILazyLoader? ALazyLoader { get; set; }
-        public ILazyLoader? ALazyLoader2 { get; set; }
         public Action<object, string>? LazyLoader { get; set; }
 
         [NotMapped]
@@ -362,13 +326,10 @@ public class ServicePropertyDiscoveryConventionTest
         public PublicUnmappedBaseSuper(
             int id,
             DbContext? context,
-            DbContext? context2,
             IEntityType? entityType,
-            IEntityType? entityType2,
             ILazyLoader? aLazyLoader,
-            ILazyLoader? aLazyLoader2,
             Action<object, string>? lazyLoader)
-            : base(id, context, context2, entityType, entityType2, aLazyLoader, aLazyLoader2, lazyLoader)
+            : base(id, context, entityType, aLazyLoader, lazyLoader)
         {
         }
     }
@@ -382,13 +343,10 @@ public class ServicePropertyDiscoveryConventionTest
         public PublicUnmappedBaseSub(
             int id,
             DbContext? context,
-            DbContext? context2,
             IEntityType? entityType,
-            IEntityType? entityType2,
             ILazyLoader? aLazyLoader,
-            ILazyLoader? aLazyLoader2,
             Action<object, string>? lazyLoader)
-            : base(id, context, context2, entityType, entityType2, aLazyLoader, aLazyLoader2, lazyLoader)
+            : base(id, context, entityType, aLazyLoader, lazyLoader)
         {
         }
     }
@@ -397,11 +355,8 @@ public class ServicePropertyDiscoveryConventionTest
     {
         public int Id { get; set; }
         public DbContext? Context { get; set; }
-        public DbContext? Context2 { get; set; }
         public IEntityType? EntityType { get; set; }
-        public IEntityType? EntityType2 { get; set; }
         public ILazyLoader? ALazyLoader { get; set; }
-        public ILazyLoader? ALazyLoader2 { get; set; }
         public Action<object, string>? LazyLoader { get; set; }
     }
 
@@ -417,33 +372,24 @@ public class ServicePropertyDiscoveryConventionTest
     {
         public int Id { get; set; }
         private DbContext? Context { get; set; }
-        private DbContext? Context2 { get; set; }
         private IEntityType? EntityType { get; set; }
-        private IEntityType? EntityType2 { get; set; }
         private ILazyLoader? ALazyLoader { get; set; }
-        private ILazyLoader? ALazyLoader2 { get; set; }
         private Action<object, string>? LazyLoader { get; set; }
     }
 
     protected class PrivateWithDuplicatesSuper : PrivateWithDuplicatesBase
     {
         private DbContext? Context { get; set; }
-        private DbContext? Context2 { get; set; }
         private IEntityType? EntityType { get; set; }
-        private IEntityType? EntityType2 { get; set; }
         private ILazyLoader? ALazyLoader { get; set; }
-        private ILazyLoader? ALazyLoader2 { get; set; }
         private Action<object, string>? LazyLoader { get; set; }
     }
 
     protected class PrivateWithDuplicatesSub : PrivateWithDuplicatesSuper
     {
         private DbContext? Context { get; set; }
-        private DbContext? Context2 { get; set; }
         private IEntityType? EntityType { get; set; }
-        private IEntityType? EntityType2 { get; set; }
         private ILazyLoader? ALazyLoader { get; set; }
-        private ILazyLoader? ALazyLoader2 { get; set; }
         private Action<object, string>? LazyLoader { get; set; }
     }
 }


### PR DESCRIPTION
Part of #10042

Current limitations are:

- The lazy-loading delegate injection doesn't support tracking of when an navigation is loaded or not; I have an idea for this
- There is no identity resolution when the entities are not tracked, even if the query behavior is NoTrackingWithIdentityResolution
- The model should validated for only a single service property for a given type

I will submit PRs and/or file issues for these things.

