### PR TITLE
[release/7.0] Update discriminator columns when PK-to-PK dependent type is changed

### DIFF
--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -26,8 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Update;
 /// </remarks>
 public class ModificationCommand : IModificationCommand, INonTrackedModificationCommand
 {
-    private static readonly bool QuirkEnabled29876
-        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29876", out var enabled) && enabled;
+    private static readonly bool QuirkEnabled29789
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29789", out var enabled) && enabled;
 
     private readonly Func<string>? _generateParameterName;
     private readonly bool _sensitiveLoggingEnabled;
@@ -546,7 +546,7 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
                     }
                     else if (((updating && property.GetAfterSaveBehavior() == PropertySaveBehavior.Save)
                                  || (!isKey && nonMainEntry)
-                                 || (!QuirkEnabled29876 && entry.SharedIdentityEntry != null))
+                                 || (!QuirkEnabled29789 && entry.SharedIdentityEntry != null))
                              && storedProcedureParameter is not { ForOriginalValue: true })
                     {
                         // Note that for stored procedures we always need to send all parameters, regardless of whether the property

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -26,6 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Update;
 /// </remarks>
 public class ModificationCommand : IModificationCommand, INonTrackedModificationCommand
 {
+    private static readonly bool QuirkEnabled29876
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29876", out var enabled) && enabled;
+
     private readonly Func<string>? _generateParameterName;
     private readonly bool _sensitiveLoggingEnabled;
     private readonly bool _detailedErrorsEnabled;
@@ -543,7 +546,7 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
                     }
                     else if (((updating && property.GetAfterSaveBehavior() == PropertySaveBehavior.Save)
                                  || (!isKey && nonMainEntry)
-                                 || entry.SharedIdentityEntry != null)
+                                 || (!QuirkEnabled29876 && entry.SharedIdentityEntry != null))
                              && storedProcedureParameter is not { ForOriginalValue: true })
                     {
                         // Note that for stored procedures we always need to send all parameters, regardless of whether the property

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -542,7 +542,8 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
                         writeValue = property.GetBeforeSaveBehavior() == PropertySaveBehavior.Save;
                     }
                     else if (((updating && property.GetAfterSaveBehavior() == PropertySaveBehavior.Save)
-                                 || (!isKey && nonMainEntry))
+                                 || (!isKey && nonMainEntry)
+                                 || entry.SharedIdentityEntry != null)
                              && storedProcedureParameter is not { ForOriginalValue: true })
                     {
                         // Note that for stored procedures we always need to send all parameters, regardless of whether the property

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
@@ -22,8 +22,14 @@ public abstract class UpdatesInMemoryTestBase<TFixture> : UpdatesTestBase<TFixtu
         Action<UpdatesContext> nestedTestOperation1 = null,
         Action<UpdatesContext> nestedTestOperation2 = null)
     {
-        base.ExecuteWithStrategyInTransaction(testOperation, nestedTestOperation1, nestedTestOperation2);
-        Fixture.Reseed();
+        try
+        {
+            base.ExecuteWithStrategyInTransaction(testOperation, nestedTestOperation1, nestedTestOperation2);
+        }
+        finally
+        {
+            Fixture.Reseed();
+        }
     }
 
     protected override async Task ExecuteWithStrategyInTransactionAsync(
@@ -31,8 +37,21 @@ public abstract class UpdatesInMemoryTestBase<TFixture> : UpdatesTestBase<TFixtu
         Func<UpdatesContext, Task> nestedTestOperation1 = null,
         Func<UpdatesContext, Task> nestedTestOperation2 = null)
     {
-        await base.ExecuteWithStrategyInTransactionAsync(testOperation, nestedTestOperation1, nestedTestOperation2);
-        Fixture.Reseed();
+        try
+        {
+            await base.ExecuteWithStrategyInTransactionAsync(testOperation, nestedTestOperation1, nestedTestOperation2);
+        }
+        finally
+        {
+            Fixture.Reseed();
+        }
+    }
+
+    // Issue #29875
+    public override Task Can_change_type_of_pk_to_pk_dependent_by_replacing_with_new_dependent(bool async)
+    {
+        return Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+            () => base.Can_change_type_of_pk_to_pk_dependent_by_replacing_with_new_dependent(async));
     }
 
     public abstract class UpdatesInMemoryFixtureBase : UpdatesFixtureBase

--- a/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Gift.cs
+++ b/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Gift.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
+
+public class Gift
+{
+    public int Id { get; set; }
+    public string? Recipient { get; set; }
+
+    public GiftObscurer? Obscurer { get; set; }
+}
+
+public abstract class GiftObscurer
+{
+    public int Id { get; set; }
+    public string? Pattern { get; set; }
+}
+
+public class GiftBag : GiftObscurer
+{
+    public int Size { get; set; }
+}
+
+public class GiftPaper : GiftObscurer
+{
+    public int Thickness { get; set; }
+}

--- a/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Lift.cs
+++ b/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Lift.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
+
+public class Lift
+{
+    public int Id { get; set; }
+    public string? Recipient { get; set; }
+
+    public LiftObscurer Obscurer { get; set; } = null!;
+}
+
+public abstract class LiftObscurer
+{
+    public int Id { get; set; }
+
+    public int LiftId { get; set; }
+    public string? Pattern { get; set; }
+}
+
+public class LiftBag : LiftObscurer
+{
+    public int Size { get; set; }
+}
+
+public class LiftPaper : LiftObscurer
+{
+    public int Thickness { get; set; }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTPCTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTPCTest.cs
@@ -110,8 +110,9 @@ WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_Princ
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.Entity<Category>()
-                .UseTpcMappingStrategy();
+            modelBuilder.Entity<Category>().UseTpcMappingStrategy();
+            // modelBuilder.Entity<GiftObscurer>().UseTpcMappingStrategy(); Issue #29874
+            modelBuilder.Entity<LiftObscurer>().UseTpcMappingStrategy();
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTPTTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTPTTest.cs
@@ -15,6 +15,10 @@ public class UpdatesSqlServerTPTTest : UpdatesSqlServerTestBase<UpdatesSqlServer
     {
     }
 
+    [ConditionalTheory(Skip = "Issue #29874. Skipped because the database is in a bad state, but the test may or may not fail.")]
+    public override Task Can_change_type_of_pk_to_pk_dependent_by_replacing_with_new_dependent(bool async)
+        => Task.CompletedTask;
+
     public override void Save_with_shared_foreign_key()
     {
         base.Save_with_shared_foreign_key();
@@ -97,8 +101,9 @@ WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_Princ
         {
             base.OnModelCreating(modelBuilder, context);
 
-            modelBuilder.Entity<Category>()
-                .UseTptMappingStrategy();
+            modelBuilder.Entity<Category>().UseTptMappingStrategy();
+            modelBuilder.Entity<GiftObscurer>().UseTptMappingStrategy();
+            modelBuilder.Entity<LiftObscurer>().UseTptMappingStrategy();
         }
     }
 }


### PR DESCRIPTION
Port of #29876
Fixes #29789

**Description**

EF generates an update when a dependent entity is deleted and replaced with a new entity that has the same PK. If that new entity is of a different type, then the discriminator column must be updated, but this is not happening in EF7.

**Customer impact**

Database contains rows that represent the wrong type of object; so potentially data corruption.

**How found**

Customer reported on 7.0

**Regression**

Yes, from EF Core 6.0.

**Testing**

Added tests for the affected scenario and related.

**Risk**

Low; the fix is simple, and a quirk was added to revert back to older behavior.
