### PR TITLE
Allow ignoring non-virtual navigations with lazy-loading proxies

### DIFF
--- a/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
@@ -16,6 +16,7 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
 {
     private DbContextOptionsExtensionInfo? _info;
     private bool _useLazyLoadingProxies;
+    private bool _ignoreNonVirtualNavigations;
     private bool _useChangeTrackingProxies;
     private bool _checkEquality;
 
@@ -38,6 +39,7 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
     protected ProxiesOptionsExtension(ProxiesOptionsExtension copyFrom)
     {
         _useLazyLoadingProxies = copyFrom._useLazyLoadingProxies;
+        _ignoreNonVirtualNavigations = copyFrom._ignoreNonVirtualNavigations;
         _useChangeTrackingProxies = copyFrom._useChangeTrackingProxies;
         _checkEquality = copyFrom._checkEquality;
     }
@@ -75,6 +77,15 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public virtual bool IgnoreNonVirtualNavigations
+        => _ignoreNonVirtualNavigations;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual bool UseChangeTrackingProxies
         => _useChangeTrackingProxies;
 
@@ -102,11 +113,12 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual ProxiesOptionsExtension WithLazyLoading(bool useLazyLoadingProxies = true)
+    public virtual ProxiesOptionsExtension WithLazyLoading(bool useLazyLoadingProxies, bool ignoreNonVirtualNavigations)
     {
         var clone = Clone();
 
         clone._useLazyLoadingProxies = useLazyLoadingProxies;
+        clone._ignoreNonVirtualNavigations = ignoreNonVirtualNavigations;
 
         return clone;
     }
@@ -117,7 +129,7 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual ProxiesOptionsExtension WithChangeTracking(bool useChangeTrackingProxies = true, bool checkEquality = true)
+    public virtual ProxiesOptionsExtension WithChangeTracking(bool useChangeTrackingProxies, bool checkEquality)
     {
         var clone = Clone();
 
@@ -187,6 +199,7 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
         {
             var hashCode = new HashCode();
             hashCode.Add(Extension.UseLazyLoadingProxies);
+            hashCode.Add(Extension.IgnoreNonVirtualNavigations);
             hashCode.Add(Extension.UseChangeTrackingProxies);
             hashCode.Add(Extension.CheckEquality);
             return hashCode.ToHashCode();
@@ -195,6 +208,7 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
         public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
             => other is ExtensionInfo otherInfo
                 && Extension.UseLazyLoadingProxies == otherInfo.Extension.UseLazyLoadingProxies
+                && Extension.IgnoreNonVirtualNavigations == otherInfo.Extension.IgnoreNonVirtualNavigations
                 && Extension.UseChangeTrackingProxies == otherInfo.Extension.UseChangeTrackingProxies
                 && Extension.CheckEquality == otherInfo.Extension.CheckEquality;
 

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
@@ -94,15 +94,20 @@ public class ProxyBindingRewriter : IModelFinalizingConvention
 
                         if (_options.UseLazyLoadingProxies)
                         {
-                            if (!navigationBase.PropertyInfo.GetMethod!.IsReallyVirtual()
-                                && (!(navigationBase is INavigation navigation
-                                    && navigation.ForeignKey.IsOwnership)))
+                            if (!navigationBase.PropertyInfo.GetMethod!.IsReallyVirtual())
                             {
-                                throw new InvalidOperationException(
-                                    ProxiesStrings.NonVirtualProperty(navigationBase.Name, entityType.DisplayName()));
+                                if (!_options.IgnoreNonVirtualNavigations
+                                    && !(navigationBase is INavigation navigation
+                                        && navigation.ForeignKey.IsOwnership))
+                                {
+                                    throw new InvalidOperationException(
+                                        ProxiesStrings.NonVirtualProperty(navigationBase.Name, entityType.DisplayName()));
+                                }
                             }
-
-                            navigationBase.SetPropertyAccessMode(PropertyAccessMode.Field);
+                            else
+                            {
+                                navigationBase.SetPropertyAccessMode(PropertyAccessMode.Field);
+                            }
                         }
                     }
                 }

--- a/src/EFCore.Proxies/ProxiesExtensions.cs
+++ b/src/EFCore.Proxies/ProxiesExtensions.cs
@@ -105,15 +105,20 @@ public static class ProxiesExtensions
     ///     or exposed AddDbContext.
     /// </param>
     /// <param name="useLazyLoadingProxies"><see langword="true" /> to use lazy loading proxies; <see langword="false" /> to prevent their use.</param>
+    /// <param name="ignoreNonVirtualNavigations">
+    ///     <see langword="true" /> to ignore navigations that are not virtual. The default value is
+    ///     <see langword="false" />, meaning an exception will be thrown if a non-virtual navigation is found.
+    /// </param>
     /// <returns>The same builder to allow method calls to be chained.</returns>
     public static DbContextOptionsBuilder UseLazyLoadingProxies(
         this DbContextOptionsBuilder optionsBuilder,
-        bool useLazyLoadingProxies = true)
+        bool useLazyLoadingProxies = true,
+        bool ignoreNonVirtualNavigations = false)
     {
         var extension = optionsBuilder.Options.FindExtension<ProxiesOptionsExtension>()
             ?? new ProxiesOptionsExtension();
 
-        extension = extension.WithLazyLoading(useLazyLoadingProxies);
+        extension = extension.WithLazyLoading(useLazyLoadingProxies, ignoreNonVirtualNavigations);
 
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
@@ -139,10 +144,15 @@ public static class ProxiesExtensions
     ///     or exposed AddDbContext.
     /// </param>
     /// <param name="useLazyLoadingProxies"><see langword="true" /> to use lazy loading proxies; <see langword="false" /> to prevent their use.</param>
+    /// <param name="ignoreNonVirtualNavigations">
+    ///     <see langword="true" /> to ignore navigations that are not virtual. The default value is
+    ///     <see langword="false" />, meaning an exception will be thrown if a non-virtual navigation is found.
+    /// </param>
     /// <returns>The same builder to allow method calls to be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseLazyLoadingProxies<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
-        bool useLazyLoadingProxies = true)
+        bool useLazyLoadingProxies = true,
+        bool ignoreNonVirtualNavigations = false)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseLazyLoadingProxies((DbContextOptionsBuilder)optionsBuilder, useLazyLoadingProxies);
 

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -29,6 +29,14 @@ public class LazyLoadingProxyTests
     }
 
     [ConditionalFact]
+    public void Does_not_throw_if_non_virtual_navigation_to_non_owned_type_is_allowed()
+    {
+        using var context = new LazyContextIgnoreVirtuals<LazyNonVirtualNavEntity>();
+        Assert.NotNull(
+            context.Model.FindEntityType(typeof(LazyNonVirtualNavEntity))!.FindNavigation(nameof(LazyNonVirtualNavEntity.SelfRef)));
+    }
+
+    [ConditionalFact]
     public void Does_not_throw_if_non_virtual_navigation_to_owned_type()
     {
         using var context = new LazyContext<LazyNonVirtualOwnedNavEntity>();
@@ -80,6 +88,15 @@ public class LazyLoadingProxyTests
                 "CoreEventId.LazyLoadOnDisposedContextWarning"),
             Assert.Throws<InvalidOperationException>(
                 () => phone.Texts).Message);
+    }
+
+    private class LazyContextIgnoreVirtuals<TEntity> : TestContext<TEntity>
+        where TEntity : class
+    {
+        public LazyContextIgnoreVirtuals()
+            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false, ignoreNonVirtualNavigations: true)
+        {
+        }
     }
 
     private class LazyContext<TEntity> : TestContext<TEntity>

--- a/test/EFCore.Proxies.Tests/TestUtilities/TestContext.cs
+++ b/test/EFCore.Proxies.Tests/TestUtilities/TestContext.cs
@@ -11,6 +11,7 @@ internal abstract class TestContext<TEntity> : DbContext
     private readonly IServiceProvider _internalServiceProvider;
     private readonly string _dbName;
     private readonly bool _useLazyLoadingProxies;
+    private readonly bool _ignoreNonVirtualNavigations;
     private readonly bool _useChangeDetectionProxies;
     private readonly bool _checkEquality;
     private readonly ChangeTrackingStrategy? _changeTrackingStrategy;
@@ -20,7 +21,8 @@ internal abstract class TestContext<TEntity> : DbContext
         bool useLazyLoading = false,
         bool useChangeDetection = false,
         bool checkEquality = true,
-        ChangeTrackingStrategy? changeTrackingStrategy = null)
+        ChangeTrackingStrategy? changeTrackingStrategy = null,
+        bool ignoreNonVirtualNavigations = false)
     {
         _internalServiceProvider
             = new ServiceCollection()
@@ -33,13 +35,14 @@ internal abstract class TestContext<TEntity> : DbContext
         _useChangeDetectionProxies = useChangeDetection;
         _checkEquality = checkEquality;
         _changeTrackingStrategy = changeTrackingStrategy;
+        _ignoreNonVirtualNavigations = ignoreNonVirtualNavigations;
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         if (_useLazyLoadingProxies)
         {
-            optionsBuilder.UseLazyLoadingProxies();
+            optionsBuilder.UseLazyLoadingProxies(ignoreNonVirtualNavigations: _ignoreNonVirtualNavigations);
         }
 
         if (_useChangeDetectionProxies)


### PR DESCRIPTION
Part of #10787

Like the EF6 behavior, but opt-in.
