### PR TITLE
Allow lazy-loading to be configured per navigation

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -1257,6 +1257,12 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
                 .Append("eagerLoaded: ").Append(_code.Literal(true));
         }
 
+        if (!navigation.LazyLoadingEnabled)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("lazyLoadingEnabled: ").Append(_code.Literal(false));
+        }
+
         mainBuilder
             .AppendLine(");")
             .AppendLine()
@@ -1344,6 +1350,12 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
             {
                 mainBuilder.AppendLine(",")
                     .Append("eagerLoaded: ").Append(_code.Literal(true));
+            }
+
+            if (!navigation.LazyLoadingEnabled)
+            {
+                mainBuilder.AppendLine(",")
+                    .Append("lazyLoadingEnabled: ").Append(_code.Literal(false));
             }
 
             mainBuilder

--- a/src/EFCore/Infrastructure/AccessorExtensions.cs
+++ b/src/EFCore/Infrastructure/AccessorExtensions.cs
@@ -59,7 +59,7 @@ public static class AccessorExtensions
     /// <returns>The requested service.</returns>
     [DebuggerStepThrough]
     public static object GetService(this IInfrastructure<IServiceProvider> accessor, Type serviceType)
-        => InfrastructureExtensions.GetService(serviceType, accessor);
+        => InfrastructureExtensions.GetService(accessor, serviceType);
 
     /// <summary>
     ///     <para>

--- a/src/EFCore/Infrastructure/AccessorExtensions.cs
+++ b/src/EFCore/Infrastructure/AccessorExtensions.cs
@@ -42,6 +42,26 @@ public static class AccessorExtensions
         => InfrastructureExtensions.GetService<TService>(accessor);
 
     /// <summary>
+    ///     Resolves a service from the <see cref="IServiceProvider" /> exposed from a type that implements
+    ///     <see cref="IInfrastructure{IServiceProvider}" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="IInfrastructure{T}" /> is used to hide properties that are not intended to be used in
+    ///         application code but can be used in extension methods written by database providers etc.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-services">Accessing DbContext services</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="accessor">The object exposing the service provider.</param>
+    /// <param name="serviceType">The type of service to be resolved.</param>
+    /// <returns>The requested service.</returns>
+    [DebuggerStepThrough]
+    public static object GetService(this IInfrastructure<IServiceProvider> accessor, Type serviceType)
+        => InfrastructureExtensions.GetService(serviceType, accessor);
+
+    /// <summary>
     ///     <para>
     ///         Gets the value from a property that is being hidden using <see cref="IInfrastructure{T}" />.
     ///     </para>

--- a/src/EFCore/Infrastructure/Internal/InfrastructureExtensions.cs
+++ b/src/EFCore/Infrastructure/Internal/InfrastructureExtensions.cs
@@ -21,7 +21,7 @@ public static class InfrastructureExtensions
     /// </summary>
     public static TService GetService<TService>(IInfrastructure<IServiceProvider> accessor)
         where TService : class
-        => (TService)GetService(typeof(TService), accessor);
+        => (TService)GetService(accessor, typeof(TService));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -29,7 +29,7 @@ public static class InfrastructureExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static object GetService(Type serviceType, IInfrastructure<IServiceProvider> accessor)
+    public static object GetService(IInfrastructure<IServiceProvider> accessor, Type serviceType)
     {
         var internalServiceProvider = accessor.Instance;
 

--- a/src/EFCore/Infrastructure/Internal/InfrastructureExtensions.cs
+++ b/src/EFCore/Infrastructure/Internal/InfrastructureExtensions.cs
@@ -21,21 +21,30 @@ public static class InfrastructureExtensions
     /// </summary>
     public static TService GetService<TService>(IInfrastructure<IServiceProvider> accessor)
         where TService : class
+        => (TService)GetService(typeof(TService), accessor);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static object GetService(Type serviceType, IInfrastructure<IServiceProvider> accessor)
     {
         var internalServiceProvider = accessor.Instance;
 
-        var service = internalServiceProvider.GetService(typeof(TService))
+        var service = internalServiceProvider.GetService(serviceType)
             ?? internalServiceProvider.GetService<IDbContextOptions>()
                 ?.Extensions.OfType<CoreOptionsExtension>().FirstOrDefault()
                 ?.ApplicationServiceProvider
-                ?.GetService(typeof(TService));
+                ?.GetService(serviceType);
 
         if (service == null)
         {
             throw new InvalidOperationException(
-                CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(TService).DisplayName()));
+                CoreStrings.NoProviderConfiguredFailedToResolveService(serviceType.DisplayName()));
         }
 
-        return (TService)service;
+        return service;
     }
 }

--- a/src/EFCore/Internal/IInjectableService.cs
+++ b/src/EFCore/Internal/IInjectableService.cs
@@ -22,7 +22,7 @@ public interface IInjectableService
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void ServiceObtained(DbContext context, ParameterBindingInfo bindingInfo);
+    void Injected(DbContext context, object entity, ParameterBindingInfo bindingInfo);
 
     /// <summary>
     ///     <para>
@@ -52,11 +52,7 @@ public interface IInjectableService
     ///     </para>
     /// </summary>
     /// <param name="context">The <see cref="DbContext" /> instance.</param>
+    /// <param name="entityType">The <see cref="IEntityType"/> of the instance being attached.</param>
     /// <param name="entity">The entity instance that is being attached.</param>
-    /// <param name="existingService">
-    ///     The existing instance of this service being held by the entity instance, or <see langword="null" /> if there
-    ///     is no existing instance.
-    /// </param>
-    /// <returns>The service instance to use, or <see langword="null" /> if a new instance should be created.</returns>
-    IInjectableService? Attaching(DbContext context, object entity, IInjectableService? existingService);
+    void Attaching(DbContext context, IEntityType entityType, object entity);
 }

--- a/src/EFCore/Metadata/Builders/IConventionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionNavigationBuilder.cs
@@ -76,6 +76,26 @@ public interface IConventionNavigationBuilder : IConventionPropertyBaseBuilder
     IConventionNavigationBuilder? AutoInclude(bool? autoInclude, bool fromDataAnnotation = false);
 
     /// <summary>
+    ///     Returns a value indicating whether this navigation can be configured to enable lazy-loading
+    ///     from the current configuration source.
+    /// </summary>
+    /// <param name="lazyLoadingEnabled">A value indicating whether the navigation should be enabled for lazy-loading.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if automatically included can be set for this navigation.</returns>
+    bool CanSetLazyLoadingEnabled(bool? lazyLoadingEnabled, bool fromDataAnnotation = false);
+
+    /// <summary>
+    ///     Configures this navigation to be enabled for lazy-loading.
+    /// </summary>
+    /// <param name="lazyLoadingEnabled">A value indicating whether the navigation should be enabled for lazy-loading.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    IConventionNavigationBuilder? EnableLazyLoading(bool? lazyLoadingEnabled, bool fromDataAnnotation = false);
+
+    /// <summary>
     ///     Returns a value indicating whether this navigation requiredness can be configured
     ///     from the current configuration source.
     /// </summary>

--- a/src/EFCore/Metadata/Builders/IConventionSkipNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionSkipNavigationBuilder.cs
@@ -124,4 +124,24 @@ public interface IConventionSkipNavigationBuilder : IConventionPropertyBaseBuild
     ///     <see langword="null" /> otherwise.
     /// </returns>
     IConventionSkipNavigationBuilder? AutoInclude(bool? autoInclude, bool fromDataAnnotation = false);
+
+    /// <summary>
+    ///     Returns a value indicating whether this navigation can be configured to enable lazy-loading
+    ///     from the current configuration source.
+    /// </summary>
+    /// <param name="lazyLoadingEnabled">A value indicating whether the navigation should be enabled for lazy-loading.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if automatically included can be set for this navigation.</returns>
+    bool CanSetLazyLoadingEnabled(bool? lazyLoadingEnabled, bool fromDataAnnotation = false);
+
+    /// <summary>
+    ///     Configures this navigation to be enabled for lazy-loading.
+    /// </summary>
+    /// <param name="lazyLoadingEnabled">A value indicating whether the navigation should be enabled for lazy-loading.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    ///     The same builder instance if the configuration was applied,
+    ///     <see langword="null" /> otherwise.
+    /// </returns>
+    IConventionSkipNavigationBuilder? EnableLazyLoading(bool? lazyLoadingEnabled, bool fromDataAnnotation = false);
 }

--- a/src/EFCore/Metadata/Builders/NavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/NavigationBuilder.cs
@@ -144,6 +144,31 @@ public class NavigationBuilder : IInfrastructure<IConventionSkipNavigationBuilde
     }
 
     /// <summary>
+    ///     Configures whether this navigation should be enabled for lazy-loading. Note that a property can only be lazy-loaded
+    ///     if a lazy-loading mechanism such as lazy-loading proxies or <see cref="ILazyLoader"/> injection has been configured.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-lazy-loading">Lazy loading</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="lazyLoadingEnabled">A value indicating if the navigation should be enabled for lazy-loading.</param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public virtual NavigationBuilder EnableLazyLoading(bool lazyLoadingEnabled = true)
+    {
+        if (InternalNavigationBuilder != null)
+        {
+            InternalNavigationBuilder.EnableLazyLoading(lazyLoadingEnabled, ConfigurationSource.Explicit);
+        }
+        else
+        {
+            InternalSkipNavigationBuilder!.EnableLazyLoading(lazyLoadingEnabled, ConfigurationSource.Explicit);
+        }
+
+        return this;
+    }
+
+    /// <summary>
     ///     Configures whether this navigation is required.
     /// </summary>
     /// <param name="required">A value indicating whether the navigation should be required.</param>

--- a/src/EFCore/Metadata/Builders/NavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/NavigationBuilder`.cs
@@ -82,6 +82,20 @@ public class NavigationBuilder<TSource, TTarget> : NavigationBuilder
         => (NavigationBuilder<TSource, TTarget>)base.AutoInclude(autoInclude);
 
     /// <summary>
+    ///     Configures whether this navigation should be enabled for lazy-loading. Note that a property can only be lazy-loaded
+    ///     if a lazy-loading mechanism such as lazy-loading proxies or <see cref="ILazyLoader"/> injection has been configured.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-lazy-loading">Lazy loading</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="lazyLoadingEnabled">A value indicating if the navigation should be enabled for lazy-loading.</param>
+    /// <returns>The same builder instance so that multiple configuration calls can be chained.</returns>
+    public new virtual NavigationBuilder<TSource, TTarget> EnableLazyLoading(bool lazyLoadingEnabled = true)
+        => (NavigationBuilder<TSource, TTarget>)base.EnableLazyLoading(lazyLoadingEnabled);
+
+    /// <summary>
     ///     Configures whether this navigation is required.
     /// </summary>
     /// <param name="required">A value indicating whether the navigation should be required.</param>

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -551,7 +551,8 @@ public class RuntimeModelConvention : IModelFinalizedConvention
                 navigation.PropertyInfo,
                 navigation.FieldInfo,
                 navigation.GetPropertyAccessMode(),
-                navigation.IsEagerLoaded);
+                navigation.IsEagerLoaded,
+                navigation.LazyLoadingEnabled);
 
     /// <summary>
     ///     Updates the navigation annotations that will be set on the read-only object.
@@ -590,7 +591,8 @@ public class RuntimeModelConvention : IModelFinalizedConvention
             navigation.PropertyInfo,
             navigation.FieldInfo,
             navigation.GetPropertyAccessMode(),
-            navigation.IsEagerLoaded);
+            navigation.IsEagerLoaded,
+            navigation.LazyLoadingEnabled);
 
     /// <summary>
     ///     Gets the corresponding foreign key in the read-optimized model.

--- a/src/EFCore/Metadata/IConventionNavigationBase.cs
+++ b/src/EFCore/Metadata/IConventionNavigationBase.cs
@@ -34,4 +34,20 @@ public interface IConventionNavigationBase : IReadOnlyNavigationBase, IConventio
     /// <returns>The configuration source for <see cref="IReadOnlyNavigationBase.IsEagerLoaded" />.</returns>
     ConfigurationSource? GetIsEagerLoadedConfigurationSource()
         => FindAnnotation(CoreAnnotationNames.EagerLoaded)?.GetConfigurationSource();
+
+    /// <summary>
+    ///     Sets a value indicating whether this navigation should be lazy-loaded, if lazy-loading is enabled and in place.
+    /// </summary>
+    /// <param name="lazyLoadingEnabled">A value indicating whether this navigation should lazy-loaded.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    bool? SetLazyLoadingEnabled(bool? lazyLoadingEnabled, bool fromDataAnnotation = false)
+        => (bool?)SetOrRemoveAnnotation(CoreAnnotationNames.LazyLoadingEnabled, lazyLoadingEnabled, fromDataAnnotation)?.Value;
+
+    /// <summary>
+    ///     Returns the configuration source for <see cref="IReadOnlyNavigationBase.LazyLoadingEnabled" />.
+    /// </summary>
+    /// <returns>The configuration source for <see cref="IReadOnlyNavigationBase.LazyLoadingEnabled" />.</returns>
+    ConfigurationSource? GetLazyLoadingEnabledConfigurationSource()
+        => FindAnnotation(CoreAnnotationNames.LazyLoadingEnabled)?.GetConfigurationSource();
 }

--- a/src/EFCore/Metadata/IMutableNavigationBase.cs
+++ b/src/EFCore/Metadata/IMutableNavigationBase.cs
@@ -26,4 +26,11 @@ public interface IMutableNavigationBase : IReadOnlyNavigationBase, IMutablePrope
     /// <param name="eagerLoaded">A value indicating whether this navigation should be eager loaded by default.</param>
     void SetIsEagerLoaded(bool? eagerLoaded)
         => SetOrRemoveAnnotation(CoreAnnotationNames.EagerLoaded, eagerLoaded);
+
+    /// <summary>
+    ///     Sets a value indicating whether this navigation should be enabled for lazy-loading.
+    /// </summary>
+    /// <param name="lazyLoadingEnabled">A value indicating whether this navigation should enabled for lazy-loading.</param>
+    void SetLazyLoadingEnabled(bool? lazyLoadingEnabled)
+        => SetOrRemoveAnnotation(CoreAnnotationNames.LazyLoadingEnabled, lazyLoadingEnabled);
 }

--- a/src/EFCore/Metadata/IReadOnlyNavigationBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyNavigationBase.cs
@@ -39,6 +39,18 @@ public interface IReadOnlyNavigationBase : IReadOnlyPropertyBase
     bool IsEagerLoaded
         => (bool?)this[CoreAnnotationNames.EagerLoaded] ?? false;
 
+    /// <summary>
+    ///     Determines whether or not this navigation should lazy-load if lazy-loading is enabled and a mechanism for lazy-loading
+    ///     has been configured in the model.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-lazy-loading">Lazy loading</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    bool LazyLoadingEnabled
+        => (bool?)this[CoreAnnotationNames.LazyLoadingEnabled] ?? true;
+
     /// <inheritdoc />
     // TODO: Remove when #3864 is implemented
     bool IReadOnlyPropertyBase.IsShadowProperty()

--- a/src/EFCore/Metadata/IReadOnlyNavigationBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyNavigationBase.cs
@@ -52,7 +52,6 @@ public interface IReadOnlyNavigationBase : IReadOnlyPropertyBase
         => (bool?)this[CoreAnnotationNames.LazyLoadingEnabled] ?? true;
 
     /// <inheritdoc />
-    // TODO: Remove when #3864 is implemented
     bool IReadOnlyPropertyBase.IsShadowProperty()
         => this.GetIdentifyingMemberInfo() == null;
 }

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -202,6 +202,14 @@ public static class CoreAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public const string LazyLoadingEnabled = "LazyLoadingEnabled";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public const string ProviderClrType = "ProviderClrType";
 
     /// <summary>
@@ -325,6 +333,7 @@ public static class CoreAnnotationNames
         DefiningQuery,
 #pragma warning restore CS0612 // Type or member is obsolete
         EagerLoaded,
+        LazyLoadingEnabled,
         ProviderClrType,
         ModelDependencies,
         ReadOnlyModel,

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -2782,6 +2782,14 @@ public class InternalForeignKeyBuilder : AnnotatableBuilder<ForeignKey, Internal
                 ((IReadOnlyNavigation)oldNavigation).IsEagerLoaded, oldIsEagerLoadedConfigurationSource.Value)!;
         }
 
+        var oldLazyLoadingEnabledConfigurationSource = ((IConventionNavigation)oldNavigation).GetLazyLoadingEnabledConfigurationSource();
+        if (oldLazyLoadingEnabledConfigurationSource.HasValue
+            && builder.CanSetLazyLoadingEnabled(((IReadOnlyNavigation)oldNavigation).LazyLoadingEnabled, oldLazyLoadingEnabledConfigurationSource.Value))
+        {
+            builder = builder.EnableLazyLoading(
+                ((IReadOnlyNavigation)oldNavigation).LazyLoadingEnabled, oldLazyLoadingEnabledConfigurationSource.Value)!;
+        }
+
         return builder.Metadata.ForeignKey.Builder;
     }
 

--- a/src/EFCore/Metadata/Internal/InternalNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalNavigationBuilder.cs
@@ -97,6 +97,46 @@ public class InternalNavigationBuilder : InternalPropertyBaseBuilder<Navigation>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public virtual bool CanSetLazyLoadingEnabled(bool? lazyLoadingEnabled, ConfigurationSource configurationSource)
+    {
+        IConventionNavigation conventionNavigation = Metadata;
+
+        return configurationSource.Overrides(conventionNavigation.GetLazyLoadingEnabledConfigurationSource())
+            || conventionNavigation.LazyLoadingEnabled == lazyLoadingEnabled;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual InternalNavigationBuilder? EnableLazyLoading(bool? lazyLoadingEnabled, ConfigurationSource configurationSource)
+    {
+        if (CanSetLazyLoadingEnabled(lazyLoadingEnabled, configurationSource))
+        {
+            if (configurationSource == ConfigurationSource.Explicit)
+            {
+                ((IMutableNavigation)Metadata).SetLazyLoadingEnabled(lazyLoadingEnabled);
+            }
+            else
+            {
+                ((IConventionNavigation)Metadata).SetLazyLoadingEnabled(
+                    lazyLoadingEnabled, configurationSource == ConfigurationSource.DataAnnotation);
+            }
+
+            return this;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual bool CanSetIsRequired(bool? required, ConfigurationSource configurationSource)
     {
         var foreignKey = Metadata.ForeignKey;
@@ -238,6 +278,16 @@ public class InternalNavigationBuilder : InternalPropertyBaseBuilder<Navigation>
     [DebuggerStepThrough]
     IConventionNavigationBuilder? IConventionNavigationBuilder.AutoInclude(bool? autoInclude, bool fromDataAnnotation)
         => AutoInclude(autoInclude, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    bool IConventionNavigationBuilder.CanSetLazyLoadingEnabled(bool? lazyLoadingEnabled, bool fromDataAnnotation)
+        => CanSetLazyLoadingEnabled(lazyLoadingEnabled, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IConventionNavigationBuilder? IConventionNavigationBuilder.EnableLazyLoading(bool? lazyLoadingEnabled, bool fromDataAnnotation)
+        => EnableLazyLoading(lazyLoadingEnabled, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <inheritdoc />
     [DebuggerStepThrough]

--- a/src/EFCore/Metadata/Internal/InternalSkipNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalSkipNavigationBuilder.cs
@@ -336,6 +336,46 @@ public class InternalSkipNavigationBuilder : InternalPropertyBaseBuilder<SkipNav
         return null;
     }
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool CanSetLazyLoadingEnabled(bool? lazyLoadingEnabled, ConfigurationSource configurationSource)
+    {
+        IConventionSkipNavigation conventionNavigation = Metadata;
+
+        return configurationSource.Overrides(conventionNavigation.GetLazyLoadingEnabledConfigurationSource())
+            || conventionNavigation.LazyLoadingEnabled == lazyLoadingEnabled;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual InternalSkipNavigationBuilder? EnableLazyLoading(bool? lazyLoadingEnabled, ConfigurationSource configurationSource)
+    {
+        if (CanSetLazyLoadingEnabled(lazyLoadingEnabled, configurationSource))
+        {
+            if (configurationSource == ConfigurationSource.Explicit)
+            {
+                ((IMutableSkipNavigation)Metadata).SetLazyLoadingEnabled(lazyLoadingEnabled);
+            }
+            else
+            {
+                ((IConventionSkipNavigation)Metadata).SetLazyLoadingEnabled(
+                    lazyLoadingEnabled, configurationSource == ConfigurationSource.DataAnnotation);
+            }
+
+            return this;
+        }
+
+        return null;
+    }
+
     IConventionPropertyBase IConventionPropertyBaseBuilder.Metadata
     {
         [DebuggerStepThrough]
@@ -462,4 +502,14 @@ public class InternalSkipNavigationBuilder : InternalPropertyBaseBuilder<SkipNav
     [DebuggerStepThrough]
     IConventionSkipNavigationBuilder? IConventionSkipNavigationBuilder.AutoInclude(bool? autoInclude, bool fromDataAnnotation)
         => AutoInclude(autoInclude, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    bool IConventionSkipNavigationBuilder.CanSetLazyLoadingEnabled(bool? lazyLoadingEnabled, bool fromDataAnnotation)
+        => CanSetLazyLoadingEnabled(lazyLoadingEnabled, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IConventionSkipNavigationBuilder? IConventionSkipNavigationBuilder.EnableLazyLoading(bool? lazyLoadingEnabled, bool fromDataAnnotation)
+        => EnableLazyLoading(lazyLoadingEnabled, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 }

--- a/src/EFCore/Metadata/ParameterBindingInfo.cs
+++ b/src/EFCore/Metadata/ParameterBindingInfo.cs
@@ -64,6 +64,11 @@ public readonly struct ParameterBindingInfo
     public Expression MaterializationContextExpression { get; }
 
     /// <summary>
+    ///     Expressions holding initialized instances for service properties.
+    /// </summary>
+    public List<ParameterExpression> ServiceInstances { get; } = new();
+
+    /// <summary>
     ///     Gets the index into the <see cref="ValueBuffer" /> where the property value can be found.
     /// </summary>
     /// <param name="property">The property.</param>

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -365,6 +365,7 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
     /// <param name="fieldInfo">The corresponding CLR field or <see langword="null" /> for a shadow navigation.</param>
     /// <param name="propertyAccessMode">The <see cref="PropertyAccessMode" /> used for this navigation.</param>
     /// <param name="eagerLoaded">A value indicating whether this navigation should be eager loaded by default.</param>
+    /// <param name="lazyLoadingEnabled">A value indicating whether this navigation should be enabled for lazy-loading.</param>
     /// <returns>The newly created navigation property.</returns>
     public virtual RuntimeNavigation AddNavigation(
         string name,
@@ -374,9 +375,10 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
         PropertyInfo? propertyInfo = null,
         FieldInfo? fieldInfo = null,
         PropertyAccessMode propertyAccessMode = Internal.Model.DefaultPropertyAccessMode,
-        bool eagerLoaded = false)
+        bool eagerLoaded = false,
+        bool lazyLoadingEnabled = true)
     {
-        var navigation = new RuntimeNavigation(name, clrType, propertyInfo, fieldInfo, foreignKey, propertyAccessMode, eagerLoaded);
+        var navigation = new RuntimeNavigation(name, clrType, propertyInfo, fieldInfo, foreignKey, propertyAccessMode, eagerLoaded, lazyLoadingEnabled);
 
         _navigations.Add(name, navigation);
 
@@ -421,6 +423,7 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
     /// <param name="fieldInfo">The corresponding CLR field or <see langword="null" /> for a shadow navigation.</param>
     /// <param name="propertyAccessMode">The <see cref="PropertyAccessMode" /> used for this navigation.</param>
     /// <param name="eagerLoaded">A value indicating whether this navigation should be eager loaded by default.</param>
+    /// <param name="lazyLoadingEnabled">A value indicating whether this navigation should be enabled for lazy-loading.</param>
     /// <returns>The newly created skip navigation property.</returns>
     public virtual RuntimeSkipNavigation AddSkipNavigation(
         string name,
@@ -432,7 +435,8 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
         PropertyInfo? propertyInfo = null,
         FieldInfo? fieldInfo = null,
         PropertyAccessMode propertyAccessMode = Internal.Model.DefaultPropertyAccessMode,
-        bool eagerLoaded = false)
+        bool eagerLoaded = false,
+        bool lazyLoadingEnabled = true)
     {
         var skipNavigation = new RuntimeSkipNavigation(
             name,
@@ -445,7 +449,8 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
             collection,
             onDependent,
             propertyAccessMode,
-            eagerLoaded);
+            eagerLoaded,
+            lazyLoadingEnabled);
 
         _skipNavigations.Add(name, skipNavigation);
 

--- a/src/EFCore/Metadata/RuntimeNavigation.cs
+++ b/src/EFCore/Metadata/RuntimeNavigation.cs
@@ -33,7 +33,8 @@ public class RuntimeNavigation : RuntimePropertyBase, INavigation
         FieldInfo? fieldInfo,
         RuntimeForeignKey foreignKey,
         PropertyAccessMode propertyAccessMode,
-        bool eagerLoaded)
+        bool eagerLoaded,
+        bool lazyLoadingEnabled)
         : base(name, propertyInfo, fieldInfo, propertyAccessMode)
     {
         ClrType = clrType;
@@ -41,6 +42,10 @@ public class RuntimeNavigation : RuntimePropertyBase, INavigation
         if (eagerLoaded)
         {
             SetAnnotation(CoreAnnotationNames.EagerLoaded, true);
+        }
+        if (!lazyLoadingEnabled)
+        {
+            SetAnnotation(CoreAnnotationNames.LazyLoadingEnabled, false);
         }
     }
 

--- a/src/EFCore/Metadata/RuntimeSkipNavigation.cs
+++ b/src/EFCore/Metadata/RuntimeSkipNavigation.cs
@@ -43,7 +43,8 @@ public class RuntimeSkipNavigation : RuntimePropertyBase, IRuntimeSkipNavigation
         bool collection,
         bool onDependent,
         PropertyAccessMode propertyAccessMode,
-        bool eagerLoaded)
+        bool eagerLoaded,
+        bool lazyLoadingEnabled)
         : base(name, propertyInfo, fieldInfo, propertyAccessMode)
     {
         ClrType = clrType;
@@ -64,6 +65,10 @@ public class RuntimeSkipNavigation : RuntimePropertyBase, IRuntimeSkipNavigation
         if (eagerLoaded)
         {
             SetAnnotation(CoreAnnotationNames.EagerLoaded, true);
+        }
+        if (!lazyLoadingEnabled)
+        {
+            SetAnnotation(CoreAnnotationNames.LazyLoadingEnabled, false);
         }
     }
 

--- a/src/EFCore/Metadata/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/ServiceParameterBinding.cs
@@ -47,9 +47,17 @@ public abstract class ServiceParameterBinding : ParameterBinding
     /// <param name="bindingInfo">The binding information.</param>
     /// <returns>The expression tree.</returns>
     public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
-        => BindToParameter(
+    {
+        var serviceInstance = bindingInfo.ServiceInstances.FirstOrDefault(e => e.Type == ServiceType);
+        if (serviceInstance != null)
+        {
+            return serviceInstance;
+        }
+
+        return BindToParameter(
             bindingInfo.MaterializationContextExpression,
             Expression.Constant(bindingInfo));
+    }
 
     /// <summary>
     ///     Creates an expression tree representing the binding of the value of a property from a
@@ -65,7 +73,7 @@ public abstract class ServiceParameterBinding : ParameterBinding
     /// <summary>
     ///     A delegate to set a CLR service property on an entity instance.
     /// </summary>
-    public virtual Func<MaterializationContext, IEntityType, object, object> ServiceDelegate
+    public virtual Func<MaterializationContext, IEntityType, object, object?> ServiceDelegate
         => NonCapturingLazyInitializer.EnsureInitialized(
             ref _serviceDelegate, this, static b =>
             {

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -41,6 +41,7 @@ public class CSharpMigrationsGeneratorTest
             CoreAnnotationNames.AfterSaveBehavior,
             CoreAnnotationNames.ProviderClrType,
             CoreAnnotationNames.EagerLoaded,
+            CoreAnnotationNames.LazyLoadingEnabled,
             CoreAnnotationNames.DuplicateServiceProperties,
             RelationalAnnotationNames.ColumnName,
             RelationalAnnotationNames.ColumnOrder,
@@ -200,6 +201,7 @@ public class CSharpMigrationsGeneratorTest
             CoreAnnotationNames.ProductVersion,
             CoreAnnotationNames.NavigationAccessMode,
             CoreAnnotationNames.EagerLoaded,
+            CoreAnnotationNames.LazyLoadingEnabled,
             CoreAnnotationNames.QueryFilter,
 #pragma warning disable CS0612 // Type or member is obsolete
             CoreAnnotationNames.DefiningQuery,

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -1109,7 +1109,8 @@ namespace TestNamespace
                 typeof(CSharpRuntimeModelCodeGeneratorTest.DependentBase<byte?>),
                 propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.PrincipalDerived<CSharpRuntimeModelCodeGeneratorTest.DependentBase<byte?>>).GetProperty(""Dependent"", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
                 fieldInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.PrincipalDerived<CSharpRuntimeModelCodeGeneratorTest.DependentBase<byte?>>).GetField(""<Dependent>k__BackingField"", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
-                eagerLoaded: true);
+                eagerLoaded: true,
+                lazyLoadingEnabled: false);
 
             return runtimeForeignKey;
         }
@@ -1733,7 +1734,8 @@ namespace TestNamespace
                 typeof(ICollection<CSharpRuntimeModelCodeGeneratorTest.PrincipalBase>),
                 propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.PrincipalDerived<CSharpRuntimeModelCodeGeneratorTest.DependentBase<byte?>>).GetProperty(""Principals"", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
                 fieldInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.PrincipalDerived<CSharpRuntimeModelCodeGeneratorTest.DependentBase<byte?>>).GetField(""<Principals>k__BackingField"", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
-                eagerLoaded: true);
+                eagerLoaded: true,
+                lazyLoadingEnabled: false);
 
             var inverse = targetEntityType.FindSkipNavigation(""Deriveds"");
             if (inverse != null)
@@ -1999,6 +2001,7 @@ namespace TestNamespace
                     Assert.Equal("<Dependent>k__BackingField", dependentNavigation.FieldInfo.Name);
                     Assert.False(dependentNavigation.IsCollection);
                     Assert.True(dependentNavigation.IsEagerLoaded);
+                    Assert.False(dependentNavigation.LazyLoadingEnabled);
                     Assert.False(dependentNavigation.IsOnDependent);
                     Assert.Equal(principalDerived, dependentNavigation.DeclaringEntityType);
                     Assert.Equal("Principal", dependentNavigation.Inverse.Name);
@@ -2047,6 +2050,7 @@ namespace TestNamespace
                     Assert.Equal(typeof(ICollection<PrincipalBase>), derivedSkipNavigation.ClrType);
                     Assert.True(derivedSkipNavigation.IsCollection);
                     Assert.True(derivedSkipNavigation.IsEagerLoaded);
+                    Assert.False(derivedSkipNavigation.LazyLoadingEnabled);
                     Assert.False(derivedSkipNavigation.IsOnDependent);
                     Assert.Equal(principalDerived, derivedSkipNavigation.DeclaringEntityType);
                     Assert.Equal("Deriveds", derivedSkipNavigation.Inverse.Name);
@@ -2282,7 +2286,7 @@ namespace TestNamespace
                             .HasForeignKey<DependentBase<byte?>>()
                             .OnDelete(DeleteBehavior.ClientNoAction);
 
-                        eb.Navigation(e => e.Dependent).AutoInclude();
+                        eb.Navigation(e => e.Dependent).AutoInclude().EnableLazyLoading(false);
 
                         eb.OwnsMany(
                             typeof(OwnedType).FullName, "ManyOwned", ob =>
@@ -2301,7 +2305,7 @@ namespace TestNamespace
                                         .HasColumnOrder(1);
                                 });
 
-                        eb.Navigation(e => e.Principals).AutoInclude();
+                        eb.Navigation(e => e.Principals).AutoInclude().EnableLazyLoading(false);
 
                         eb.ToTable("PrincipalDerived");
                     });
@@ -2940,6 +2944,7 @@ namespace TestNamespace
                     Assert.Equal("<Dependent>k__BackingField", dependentNavigation.FieldInfo.Name);
                     Assert.False(dependentNavigation.IsCollection);
                     Assert.False(dependentNavigation.IsEagerLoaded);
+                    Assert.True(dependentNavigation.LazyLoadingEnabled);
                     Assert.False(dependentNavigation.IsOnDependent);
                     Assert.Equal(principalDerived, dependentNavigation.DeclaringEntityType);
                     Assert.Equal("Principal", dependentNavigation.Inverse.Name);

--- a/test/EFCore.InMemory.FunctionalTests/NonLoadingNavigationsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/NonLoadingNavigationsInMemoryTest.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class NonLoadingNavigationsInMemoryTest : LoadTestBase<NonLoadingNavigationsInMemoryTest.NonLoadingNavigationsInMemoryFixture>
+{
+    public NonLoadingNavigationsInMemoryTest(NonLoadingNavigationsInMemoryFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    protected override bool LazyLoadingEnabled
+        => false;
+
+    public class NonLoadingNavigationsInMemoryFixture : LoadFixtureBase
+    {
+        protected override string StoreName
+            => "NonLoadingNavigations";
+
+        protected override ITestStoreFactory TestStoreFactory
+            => InMemoryTestStoreFactory.Instance;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder.Entity<Parent>(
+                b =>
+                {
+                    b.Navigation(e => e.Children).EnableLazyLoading(false);
+                    b.Navigation(e => e.ChildrenAk).EnableLazyLoading(false);
+                    b.Navigation(e => e.ChildrenCompositeKey).EnableLazyLoading(false);
+                    b.Navigation(e => e.ChildrenShadowFk).EnableLazyLoading(false);
+                    b.Navigation(e => e.Single).EnableLazyLoading(false);
+                    b.Navigation(e => e.SingleAk).EnableLazyLoading(false);
+                    b.Navigation(e => e.SingleCompositeKey).EnableLazyLoading(false);
+                    b.Navigation(e => e.SingleShadowFk).EnableLazyLoading(false);
+                    b.Navigation(e => e.SinglePkToPk).EnableLazyLoading(false);
+                    b.Navigation(e => e.RequiredSingle).EnableLazyLoading(false);
+                });
+
+            modelBuilder.Entity<Child>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<ChildAk>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<ChildShadowFk>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<ChildCompositeKey>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<Single>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<SingleAk>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<SingleCompositeKey>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<SingleShadowFk>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<SinglePkToPk>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<RequiredSingle>().Navigation(e => e.Parent).EnableLazyLoading(false);
+
+            modelBuilder.Entity<ParentFullLoaderByConstructor>(
+                b =>
+                {
+                    b.Navigation(e => e.Children).EnableLazyLoading(false);
+                    b.Navigation(e => e.Single).EnableLazyLoading(false);
+                });
+
+            modelBuilder.Entity<ChildFullLoaderByConstructor>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<SingleFullLoaderByConstructor>().Navigation(e => e.Parent).EnableLazyLoading(false);
+
+            modelBuilder.Entity<ParentDelegateLoaderByConstructor>(
+                b =>
+                {
+                    b.Navigation(e => e.Children).EnableLazyLoading(false);
+                    b.Navigation(e => e.Single).EnableLazyLoading(false);
+                });
+
+            modelBuilder.Entity<ChildDelegateLoaderByConstructor>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<SingleDelegateLoaderByConstructor>().Navigation(e => e.Parent).EnableLazyLoading(false);
+
+            modelBuilder.Entity<ParentDelegateLoaderByProperty>(
+                b =>
+                {
+                    b.Navigation(e => e.Children).EnableLazyLoading(false);
+                    b.Navigation(e => e.Single).EnableLazyLoading(false);
+                });
+
+            modelBuilder.Entity<ChildDelegateLoaderByProperty>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<SingleDelegateLoaderByProperty>().Navigation(e => e.Parent).EnableLazyLoading(false);
+
+            modelBuilder.Entity<ParentDelegateLoaderWithStateByProperty>(
+                b =>
+                {
+                    b.Navigation(e => e.Children).EnableLazyLoading(false);
+                    b.Navigation(e => e.Single).EnableLazyLoading(false);
+                });
+
+            modelBuilder.Entity<ChildDelegateLoaderWithStateByProperty>().Navigation(e => e.Parent).EnableLazyLoading(false);
+            modelBuilder.Entity<SingleDelegateLoaderWithStateByProperty>().Navigation(e => e.Parent).EnableLazyLoading(false);
+
+            modelBuilder.Entity<Product>().Navigation(e => e.Deposit).EnableLazyLoading(false);
+            modelBuilder.Entity<OptionalChildView>().HasNoKey().Navigation(e => e.Root).EnableLazyLoading(false);
+            modelBuilder.Entity<RequiredChildView>().HasNoKey().Navigation(e => e.Root).EnableLazyLoading(false);
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
@@ -75,6 +75,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             }
             else
             {
+                Assert.Null(left.TwoSkip);
                 if (async)
                 {
                     await collectionEntry.LoadAsync();
@@ -86,7 +87,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             }
 
             Assert.True(collectionEntry.IsLoaded);
-            foreach (var entityTwo in left.TwoSkip)
+            foreach (var entityTwo in left.TwoSkip!)
             {
                 Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkip).IsLoaded);
             }
@@ -261,6 +262,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         }
         else
         {
+            Assert.Equal(4, left.ThreeSkipPayloadFull.Count);
             if (async)
             {
                 await collectionEntry.LoadAsync();
@@ -583,6 +585,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         }
         else
         {
+            Assert.Single(left.ThreeSkipPayloadFull);
             if (queryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution)
             {
                 collectionEntry.LoadWithIdentityResolution();
@@ -650,6 +653,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             }
             else
             {
+                Assert.Null(left.TwoSkip);
                 if (async)
                 {
                     await navigationEntry.LoadAsync();
@@ -661,7 +665,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             }
 
             Assert.True(navigationEntry.IsLoaded);
-            foreach (var entityTwo in left.TwoSkip)
+            foreach (var entityTwo in left.TwoSkip!)
             {
                 Assert.False(context.Entry((object)entityTwo).Collection("OneSkip").IsLoaded);
             }
@@ -771,6 +775,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             }
             else
             {
+                Assert.Null(left.TwoSkip);
                 if (async)
                 {
                     await navigationEntry.LoadAsync();
@@ -786,7 +791,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
 
-            Assert.Empty(left.TwoSkip);
+            Assert.Empty(left.TwoSkip!);
         }
 
         Assert.Equal(state == EntityState.Detached ? 0 : 1, context.ChangeTracker.Entries().Count());
@@ -883,6 +888,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         }
         else
         {
+            Assert.Equal(4, left.ThreeSkipPayloadFull.Count);
             if (async)
             {
                 await navigationEntry.LoadAsync();
@@ -1025,6 +1031,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             }
             else
             {
+                Assert.Null(left.ThreeSkipFull);
                 if (async)
                 {
                     await collectionEntry.LoadAsync();
@@ -1036,7 +1043,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             }
 
             Assert.True(collectionEntry.IsLoaded);
-            foreach (var entityTwo in left.ThreeSkipFull)
+            foreach (var entityTwo in left.ThreeSkipFull!)
             {
                 Assert.False(context.Entry(entityTwo).Collection(e => e.CompositeKeySkipFull).IsLoaded);
             }

--- a/test/EFCore.Sqlite.FunctionalTests/NonLoadingNavigationsManyToManyLoadSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/NonLoadingNavigationsManyToManyLoadSqliteTest.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class NonLoadingNavigationsManyToManyLoadSqliteTest
+    : ManyToManyLoadTestBase<NonLoadingNavigationsManyToManyLoadSqliteTest.NonLoadingNavigationsManyToManyLoadSqliteFixture>
+{
+    public NonLoadingNavigationsManyToManyLoadSqliteTest(NonLoadingNavigationsManyToManyLoadSqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    public class NonLoadingNavigationsManyToManyLoadSqliteFixture : ManyToManyLoadFixtureBase
+    {
+        protected override string StoreName
+            => "NonLoadingNavigationsManyToMany";
+
+        protected override ITestStoreFactory TestStoreFactory
+            => SqliteTestStoreFactory.Instance;
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder).UseLazyLoadingProxies();
+
+        protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+            => base.AddServices(serviceCollection.AddEntityFrameworkProxies());
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.OnModelCreating(modelBuilder, context);
+
+            modelBuilder.Entity<EntityOne>(
+                b =>
+                {
+                    b.Navigation(e => e.Reference).EnableLazyLoading(false);
+                    b.Navigation(e => e.Collection).EnableLazyLoading(false);
+                    b.Navigation(e => e.TwoSkip).EnableLazyLoading(false);
+                    b.Navigation(e => e.ThreeSkipPayloadFull).EnableLazyLoading(false);
+                    b.Navigation(e => e.TwoSkipShared).EnableLazyLoading(false);
+                    b.Navigation(e => e.ThreeSkipPayloadFullShared).EnableLazyLoading(false);
+                    b.Navigation(e => e.JoinThreePayloadFullShared).EnableLazyLoading(false);
+                    b.Navigation(e => e.SelfSkipPayloadLeft).EnableLazyLoading(false);
+                    b.Navigation(e => e.JoinSelfPayloadLeft).EnableLazyLoading(false);
+                    b.Navigation(e => e.SelfSkipPayloadRight).EnableLazyLoading(false);
+                    b.Navigation(e => e.JoinSelfPayloadRight).EnableLazyLoading(false);
+                    b.Navigation(e => e.BranchSkip).EnableLazyLoading(false);
+                });
+
+            modelBuilder.Entity<EntityCompositeKey>(
+                b =>
+                {
+                    b.Navigation(e => e.TwoSkipShared).EnableLazyLoading(false);
+                    b.Navigation(e => e.ThreeSkipFull).EnableLazyLoading(false);
+                    b.Navigation(e => e.JoinThreeFull).EnableLazyLoading(false);
+                    b.Navigation(e => e.RootSkipShared).EnableLazyLoading(false);
+                    b.Navigation(e => e.LeafSkipFull).EnableLazyLoading(false);
+                    b.Navigation(e => e.JoinLeafFull).EnableLazyLoading(false);
+                });
+        }
+    }
+}

--- a/test/EFCore.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Tests/ApiConsistencyTest.cs
@@ -92,6 +92,20 @@ public class ApiConsistencyTest : ApiConsistencyTestBase<ApiConsistencyTest.ApiC
             typeof(IEntityTypeConfiguration<>).GetMethod(nameof(IEntityTypeConfiguration<Type>.Configure))
         };
 
+        public override Dictionary<MethodInfo, string> MetadataMethodNameTransformers { get; } = new()
+        {
+            {
+                typeof(IConventionNavigationBuilder).GetMethod(
+                    nameof(IConventionNavigationBuilder.EnableLazyLoading), new[] { typeof(bool?), typeof(bool) })!,
+                "LazyLoadingEnabled"
+            },
+            {
+                typeof(IConventionSkipNavigationBuilder).GetMethod(
+                    nameof(IConventionSkipNavigationBuilder.EnableLazyLoading), new[] { typeof(bool?), typeof(bool) })!,
+                "LazyLoadingEnabled"
+            }
+        };
+
         public override HashSet<MethodInfo> UnmatchedMetadataMethods { get; } = new()
         {
             typeof(OwnedNavigationBuilder).GetMethod(

--- a/test/EFCore.Tests/Metadata/Internal/InternalNavigationBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalNavigationBuilderTest.cs
@@ -155,6 +155,42 @@ public class InternalNavigationBuilderTest
     }
 
     [ConditionalFact]
+    public void Can_only_override_lower_or_equal_source_LazyLoadingEnabled()
+    {
+        var builder = CreateInternalNavigationBuilder();
+        IConventionNavigation metadata = builder.Metadata;
+
+        Assert.True(metadata.LazyLoadingEnabled);
+        Assert.Null(metadata.GetLazyLoadingEnabledConfigurationSource());
+
+        Assert.True(builder.CanSetLazyLoadingEnabled(lazyLoadingEnabled: false, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.EnableLazyLoading(lazyLoadingEnabled: false, ConfigurationSource.DataAnnotation));
+
+        Assert.False(metadata.LazyLoadingEnabled);
+        Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetLazyLoadingEnabledConfigurationSource());
+
+        Assert.True(builder.CanSetLazyLoadingEnabled(lazyLoadingEnabled: false, ConfigurationSource.Convention));
+        Assert.False(builder.CanSetLazyLoadingEnabled(lazyLoadingEnabled: true, ConfigurationSource.Convention));
+        Assert.NotNull(builder.EnableLazyLoading(lazyLoadingEnabled: false, ConfigurationSource.Convention));
+        Assert.Null(builder.EnableLazyLoading(lazyLoadingEnabled: true, ConfigurationSource.Convention));
+
+        Assert.False(metadata.LazyLoadingEnabled);
+        Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetLazyLoadingEnabledConfigurationSource());
+
+        Assert.True(builder.CanSetLazyLoadingEnabled(lazyLoadingEnabled: true, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.EnableLazyLoading(lazyLoadingEnabled: true, ConfigurationSource.DataAnnotation));
+
+        Assert.True(metadata.LazyLoadingEnabled);
+        Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetLazyLoadingEnabledConfigurationSource());
+
+        Assert.True(builder.CanSetLazyLoadingEnabled(null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.EnableLazyLoading(null, ConfigurationSource.DataAnnotation));
+
+        Assert.True(metadata.LazyLoadingEnabled);
+        Assert.Null(metadata.GetLazyLoadingEnabledConfigurationSource());
+    }
+
+    [ConditionalFact]
     public void Configuring_IsRequired_on_to_dependent_nonUnique_throws()
     {
         var builder = CreateInternalNavigationBuilder();

--- a/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
@@ -262,6 +262,42 @@ public class InternalSkipNavigationBuilderTest
         Assert.Null(metadata.GetIsEagerLoadedConfigurationSource());
     }
 
+    [ConditionalFact]
+    public void Can_only_override_lower_or_equal_source_LazyLoadingEnabled()
+    {
+        var builder = CreateInternalSkipNavigationBuilder();
+        IConventionSkipNavigation metadata = builder.Metadata;
+
+        Assert.True(metadata.LazyLoadingEnabled);
+        Assert.Null(metadata.GetLazyLoadingEnabledConfigurationSource());
+
+        Assert.True(builder.CanSetLazyLoadingEnabled(lazyLoadingEnabled: false, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.EnableLazyLoading(lazyLoadingEnabled: false, ConfigurationSource.DataAnnotation));
+
+        Assert.False(metadata.LazyLoadingEnabled);
+        Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetLazyLoadingEnabledConfigurationSource());
+
+        Assert.True(builder.CanSetLazyLoadingEnabled(lazyLoadingEnabled: false, ConfigurationSource.Convention));
+        Assert.False(builder.CanSetLazyLoadingEnabled(lazyLoadingEnabled: true, ConfigurationSource.Convention));
+        Assert.NotNull(builder.EnableLazyLoading(lazyLoadingEnabled: false, ConfigurationSource.Convention));
+        Assert.Null(builder.EnableLazyLoading(lazyLoadingEnabled: true, ConfigurationSource.Convention));
+
+        Assert.False(metadata.LazyLoadingEnabled);
+        Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetLazyLoadingEnabledConfigurationSource());
+
+        Assert.True(builder.CanSetLazyLoadingEnabled(lazyLoadingEnabled: true, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.EnableLazyLoading(lazyLoadingEnabled: true, ConfigurationSource.DataAnnotation));
+
+        Assert.True(metadata.LazyLoadingEnabled);
+        Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetLazyLoadingEnabledConfigurationSource());
+
+        Assert.True(builder.CanSetLazyLoadingEnabled(null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.EnableLazyLoading(null, ConfigurationSource.DataAnnotation));
+
+        Assert.True(metadata.LazyLoadingEnabled);
+        Assert.Null(metadata.GetLazyLoadingEnabledConfigurationSource());
+    }
+
     private InternalSkipNavigationBuilder CreateInternalSkipNavigationBuilder()
     {
         var modelBuilder = (InternalModelBuilder)

--- a/test/EFCore.Tests/Metadata/Internal/SkipNavigationTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/SkipNavigationTest.cs
@@ -47,6 +47,10 @@ public class SkipNavigationTest
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
+            Assert.Throws<InvalidOperationException>(() => navigation.SetLazyLoadingEnabled(null)).Message);
+
+        Assert.Equal(
+            CoreStrings.ModelReadOnly,
             Assert.Throws<InvalidOperationException>(() => navigation.SetPropertyAccessMode(null)).Message);
     }
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -664,6 +664,9 @@ public class ModelBuilderGenericTest : ModelBuilderTest
         public override TestNavigationBuilder AutoInclude(bool autoInclude = true)
             => new GenericTestNavigationBuilder<TSource, TTarget>(NavigationBuilder.AutoInclude(autoInclude));
 
+        public override TestNavigationBuilder EnableLazyLoading(bool lazyLoadingEnabled = true)
+            => new GenericTestNavigationBuilder<TSource, TTarget>(NavigationBuilder.EnableLazyLoading(lazyLoadingEnabled));
+
         public override TestNavigationBuilder IsRequired(bool required = true)
             => new GenericTestNavigationBuilder<TSource, TTarget>(NavigationBuilder.IsRequired(required));
     }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -695,6 +695,9 @@ public class ModelBuilderNonGenericTest : ModelBuilderTest
         public override TestNavigationBuilder AutoInclude(bool autoInclude = true)
             => new NonGenericTestNavigationBuilder(NavigationBuilder.AutoInclude(autoInclude));
 
+        public override TestNavigationBuilder EnableLazyLoading(bool lazyLoadingEnabled = true)
+            => new NonGenericTestNavigationBuilder(NavigationBuilder.EnableLazyLoading(lazyLoadingEnabled));
+
         public override TestNavigationBuilder IsRequired(bool required = true)
             => new NonGenericTestNavigationBuilder(NavigationBuilder.IsRequired(required));
     }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -456,6 +456,7 @@ public abstract partial class ModelBuilderTest
         public abstract TestNavigationBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode);
         public abstract TestNavigationBuilder HasField(string fieldName);
         public abstract TestNavigationBuilder AutoInclude(bool autoInclude = true);
+        public abstract TestNavigationBuilder EnableLazyLoading(bool lazyLoadingEnabled = true);
         public abstract TestNavigationBuilder IsRequired(bool required = true);
     }
 


### PR DESCRIPTION
Part of #10787

Also fixes two issues with service properties and their delegates:

- The delegate is now always created pointing to the instance of the service property stored in the entity. Previously, it could sometimes be a delegate pointing to a new service instance.
- The service property instance is always treated as an IInjectableService when attaching or materializing, so the metadata is always present on the instance.


