### PR TITLE
Identity resolution for loading detached entities

### DIFF
--- a/src/EFCore.Proxies/Proxies/Internal/ProxyFactory.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyFactory.cs
@@ -79,10 +79,7 @@ public class ProxyFactory : IProxyFactory
             throw new InvalidOperationException(ProxiesStrings.ProxyServicesMissing);
         }
 
-        return CreateLazyLoadingProxy(
-            entityType,
-            context.GetService<ILazyLoader>(),
-            constructorArguments);
+        return CreateLazyLoadingProxy(entityType, loader, constructorArguments);
     }
 
     private object CreateLazyLoadingProxy(

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-using System.Xml.Linq;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
@@ -308,7 +306,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     if (!trackingQuery)
                     {
                         fixup(entity, relatedEntity);
-                        if (inverseNavigation != null)
+                        if (inverseNavigation != null
+                            && !inverseNavigation.IsCollection)
                         {
                             inverseNavigation.SetIsLoadedWhenNoTracking(relatedEntity);
                         }
@@ -477,7 +476,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 // Execute and fetch data reader
                 var dataReader = await executionStrategy.ExecuteAsync(
                         (queryContext, relationalCommandCache, readerColumns, detailedErrorsEnabled),
-                        ((RelationalQueryContext, RelationalCommandCache, IReadOnlyList<ReaderColumn?>?, bool) tup, CancellationToken cancellationToken)
+                        (
+                                (RelationalQueryContext, RelationalCommandCache, IReadOnlyList<ReaderColumn?>?, bool) tup,
+                                CancellationToken cancellationToken)
                             => InitializeReaderAsync(tup.Item1, tup.Item2, tup.Item3, tup.Item4, cancellationToken),
                         verifySucceeded: null,
                         queryContext.CancellationToken)
@@ -800,7 +801,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 // Execute and fetch data reader
                 var dataReader = await executionStrategy.ExecuteAsync(
                         (queryContext, relationalCommandCache, readerColumns, detailedErrorsEnabled),
-                        ((RelationalQueryContext, RelationalCommandCache, IReadOnlyList<ReaderColumn?>?, bool) tup, CancellationToken cancellationToken)
+                        (
+                                (RelationalQueryContext, RelationalCommandCache, IReadOnlyList<ReaderColumn?>?, bool) tup,
+                                CancellationToken cancellationToken)
                             => InitializeReaderAsync(tup.Item1, tup.Item2, tup.Item3, tup.Item4, cancellationToken),
                         verifySucceeded: null,
                         queryContext.CancellationToken)
@@ -929,7 +932,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
             if (nullable)
             {
-                return default(TEntity);
+                return default;
             }
 
             throw new InvalidOperationException(
@@ -966,7 +969,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 return result;
             }
 
-            return default(TResult);
+            return default;
         }
 
         private static async Task TaskAwaiter(Func<Task>[] taskFactories)

--- a/src/EFCore/ChangeTracking/CollectionEntry.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry.cs
@@ -207,11 +207,20 @@ public class CollectionEntry : NavigationEntry
 
     /// <summary>
     ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to true.
+    ///     is already set to <see langword="true"/>.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Note that entities that are already being tracked are not overwritten with new data from the database.
+    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
+    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
+    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
+    ///         instances in the collection or inverse collection for any entities with the same key value.
+    ///         Use <see cref="LoadWithIdentityResolution" /> to avoid getting these duplicates.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadWithIdentityResolution" />. For entities that are not tracked, this method can be faster than
+    ///         <see cref="LoadWithIdentityResolution" />.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
@@ -224,17 +233,54 @@ public class CollectionEntry : NavigationEntry
 
         if (!IsLoaded)
         {
-            TargetLoader.Load(InternalEntry);
+            TargetLoader.Load(InternalEntry, forceIdentityResolution: false);
+        }
+    }
+
+    /// <summary>
+    ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
+    ///         This navigation and its inverse will not contain duplicate entities.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="Load" />. For entities that are not tracked, this method can be slower than <see cref="Load" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
+    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    public override void LoadWithIdentityResolution()
+    {
+        EnsureInitialized();
+
+        if (!IsLoaded)
+        {
+            TargetLoader.Load(InternalEntry, forceIdentityResolution: true);
         }
     }
 
     /// <summary>
     ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to true.
+    ///     is already set to <see langword="true"/>.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Note that entities that are already being tracked are not overwritten with new data from the database.
+    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
+    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
+    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
+    ///         instances in the collection or inverse collection for any entities with the same key value.
+    ///         Use <see cref="LoadWithIdentityResolutionAsync" /> to avoid getting these duplicates.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadWithIdentityResolutionAsync" />. For entities that are not tracked, this method can be faster than
+    ///         <see cref="LoadWithIdentityResolutionAsync" />.
     ///     </para>
     ///     <para>
     ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
@@ -254,7 +300,41 @@ public class CollectionEntry : NavigationEntry
 
         return IsLoaded
             ? Task.CompletedTask
-            : TargetLoader.LoadAsync(InternalEntry, cancellationToken);
+            : TargetLoader.LoadAsync(InternalEntry, forceIdentityResolution: false, cancellationToken);
+    }
+
+    /// <summary>
+    ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
+    ///         This navigation and its inverse will not contain duplicate entities.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadAsync" />. For entities that are not tracked, this method can be slower than <see cref="LoadAsync" />.
+    ///     </para>
+    ///     <para>
+    ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
+    ///         that any asynchronous operations have completed before calling another method on this context.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
+    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous save operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public override Task LoadWithIdentityResolutionAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureInitialized();
+
+        return IsLoaded
+            ? Task.CompletedTask
+            : TargetLoader.LoadAsync(InternalEntry, forceIdentityResolution: true, cancellationToken);
     }
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -132,6 +132,14 @@ public interface IStateManager : IResettableService
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    InternalEntityEntry? TryGetExistingEntry(object entity, IKey key);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     IEnumerable<InternalEntityEntry> Entries { get; }
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -418,6 +418,37 @@ public class StateManager : IStateManager
                 : entry
             : null;
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual InternalEntityEntry? TryGetExistingEntry(object entity, IKey key)
+    {
+        var keyValues = GetKeyValues();
+        return keyValues == null ? null : TryGetEntry(key, keyValues);
+
+        object[]? GetKeyValues()
+        {
+            var entry = GetOrCreateEntry(entity);
+            var properties = key.Properties;
+            var propertyValues = new object[properties.Count];
+            for (var i = 0; i < propertyValues.Length; i++)
+            {
+                var propertyValue = entry[properties[i]];
+                if (propertyValue == null)
+                {
+                    return null;
+                }
+
+                propertyValues[i] = propertyValue;
+            }
+
+            return propertyValues;
+        }
+    }
+
     private IIdentityMap GetOrCreateIdentityMap(IKey key)
     {
         if (_identityMap0 == null)

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -85,12 +85,21 @@ public abstract class NavigationEntry : MemberEntry
     }
 
     /// <summary>
-    ///     Loads the entity or entities referenced by this navigation property, unless <see cref="IsLoaded" />
-    ///     is already set to true.
+    ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Note that entities that are already being tracked are not overwritten with new data from the database.
+    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
+    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
+    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
+    ///         instances in the collection or inverse collection for any entities with the same key value.
+    ///         Use <see cref="LoadWithIdentityResolution" /> to avoid getting these duplicates.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadWithIdentityResolution" />. For entities that are not tracked, this method can be faster than
+    ///         <see cref="LoadWithIdentityResolution" />.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
@@ -100,12 +109,41 @@ public abstract class NavigationEntry : MemberEntry
     public abstract void Load();
 
     /// <summary>
-    ///     Loads the entity or entities referenced by this navigation property, unless <see cref="IsLoaded" />
-    ///     is already set to true.
+    ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Note that entities that are already being tracked are not overwritten with new data from the database.
+    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
+    ///         This navigation and its inverse will not contain duplicate entities.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="Load" />. For entities that are not tracked, this method can be slower than <see cref="Load" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
+    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    public abstract void LoadWithIdentityResolution();
+
+    /// <summary>
+    ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
+    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
+    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
+    ///         instances in the collection or inverse collection for any entities with the same key value.
+    ///         Use <see cref="LoadWithIdentityResolutionAsync" /> to avoid getting these duplicates.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadWithIdentityResolutionAsync" />. For entities that are not tracked, this method can be faster than
+    ///         <see cref="LoadWithIdentityResolutionAsync" />.
     ///     </para>
     ///     <para>
     ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
@@ -117,9 +155,36 @@ public abstract class NavigationEntry : MemberEntry
     ///     </para>
     /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <returns>A task that represents the asynchronous save operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     public abstract Task LoadAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
+    ///         This navigation and its inverse will not contain duplicate entities.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadAsync" />. For entities that are not tracked, this method can be slower than <see cref="LoadAsync" />.
+    ///     </para>
+    ///     <para>
+    ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
+    ///         that any asynchronous operations have completed before calling another method on this context.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
+    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous save operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public abstract Task LoadWithIdentityResolutionAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Returns the query that would be used by <see cref="Load" /> to load entities referenced by
@@ -155,7 +220,7 @@ public abstract class NavigationEntry : MemberEntry
     ///         It is possible for IsLoaded to be false even if all related entities are loaded. This is because, depending on
     ///         how entities are loaded, it is not always possible to know for sure that all entities in a related collection
     ///         have been loaded. In such cases, calling <see cref="Load" /> or <see cref="LoadAsync" /> will ensure all
-    ///         related entities are loaded and will set this flag to true.
+    ///         related entities are loaded and will set this flag to <see langword="true"/>.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
@@ -163,7 +228,7 @@ public abstract class NavigationEntry : MemberEntry
     ///     </para>
     /// </remarks>
     /// <value>
-    ///     <see langword="true" /> if all the related entities are loaded or the IsLoaded has been explicitly set to true.
+    ///     <see langword="true" /> if all the related entities are loaded or the IsLoaded has been explicitly set to <see langword="true"/>.
     /// </value>
     public virtual bool IsLoaded
     {

--- a/src/EFCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry.cs
@@ -76,12 +76,21 @@ public class ReferenceEntry : NavigationEntry
     }
 
     /// <summary>
-    ///     Loads the entity or entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to true.
+    ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Note that entities that are already being tracked are not overwritten with new data from the database.
+    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
+    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
+    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
+    ///         instances in the collection or inverse collection for any entities with the same key value.
+    ///         Use <see cref="LoadWithIdentityResolution" /> to avoid getting these duplicates.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadWithIdentityResolution" />. For entities that are not tracked, this method can be faster than
+    ///         <see cref="LoadWithIdentityResolution" />.
     ///     </para>
     ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
@@ -92,17 +101,52 @@ public class ReferenceEntry : NavigationEntry
     {
         if (!IsLoaded)
         {
-            TargetFinder.Load((INavigation)Metadata, InternalEntry);
+            TargetFinder.Load((INavigation)Metadata, InternalEntry, forceIdentityResolution: false);
         }
     }
 
     /// <summary>
-    ///     Loads the entity or entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to true.
+    ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Note that entities that are already being tracked are not overwritten with new data from the database.
+    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
+    ///         This navigation and its inverse will not contain duplicate entities.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="Load" />. For entities that are not tracked, this method can be slower than <see cref="Load" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
+    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    public override void LoadWithIdentityResolution()
+    {
+        if (!IsLoaded)
+        {
+            TargetFinder.Load((INavigation)Metadata, InternalEntry, forceIdentityResolution: true);
+        }
+    }
+
+    /// <summary>
+    ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
+    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
+    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
+    ///         instances in the collection or inverse collection for any entities with the same key value.
+    ///         Use <see cref="LoadWithIdentityResolutionAsync" /> to avoid getting these duplicates.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadWithIdentityResolutionAsync" />. For entities that are not tracked, this method can be faster than
+    ///         <see cref="LoadWithIdentityResolutionAsync" />.
     ///     </para>
     ///     <para>
     ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
@@ -114,12 +158,42 @@ public class ReferenceEntry : NavigationEntry
     ///     </para>
     /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <returns>A task that represents the asynchronous save operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
     public override Task LoadAsync(CancellationToken cancellationToken = default)
         => IsLoaded
             ? Task.CompletedTask
-            : TargetFinder.LoadAsync((INavigation)Metadata, InternalEntry, cancellationToken);
+            : TargetFinder.LoadAsync((INavigation)Metadata, InternalEntry, forceIdentityResolution: false, cancellationToken);
+
+    /// <summary>
+    ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+    ///     is already set to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
+    ///         This navigation and its inverse will not contain duplicate entities.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this method behaves in the same way and has the same performance as
+    ///         <see cref="LoadAsync" />. For entities that are not tracked, this method can be slower than <see cref="LoadAsync" />.
+    ///     </para>
+    ///     <para>
+    ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
+    ///         that any asynchronous operations have completed before calling another method on this context.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
+    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous save operation.</returns>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public override Task LoadWithIdentityResolutionAsync(CancellationToken cancellationToken = default)
+        => IsLoaded
+            ? Task.CompletedTask
+            : TargetFinder.LoadAsync((INavigation)Metadata, InternalEntry, forceIdentityResolution: true, cancellationToken);
 
     /// <summary>
     ///     Returns the query that would be used by <see cref="Load" /> to load entities referenced by

--- a/src/EFCore/Internal/EntityFinderCollectionLoaderAdapter.cs
+++ b/src/EFCore/Internal/EntityFinderCollectionLoaderAdapter.cs
@@ -34,8 +34,8 @@ public class EntityFinderCollectionLoaderAdapter : ICollectionLoader
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void Load(InternalEntityEntry entry)
-        => _entityFinder.Load(_navigation, entry);
+    public virtual void Load(InternalEntityEntry entry, bool forceIdentityResolution)
+        => _entityFinder.Load(_navigation, entry, forceIdentityResolution);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -43,8 +43,8 @@ public class EntityFinderCollectionLoaderAdapter : ICollectionLoader
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Task LoadAsync(InternalEntityEntry entry, CancellationToken cancellationToken = default)
-        => _entityFinder.LoadAsync(_navigation, entry, cancellationToken);
+    public virtual Task LoadAsync(InternalEntityEntry entry, bool forceIdentityResolution, CancellationToken cancellationToken = default)
+        => _entityFinder.LoadAsync(_navigation, entry, forceIdentityResolution, cancellationToken);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/ICollectionLoader.cs
+++ b/src/EFCore/Internal/ICollectionLoader.cs
@@ -19,7 +19,7 @@ public interface ICollectionLoader
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void Load(InternalEntityEntry entry);
+    void Load(InternalEntityEntry entry, bool forceIdentityResolution);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -27,7 +27,7 @@ public interface ICollectionLoader
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    Task LoadAsync(InternalEntityEntry entry, CancellationToken cancellationToken = default);
+    Task LoadAsync(InternalEntityEntry entry, bool forceIdentityResolution, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/IEntityFinder.cs
+++ b/src/EFCore/Internal/IEntityFinder.cs
@@ -83,7 +83,7 @@ public interface IEntityFinder
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void Load(INavigation navigation, InternalEntityEntry entry);
+    void Load(INavigation navigation, InternalEntityEntry entry, bool forceIdentityResolution);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -94,6 +94,7 @@ public interface IEntityFinder
     Task LoadAsync(
         INavigation navigation,
         InternalEntityEntry entry,
+        bool forceIdentityResolution,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/EFCore/Internal/IInjectableService.cs
+++ b/src/EFCore/Internal/IInjectableService.cs
@@ -17,6 +17,14 @@ namespace Microsoft.EntityFrameworkCore.Internal;
 public interface IInjectableService
 {
     /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    void ServiceObtained(DbContext context, ParameterBindingInfo bindingInfo);
+
+    /// <summary>
     ///     <para>
     ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -27,7 +35,7 @@ public interface IInjectableService
     ///         Called when the entity holding this service is being detached from a DbContext.
     ///     </para>
     /// </summary>
-    /// <param name="context">The <see cref="DbContext"/> instance.</param>
+    /// <param name="context">The <see cref="DbContext" /> instance.</param>
     /// <param name="entity">The entity instance that is being detached.</param>
     /// <returns><see langword="true" /> if the service property should be set to <see langword="null" />. </returns>
     bool Detaching(DbContext context, object entity);
@@ -43,7 +51,7 @@ public interface IInjectableService
     ///         Called when an entity that needs this is being attached to a DbContext.
     ///     </para>
     /// </summary>
-    /// <param name="context">The <see cref="DbContext"/> instance.</param>
+    /// <param name="context">The <see cref="DbContext" /> instance.</param>
     /// <param name="entity">The entity instance that is being attached.</param>
     /// <param name="existingService">
     ///     The existing instance of this service being held by the entity instance, or <see langword="null" /> if there

--- a/src/EFCore/Metadata/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/ContextParameterBinding.cs
@@ -29,14 +29,14 @@ public class ContextParameterBinding : ServiceParameterBinding
     ///     materialization expression to a parameter of the constructor, factory method, etc.
     /// </summary>
     /// <param name="materializationExpression">The expression representing the materialization context.</param>
-    /// <param name="entityTypeExpression">The expression representing the <see cref="IEntityType" /> constant.</param>
+    /// <param name="bindingInfoExpression">The expression representing the <see cref="ParameterBindingInfo" /> constant.</param>
     /// <returns>The expression tree.</returns>
     public override Expression BindToParameter(
         Expression materializationExpression,
-        Expression entityTypeExpression)
+        Expression bindingInfoExpression)
     {
         Check.NotNull(materializationExpression, nameof(materializationExpression));
-        Check.NotNull(entityTypeExpression, nameof(entityTypeExpression));
+        Check.NotNull(bindingInfoExpression, nameof(bindingInfoExpression));
 
         var propertyExpression
             = Expression.Property(
@@ -44,7 +44,7 @@ public class ContextParameterBinding : ServiceParameterBinding
                 MaterializationContext.ContextProperty);
 
         return ServiceType != typeof(DbContext)
-            ? (Expression)Expression.TypeAs(propertyExpression, ServiceType)
+            ? Expression.TypeAs(propertyExpression, ServiceType)
             : propertyExpression;
     }
 

--- a/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
@@ -43,14 +43,14 @@ public class DependencyInjectionMethodParameterBinding : DependencyInjectionPara
     ///     materialization expression to a parameter of the constructor, factory method, etc.
     /// </summary>
     /// <param name="materializationExpression">The expression representing the materialization context.</param>
-    /// <param name="entityTypeExpression">The expression representing the <see cref="IEntityType" /> constant.</param>
+    /// <param name="bindingInfoExpression">The expression representing the <see cref="ParameterBindingInfo" /> constant.</param>
     /// <returns>The expression tree.</returns>
     public override Expression BindToParameter(
         Expression materializationExpression,
-        Expression entityTypeExpression)
+        Expression bindingInfoExpression)
     {
         Check.NotNull(materializationExpression, nameof(materializationExpression));
-        Check.NotNull(entityTypeExpression, nameof(entityTypeExpression));
+        Check.NotNull(bindingInfoExpression, nameof(bindingInfoExpression));
 
         var parameters = Method.GetParameters().Select(
             (p, i) => Expression.Parameter(p.ParameterType, "param" + i)).ToArray();
@@ -64,7 +64,7 @@ public class DependencyInjectionMethodParameterBinding : DependencyInjectionPara
             {
                 Expression.Assign(
                     serviceVariable,
-                    base.BindToParameter(materializationExpression, entityTypeExpression)),
+                    base.BindToParameter(materializationExpression, bindingInfoExpression)),
                 Expression.Assign(
                     delegateVariable,
                     Expression.Condition(

--- a/src/EFCore/Metadata/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/EntityTypeParameterBinding.cs
@@ -26,12 +26,14 @@ public class EntityTypeParameterBinding : ServiceParameterBinding
     ///     materialization expression to a parameter of the constructor, factory method, etc.
     /// </summary>
     /// <param name="materializationExpression">The expression representing the materialization context.</param>
-    /// <param name="entityTypeExpression">The expression representing the <see cref="IEntityType" /> constant.</param>
+    /// <param name="bindingInfoExpression">The expression representing the <see cref="ParameterBindingInfo" /> constant.</param>
     /// <returns>The expression tree.</returns>
     public override Expression BindToParameter(
         Expression materializationExpression,
-        Expression entityTypeExpression)
-        => Check.NotNull(entityTypeExpression, nameof(entityTypeExpression));
+        Expression bindingInfoExpression)
+        => bindingInfoExpression.Type == typeof(IEntityType)
+            ? bindingInfoExpression
+            : Expression.Property(bindingInfoExpression, nameof(ParameterBindingInfo.EntityType));
 
     /// <summary>
     ///     Creates a copy that contains the given consumed properties.

--- a/src/EFCore/Metadata/ParameterBindingInfo.cs
+++ b/src/EFCore/Metadata/ParameterBindingInfo.cs
@@ -24,6 +24,22 @@ public readonly struct ParameterBindingInfo
         Check.NotNull(entityType, nameof(materializationContextExpression));
 
         EntityType = entityType;
+        EntityInstanceName = "instance";
+        MaterializationContextExpression = materializationContextExpression;
+    }
+
+    /// <summary>
+    ///     Creates a new <see cref="ParameterBindingInfo" /> to define a parameter binding.
+    /// </summary>
+    /// <param name="materializerSourceParameters">Parameters for the materialization that is happening.</param>
+    /// <param name="materializationContextExpression">The expression tree from which the parameter value will come.</param>
+    public ParameterBindingInfo(
+        EntityMaterializerSourceParameters materializerSourceParameters,
+        Expression materializationContextExpression)
+    {
+        EntityType = materializerSourceParameters.EntityType;
+        QueryTrackingBehavior = materializerSourceParameters.QueryTrackingBehavior;
+        EntityInstanceName = materializerSourceParameters.EntityInstanceName;
         MaterializationContextExpression = materializationContextExpression;
     }
 
@@ -31,6 +47,16 @@ public readonly struct ParameterBindingInfo
     ///     The entity type for this binding.
     /// </summary>
     public IEntityType EntityType { get; }
+
+    /// <summary>
+    ///     The name of the instance being materialized.
+    /// </summary>
+    public string EntityInstanceName { get; }
+
+    /// <summary>
+    ///     The query tracking behavior, or <see langword="null" /> if this materialization is not from a query.
+    /// </summary>
+    public QueryTrackingBehavior? QueryTrackingBehavior { get; }
 
     /// <summary>
     ///     The expression tree from which the parameter value will come.

--- a/src/EFCore/Metadata/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/ServiceParameterBinding.cs
@@ -49,18 +49,18 @@ public abstract class ServiceParameterBinding : ParameterBinding
     public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
         => BindToParameter(
             bindingInfo.MaterializationContextExpression,
-            Expression.Constant(bindingInfo.EntityType));
+            Expression.Constant(bindingInfo));
 
     /// <summary>
     ///     Creates an expression tree representing the binding of the value of a property from a
     ///     materialization expression to a parameter of the constructor, factory method, etc.
     /// </summary>
     /// <param name="materializationExpression">The expression representing the materialization context.</param>
-    /// <param name="entityTypeExpression">The expression representing the <see cref="IEntityType" /> constant.</param>
+    /// <param name="bindingInfoExpression">The expression representing the <see cref="ParameterBindingInfo" /> constant.</param>
     /// <returns>The expression tree.</returns>
     public abstract Expression BindToParameter(
         Expression materializationExpression,
-        Expression entityTypeExpression);
+        Expression bindingInfoExpression);
 
     /// <summary>
     ///     A delegate to set a CLR service property on an entity instance.
@@ -74,7 +74,12 @@ public abstract class ServiceParameterBinding : ParameterBinding
                 var entityParam = Expression.Parameter(typeof(object));
 
                 return Expression.Lambda<Func<MaterializationContext, IEntityType, object, object>>(
-                    b.BindToParameter(materializationContextParam, entityTypeParam),
+                    b.BindToParameter(
+                        materializationContextParam,
+                        Expression.New(
+                            typeof(ParameterBindingInfo).GetConstructor(new[] { typeof(IEntityType), typeof(Expression) })!,
+                            entityTypeParam,
+                            Expression.Constant(materializationContextParam))),
                     materializationContextParam,
                     entityTypeParam,
                     entityParam).Compile();

--- a/src/EFCore/Query/EntityMaterializerSourceParameters.cs
+++ b/src/EFCore/Query/EntityMaterializerSourceParameters.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     Parameter object for <see cref="IEntityMaterializerSource" />.
+/// </summary>
+public readonly record struct EntityMaterializerSourceParameters
+{
+    /// <summary>
+    ///     Creates a new <see cref="EntityMaterializerSourceParameters" />.
+    /// </summary>
+    /// <param name="entityType">The entity type being materialized.</param>
+    /// <param name="entityInstanceName">The name of the instance being materialized.</param>
+    /// <param name="queryTrackingBehavior">The query tracking behavior, or <see langword="null" /> if this materialization is not from a query.</param>
+    public EntityMaterializerSourceParameters(
+        IEntityType entityType,
+        string entityInstanceName,
+        QueryTrackingBehavior? queryTrackingBehavior)
+    {
+        EntityType = entityType;
+        EntityInstanceName = entityInstanceName;
+        QueryTrackingBehavior = queryTrackingBehavior;
+    }
+
+    /// <summary>
+    ///     The entity type being materialized.
+    /// </summary>
+    public IEntityType EntityType { get; }
+
+    /// <summary>
+    ///     The name of the instance being materialized.
+    /// </summary>
+    public string EntityInstanceName { get; }
+
+    /// <summary>
+    ///     The query tracking behavior, or <see langword="null" /> if this materialization is not from a query.
+    /// </summary>
+    public QueryTrackingBehavior? QueryTrackingBehavior { get; }
+}

--- a/src/EFCore/Query/IEntityMaterializerSource.cs
+++ b/src/EFCore/Query/IEntityMaterializerSource.cs
@@ -39,10 +39,30 @@ public interface IEntityMaterializerSource
     /// <param name="entityInstanceName">The name of the instance being materialized.</param>
     /// <param name="materializationExpression">The materialization expression to build on.</param>
     /// <returns>An expression to read the value.</returns>
+    [Obsolete("Use the overload that accepts an EntityMaterializerSourceParameters object.")]
     Expression CreateMaterializeExpression(
         IEntityType entityType,
         string entityInstanceName,
         Expression materializationExpression);
+
+    /// <summary>
+    ///     <para>
+    ///         Creates an <see cref="Expression" /> tree representing creating an entity instance.
+    ///     </para>
+    ///     <para>
+    ///         This method is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    /// <param name="parameters">Parameters for the entity being materialized.</param>
+    /// <param name="materializationExpression">The materialization expression to build on.</param>
+    /// <returns>An expression to read the value.</returns>
+    Expression CreateMaterializeExpression(
+        EntityMaterializerSourceParameters parameters,
+        Expression materializationExpression)
+#pragma warning disable CS0618
+        => CreateMaterializeExpression(parameters.EntityType, parameters.EntityInstanceName, materializationExpression);
+#pragma warning restore CS0618
 
     /// <summary>
     ///     <para>

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -579,7 +579,9 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             var blockExpressions = new List<Expression>(2);
 
             var materializer = _entityMaterializerSource
-                .CreateMaterializeExpression(concreteEntityType, "instance", materializationContextVariable);
+                .CreateMaterializeExpression(
+                    new EntityMaterializerSourceParameters(
+                        concreteEntityType, "instance", _queryTrackingBehavior), materializationContextVariable);
 
             if (_queryStateManager
                 && concreteEntityType.ShadowPropertyCount() > 0)

--- a/test/EFCore.Specification.Tests/LoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoadTestBase.cs
@@ -5607,7 +5607,7 @@ public abstract partial class LoadTestBase<TFixture> : IClassFixture<TFixture>
 
         public IEnumerable<ChildDelegateLoaderByConstructor> Children
         {
-            get => _children ?? _loader.Load(this, ref _children);
+            get => _loader.Load(this, ref _children);
             set => _children = value;
         }
 
@@ -5706,7 +5706,7 @@ public abstract partial class LoadTestBase<TFixture> : IClassFixture<TFixture>
 
         public IEnumerable<ChildDelegateLoaderByProperty> Children
         {
-            get => _children ?? LazyLoader.Load(this, ref _children);
+            get => LazyLoader.Load(this, ref _children);
             set => _children = value;
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
@@ -17,7 +17,27 @@ public class ManyToManyLoadSqlServerTest : ManyToManyLoadTestBase<ManyToManyLoad
         await base.Load_collection(state, queryTrackingBehavior, async);
 
         AssertSql(
+            state == EntityState.Detached
+                ? """
+@__p_0='3'
+
+SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[TwoId], [t0].[Id], [t0].[Name], [t0].[OneId], [t0].[TwoId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[ExtraId], [e0].[Name], [e0].[ReferenceInverseId], [j].[OneId], [j].[TwoId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[OneId]
+LEFT JOIN (
+    SELECT [e1].[Id], [e1].[Name], [j0].[OneId], [j0].[TwoId]
+    FROM [JoinOneToTwo] AS [j0]
+    INNER JOIN [EntityOnes] AS [e1] ON [j0].[OneId] = [e1].[Id]
+    WHERE [e1].[Id] = @__p_0
+) AS [t0] ON [t].[Id] = [t0].[TwoId]
+WHERE [e].[Id] = @__p_0
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t0].[OneId], [t0].[TwoId]
 """
+                : """
 @__p_0='3'
 
 SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[TwoId], [t0].[OneId], [t0].[TwoId], [t0].[JoinOneToTwoExtraId], [t0].[Id], [t0].[Name]
@@ -43,7 +63,7 @@ ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t0].[OneId], [t0].[TwoId
         await base.Load_collection_using_Query_with_Include_for_inverse(async);
 
         AssertSql(
-"""
+            """
 @__p_0='3'
 
 SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t0].[OneSkipSharedId], [t0].[TwoSkipSharedId], [t0].[Id], [t0].[Name]
@@ -69,7 +89,7 @@ ORDER BY [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t].[Id], [t0].
         await base.Load_collection_using_Query_with_Include_for_same_collection(async);
 
         AssertSql(
-"""
+            """
 @__p_0='3'
 
 SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t0].[OneSkipSharedId], [t0].[TwoSkipSharedId], [t0].[Id], [t0].[Name], [t0].[OneSkipSharedId0], [t0].[TwoSkipSharedId0], [t0].[Id0], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId]
@@ -100,7 +120,7 @@ ORDER BY [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t].[Id], [t0].
         await base.Load_collection_using_Query_with_Include(async);
 
         AssertSql(
-"""
+            """
 @__p_0='3'
 
 SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t0].[OneSkipSharedId], [t0].[TwoSkipSharedId], [t0].[Id], [t0].[Name], [t1].[ThreeId], [t1].[TwoId], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId]
@@ -131,7 +151,7 @@ ORDER BY [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t].[Id], [t0].
         await base.Load_collection_using_Query_with_filtered_Include(async);
 
         AssertSql(
-"""
+            """
 @__p_0='3'
 
 SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t0].[OneSkipSharedId], [t0].[TwoSkipSharedId], [t0].[Id], [t0].[Name], [t1].[ThreeId], [t1].[TwoId], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId]
@@ -163,7 +183,7 @@ ORDER BY [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t].[Id], [t0].
         await base.Load_collection_using_Query_with_filtered_Include_and_projection(async);
 
         AssertSql(
-"""
+            """
 @__p_0='3'
 
 SELECT [t].[Id], [t].[Name], (
@@ -191,7 +211,7 @@ ORDER BY [t].[Id]
         await base.Load_collection_using_Query_with_join(async);
 
         AssertSql(
-"""
+            """
 @__p_0='3'
 
 SELECT [t].[Id], [t].[CollectionInverseId], [t].[ExtraId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[OneSkipSharedId], [t].[TwoSkipSharedId], [t0].[Id], [t0].[OneSkipSharedId], [t0].[TwoSkipSharedId], [t0].[Id0], [t2].[OneSkipSharedId], [t2].[TwoSkipSharedId], [t2].[Id], [t2].[Name], [t0].[CollectionInverseId], [t0].[ExtraId], [t0].[Name0], [t0].[ReferenceInverseId]

--- a/test/EFCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
@@ -20,16 +20,21 @@ public class EntityMaterializerSourceTest
     public void Throws_for_abstract_types()
     {
         var entityType = CreateConventionalModelBuilder().Model.AddEntityType(typeof(SomeAbstractEntity));
-        var source = new EntityMaterializerSource(new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>()));
+        var source = (IEntityMaterializerSource)new EntityMaterializerSource(
+            new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>()));
 
         Assert.Equal(
             CoreStrings.CannotMaterializeAbstractType(nameof(SomeAbstractEntity)),
-            Assert.Throws<InvalidOperationException>(() => source.CreateMaterializeExpression((IEntityType)entityType, "", null!))
+            Assert.Throws<InvalidOperationException>(
+                    () => source.CreateMaterializeExpression(
+                        new EntityMaterializerSourceParameters((IEntityType)entityType, "", null), null!))
                 .Message);
     }
 
-    [ConditionalFact]
-    public void Can_create_materializer_for_entity_with_constructor_properties()
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Can_create_materializer_for_entity_with_constructor_properties(bool useParameters)
     {
         var entityType = CreateEntityType();
 
@@ -47,7 +52,7 @@ public class EntityMaterializerSourceTest
 
         var factory = GetMaterializer(
             new EntityMaterializerSource(
-                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType);
+                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType, useParameters);
 
         var gu = Guid.NewGuid();
         var entity = (SomeEntity)factory(
@@ -67,8 +72,10 @@ public class EntityMaterializerSourceTest
         Assert.False(entity.GooSetterCalled);
     }
 
-    [ConditionalFact]
-    public void Can_create_materializer_for_entity_with_factory_method()
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Can_create_materializer_for_entity_with_factory_method(bool useParameters)
     {
         var entityType = CreateEntityType();
 
@@ -86,7 +93,7 @@ public class EntityMaterializerSourceTest
 
         var factory = GetMaterializer(
             new EntityMaterializerSource(
-                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType);
+                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType, useParameters);
 
         var gu = Guid.NewGuid();
         var entity = (SomeEntity)factory(
@@ -106,8 +113,10 @@ public class EntityMaterializerSourceTest
         Assert.False(entity.GooSetterCalled);
     }
 
-    [ConditionalFact]
-    public void Can_create_materializer_for_entity_with_factory_method_with_object_array()
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Can_create_materializer_for_entity_with_factory_method_with_object_array(bool useParameters)
     {
         var entityType = CreateEntityType();
 
@@ -129,7 +138,7 @@ public class EntityMaterializerSourceTest
 
         var factory = GetMaterializer(
             new EntityMaterializerSource(
-                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType);
+                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType, useParameters);
 
         var gu = Guid.NewGuid();
         var entity = (SomeEntity)factory(
@@ -149,8 +158,10 @@ public class EntityMaterializerSourceTest
         Assert.False(entity.GooSetterCalled);
     }
 
-    [ConditionalFact]
-    public void Can_create_materializer_for_entity_with_instance_factory_method()
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Can_create_materializer_for_entity_with_instance_factory_method(bool useParameters)
     {
         var entityType = CreateEntityType();
 
@@ -165,7 +176,7 @@ public class EntityMaterializerSourceTest
 
         var factory = GetMaterializer(
             new EntityMaterializerSource(
-                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType);
+                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType, useParameters);
 
         var gu = Guid.NewGuid();
         var entity = (SomeEntity)factory(
@@ -196,15 +207,17 @@ public class EntityMaterializerSourceTest
     private EntityType CreateEntityType()
         => (EntityType)CreateConventionalModelBuilder().Entity<SomeEntity>().Metadata;
 
-    [ConditionalFact]
-    public void Can_create_materializer_for_entity_with_auto_properties()
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Can_create_materializer_for_entity_with_auto_properties(bool useParameters)
     {
         var entityType = CreateEntityType();
         entityType.Model.FinalizeModel();
 
         var factory = GetMaterializer(
             new EntityMaterializerSource(
-                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType);
+                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType, useParameters);
 
         var gu = Guid.NewGuid();
         var entity = (SomeEntity)factory(
@@ -219,8 +232,10 @@ public class EntityMaterializerSourceTest
         Assert.Equal(SomeEnum.EnumValue, entity.MaybeEnum);
     }
 
-    [ConditionalFact]
-    public void Can_create_materializer_for_entity_with_fields()
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Can_create_materializer_for_entity_with_fields(bool useParameters)
     {
         var modelBuilder = CreateConventionalModelBuilder();
         modelBuilder.Entity<SomeEntityWithFields>(
@@ -239,7 +254,7 @@ public class EntityMaterializerSourceTest
 
         var factory = GetMaterializer(
             new EntityMaterializerSource(
-                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType);
+                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType, useParameters);
 
         var gu = Guid.NewGuid();
         var entity = (SomeEntityWithFields)factory(
@@ -254,8 +269,10 @@ public class EntityMaterializerSourceTest
         Assert.Null(entity.MaybeEnum);
     }
 
-    [ConditionalFact]
-    public void Can_read_nulls()
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Can_read_nulls(bool useParameters)
     {
         var modelBuilder = CreateConventionalModelBuilder();
         modelBuilder.Entity<SomeEntity>(
@@ -269,7 +286,7 @@ public class EntityMaterializerSourceTest
 
         var factory = GetMaterializer(
             new EntityMaterializerSource(
-                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType);
+                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType, useParameters);
 
         var entity = (SomeEntity)factory(
             new MaterializationContext(
@@ -281,8 +298,10 @@ public class EntityMaterializerSourceTest
         Assert.Null(entity.Goo);
     }
 
-    [ConditionalFact]
-    public void Can_create_materializer_for_entity_ignoring_shadow_fields()
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Can_create_materializer_for_entity_ignoring_shadow_fields(bool useParameters)
     {
         var modelBuilder = CreateConventionalModelBuilder();
 
@@ -303,7 +322,7 @@ public class EntityMaterializerSourceTest
 
         var factory = GetMaterializer(
             new EntityMaterializerSource(
-                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType);
+                new EntityMaterializerSourceDependencies(Array.Empty<ISingletonInterceptor>())), entityType, useParameters);
 
         var gu = Guid.NewGuid();
         var entity = (SomeEntity)factory(
@@ -587,9 +606,15 @@ public class EntityMaterializerSourceTest
 
     public virtual Func<MaterializationContext, object> GetMaterializer(
         IEntityMaterializerSource source,
-        IReadOnlyEntityType entityType)
+        IReadOnlyEntityType entityType,
+        bool useParameters)
         => Expression.Lambda<Func<MaterializationContext, object>>(
-                source.CreateMaterializeExpression((IEntityType)entityType, "instance", _contextParameter),
+                useParameters
+                    ? source.CreateMaterializeExpression(
+                        new EntityMaterializerSourceParameters((IEntityType)entityType, "instance", null), _contextParameter)
+#pragma warning disable CS0618
+                    : source.CreateMaterializeExpression((IEntityType)entityType, "instance", _contextParameter),
+#pragma warning restore CS0618
                 _contextParameter)
             .Compile();
 

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -47,6 +47,9 @@ public class FakeStateManager : IStateManager
         return Task.FromResult(1);
     }
 
+    public InternalEntityEntry TryGetExistingEntry(object entity, IKey key)
+        => throw new NotImplementedException();
+
     public IEnumerable<InternalEntityEntry> Entries
         => InternalEntries ?? Enumerable.Empty<InternalEntityEntry>();
 


### PR DESCRIPTION
Part of #10042

Avoids duplicates when loading collections that already contain some entities. Entities queried using NoTrackingWithIdentityResolution get this behavior when lazy-loading.

