### PR TITLE
Warn when entity type, property, or navigation is ignored after being explicitly mapped

### DIFF
--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -117,6 +117,9 @@ public static class CoreEventId
         RequiredAttributeOnSkipNavigation,
         AmbiguousEndRequiredWarning,
         ShadowForeignKeyPropertyCreated,
+        MappedEntityTypeIgnoredWarning,
+        MappedNavigationIgnoredWarning,
+        MappedPropertyIgnoredWarning,
 
         // ChangeTracking events
         DetectChangesStarting = CoreBaseId + 800,
@@ -511,6 +514,57 @@ public static class CoreEventId
     ///     </para>
     /// </remarks>
     public static readonly EventId ShadowForeignKeyPropertyCreated = MakeModelValidationId(Id.ShadowForeignKeyPropertyCreated);
+
+    /// <summary>
+    ///     An entity type  was first mapped explicitly and then ignored.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="EntityTypeEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and
+    ///         examples.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId MappedEntityTypeIgnoredWarning = MakeModelId(Id.MappedEntityTypeIgnoredWarning);
+
+    /// <summary>
+    ///     A navigation was first mapped explicitly and then ignored.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="NavigationBaseEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and
+    ///         examples.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId MappedNavigationIgnoredWarning = MakeModelId(Id.MappedNavigationIgnoredWarning);
+
+    /// <summary>
+    ///     A property was first mapped explicitly and then ignored.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="PropertyEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and
+    ///         examples.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId MappedPropertyIgnoredWarning = MakeModelId(Id.MappedPropertyIgnoredWarning);
 
     /// <summary>
     ///     An index was not created as the properties are already covered.

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -3012,6 +3012,99 @@ public static class CoreLoggerExtensions
     }
 
     /// <summary>
+    ///     Logs for the <see cref="CoreEventId.MappedNavigationIgnoredWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="navigation">The navigation.</param>
+    public static void MappedNavigationIgnoredWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+        INavigationBase navigation)
+    {
+        var definition = CoreResources.LogMappedNavigationIgnored(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, navigation.DeclaringType.ShortName(), navigation.Name);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new NavigationBaseEventData(definition, MappedNavigationIgnoredWarning, navigation);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string MappedNavigationIgnoredWarning(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string, string>)definition;
+        var p = (NavigationBaseEventData)payload;
+        return d.GenerateMessage(p.NavigationBase.DeclaringType.ShortName(), p.NavigationBase.Name);
+    }
+
+    /// <summary>
+    ///     Logs for the <see cref="CoreEventId.MappedPropertyIgnoredWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="property">The property.</param>
+    public static void MappedPropertyIgnoredWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+        IProperty property)
+    {
+        var definition = CoreResources.LogMappedPropertyIgnored(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, property.DeclaringType.ShortName(), property.Name);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new PropertyEventData(definition, MappedPropertyIgnoredWarning, property);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string MappedPropertyIgnoredWarning(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string, string>)definition;
+        var p = (PropertyEventData)payload;
+        return d.GenerateMessage(p.Property.DeclaringType.ShortName(), p.Property.Name);
+    }
+
+    /// <summary>
+    ///     Logs for the <see cref="CoreEventId.MappedEntityTypeIgnoredWarning" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="entityType">The entity type.</param>
+    public static void MappedEntityTypeIgnoredWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+        IEntityType entityType)
+    {
+        var definition = CoreResources.LogMappedEntityTypeIgnored(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, entityType.ShortName());
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new EntityTypeEventData(definition, MappedEntityTypeIgnoredWarning, entityType);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string MappedEntityTypeIgnoredWarning(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string>)definition;
+        var p = (EntityTypeEventData)payload;
+        return d.GenerateMessage(p.EntityType.ShortName());
+    }
+
+    /// <summary>
     ///     Logs for the <see cref="CoreEventId.CascadeDeleteOrphan" /> event.
     /// </summary>
     /// <param name="diagnostics">The diagnostics logger to use.</param>

--- a/src/EFCore/Diagnostics/LoggingDefinitions.cs
+++ b/src/EFCore/Diagnostics/LoggingDefinitions.cs
@@ -50,6 +50,33 @@ public abstract class LoggingDefinitions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
+    public EventDefinitionBase? LogMappedEntityTypeIgnored;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? LogMappedNavigationIgnored;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? LogMappedPropertyIgnored;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     public EventDefinitionBase? LogServiceProviderDebugInfo;
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1181,6 +1181,11 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
                 var foreignKey = navigation.ForeignKey;
                 Check.DebugAssert(navigation.DeclaringEntityType == Metadata, "navigation.DeclaringEntityType != Metadata");
 
+                if (navigation.GetConfigurationSource() == ConfigurationSource.Explicit)
+                {
+                    ModelBuilder.Metadata.ScopedModelDependencies?.Logger.MappedNavigationIgnoredWarning(navigation);
+                }
+
                 var navigationConfigurationSource = navigation.GetConfigurationSource();
                 if ((navigation.IsOnDependent
                         && foreignKey.IsOwnership)
@@ -1211,6 +1216,11 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
                 {
                     Check.DebugAssert(property.DeclaringEntityType == Metadata, "property.DeclaringEntityType != Metadata");
 
+                    if (property.GetConfigurationSource() == ConfigurationSource.Explicit)
+                    {
+                        ModelBuilder.Metadata.ScopedModelDependencies?.Logger.MappedPropertyIgnoredWarning(property);
+                    }
+
                     var removedProperty = RemoveProperty(property, configurationSource);
 
                     Check.DebugAssert(removedProperty != null, "removedProperty is null");
@@ -1229,6 +1239,11 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
 
                         Check.DebugAssert(
                             skipNavigation.DeclaringEntityType == Metadata, "skipNavigation.DeclaringEntityType != Metadata");
+
+                        if (skipNavigation.GetConfigurationSource() == ConfigurationSource.Explicit)
+                        {
+                            ModelBuilder.Metadata.ScopedModelDependencies?.Logger.MappedNavigationIgnoredWarning(skipNavigation);
+                        }
 
                         Metadata.Builder.HasNoSkipNavigation(skipNavigation, configurationSource);
                     }

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -469,6 +469,11 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
             var entityType = Metadata.FindEntityType(name);
             if (entityType != null)
             {
+                if (entityType.GetConfigurationSource() == ConfigurationSource.Explicit)
+                {
+                    Metadata.ScopedModelDependencies?.Logger.MappedEntityTypeIgnoredWarning(entityType);
+                }
+
                 HasNoEntityType(entityType, configurationSource);
             }
 
@@ -479,10 +484,6 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
             else
             {
                 Metadata.AddIgnored(type.Type, configurationSource);
-            }
-
-            if (type.Type != null)
-            {
                 Metadata.RemoveOwned(type.Type);
             }
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -3650,6 +3650,81 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     The entity type '{entityType}' was first mapped explicitly and then ignored. Consider not mapping the entity type in the first place.
+        /// </summary>
+        public static EventDefinition<string> LogMappedEntityTypeIgnored(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogMappedEntityTypeIgnored;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).LogMappedEntityTypeIgnored,
+                    logger,
+                    static logger => new EventDefinition<string>(
+                        logger.Options,
+                        CoreEventId.MappedEntityTypeIgnoredWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.MappedEntityTypeIgnoredWarning",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            CoreEventId.MappedEntityTypeIgnoredWarning,
+                            _resourceManager.GetString("LogMappedEntityTypeIgnored")!)));
+            }
+
+            return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
+        ///     The navigation '{entityType}.{navigation}' was first mapped explicitly and then ignored. Consider not mapping the navigation in the first place.
+        /// </summary>
+        public static EventDefinition<string, string> LogMappedNavigationIgnored(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogMappedNavigationIgnored;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).LogMappedNavigationIgnored,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        CoreEventId.MappedNavigationIgnoredWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.MappedNavigationIgnoredWarning",
+                        level => LoggerMessage.Define<string, string?>(
+                            level,
+                            CoreEventId.MappedNavigationIgnoredWarning,
+                            _resourceManager.GetString("LogMappedNavigationIgnored")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
+        ///     The property '{entityType}.{property}' was first mapped explicitly and then ignored. Consider not mapping the property in the first place.
+        /// </summary>
+        public static EventDefinition<string, string> LogMappedPropertyIgnored(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogMappedPropertyIgnored;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).LogMappedPropertyIgnored,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        CoreEventId.MappedPropertyIgnoredWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.MappedPropertyIgnoredWarning",
+                        level => LoggerMessage.Define<string, string?>(
+                            level,
+                            CoreEventId.MappedPropertyIgnoredWarning,
+                            _resourceManager.GetString("LogMappedPropertyIgnored")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
         ///     There are multiple navigations ({navigations}) configured with [InverseProperty] attribute which point to the same inverse navigation '{inverseNavigation}' therefore no relationship was configured by convention.
         /// </summary>
         public static EventDefinition<string, string?> LogMultipleInversePropertiesSameTarget(IDiagnosticsLogger logger)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -817,6 +817,18 @@
     <value>More than twenty 'IServiceProvider' instances have been created for internal use by Entity Framework. This is commonly caused by injection of a new singleton service instance into every DbContext instance. For example, calling 'UseLoggerFactory' passing in a new instance each time--see https://go.microsoft.com/fwlink/?linkid=869049 for more details. This may lead to performance issues, consider reviewing calls on 'DbContextOptionsBuilder' that may require new service providers to be built.</value>
     <comment>Warning CoreEventId.ManyServiceProvidersCreatedWarning</comment>
   </data>
+  <data name="LogMappedEntityTypeIgnored" xml:space="preserve">
+    <value>The entity type '{entityType}' was first mapped explicitly and then ignored. Consider not mapping the entity type in the first place.</value>
+    <comment>Warning CoreEventId.MappedEntityTypeIgnored string</comment>
+  </data>
+  <data name="LogMappedPropertyIgnored" xml:space="preserve">
+    <value>The property '{entityType}.{property}' was first mapped explicitly and then ignored. Consider not mapping the property in the first place.</value>
+    <comment>Warning CoreEventId.MappedPropertyIgnored string string</comment>
+  </data>
+  <data name="LogMappedNavigationIgnored" xml:space="preserve">
+    <value>The navigation '{entityType}.{navigation}' was first mapped explicitly and then ignored. Consider not mapping the navigation in the first place.</value>
+    <comment>Warning CoreEventId.MappedNavigationIgnored string string</comment>
+  </data>
   <data name="LogMultipleInversePropertiesSameTarget" xml:space="preserve">
     <value>There are multiple navigations ({navigations}) configured with [InverseProperty] attribute which point to the same inverse navigation '{inverseNavigation}' therefore no relationship was configured by convention.</value>
     <comment>Warning CoreEventId.MultipleInversePropertiesSameTargetWarning string string?</comment>

--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/InheritanceBulkUpdatesFixtureBase.cs
@@ -9,7 +9,12 @@ public abstract class InheritanceBulkUpdatesFixtureBase : InheritanceQueryFixtur
         => "InheritanceBulkUpdatesTest";
 
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-        => base.AddOptions(builder).ConfigureWarnings(w => w.Log(CoreEventId.FirstWithoutOrderByAndFilterWarning));
+        => base.AddOptions(builder).ConfigureWarnings(
+            w => w.Log(CoreEventId.FirstWithoutOrderByAndFilterWarning)
+                .Ignore(
+                    CoreEventId.MappedEntityTypeIgnoredWarning,
+                    CoreEventId.MappedPropertyIgnoredWarning,
+                    CoreEventId.MappedNavigationIgnoredWarning));
 
     public void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
         => facade.UseTransaction(transaction.GetDbTransaction());

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -2113,6 +2113,13 @@ public abstract class BuiltInDataTypesTestBase<TFixture> : IClassFixture<TFixtur
         public virtual string ReallyLargeString
             => string.Join("", Enumerable.Repeat(Environment.NewLine, 1001));
 
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder).ConfigureWarnings(
+                w => w.Ignore(
+                    CoreEventId.MappedEntityTypeIgnoredWarning,
+                    CoreEventId.MappedPropertyIgnoredWarning,
+                    CoreEventId.MappedNavigationIgnoredWarning));
+
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {
             modelBuilder.Entity<BinaryKeyDataType>();

--- a/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
@@ -5996,6 +5996,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture> : IClassFixtu
             return context;
         }
 
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder).ConfigureWarnings(
+                w => w.Ignore(
+                    CoreEventId.MappedEntityTypeIgnoredWarning,
+                    CoreEventId.MappedPropertyIgnoredWarning,
+                    CoreEventId.MappedNavigationIgnoredWarning));
+
         protected override string StoreName
             => "ManyToManyTracking";
     }

--- a/test/EFCore.Specification.Tests/NonSharedModelTestBase.cs
+++ b/test/EFCore.Specification.Tests/NonSharedModelTestBase.cs
@@ -131,7 +131,11 @@ public abstract class NonSharedModelTestBase : IDisposable, IAsyncLifetime
             .ConfigureWarnings(
                 b => b.Default(WarningBehavior.Throw)
                     .Log(CoreEventId.SensitiveDataLoggingEnabledWarning)
-                    .Log(CoreEventId.PossibleUnintendedReferenceComparisonWarning));
+                    .Log(CoreEventId.PossibleUnintendedReferenceComparisonWarning)
+                    .Ignore(
+                        CoreEventId.MappedEntityTypeIgnoredWarning,
+                        CoreEventId.MappedPropertyIgnoredWarning,
+                        CoreEventId.MappedNavigationIgnoredWarning));
 
     protected virtual TestStore CreateTestStore()
         => TestStoreFactory.Create(StoreName);

--- a/test/EFCore.Specification.Tests/Query/InheritanceQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceQueryFixtureBase.cs
@@ -24,6 +24,13 @@ public abstract class InheritanceQueryFixtureBase : SharedStoreFixtureBase<Inher
     protected virtual bool UseGeneratedKeys
         => true;
 
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder).ConfigureWarnings(
+            w => w.Ignore(
+                CoreEventId.MappedEntityTypeIgnoredWarning,
+                CoreEventId.MappedPropertyIgnoredWarning,
+                CoreEventId.MappedNavigationIgnoredWarning));
+
     public Func<DbContext> GetContextCreator()
         => () => CreateContext();
 

--- a/test/EFCore.Specification.Tests/ValueConvertersEndToEndTestBase.cs
+++ b/test/EFCore.Specification.Tests/ValueConvertersEndToEndTestBase.cs
@@ -668,6 +668,13 @@ public abstract class ValueConvertersEndToEndTestBase<TFixture> : IClassFixture<
         protected override string StoreName
             => "ValueConvertersEndToEnd";
 
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder).ConfigureWarnings(
+                w => w.Ignore(
+                    CoreEventId.MappedEntityTypeIgnoredWarning,
+                    CoreEventId.MappedPropertyIgnoredWarning,
+                    CoreEventId.MappedNavigationIgnoredWarning));
+
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
             => modelBuilder.Entity<ConvertingEntity>(
                 b =>

--- a/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 
 // ReSharper disable UnusedMember.Local
@@ -41,7 +42,8 @@ public class InternalModelBuilderTest
     [ConditionalFact]
     public void Can_ignore_lower_or_equal_source_entity_type_using_entity_clr_type()
     {
-        var model = new Model();
+        var logger = CreateTestLogger();
+        var model = new Model(new ConventionSet(), new ModelDependencies(logger));
         var modelBuilder = CreateModelBuilder(model);
         modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
 
@@ -51,29 +53,42 @@ public class InternalModelBuilderTest
         Assert.NotNull(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
         Assert.Null(modelBuilder.Entity(typeof(Customer), ConfigurationSource.DataAnnotation));
 
+        Assert.Null(logger.Message);
+
         Assert.NotNull(modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit));
 
         Assert.NotNull(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Explicit));
         Assert.Null(model.FindEntityType(typeof(Customer)));
+
+        Assert.Equal(
+            CoreResources.LogMappedEntityTypeIgnored(logger).GenerateMessage(nameof(Customer)),
+            logger.Message);
     }
 
     [ConditionalFact]
     public void Can_ignore_lower_or_equal_source_entity_type_using_entity_type_name()
     {
-        var model = new Model();
+        var logger = CreateTestLogger();
+        var model = new Model(new ConventionSet(), new ModelDependencies(logger));
         var modelBuilder = CreateModelBuilder(model);
-        modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.DataAnnotation);
+        modelBuilder.Entity(typeof(Customer).FullName!, ConfigurationSource.DataAnnotation);
 
-        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName!, ConfigurationSource.DataAnnotation));
 
-        Assert.Null(model.FindEntityType(typeof(Customer).FullName));
-        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.Explicit));
-        Assert.Null(modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.DataAnnotation));
+        Assert.Null(model.FindEntityType(typeof(Customer).FullName!));
+        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName!, ConfigurationSource.Explicit));
+        Assert.Null(modelBuilder.Entity(typeof(Customer).FullName!, ConfigurationSource.DataAnnotation));
 
-        Assert.NotNull(modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.Explicit));
+        Assert.Null(logger.Message);
 
-        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.Explicit));
-        Assert.Null(model.FindEntityType(typeof(Customer).FullName));
+        Assert.NotNull(modelBuilder.Entity(typeof(Customer).FullName!, ConfigurationSource.Explicit));
+
+        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName!, ConfigurationSource.Explicit));
+        Assert.Null(model.FindEntityType(typeof(Customer).FullName!));
+
+        Assert.Equal(
+            CoreResources.LogMappedEntityTypeIgnored(logger).GenerateMessage(nameof(Customer)),
+            logger.Message);
     }
 
     [ConditionalFact]
@@ -109,32 +124,46 @@ public class InternalModelBuilderTest
     [ConditionalFact]
     public void Can_ignore_existing_entity_type_using_entity_clr_type()
     {
-        var model = new Model();
+        var logger = CreateTestLogger();
+        var model = new Model(new ConventionSet(), new ModelDependencies(logger));
         var entityType = model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit);
         var modelBuilder = CreateModelBuilder(model);
-        Assert.Same(entityType, modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention).Metadata);
+        Assert.Same(entityType, modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention)!.Metadata);
         Assert.Null(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
         Assert.NotNull(model.FindEntityType(typeof(Customer)));
+
+        Assert.Null(logger.Message);
 
         Assert.NotNull(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Explicit));
 
         Assert.Null(model.FindEntityType(typeof(Customer)));
+
+        Assert.Equal(
+            CoreResources.LogMappedEntityTypeIgnored(logger).GenerateMessage(nameof(Customer)),
+            logger.Message);
     }
 
     [ConditionalFact]
     public void Can_ignore_existing_entity_type_using_entity_type_name()
     {
-        var model = new Model();
-        var entityType = model.AddEntityType(typeof(Customer).FullName, owned: false, ConfigurationSource.Explicit);
+        var logger = CreateTestLogger();
+        var model = new Model(new ConventionSet(), new ModelDependencies(logger));
+        var entityType = model.AddEntityType(typeof(Customer).FullName!, owned: false, ConfigurationSource.Explicit);
         var modelBuilder = CreateModelBuilder(model);
 
-        Assert.Same(entityType, modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.Convention).Metadata);
-        Assert.Null(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.DataAnnotation));
-        Assert.NotNull(model.FindEntityType(typeof(Customer).FullName));
+        Assert.Same(entityType, modelBuilder.Entity(typeof(Customer).FullName!, ConfigurationSource.Convention)!.Metadata);
+        Assert.Null(modelBuilder.Ignore(typeof(Customer).FullName!, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(model.FindEntityType(typeof(Customer).FullName!));
 
-        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.Explicit));
+        Assert.Null(logger.Message);
 
-        Assert.Null(model.FindEntityType(typeof(Customer).FullName));
+        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName!, ConfigurationSource.Explicit));
+
+        Assert.Null(model.FindEntityType(typeof(Customer).FullName!));
+
+        Assert.Equal(
+            CoreResources.LogMappedEntityTypeIgnored(logger).GenerateMessage(nameof(Customer)),
+            logger.Message);
     }
 
     [ConditionalFact]
@@ -505,6 +534,9 @@ public class InternalModelBuilderTest
                     () => modelBuilder.SharedTypeEntity(typeof(Customer).DisplayName(), typeof(Customer), ConfigurationSource.Explicit))
                 .Message);
     }
+
+    private static TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions> CreateTestLogger()
+        => new() { EnabledFor = LogLevel.Warning };
 
     private static void Cleanup(InternalModelBuilder modelBuilder)
         => new ModelCleanupConvention(CreateDependencies())


### PR DESCRIPTION
An old bug.

Fixes #12082
