### PR TITLE
[release/7.0] Avoid circular dependency for unique indexes with null values

### DIFF
--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -14,10 +14,13 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal;
 /// </summary>
 public class CommandBatchPreparer : ICommandBatchPreparer
 {
+    private static readonly bool QuirkEnabled29647
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29647", out var enabled) && enabled;
+
     private readonly int _minBatchSize;
     private readonly bool _sensitiveLoggingEnabled;
     private readonly bool _detailedErrorsEnabled;
-    private readonly Multigraph<IReadOnlyModificationCommand, IAnnotatable> _modificationCommandGraph;
+    private readonly Multigraph<IReadOnlyModificationCommand, CommandDependency> _modificationCommandGraph;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -31,7 +34,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
             dependencies.Options.Extensions.OfType<RelationalOptionsExtension>().FirstOrDefault()?.MinBatchSize
             ?? 1;
 
-        _modificationCommandGraph = new Multigraph<IReadOnlyModificationCommand, IAnnotatable>(dependencies.ModificationCommandComparer);
+        _modificationCommandGraph = new Multigraph<IReadOnlyModificationCommand, CommandDependency>(dependencies.ModificationCommandComparer);
         Dependencies = dependencies;
 
         if (dependencies.LoggingOptions.IsSensitiveDataLoggingEnabled)
@@ -337,22 +340,19 @@ public class CommandBatchPreparer : ICommandBatchPreparer
         _modificationCommandGraph.Clear();
         _modificationCommandGraph.AddVertices(commands);
 
-        AddForeignKeyEdges(_modificationCommandGraph);
+        AddForeignKeyEdges();
 
-        AddUniqueValueEdges(_modificationCommandGraph);
+        AddUniqueValueEdges();
 
-        AddSameTableEdges(_modificationCommandGraph);
+        AddSameTableEdges();
 
         return _modificationCommandGraph.BatchingTopologicalSort(
-            static (_, _, edges) => edges.All(
-                e =>
-                    e is ITable
-                    || (e is ITableIndex index && index.Filter != null)),
+            static (_, _, edges) => edges.All(e => e.Breakable),
             FormatCycle);
     }
 
     private string FormatCycle(
-        IReadOnlyList<Tuple<IReadOnlyModificationCommand, IReadOnlyModificationCommand, IEnumerable<IAnnotatable>>> data)
+        IReadOnlyList<Tuple<IReadOnlyModificationCommand, IReadOnlyModificationCommand, IEnumerable<CommandDependency>>> data)
     {
         var builder = new StringBuilder();
         for (var i = 0; i < data.Count; i++)
@@ -360,7 +360,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
             var (command1, command2, edges) = data[i];
             Format(command1, builder);
 
-            switch (edges.First())
+            switch (edges.First().Metadata)
             {
                 case IForeignKey foreignKey:
                     Format(foreignKey, command1, command2, builder);
@@ -565,8 +565,8 @@ public class CommandBatchPreparer : ICommandBatchPreparer
 
         var rowForeignKeyValueFactory = ((TableIndex)index).GetRowIndexValueFactory();
         var dependentCommand = reverseDependency ? target : source;
-        var values = rowForeignKeyValueFactory.CreateIndexValue(dependentCommand, fromOriginalValues: !reverseDependency)!;
-        FormatValues(values, index.Columns, dependentCommand, builder);
+        var indexValue = rowForeignKeyValueFactory.CreateIndexValue(dependentCommand, fromOriginalValues: !reverseDependency)!;
+        FormatValues(indexValue.Value!, index.Columns, dependentCommand, builder);
 
         builder.Append(" } ");
 
@@ -577,7 +577,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
     }
 
     private void FormatValues(
-        object[] values,
+        object?[] values,
         IReadOnlyList<IColumn> columns,
         IReadOnlyModificationCommand dependentCommand,
         StringBuilder builder)
@@ -591,7 +591,15 @@ public class CommandBatchPreparer : ICommandBatchPreparer
             if (_sensitiveLoggingEnabled)
             {
                 builder.Append(": ");
-                builder.Append(values[i]);
+                var value = values[i];
+                if (value != null)
+                {
+                    builder.Append(values[i]);
+                }
+                else
+                {
+                    builder.Append("NULL");
+                }
             }
 
             if (i != columns.Count - 1)
@@ -601,12 +609,11 @@ public class CommandBatchPreparer : ICommandBatchPreparer
         }
     }
 
-    private void AddForeignKeyEdges(
-        Multigraph<IReadOnlyModificationCommand, IAnnotatable> commandGraph)
+    private void AddForeignKeyEdges()
     {
         var predecessorsMap = new Dictionary<object, List<IReadOnlyModificationCommand>>();
         var originalPredecessorsMap = new Dictionary<object, List<IReadOnlyModificationCommand>>();
-        foreach (var command in commandGraph.Vertices)
+        foreach (var command in _modificationCommandGraph.Vertices)
         {
             if (command.EntityState is EntityState.Modified or EntityState.Added)
             {
@@ -717,7 +724,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
             }
         }
 
-        foreach (var command in commandGraph.Vertices)
+        foreach (var command in _modificationCommandGraph.Vertices)
         {
             if (command.EntityState is EntityState.Modified or EntityState.Added)
             {
@@ -738,7 +745,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                         }
 
                         AddMatchingPredecessorEdge(
-                            predecessorsMap, dependentKeyValue, commandGraph, command, foreignKey, checkStoreGenerated: true);
+                            predecessorsMap, dependentKeyValue, command, foreignKey, checkStoreGenerated: true);
                     }
                 }
 
@@ -762,7 +769,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                         }
 
                         AddMatchingPredecessorEdge(
-                            predecessorsMap, dependentKeyValue, commandGraph, command, foreignKey, checkStoreGenerated: true);
+                            predecessorsMap, dependentKeyValue, command, foreignKey, checkStoreGenerated: true);
                     }
                 }
             }
@@ -782,7 +789,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                             .CreatePrincipalEquatableKeyValue(command, fromOriginalValues: true);
                         Check.DebugAssert(principalKeyValue != null, "null principalKeyValue");
                         AddMatchingPredecessorEdge(
-                            originalPredecessorsMap, principalKeyValue, commandGraph, command, foreignKey);
+                            originalPredecessorsMap, principalKeyValue, command, foreignKey);
                     }
                 }
                 else
@@ -802,7 +809,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                                 .CreatePrincipalEquatableKey(entry, fromOriginalValues: true);
                             Check.DebugAssert(principalKeyValue != null, "null principalKeyValue");
                             AddMatchingPredecessorEdge(
-                                originalPredecessorsMap, principalKeyValue, commandGraph, command, foreignKey);
+                                originalPredecessorsMap, principalKeyValue, command, foreignKey);
                         }
                     }
                 }
@@ -993,10 +1000,9 @@ public class CommandBatchPreparer : ICommandBatchPreparer
         return false;
     }
 
-    private static void AddMatchingPredecessorEdge<T>(
+    private void AddMatchingPredecessorEdge<T>(
         Dictionary<T, List<IReadOnlyModificationCommand>> predecessorsMap,
         T keyValue,
-        Multigraph<IReadOnlyModificationCommand, IAnnotatable> commandGraph,
         IReadOnlyModificationCommand command,
         IForeignKey foreignKey,
         bool checkStoreGenerated = false)
@@ -1028,16 +1034,15 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                     }
 
                     AfterLoop:
-                    commandGraph.AddEdge(predecessor, command, foreignKey, requiresBatchingBoundary);
+                    _modificationCommandGraph.AddEdge(predecessor, command, new CommandDependency(foreignKey), requiresBatchingBoundary);
                 }
             }
         }
     }
 
-    private static void AddMatchingPredecessorEdge<T>(
+    private void AddMatchingPredecessorEdge<T>(
         Dictionary<T, List<IReadOnlyModificationCommand>> predecessorsMap,
         T keyValue,
-        Multigraph<IReadOnlyModificationCommand, IAnnotatable> commandGraph,
         IReadOnlyModificationCommand command,
         IForeignKeyConstraint foreignKey,
         bool checkStoreGenerated = false)
@@ -1074,18 +1079,17 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                     }
 
                     AfterLoop:
-                    commandGraph.AddEdge(predecessor, command, foreignKey, requiresBatchingBoundary);
+                    _modificationCommandGraph.AddEdge(predecessor, command, new CommandDependency(foreignKey), requiresBatchingBoundary);
                 }
             }
         }
     }
 
-    private static void AddMatchingPredecessorEdge<T>(
+    private void AddMatchingPredecessorEdge<T>(
         Dictionary<T, List<IReadOnlyModificationCommand>> predecessorsMap,
         T keyValue,
-        Multigraph<IReadOnlyModificationCommand, IAnnotatable> commandGraph,
         IReadOnlyModificationCommand command,
-        IAnnotatable edgeAnnotatable)
+        CommandDependency edge)
         where T : notnull
     {
         if (predecessorsMap.TryGetValue(keyValue, out var predecessorCommands))
@@ -1094,17 +1098,17 @@ public class CommandBatchPreparer : ICommandBatchPreparer
             {
                 if (predecessor != command)
                 {
-                    commandGraph.AddEdge(predecessor, command, edgeAnnotatable);
+                    _modificationCommandGraph.AddEdge(predecessor, command, edge);
                 }
             }
         }
     }
 
-    private void AddUniqueValueEdges(Multigraph<IReadOnlyModificationCommand, IAnnotatable> commandGraph)
+    private void AddUniqueValueEdges()
     {
         Dictionary<object, List<IReadOnlyModificationCommand>>? indexPredecessorsMap = null;
         var keyPredecessorsMap = new Dictionary<object, List<IReadOnlyModificationCommand>>();
-        foreach (var command in commandGraph.Vertices)
+        foreach (var command in _modificationCommandGraph.Vertices)
         {
             if (command.EntityState is EntityState.Added)
             {
@@ -1123,13 +1127,13 @@ public class CommandBatchPreparer : ICommandBatchPreparer
 
                     var indexValue = ((TableIndex)index).GetRowIndexValueFactory()
                         .CreateEquatableIndexValue(command, fromOriginalValues: true);
-                    if (indexValue != null)
+                    if (indexValue.Value != null)
                     {
                         indexPredecessorsMap ??= new Dictionary<object, List<IReadOnlyModificationCommand>>();
-                        if (!indexPredecessorsMap.TryGetValue(indexValue, out var predecessorCommands))
+                        if (!indexPredecessorsMap.TryGetValue(indexValue.Value, out var predecessorCommands))
                         {
                             predecessorCommands = new List<IReadOnlyModificationCommand>();
-                            indexPredecessorsMap.Add(indexValue, predecessorCommands);
+                            indexPredecessorsMap.Add(indexValue.Value, predecessorCommands);
                         }
 
                         predecessorCommands.Add(command);
@@ -1187,7 +1191,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
 
         if (indexPredecessorsMap != null)
         {
-            foreach (var command in commandGraph.Vertices)
+            foreach (var command in _modificationCommandGraph.Vertices)
             {
                 if (command.EntityState is EntityState.Deleted
                     || command.Table == null)
@@ -1205,10 +1209,11 @@ public class CommandBatchPreparer : ICommandBatchPreparer
 
                     var indexValue = ((TableIndex)index).GetRowIndexValueFactory()
                         .CreateEquatableIndexValue(command);
-                    if (indexValue != null)
+                    if (indexValue.Value != null)
                     {
-                        AddMatchingPredecessorEdge(
-                            indexPredecessorsMap, indexValue, commandGraph, command, index);
+                        AddMatchingPredecessorEdge(indexPredecessorsMap, indexValue.Value, command,
+                            new CommandDependency(index, breakable: index.Filter != null
+                            || (!QuirkEnabled29647 && indexValue.HasNullValue)));
                     }
                 }
             }
@@ -1216,7 +1221,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
 
         if (keyPredecessorsMap != null)
         {
-            foreach (var command in commandGraph.Vertices)
+            foreach (var command in _modificationCommandGraph.Vertices)
             {
                 if (command.EntityState is not EntityState.Added)
                 {
@@ -1231,8 +1236,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                             .CreateEquatableKeyValue(command, fromOriginalValues: true);
                         Check.DebugAssert(keyValue != null, "null keyValue");
 
-                        AddMatchingPredecessorEdge(
-                            keyPredecessorsMap, keyValue, commandGraph, command, key);
+                        AddMatchingPredecessorEdge(keyPredecessorsMap, keyValue, command, new CommandDependency(key));
                     }
                 }
                 else
@@ -1251,8 +1255,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                                 .CreateEquatableKey(entry, fromOriginalValues: true);
                             Check.DebugAssert(keyValue != null, "null keyValue");
 
-                            AddMatchingPredecessorEdge(
-                                keyPredecessorsMap, keyValue, commandGraph, command, key);
+                            AddMatchingPredecessorEdge(keyPredecessorsMap, keyValue, command, new CommandDependency(key));
                         }
                     }
                 }
@@ -1260,11 +1263,11 @@ public class CommandBatchPreparer : ICommandBatchPreparer
         }
     }
 
-    private static void AddSameTableEdges(Multigraph<IReadOnlyModificationCommand, IAnnotatable> modificationCommandGraph)
+    private void AddSameTableEdges()
     {
         var deletedDictionary = new Dictionary<(string, string?), (List<IReadOnlyModificationCommand> List, bool EdgesAdded)>();
 
-        foreach (var command in modificationCommandGraph.Vertices)
+        foreach (var command in _modificationCommandGraph.Vertices)
         {
             if (command.EntityState == EntityState.Deleted)
             {
@@ -1279,7 +1282,7 @@ public class CommandBatchPreparer : ICommandBatchPreparer
             }
         }
 
-        foreach (var command in modificationCommandGraph.Vertices)
+        foreach (var command in _modificationCommandGraph.Vertices)
         {
             if (command.EntityState == EntityState.Added)
             {
@@ -1292,15 +1295,27 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                         for (var i = 0; i < deletedCommands.List.Count - 1; i++)
                         {
                             var deleted = deletedCommands.List[i];
-                            modificationCommandGraph.AddEdge(deleted, lastDelete, deleted.Table!);
+                            _modificationCommandGraph.AddEdge(deleted, lastDelete, new CommandDependency(deleted.Table!, breakable: true));
                         }
 
                         deletedDictionary[table] = (deletedCommands.List, true);
                     }
 
-                    modificationCommandGraph.AddEdge(lastDelete, command, command.Table!);
+                    _modificationCommandGraph.AddEdge(lastDelete, command, new CommandDependency(command.Table!, breakable: true));
                 }
             }
         }
+    }
+
+    private sealed record class CommandDependency
+    {
+        public CommandDependency(IAnnotatable metadata, bool breakable = false)
+        {
+            Metadata = metadata;
+            Breakable = breakable;
+        }
+
+        public IAnnotatable Metadata { get; init; }
+        public bool Breakable { get; init; }
     }
 }

--- a/src/EFCore.Relational/Update/Internal/CompositeRowIndexValueFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/CompositeRowIndexValueFactory.cs
@@ -35,8 +35,11 @@ public class CompositeRowIndexValueFactory : CompositeRowValueFactory, IRowIndex
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool TryCreateIndexValue(object?[] keyValues, [NotNullWhen(true)] out object?[]? key)
-        => TryCreateDependentKeyValue(keyValues, out key);
+    public virtual bool TryCreateIndexValue(
+        object?[] keyValues,
+        out object?[]? key,
+        out bool hasNullValue)
+        => TryCreateDependentKeyValue(keyValues, out key, out hasNullValue);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -44,8 +47,11 @@ public class CompositeRowIndexValueFactory : CompositeRowValueFactory, IRowIndex
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool TryCreateIndexValue(IDictionary<string, object?> keyValues, [NotNullWhen(true)] out object?[]? key)
-        => TryCreateDependentKeyValue(keyValues, out key);
+    public virtual bool TryCreateIndexValue(
+        IDictionary<string, object?> keyValues,
+        out object?[]? key,
+        out bool hasNullValue)
+        => TryCreateDependentKeyValue(keyValues, out key, out hasNullValue);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -56,8 +62,9 @@ public class CompositeRowIndexValueFactory : CompositeRowValueFactory, IRowIndex
     public virtual bool TryCreateIndexValue(
         IReadOnlyModificationCommand command,
         bool fromOriginalValues,
-        [NotNullWhen(true)] out object?[]? key)
-        => TryCreateDependentKeyValue(command, fromOriginalValues, out key);
+        out object?[]? keyValue,
+        out bool hasNullValue)
+        => TryCreateDependentKeyValue(command, fromOriginalValues, out keyValue, out hasNullValue);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -65,10 +72,11 @@ public class CompositeRowIndexValueFactory : CompositeRowValueFactory, IRowIndex
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual object? CreateEquatableIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false)
-        => TryCreateDependentKeyValue(command, fromOriginalValues, out var keyValue)
-            ? new EquatableKeyValue<object?[]>(_index, keyValue, EqualityComparer)
-            : null;
+    public virtual (object? Value, bool HasNullValue) CreateEquatableIndexValue(
+        IReadOnlyModificationCommand command, bool fromOriginalValues = false)
+        => TryCreateIndexValue(command, fromOriginalValues, out var keyValue, out var hasNullValue)
+            ? (new EquatableKeyValue<object?[]>(_index, keyValue, EqualityComparer), hasNullValue)
+            : (null, true);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -76,8 +84,9 @@ public class CompositeRowIndexValueFactory : CompositeRowValueFactory, IRowIndex
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual object[]? CreateIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false)
-        => TryCreateIndexValue(command, fromOriginalValues, out var keyValue)
-            ? (object[])keyValue
-            : null;
+    public virtual (object?[]? Value, bool HasNullValue) CreateIndexValue(
+        IReadOnlyModificationCommand command, bool fromOriginalValues = false)
+        => TryCreateIndexValue(command, fromOriginalValues, out var keyValue, out bool hasNullValue)
+            ? (keyValue, hasNullValue)
+            : (null, true);
 }

--- a/src/EFCore.Relational/Update/Internal/CompositeRowKeyValueFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/CompositeRowKeyValueFactory.cs
@@ -73,15 +73,15 @@ public class CompositeRowKeyValueFactory : CompositeRowValueFactory, IRowKeyValu
     /// </summary>
     public virtual object?[] CreateKeyValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false)
     {
-        if (!TryCreateDependentKeyValue(command, fromOriginalValues, out var key))
+        if (!TryCreateDependentKeyValue(command, fromOriginalValues, out var keyValue))
         {
             throw new InvalidOperationException(
                 RelationalStrings.NullKeyValue(
                     _constraint.Table.SchemaQualifiedName,
-                    FindNullColumnInKeyValues(key).Name));
+                    FindNullColumnInKeyValues(keyValue).Name));
         }
 
-        return key;
+        return keyValue;
     }
 
     private IColumn FindNullColumnInKeyValues(object?[]? keyValues)

--- a/src/EFCore.Relational/Update/Internal/CompositeRowValueFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/CompositeRowValueFactory.cs
@@ -55,9 +55,23 @@ public abstract class CompositeRowValueFactory
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool TryCreateDependentKeyValue(object?[] keyValues, [NotNullWhen(true)] out object?[]? key)
+        => TryCreateDependentKeyValue(keyValues, out key, out var hasNullValue)
+            && !hasNullValue;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual bool TryCreateDependentKeyValue(
+        object?[] keyValues,
+        [NotNullWhen(true)] out object?[]? key,
+        out bool hasNullValue)
     {
         key = keyValues;
-        return keyValues.All(k => k != null);
+        hasNullValue = keyValues.All(k => k != null);
+        return true;
     }
 
     /// <summary>
@@ -67,16 +81,34 @@ public abstract class CompositeRowValueFactory
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool TryCreateDependentKeyValue(IDictionary<string, object?> keyValues, [NotNullWhen(true)] out object?[]? key)
+        => TryCreateDependentKeyValue(keyValues, out key, out var hasNullValue)
+            && !hasNullValue;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual bool TryCreateDependentKeyValue(
+        IDictionary<string, object?> keyValues,
+        [NotNullWhen(true)] out object?[]? key,
+        out bool hasNullValue)
     {
         key = new object[Columns.Count];
         var index = 0;
+        hasNullValue = false;
 
         foreach (var column in Columns)
         {
-            if (!keyValues.TryGetValue(column.Name, out var value)
-                || value == null)
+            if (!keyValues.TryGetValue(column.Name, out var value))
             {
                 return false;
+            }
+
+            if (value == null)
+            {
+                hasNullValue = true;
             }
 
             key[index++] = value;
@@ -96,9 +128,33 @@ public abstract class CompositeRowValueFactory
         bool fromOriginalValues,
         [NotNullWhen(true)] out object?[]? key)
     {
+        var result = TryCreateDependentKeyValue(command, fromOriginalValues, out key, out var hasNullValue);
+        if (!result
+            || hasNullValue)
+        {
+            key = null;
+            return result;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual bool TryCreateDependentKeyValue(
+        IReadOnlyModificationCommand command,
+        bool fromOriginalValues,
+        [NotNullWhen(true)] out object?[]? key,
+        out bool hasNullValue)
+    {
         var converters = ValueConverters;
         key = new object[Columns.Count];
         var index = 0;
+        hasNullValue = false;
 
         for (var i = 0; i < Columns.Count; i++)
         {
@@ -144,6 +200,11 @@ public abstract class CompositeRowValueFactory
                     return false;
                 }
 
+                if (value == null)
+                {
+                    hasNullValue = true;
+                }
+
                 key[index++] = value;
             }
             else
@@ -155,6 +216,11 @@ public abstract class CompositeRowValueFactory
                 }
 
                 var value = fromOriginalValues ? modification.OriginalValue : modification.Value;
+                if (value == null)
+                {
+                    hasNullValue = true;
+                }
+
                 key[index++] = value;
             }
         }

--- a/src/EFCore.Relational/Update/Internal/IRowIndexValueFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/IRowIndexValueFactory.cs
@@ -17,7 +17,7 @@ public interface IRowIndexValueFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    object[]? CreateIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false);
+    (object?[]? Value, bool HasNullValue) CreateIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -25,5 +25,5 @@ public interface IRowIndexValueFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    object? CreateEquatableIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false);
+    (object? Value, bool HasNullValue) CreateEquatableIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false);
 }

--- a/src/EFCore.Relational/Update/Internal/IRowIndexValueFactory`.cs
+++ b/src/EFCore.Relational/Update/Internal/IRowIndexValueFactory`.cs
@@ -19,7 +19,7 @@ public interface IRowIndexValueFactory<TKey> : IRowIndexValueFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool TryCreateIndexValue(object?[] keyValues, [NotNullWhen(true)] out TKey? key);
+    bool TryCreateIndexValue(object?[] keyValues, out TKey? key, out bool hasNullValue);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -27,7 +27,7 @@ public interface IRowIndexValueFactory<TKey> : IRowIndexValueFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool TryCreateIndexValue(IDictionary<string, object?> keyValues, [NotNullWhen(true)] out TKey? key);
+    bool TryCreateIndexValue(IDictionary<string, object?> keyValues, out TKey? key, out bool hasNullValue);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -35,7 +35,7 @@ public interface IRowIndexValueFactory<TKey> : IRowIndexValueFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool TryCreateIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues, [NotNullWhen(true)] out TKey? key);
+    bool TryCreateIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues, out TKey? key, out bool hasNullValue);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Update/Internal/SimpleRowIndexValueFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/SimpleRowIndexValueFactory.cs
@@ -49,10 +49,11 @@ public class SimpleRowIndexValueFactory<TKey> : IRowIndexValueFactory<TKey>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool TryCreateIndexValue(object?[] keyValues, [NotNullWhen(true)] out TKey? key)
+    public virtual bool TryCreateIndexValue(object?[] keyValues, out TKey? key, out bool hasNullValue)
     {
         key = (TKey?)keyValues[0];
-        return key != null;
+        hasNullValue = key == null;
+        return true;
     }
 
     /// <summary>
@@ -61,15 +62,17 @@ public class SimpleRowIndexValueFactory<TKey> : IRowIndexValueFactory<TKey>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool TryCreateIndexValue(IDictionary<string, object?> keyValues, [NotNullWhen(true)] out TKey? key)
+    public virtual bool TryCreateIndexValue(IDictionary<string, object?> keyValues, out TKey? key, out bool hasNullValue)
     {
         if (keyValues.TryGetValue(_column.Name, out var value))
         {
             key = (TKey?)value;
-            return key != null;
+            hasNullValue = key == null;
+            return true;
         }
 
         key = default;
+        hasNullValue = true;
         return false;
     }
 
@@ -82,12 +85,14 @@ public class SimpleRowIndexValueFactory<TKey> : IRowIndexValueFactory<TKey>
     public virtual bool TryCreateIndexValue(
         IReadOnlyModificationCommand command,
         bool fromOriginalValues,
-        [NotNullWhen(true)] out TKey? key)
+        out TKey? key,
+        out bool hasNullValue)
     {
         (key, var present) = fromOriginalValues
             ? ((Func<IReadOnlyModificationCommand, (TKey, bool)>)_columnAccessors.OriginalValueGetter)(command)
             : ((Func<IReadOnlyModificationCommand, (TKey, bool)>)_columnAccessors.CurrentValueGetter)(command);
-        return present && key != null;
+        hasNullValue = key == null;
+        return present;
     }
 
     /// <summary>
@@ -96,10 +101,11 @@ public class SimpleRowIndexValueFactory<TKey> : IRowIndexValueFactory<TKey>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual object? CreateEquatableIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false)
-        => TryCreateIndexValue(command, fromOriginalValues, out var keyValue)
-            ? new EquatableKeyValue<TKey>(_index, keyValue, EqualityComparer)
-            : null;
+    public virtual (object? Value, bool HasNullValue) CreateEquatableIndexValue(
+        IReadOnlyModificationCommand command, bool fromOriginalValues = false)
+        => TryCreateIndexValue(command, fromOriginalValues, out var keyValue, out var hasNullValue)
+            ? (new EquatableKeyValue<TKey>(_index, keyValue, EqualityComparer), hasNullValue)
+            : (null, true);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -107,8 +113,9 @@ public class SimpleRowIndexValueFactory<TKey> : IRowIndexValueFactory<TKey>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual object[]? CreateIndexValue(IReadOnlyModificationCommand command, bool fromOriginalValues = false)
-        => TryCreateIndexValue(command, fromOriginalValues, out var value)
-            ? (new object[] { value })
-            : null;
+    public virtual (object?[]? Value, bool HasNullValue) CreateIndexValue(
+        IReadOnlyModificationCommand command, bool fromOriginalValues = false)
+        => TryCreateIndexValue(command, fromOriginalValues, out var value, out var hasNullValue)
+            ? (new object?[] { value }, hasNullValue)
+            : (null, true);
 }

--- a/src/EFCore/Update/EquatableKeyValue.cs
+++ b/src/EFCore/Update/EquatableKeyValue.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Update;
 public sealed class EquatableKeyValue<TKey>
 {
     private readonly IAnnotatable _metadata;
-    private readonly TKey _keyValue;
+    private readonly TKey? _keyValue;
     private readonly IEqualityComparer<TKey> _keyComparer;
 
     /// <summary>
@@ -22,7 +22,7 @@ public sealed class EquatableKeyValue<TKey>
     /// <param name="keyComparer">The key comparer.</param>
     public EquatableKeyValue(
         IAnnotatable metadata,
-        TKey keyValue,
+        TKey? keyValue,
         IEqualityComparer<TKey> keyComparer)
     {
         _metadata = metadata;
@@ -44,7 +44,11 @@ public sealed class EquatableKeyValue<TKey>
     {
         var hash = new HashCode();
         hash.Add(_metadata);
-        hash.Add(_keyValue, _keyComparer);
+        if (_keyValue != null)
+        {
+            hash.Add(_keyValue, _keyComparer);
+        }
+
         return hash.ToHashCode();
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/UpdatesRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/UpdatesRelationalTestBase.cs
@@ -172,7 +172,7 @@ public abstract class UpdatesRelationalTestBase<TFixture> : UpdatesTestBase<TFix
             modelBuilder.Entity<ProductTableWithView>().HasBaseType((string)null).ToView("ProductView").ToTable("ProductTable");
             modelBuilder.Entity<ProductTableView>().HasBaseType((string)null).ToView("ProductTable");
 
-            modelBuilder.Entity<Product>().HasIndex(p => new { p.Name, p.Price }).IsUnique().HasFilter("Name IS NOT NULL");
+            modelBuilder.Entity<Product>().HasIndex(p => new { p.Name, p.Price }).IsUnique();
 
             modelBuilder.Entity<Person>()
                 .Property(p => p.Country)

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTestBase.cs
@@ -245,6 +245,8 @@ LEFT JOIN [Person] AS [p2] ON [p1].[ParentId] = [p2].[PersonId]
 
             modelBuilder.Entity<ProductBase>()
                 .Property(p => p.Id).HasDefaultValueSql("NEWID()");
+
+            modelBuilder.Entity<Product>().HasIndex(p => new { p.Name, p.Price }).HasFilter("Name IS NOT NULL");
         }
         public virtual void ResetIdentity()
         {


### PR DESCRIPTION
Port of #29796
Fixes #29647

**Description**

When SaveChanges performs the topological sort of the update commands it considers duplicate values for unique indexes as invalid and throws an exception. However, in many database providers duplicate `null` values are allowed for unique indexes.

**Customer impact**

Affected apps throw during SaveChanges for duplicate `null` values. The workaround is to add a filter to every unique index in the model and then manually edit the migration to avoid rebuilding the indexes.

**How found**

Multiple customer reports on 7.0

**Regression**

Yes.

**Testing**

Added tests for the affected scenario.

**Risk**

Medium; the fix considerably changes the implementation, but a quirk was added to revert back to older behavior.
