### PR TITLE
Allow service properties typed as object

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -1020,7 +1020,9 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
         mainBuilder
             .Append("var ").Append(variableName).Append(" = ").Append(parameters.TargetName).AppendLine(".AddServiceProperty(")
             .IncrementIndent()
-            .Append(_code.Literal(property.Name));
+            .Append(_code.Literal(property.Name))
+            .AppendLine(",")
+            .Append("typeof(" + property.ClrType.DisplayName(fullName: true, compilable: true) + ")");
 
         PropertyBaseParameters(property, parameters, skipType: true);
 

--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -174,6 +174,22 @@ public interface IConventionEntityTypeBuilder : IConventionAnnotatableBuilder
         bool fromDataAnnotation = false);
 
     /// <summary>
+    ///     Returns an object that can be used to configure the service property with the given member info.
+    ///     If no matching property exists, then a new property will be added.
+    /// </summary>
+    /// <param name="serviceType">The type of the service.</param>
+    /// <param name="memberInfo">The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     An object that can be used to configure the property if it exists on the entity type,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    IConventionServicePropertyBuilder? ServiceProperty(
+        Type serviceType,
+        MemberInfo memberInfo,
+        bool fromDataAnnotation = false);
+
+    /// <summary>
     ///     Returns a value indicating whether the given service property can be added to this entity type.
     /// </summary>
     /// <param name="memberInfo">The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property.</param>

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -385,6 +385,7 @@ public class RuntimeModelConvention : IModelFinalizedConvention
     private static RuntimeServiceProperty Create(IServiceProperty property, RuntimeEntityType runtimeEntityType)
         => runtimeEntityType.AddServiceProperty(
             property.Name,
+            property.ClrType,
             property.PropertyInfo,
             property.FieldInfo,
             property.GetPropertyAccessMode());

--- a/src/EFCore/Metadata/IConventionEntityType.cs
+++ b/src/EFCore/Metadata/IConventionEntityType.cs
@@ -972,6 +972,15 @@ public interface IConventionEntityType : IReadOnlyEntityType, IConventionTypeBas
     IConventionServiceProperty AddServiceProperty(MemberInfo memberInfo, bool fromDataAnnotation = false);
 
     /// <summary>
+    ///     Adds a service property to this entity type.
+    /// </summary>
+    /// <param name="serviceType">The type of the service.</param>
+    /// <param name="memberInfo">The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property to add.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The newly created service property.</returns>
+    IConventionServiceProperty AddServiceProperty(Type serviceType, MemberInfo memberInfo, bool fromDataAnnotation = false);
+
+    /// <summary>
     ///     Gets the service property with a given name.
     ///     Returns <see langword="null" /> if no property with the given name is defined.
     /// </summary>

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -840,6 +840,14 @@ public interface IMutableEntityType : IReadOnlyEntityType, IMutableTypeBase
     IMutableServiceProperty AddServiceProperty(MemberInfo memberInfo);
 
     /// <summary>
+    ///     Adds a service property to this entity type.
+    /// </summary>
+    /// <param name="serviceType">The type of the service.</param>
+    /// <param name="memberInfo">The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property to add.</param>
+    /// <returns>The newly created service property.</returns>
+    IMutableServiceProperty AddServiceProperty(Type serviceType, MemberInfo memberInfo);
+
+    /// <summary>
     ///     Gets the service property with a given name.
     ///     Returns <see langword="null" /> if no property with the given name is defined.
     /// </summary>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2793,6 +2793,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual ServiceProperty AddServiceProperty(
+        Type serviceType,
         MemberInfo memberInfo,
         // ReSharper disable once MethodOverloadWithOptionalParameter
         ConfigurationSource configurationSource)
@@ -2816,6 +2817,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
             name,
             memberInfo as PropertyInfo,
             memberInfo as FieldInfo,
+            serviceType,
             this,
             configurationSource);
 
@@ -5145,7 +5147,17 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     /// </summary>
     [DebuggerStepThrough]
     IMutableServiceProperty IMutableEntityType.AddServiceProperty(MemberInfo memberInfo)
-        => AddServiceProperty(memberInfo, ConfigurationSource.Explicit);
+        => AddServiceProperty(memberInfo.GetMemberType(), memberInfo, ConfigurationSource.Explicit);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
+    IMutableServiceProperty IMutableEntityType.AddServiceProperty(Type serviceType, MemberInfo memberInfo)
+        => AddServiceProperty(serviceType, memberInfo, ConfigurationSource.Explicit);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -5155,7 +5167,20 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     /// </summary>
     [DebuggerStepThrough]
     IConventionServiceProperty IConventionEntityType.AddServiceProperty(MemberInfo memberInfo, bool fromDataAnnotation)
-        => AddServiceProperty(memberInfo, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+        => AddServiceProperty(
+            memberInfo.GetMemberType(), memberInfo,
+            fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
+    IConventionServiceProperty IConventionEntityType.AddServiceProperty(Type serviceType, MemberInfo memberInfo, bool fromDataAnnotation)
+        => AddServiceProperty(
+            serviceType, memberInfo, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -880,6 +880,18 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     public virtual InternalServicePropertyBuilder? ServiceProperty(
         MemberInfo memberInfo,
         ConfigurationSource? configurationSource)
+        => ServiceProperty(memberInfo.GetMemberType(), memberInfo, configurationSource);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual InternalServicePropertyBuilder? ServiceProperty(
+        Type serviceType,
+        MemberInfo memberInfo,
+        ConfigurationSource? configurationSource)
     {
         var propertyName = memberInfo.GetSimpleMemberName();
         List<ServiceProperty>? propertiesToDetach = null;
@@ -999,7 +1011,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
                 }
             }
 
-            builder = Metadata.AddServiceProperty(memberInfo, configurationSource.Value).Builder;
+            builder = Metadata.AddServiceProperty(serviceType, memberInfo, configurationSource.Value).Builder;
 
             if (detachedProperties != null)
             {
@@ -5286,6 +5298,17 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
     [DebuggerStepThrough]
     IConventionServicePropertyBuilder? IConventionEntityTypeBuilder.ServiceProperty(MemberInfo memberInfo, bool fromDataAnnotation)
         => ServiceProperty(memberInfo, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
+    IConventionServicePropertyBuilder? IConventionEntityTypeBuilder.ServiceProperty(
+        Type serviceType, MemberInfo memberInfo, bool fromDataAnnotation)
+        => ServiceProperty(serviceType, memberInfo, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/InternalServicePropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalServicePropertyBuilder.cs
@@ -93,7 +93,7 @@ public class InternalServicePropertyBuilder : InternalPropertyBaseBuilder<Servic
     public virtual InternalServicePropertyBuilder? Attach(InternalEntityTypeBuilder entityTypeBuilder)
     {
         var newPropertyBuilder = entityTypeBuilder.ServiceProperty(
-            Metadata.GetIdentifyingMemberInfo()!, Metadata.GetConfigurationSource());
+            Metadata.ClrType, Metadata.GetIdentifyingMemberInfo()!, Metadata.GetConfigurationSource());
         if (newPropertyBuilder == null)
         {
             return null;

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -29,12 +29,13 @@ public class ServiceProperty : PropertyBase, IMutableServiceProperty, IConventio
         string name,
         PropertyInfo? propertyInfo,
         FieldInfo? fieldInfo,
+        Type serviceType,
         EntityType declaringEntityType,
         ConfigurationSource configurationSource)
         : base(name, propertyInfo, fieldInfo, configurationSource)
     {
         DeclaringEntityType = declaringEntityType;
-        ClrType = (propertyInfo?.PropertyType ?? fieldInfo?.FieldType)!;
+        ClrType = serviceType;
 
         _builder = new InternalServicePropertyBuilder(this, declaringEntityType.Model.Builder);
     }

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -715,11 +715,29 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
         PropertyInfo? propertyInfo = null,
         FieldInfo? fieldInfo = null,
         PropertyAccessMode propertyAccessMode = Internal.Model.DefaultPropertyAccessMode)
+        => AddServiceProperty(name, (propertyInfo?.PropertyType ?? fieldInfo?.FieldType)!, propertyInfo, fieldInfo, propertyAccessMode);
+
+    /// <summary>
+    ///     Adds a service property to this entity type.
+    /// </summary>
+    /// <param name="name">The name of the property to add.</param>
+    /// <param name="serviceType">The type of the service.</param>
+    /// <param name="propertyInfo">The corresponding CLR property or <see langword="null" /> for a shadow property.</param>
+    /// <param name="fieldInfo">The corresponding CLR field or <see langword="null" /> for a shadow property.</param>
+    /// <param name="propertyAccessMode">The <see cref="PropertyAccessMode" /> used for this property.</param>
+    /// <returns>The newly created service property.</returns>
+    public virtual RuntimeServiceProperty AddServiceProperty(
+        string name,
+        Type serviceType,
+        PropertyInfo? propertyInfo = null,
+        FieldInfo? fieldInfo = null,
+        PropertyAccessMode propertyAccessMode = Internal.Model.DefaultPropertyAccessMode)
     {
         var serviceProperty = new RuntimeServiceProperty(
             name,
             propertyInfo,
             fieldInfo,
+            serviceType,
             this,
             propertyAccessMode);
 

--- a/src/EFCore/Metadata/RuntimeServiceProperty.cs
+++ b/src/EFCore/Metadata/RuntimeServiceProperty.cs
@@ -28,6 +28,7 @@ public class RuntimeServiceProperty : RuntimePropertyBase, IServiceProperty
         string name,
         PropertyInfo? propertyInfo,
         FieldInfo? fieldInfo,
+        Type serviceType,
         RuntimeEntityType declaringEntityType,
         PropertyAccessMode propertyAccessMode)
         : base(name, propertyInfo, fieldInfo, propertyAccessMode)
@@ -35,7 +36,7 @@ public class RuntimeServiceProperty : RuntimePropertyBase, IServiceProperty
         Check.NotNull(declaringEntityType, nameof(declaringEntityType));
 
         DeclaringEntityType = declaringEntityType;
-        ClrType = (propertyInfo?.PropertyType ?? fieldInfo?.FieldType)!;
+        ClrType = serviceType;
     }
 
     /// <summary>

--- a/test/EFCore.Specification.Tests/LazyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadTestBase.cs
@@ -5641,6 +5641,966 @@ public abstract partial class LoadTestBase<TFixture>
         }
     }
 
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderWithStateByProperty>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.Children); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.Children);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(collectionEntry.IsLoaded);
+
+            Assert.All(parent.Children.Select(e => e.Parent), p => Assert.Same(parent, p));
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, parent.Children.Count());
+        }
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 3, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<ChildDelegateLoaderWithStateByProperty>().Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(child.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(child.Parent);
+            }
+            else
+            {
+                Assert.NotNull(child.Parent);
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(child, child.Parent!.Children.Single());
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderWithStateByProperty>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(child.Parent);
+                    Assert.Null(parent.Children);
+                }
+                else
+                {
+                    Assert.Same(parent, child.Parent);
+                    Assert.Same(child, parent.Children.Single());
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SingleDelegateLoaderWithStateByProperty>().Single();
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(single.Parent); // Explicitly detached
+        }
+        else
+        {
+            if (state == EntityState.Deleted)
+            {
+                Assert.Null(single.Parent);
+            }
+            else
+            {
+                Assert.NotNull(single.Parent);
+            }
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(single, single.Parent!.Single);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderWithStateByProperty>().Single().Entity;
+
+                if (state == EntityState.Deleted)
+                {
+                    Assert.Null(single.Parent);
+                    Assert.Null(parent.Single);
+                }
+                else
+                {
+                    Assert.Same(parent, single.Parent);
+                    Assert.Same(single, parent.Single);
+                }
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderWithStateByProperty>().Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.Null(parent.Single); // Explicitly detached
+        }
+        else
+        {
+            Assert.NotNull(parent.Single);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            if (state != EntityState.Deleted)
+            {
+                Assert.Same(parent, parent.Single.Parent);
+            }
+
+            if (state != EntityState.Detached)
+            {
+                var single = context.ChangeTracker.Entries<SingleDelegateLoaderWithStateByProperty>().Single().Entity;
+
+                Assert.Same(single, parent.Single);
+                Assert.Same(parent, single.Parent);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_null_FK_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new ChildDelegateLoaderWithStateByProperty { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(child.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_null_FK_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new SingleDelegateLoaderWithStateByProperty { Id = 767, ParentId = null }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(single.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_not_found_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new ParentDelegateLoaderWithStateByProperty { Id = 767 }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        if (state == EntityState.Detached)
+        {
+            Assert.Null(parent.Children); // Explicitly detached
+        }
+        else
+        {
+            Assert.Empty(parent.Children);
+            Assert.False(changeDetector.DetectChangesCalled);
+            Assert.True(collectionEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Single(context.ChangeTracker.Entries());
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_not_found_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Attach(new ChildDelegateLoaderWithStateByProperty { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(child.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+        Assert.Null(child.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_not_found_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Attach(new SingleDelegateLoaderWithStateByProperty { Id = 767, ParentId = 787 }).Entity;
+
+        ClearLog();
+
+        SetState(context, single, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(single.Parent);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+
+        Assert.Null(single.Parent);
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_not_found_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Attach(new ParentDelegateLoaderWithStateByProperty { Id = 767 }).Entity;
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior, isAttached: true);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.False(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.Null(parent.Single);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.Equal(state != EntityState.Detached, referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Null(parent.Single);
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_already_loaded_delegate_loader_with_state_property_injection(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderWithStateByProperty>().Include(e => e.Children).Single();
+
+        ClearLog();
+
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.True(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Children);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(collectionEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(2, parent.Children.Count());
+
+        if (queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+            && state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Null(c));
+        }
+        else
+        {
+            Assert.All(parent.Children.Select(e => e.Parent), p => Assert.Same(parent, p));
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_many_to_one_reference_to_principal_already_loaded_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var child = context.Set<ChildDelegateLoaderWithStateByProperty>().Include(e => e.Parent).Single(e => e.Id == 12);
+
+        ClearLog();
+
+        SetState(context, child.Parent, state, queryTrackingBehavior);
+        SetState(context, child, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(child.Parent);
+        }
+        else
+        {
+            Assert.True(referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(child.Parent);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(child, child.Parent.Children.Single());
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderWithStateByProperty>().Single().Entity;
+
+                Assert.Same(parent, child.Parent);
+                Assert.Same(child, parent.Children.Single());
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_principal_already_loaded_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var single = context.Set<SingleDelegateLoaderWithStateByProperty>().Include(e => e.Parent).Single();
+
+        ClearLog();
+
+        SetState(context, single.Parent, state, queryTrackingBehavior);
+        SetState(context, single, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+        if (state == EntityState.Deleted && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(referenceEntry.IsLoaded);
+            Assert.Null(single.Parent);
+        }
+        else
+        {
+            Assert.True(referenceEntry.IsLoaded);
+
+            changeDetector.DetectChangesCalled = false;
+
+            Assert.NotNull(single.Parent);
+
+            Assert.False(changeDetector.DetectChangesCalled);
+
+            Assert.True(referenceEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+            Assert.Same(single, single.Parent.Single);
+
+            if (state != EntityState.Detached)
+            {
+                var parent = context.ChangeTracker.Entries<ParentDelegateLoaderWithStateByProperty>().Single().Entity;
+
+                Assert.Same(parent, single.Parent);
+                Assert.Same(single, parent.Single);
+            }
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.Immediate, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Unchanged, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Deleted, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, CascadeTiming.OnSaveChanges, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_one_to_one_reference_to_dependent_already_loaded_delegate_loader_with_state_property_injection(
+        EntityState state,
+        CascadeTiming deleteOrphansTiming,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        var parent = context.Set<ParentDelegateLoaderWithStateByProperty>().Include(e => e.Single).Single();
+
+        ClearLog();
+
+        SetState(context, parent.Single, state, queryTrackingBehavior);
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Single);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        Assert.True(referenceEntry.IsLoaded);
+
+        RecordLog();
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        Assert.Equal(state == EntityState.Detached ? 0 : 2, context.ChangeTracker.Entries().Count());
+
+        if (state == EntityState.Deleted
+            && deleteOrphansTiming != CascadeTiming.Never)
+        {
+            Assert.Same(parent, parent.Single.Parent);
+        }
+
+        if (state != EntityState.Detached)
+        {
+            var single = context.ChangeTracker.Entries<SingleDelegateLoaderWithStateByProperty>().Single().Entity;
+
+            Assert.Same(single, parent.Single);
+            Assert.Same(parent, single.Parent);
+        }
+    }
+
+    [ConditionalTheory]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.TrackAll)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTracking)]
+    [InlineData(EntityState.Unchanged, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Added, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Modified, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    [InlineData(EntityState.Detached, QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
+    public virtual void Lazy_load_collection_already_partially_loaded_delegate_loader_with_state_property_injection(
+        EntityState state,
+        QueryTrackingBehavior queryTrackingBehavior)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+
+        var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
+
+        context.ChangeTracker.LazyLoadingEnabled = false;
+
+        var child = context.Set<ChildDelegateLoaderWithStateByProperty>().OrderBy(e => e.Id).First();
+        var parent = context.Set<ParentDelegateLoaderWithStateByProperty>().Single();
+        if (parent.Children == null)
+        {
+            parent.Children = new List<ChildDelegateLoaderWithStateByProperty> { child };
+            child.Parent = parent;
+        }
+
+        context.ChangeTracker.LazyLoadingEnabled = true;
+
+        ClearLog();
+
+        SetState(context, child, state, queryTrackingBehavior);
+        SetState(context, parent, state, queryTrackingBehavior);
+
+        var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+        Assert.False(collectionEntry.IsLoaded);
+
+        changeDetector.DetectChangesCalled = false;
+
+        Assert.NotNull(parent.Children);
+
+        Assert.False(changeDetector.DetectChangesCalled);
+
+        RecordLog();
+
+        if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+        {
+            Assert.False(collectionEntry.IsLoaded); // Explicitly detached
+            Assert.Equal(1, parent.Children.Count());
+
+            Assert.All(parent.Children.Select(e => e.Parent), p => Assert.Same(parent, p));
+        }
+        else
+        {
+            Assert.True(collectionEntry.IsLoaded);
+
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            // Note that when detached there is no identity resolution, so loading results in duplicates
+            Assert.Equal(
+                state == EntityState.Detached && queryTrackingBehavior != QueryTrackingBehavior.NoTrackingWithIdentityResolution
+                    ? 3
+                    : 2, parent.Children.Count());
+
+            Assert.All(parent.Children.Select(e => e.Parent), p => Assert.Same(parent, p));
+        }
+    }
+
     [ConditionalFact]
     public virtual void Lazy_loading_uses_field_access_when_abstract_base_class_navigation()
     {


### PR DESCRIPTION
Fixes #10042

Service properties have two uses:

1. Allow the entity to use the service directly
2. Allow EF to store state on the entity

This change allows 2 to happen without the entity needing to take a dependency on the service type. This allows the lazy-loader to store loaded state in the entity.

