### PR TITLE
Working implementation of precompiled queries

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -296,6 +296,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=funcletization/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Includable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=initializers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Inliner/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keyless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializers/@EntryIndexedValue">True</s:Boolean>
@@ -307,6 +308,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=niladic/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pluralizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Poolable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=precompilation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pushdown/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=remapper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=requiredness/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Design;
@@ -60,6 +61,13 @@ public static class DesignTimeServiceCollectionExtensions
                     .TryAddSingleton<IScaffoldingTypeMapper, ScaffoldingTypeMapper>()
                     .TryAddSingleton<MigrationsCodeGeneratorDependencies, MigrationsCodeGeneratorDependencies>()
                     .TryAddSingleton<ModelCodeGeneratorDependencies, ModelCodeGeneratorDependencies>()
+
+                    // Query precompilation
+                    .TryAddSingleton<IPrecompiledQueryCodeGenerator, PrecompiledQueryCodeGenerator>()
+                    .TryAddSingleton<IQueryLocator, QueryLocator>()
+                    .TryAddSingleton<ICSharpToLinqTranslator, CSharpToLinqTranslator>()
+                    .TryAddSingleton<ISqlTreeQuoter, SqlTreeQuoter>()
+
                     .TryAddScoped<IReverseEngineerScaffolder, ReverseEngineerScaffolder>()
                     .TryAddScoped<MigrationsScaffolderDependencies, MigrationsScaffolderDependencies>()
                     .TryAddScoped<IMigrationsScaffolder, MigrationsScaffolder>()

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -530,6 +530,42 @@ public class OperationExecutor : MarshalByRefObject
         => ContextOperations.Optimize(outputDir, modelNamespace, contextType);
 
     /// <summary>
+    ///     Represents an operation to precompile LINQ queries.
+    /// </summary>
+    public class PrecompileQueries : OperationBase
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PrecompileQueries" /> class.
+        /// </summary>
+        /// <remarks>
+        ///     <para>The arguments supported by <paramref name="args" /> are:</para>
+        ///     <para><c>outputDir</c>--The directory to put files in. Paths are relative to the project directory.</para>
+        ///     <para><c>modelNamespace</c>--Specify to override the namespace of the generated model.</para>
+        ///     <para><c>contextType</c>--The <see cref="DbContext" /> to use.</para>
+        /// </remarks>
+        /// <param name="executor">The operation executor.</param>
+        /// <param name="resultHandler">The <see cref="IOperationResultHandler" />.</param>
+        /// <param name="args">The operation arguments.</param>
+        public PrecompileQueries(
+            OperationExecutor executor,
+            IOperationResultHandler resultHandler,
+            IDictionary args)
+            : base(resultHandler)
+        {
+            Check.NotNull(executor, nameof(executor));
+            Check.NotNull(args, nameof(args));
+
+            var outputDir = (string?)args["outputDir"];
+            var contextType = (string?)args["contextType"];
+
+            Execute(() => executor.PrecompileQueriesImpl(outputDir, contextType));
+        }
+    }
+
+    private void PrecompileQueriesImpl(string? outputDir, string? contextType)
+        => ContextOperations.PrecompileQueries(outputDir, contextType);
+
+    /// <summary>
     ///     Represents an operation to scaffold a <see cref="DbContext" /> and entity types for a database.
     /// </summary>
     public class ScaffoldContext : OperationBase

--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -62,6 +62,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <PackageReference Include="Microsoft.Extensions.HostFactoryResolver.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsHostFactoryResolverSourcesVersion)" />
     <PackageReference Include="Mono.TextTemplating" Version="2.2.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EFCore.Design/Extensions/Internal/TypeExtensions.cs
+++ b/src/EFCore.Design/Extensions/Internal/TypeExtensions.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+internal static class TypeExtensions
+{
+    internal static TypeSyntax GetTypeSyntax(this Type type)
+    {
+        // TODO: Qualification...
+        if (type.IsGenericType)
+        {
+            return GenericName(
+                Identifier(type.Name.Substring(0, type.Name.IndexOf('`'))),
+                TypeArgumentList(SeparatedList(type.GenericTypeArguments.Select(GetTypeSyntax))));
+        }
+
+        if (type == typeof(string))
+        {
+            return PredefinedType(Token(SyntaxKind.StringKeyword));
+        }
+
+        if (type == typeof(bool))
+        {
+            return PredefinedType(Token(SyntaxKind.BoolKeyword));
+        }
+
+        if (type == typeof(byte))
+        {
+            return PredefinedType(Token(SyntaxKind.ByteKeyword));
+        }
+
+        if (type == typeof(sbyte))
+        {
+            return PredefinedType(Token(SyntaxKind.SByteKeyword));
+        }
+
+        if (type == typeof(int))
+        {
+            return PredefinedType(Token(SyntaxKind.IntKeyword));
+        }
+
+        if (type == typeof(uint))
+        {
+            return PredefinedType(Token(SyntaxKind.UIntKeyword));
+        }
+
+        if (type == typeof(short))
+        {
+            return PredefinedType(Token(SyntaxKind.ShortKeyword));
+        }
+
+        if (type == typeof(ushort))
+        {
+            return PredefinedType(Token(SyntaxKind.UShortKeyword));
+        }
+
+        if (type == typeof(long))
+        {
+            return PredefinedType(Token(SyntaxKind.LongKeyword));
+        }
+
+        if (type == typeof(ulong))
+        {
+            return PredefinedType(Token(SyntaxKind.ULongKeyword));
+        }
+
+        if (type == typeof(float))
+        {
+            return PredefinedType(Token(SyntaxKind.FloatKeyword));
+        }
+
+        if (type == typeof(double))
+        {
+            return PredefinedType(Token(SyntaxKind.DoubleKeyword));
+        }
+
+        if (type == typeof(decimal))
+        {
+            return PredefinedType(Token(SyntaxKind.DecimalKeyword));
+        }
+
+        if (type == typeof(char))
+        {
+            return PredefinedType(Token(SyntaxKind.CharKeyword));
+        }
+
+        if (type == typeof(object))
+        {
+            return PredefinedType(Token(SyntaxKind.ObjectKeyword));
+        }
+
+        if (type == typeof(void))
+        {
+            return PredefinedType(Token(SyntaxKind.VoidKeyword));
+        }
+
+        return IdentifierName(type.Name);
+    }
+}

--- a/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/CSharpToLinqTranslator.cs
@@ -1,0 +1,1166 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static System.Linq.Expressions.Expression;
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class CSharpToLinqTranslator : CSharpSyntaxVisitor<Expression>, ICSharpToLinqTranslator
+{
+    private static readonly SymbolDisplayFormat QualifiedTypeNameSymbolDisplayFormat = new(
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+
+    private Compilation? _compilation;
+
+#pragma warning disable CS8618 // Uninitialized non-nullable fields. We check _compilation to make sure LoadCompilation was invoked.
+    private DbContext _userDbContext;
+    private Type _userDbContextType;
+    private INamedTypeSymbol _userDbContextSymbol;
+    private INamedTypeSymbol _dbSetSymbol;
+#pragma warning restore CS8618
+
+    private SemanticModel _semanticModel = null!;
+
+    private static MethodInfo? _stringConcatMethod;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public void Load(Compilation compilation, DbContext userDbContext)
+    {
+        _compilation = compilation;
+        _userDbContext = userDbContext;
+        _userDbContextType = userDbContext.GetType();
+        _userDbContextSymbol = GetTypeSymbolOrThrow(_userDbContextType.FullName!);
+        _dbSetSymbol = GetTypeSymbolOrThrow("Microsoft.EntityFrameworkCore.DbSet`1");
+
+        INamedTypeSymbol GetTypeSymbolOrThrow(string fullyQualifiedMetadataName)
+            => _compilation.GetTypeByMetadataName(fullyQualifiedMetadataName)
+                ?? throw new InvalidOperationException("Could not find type symbol for: " + fullyQualifiedMetadataName);
+    }
+
+    private readonly Stack<ImmutableDictionary<string, ParameterExpression>> _parameterStack
+        = new(new[] { ImmutableDictionary<string, ParameterExpression>.Empty });
+
+    private readonly Dictionary<ISymbol, MemberExpression?> _capturedVariables = new(SymbolEqualityComparer.Default);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public Expression Translate(SyntaxNode node, SemanticModel semanticModel)
+    {
+        if (_compilation is null)
+        {
+            throw new InvalidOperationException("A compilation must be loaded.");
+        }
+
+        Check.DebugAssert(
+            ReferenceEquals(semanticModel.SyntaxTree, node.SyntaxTree),
+            "Provided semantic model doesn't match the provided syntax node");
+
+        _semanticModel = semanticModel;
+
+        // Perform data flow analysis to detect all captured data (closure parameters)
+        _capturedVariables.Clear();
+        foreach (var captured in _semanticModel.AnalyzeDataFlow(node).Captured)
+        {
+            _capturedVariables[captured] = null;
+        }
+
+        var result = Visit(node);
+
+        // TODO: Sanity check: make sure all captured variables in _capturedVariables have non-null values
+        // (i.e. have been encountered and referenced)
+
+        Debug.Assert(_parameterStack.Count == 1);
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [return: NotNullIfNotNull("node")]
+    public override Expression? Visit(SyntaxNode? node)
+        => base.Visit(node);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitAnonymousObjectCreationExpression(
+        AnonymousObjectCreationExpressionSyntax objectCreation)
+    {
+        // Creating an actual anonymous object means creating a new type, which can only be done with Reflection.Emit.
+        // At least for EF's purposes, it doesn't matter, so we build a placeholder.
+        if (_semanticModel.GetSymbolInfo(objectCreation).Symbol is not IMethodSymbol constructorSymbol)
+        {
+            throw new InvalidOperationException(
+                "Could not find symbol for anonymous object creation initializer: " + objectCreation);
+        }
+
+        var anonymousType = ResolveType(constructorSymbol.ContainingType);
+
+        var parameters = constructorSymbol.Parameters.ToArray();
+
+        var parameterInfos = new ParameterInfo[parameters.Length];
+        var memberInfos = new MemberInfo[parameters.Length];
+        var arguments = new Expression[parameters.Length];
+
+        foreach (var initializer in objectCreation.Initializers)
+        {
+            if (initializer.NameEquals is null)
+            {
+                throw new NotImplementedException("Unnamed anonymous object initializer");
+            }
+            else
+            {
+                var position = Array.FindIndex(parameters, p => p.Name == initializer.NameEquals.Name.Identifier.Text);
+                var parameter = parameters[position];
+                var parameterType = ResolveType(parameter.Type) ?? throw new InvalidOperationException(
+                    "Could not resolve type symbol for: " + parameter.Type);
+
+                parameterInfos[position] = new FakeParameterInfo(
+                    initializer.NameEquals.Name.Identifier.Text,
+                    parameterType,
+                    position);
+                arguments[position] = Visit(initializer.Expression);
+                memberInfos[position] = anonymousType.GetProperty(parameter.Name)!;
+            }
+        }
+
+        return New(
+            new FakeConstructorInfo(anonymousType, parameterInfos),
+            arguments: arguments,
+            memberInfos);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitArgument(ArgumentSyntax argument)
+    {
+        if (!argument.RefKindKeyword.IsKind(SyntaxKind.None))
+        {
+            throw new InvalidOperationException($"Argument with ref/out: {argument}");
+        }
+
+        return Visit(argument.Expression);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitArrayCreationExpression(ArrayCreationExpressionSyntax arrayCreation)
+    {
+        if (_semanticModel.GetTypeInfo(arrayCreation).Type is not IArrayTypeSymbol arrayTypeSymbol)
+        {
+            throw new InvalidOperationException($"ArrayCreation: non-array type symbol: {arrayCreation}");
+        }
+
+        if (arrayTypeSymbol.Rank > 1)
+        {
+            throw new NotImplementedException($"ArrayCreation: multi-dimensional array: {arrayCreation}");
+        }
+
+        var elementType = ResolveType(arrayTypeSymbol.ElementType);
+        Check.DebugAssert(elementType is not null, "elementType is not null");
+
+        return arrayCreation.Initializer is null
+            ? NewArrayBounds(elementType, Visit(arrayCreation.Type.RankSpecifiers[0].Sizes[0]))
+            : NewArrayInit(elementType, arrayCreation.Initializer.Expressions.Select(e => Visit(e)));
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitBinaryExpression(BinaryExpressionSyntax binary)
+    {
+        var left = Visit(binary.Left);
+        var right = Visit(binary.Right);
+
+        // https://learn.microsoft.com/dotnet/api/Microsoft.CodeAnalysis.CSharp.Syntax.BinaryExpressionSyntax
+        return binary.Kind() switch
+        {
+            // String concatenation
+            SyntaxKind.AddExpression
+                when left.Type == typeof(string) && right.Type == typeof(string)
+                => Add(left, right,
+                    _stringConcatMethod ??=
+                        typeof(string).GetMethod(nameof(string.Concat), new[] { typeof(string), typeof(string) })),
+
+            SyntaxKind.AddExpression => Add(left, right),
+            SyntaxKind.SubtractExpression => Subtract(left, right),
+            SyntaxKind.MultiplyExpression => Multiply(left, right),
+            SyntaxKind.DivideExpression => Divide(left, right),
+            SyntaxKind.ModuloExpression => Modulo(left, right),
+            SyntaxKind.LeftShiftExpression => LeftShift(left, right),
+            SyntaxKind.RightShiftExpression => RightShift(left, right),
+            // TODO UnsignedRightShiftExpression
+            SyntaxKind.LogicalOrExpression => OrElse(left, right),
+            SyntaxKind.LogicalAndExpression => AndAlso(left, right),
+            SyntaxKind.BitwiseOrExpression => Or(left, right),
+            SyntaxKind.BitwiseAndExpression => And(left, right),
+            SyntaxKind.ExclusiveOrExpression => ExclusiveOr(left, right),
+            SyntaxKind.EqualsExpression => Equal(left, right),
+            SyntaxKind.NotEqualsExpression => NotEqual(left, right),
+            SyntaxKind.LessThanExpression => LessThan(left, right),
+            SyntaxKind.LessThanOrEqualExpression => LessThanOrEqual(left, right),
+            SyntaxKind.GreaterThanExpression => GreaterThan(left, right),
+            SyntaxKind.GreaterThanOrEqualExpression => GreaterThanOrEqual(left, right),
+            SyntaxKind.IsExpression => TypeIs(left, right is ConstantExpression { Value : Type type }
+                ? type
+                : throw new InvalidOperationException($"Encountered {SyntaxKind.IsExpression} with non-constant type right argument: {right}")),
+            SyntaxKind.AsExpression => TypeAs(left, right is ConstantExpression { Value : Type type }
+                ? type
+                : throw new InvalidOperationException($"Encountered {SyntaxKind.AsExpression} with non-constant type right argument: {right}")),
+            SyntaxKind.CoalesceExpression => Coalesce(left, right),
+
+            _ => throw new ArgumentOutOfRangeException($"BinaryExpressionSyntax with {binary.Kind()}")
+        };
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitCastExpression(CastExpressionSyntax cast)
+        => Convert(Visit(cast.Expression), ResolveType(cast.Type));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitConditionalExpression(ConditionalExpressionSyntax conditional)
+        => Condition(
+            Visit(conditional.Condition),
+            Visit(conditional.WhenTrue),
+            Visit(conditional.WhenFalse));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitElementAccessExpression(ElementAccessExpressionSyntax elementAccessExpression)
+    {
+        var visitedExpression = Visit(elementAccessExpression.Expression);
+
+        var expressionType = _semanticModel.GetTypeInfo(elementAccessExpression.Expression).ConvertedType;
+        if (expressionType is null)
+        {
+            throw new InvalidOperationException(
+                $"No type for expression {elementAccessExpression.Expression} in {nameof(ElementAccessExpressionSyntax)}");
+        }
+
+        if (expressionType is IArrayTypeSymbol)
+        {
+            Check.DebugAssert(elementAccessExpression.ArgumentList.Arguments.Count == 1,
+                $"ElementAccessExpressionSyntax over array with {elementAccessExpression.ArgumentList.Arguments.Count} arguments");
+
+            var visitedArgument = Visit(elementAccessExpression.ArgumentList.Arguments[0].Expression);
+
+            return ArrayIndex(visitedExpression, visitedArgument);
+        }
+
+        throw new NotImplementedException($"{nameof(ElementAccessExpressionSyntax)} over non-array");
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitIdentifierName(IdentifierNameSyntax identifierName)
+    {
+        if (_parameterStack.Peek().TryGetValue(identifierName.Identifier.Text, out var parameter))
+        {
+            return parameter;
+        }
+
+        var symbol = _semanticModel.GetSymbolInfo(identifierName).Symbol;
+
+        ILocalSymbol localSymbol;
+        switch (symbol)
+        {
+            case INamedTypeSymbol typeSymbol:
+                return Constant(ResolveType(typeSymbol));
+            case ILocalSymbol ls:
+                localSymbol = ls;
+                break;
+            case null:
+                throw new InvalidOperationException($"Identifier without symbol: {identifierName}");
+            default:
+                throw new NotImplementedException($"IdentifierName of type {symbol.GetType().Name}: {identifierName}");
+        }
+
+        // TODO: Separate out EF Core-specific logic (EF Core would extend this visitor)
+        if (localSymbol.Type.Name.Contains("DbSet"))
+        {
+            var queryRootType = ResolveType(localSymbol.Type)!;
+            // TODO: Decide what to actually return for query root
+            return Constant(null, queryRootType);
+        }
+
+        // We have an identifier which isn't in our parameters stack - it's a closure parameter.
+        // Check if this closure parameter has already been referenced elsewhere in the query (two references to the
+        // same local variable)
+        // TODO: Test closure over class member (not local variable)
+        if (!_capturedVariables.TryGetValue(localSymbol, out var memberExpression))
+        {
+            throw new InvalidOperationException(
+                $"Encountered unknown identifier name {identifierName}, which doesn't correspond to a lambda parameter or captured variable");
+        }
+
+        // We haven't seen this captured variable yet
+        if (memberExpression is null)
+        {
+            memberExpression = _capturedVariables[localSymbol] = _capturedVariables[localSymbol] =
+                Field(
+                    Constant(new FakeClosureFrameClass()),
+                    new FakeFieldInfo(
+                        typeof(FakeClosureFrameClass),
+                        ResolveType(localSymbol.Type),
+                        localSymbol.Name));
+        }
+
+        return memberExpression;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitImplicitArrayCreationExpression(ImplicitArrayCreationExpressionSyntax implicitArrayCreation)
+    {
+        if (_semanticModel.GetTypeInfo(implicitArrayCreation).Type is not IArrayTypeSymbol arrayTypeSymbol)
+        {
+            throw new InvalidOperationException($"ArrayCreation: non-array type symbol: {implicitArrayCreation}");
+        }
+
+        if (arrayTypeSymbol.Rank > 1)
+        {
+            throw new NotImplementedException($"ArrayCreation: multi-dimensional array: {implicitArrayCreation}");
+        }
+
+        var elementType = ResolveType(arrayTypeSymbol.ElementType);
+        Check.DebugAssert(elementType is not null, "elementType is not null");
+
+        var initializers = implicitArrayCreation.Initializer.Expressions.Select(e => Visit(e));
+
+        return NewArrayInit(elementType, initializers);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitInvocationExpression(InvocationExpressionSyntax invocation)
+    {
+        if (_semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol methodSymbol)
+        {
+            throw new InvalidOperationException("Could not find symbol for method invocation: " + invocation);
+        }
+
+        var declaringType = ResolveType(methodSymbol.ContainingType);
+
+        Expression? instance = null;
+        if (!methodSymbol.IsStatic || methodSymbol.IsExtensionMethod)
+        {
+            // In normal method calls (the ones we support), the invocation node is composed on top of a member access
+            if (invocation.Expression is not MemberAccessExpressionSyntax { Expression: var receiver })
+            {
+                throw new NotSupportedException($"Invocation over non-member access: {invocation}");
+            }
+
+            instance = Visit(receiver);
+        }
+
+        MethodInfo? methodInfo;
+
+        if (methodSymbol.IsGenericMethod)
+        {
+            var originalDefinition = methodSymbol.OriginalDefinition;
+            if (originalDefinition.ReducedFrom is not null)
+            {
+                originalDefinition = originalDefinition.ReducedFrom;
+            }
+
+            // var originalDefParamTypes = originalDefinition.Parameters.Select(p => ResolveType(p.Type)).ToArray();
+            // var paramTypes = reducedMethodSymbol.Parameters.Select(p => ResolveType(p.Type)).ToArray();
+
+            // TODO: Populate with generic type parameters from the containing type (and nested containing types, methods?), not just method
+            // below
+            // TODO: We match Roslyn type parameters by name, not sure that's right
+            var genericParameterMap = new Dictionary<string, Type>();
+
+            var definitionMethodInfos = declaringType.GetMethods()
+                .Where(m =>
+                {
+                    if (m.Name == methodSymbol.Name
+                        && m.IsGenericMethodDefinition
+                        && m.GetGenericArguments() is var candidateGenericArguments
+                        && candidateGenericArguments.Length == originalDefinition.TypeParameters.Length
+                        && m.GetParameters() is var candidateParams
+                        && candidateParams.Length == originalDefinition.Parameters.Length)
+                    {
+                        // Prepare a dictionary that will be used to resolve generic type parameters (ITypeParameterSymbol) to the
+                        // corresponding reflection Type. This is needed to correctly (and recursively) resolve the type of parameters
+                        // below.
+                        genericParameterMap.Clear();
+                        foreach (var (symbol, type) in methodSymbol.TypeParameters.Zip(candidateGenericArguments))
+                        {
+                            if (symbol.Name != type.Name)
+                            {
+                                return false;
+                            }
+
+                            genericParameterMap[symbol.Name] = type;
+                        }
+
+                        for (var i = 0; i < candidateParams.Length; i++)
+                        {
+                            var translatedParamType = ResolveType(originalDefinition.Parameters[i].Type, genericParameterMap);
+                            if (translatedParamType != candidateParams[i].ParameterType)
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }
+
+                    return false;
+                }).ToArray();
+
+            if (definitionMethodInfos.Length != 1)
+            {
+                throw new InvalidOperationException($"Invocation: Found {definitionMethodInfos.Length} matches for generic method: {invocation}");
+            }
+
+            var definitionMethodInfo = definitionMethodInfos[0];
+            var typeParams = methodSymbol.TypeArguments.Select(a => ResolveType(a)).ToArray();
+            methodInfo = definitionMethodInfo.MakeGenericMethod(typeParams);
+        }
+        else
+        {
+            // Non-generic method
+
+            // TODO: private/internal binding flags
+            var reducedMethodSymbol = methodSymbol.ReducedFrom ?? methodSymbol;
+
+            methodInfo = declaringType.GetMethod(
+                methodSymbol.Name,
+                reducedMethodSymbol.Parameters.Select(p => ResolveType(p.Type)).ToArray());
+
+            if (methodInfo is null)
+            {
+                throw new InvalidOperationException($"Invocation: couldn't find method '{methodSymbol.Name}' on type '{declaringType.Name}': {invocation}");
+            }
+        }
+
+        // We have the reflection MethodInfo for the method, prepare the arguments.
+
+        // We can have less arguments than parameters when the method has optional parameters.
+        // Fill in the missing ones with the default value
+        var parameters = methodInfo.GetParameters();
+        var arguments = new Expression?[parameters.Length];
+        var destArgBase = 0;
+        var destArgIndex = 0;
+
+        // At the syntactic level, an extension method invocation looks like a normal instance's.
+        // Prepend the instance to the argument list.
+        // TODO: Test invoking extension without extension syntax (as static)
+        if (methodSymbol is { IsExtensionMethod: true /*, ReceiverType: { } */ })
+        {
+            arguments[0] = instance;
+            instance = null;
+            destArgBase = destArgIndex = 1;
+        }
+
+        var sourceArguments = invocation.ArgumentList.Arguments;
+        for (var sourceArgIndex = 0; sourceArgIndex < sourceArguments.Count; sourceArgIndex++, destArgIndex++)
+        {
+            var argument = invocation.ArgumentList.Arguments[sourceArgIndex];
+
+            // Positional argument
+            if (argument.NameColon is null)
+            {
+                arguments[destArgIndex] = Visit(sourceArguments[sourceArgIndex]);
+                continue;
+            }
+
+            // Named argument
+            throw new NotImplementedException("Named argument");
+        }
+
+        // We can have less arguments than parameters when the method has optional parameters.
+        // Fill in the missing ones with the default value
+        if (sourceArguments.Count < parameters.Length)
+        {
+            for (var paramIndex = destArgBase; paramIndex < parameters.Length; paramIndex++)
+            {
+                if (arguments[paramIndex] is null)
+                {
+                    var parameter = parameters[paramIndex];
+                    Check.DebugAssert(parameter.IsOptional, "Missing non-optional argument");
+                    arguments[paramIndex] = Constant(
+                        parameter.DefaultValue is null && parameter.ParameterType.IsValueType
+                            ? Activator.CreateInstance(parameter.ParameterType)
+                            : parameter.DefaultValue,
+                        parameter.ParameterType);
+                }
+            }
+        }
+
+        Check.DebugAssert(arguments.All(a => a is not null), "arguments.All(a => a is not null)");
+
+        // TODO: Generic type arguments
+        return Call(instance, methodInfo, arguments!);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitLiteralExpression(LiteralExpressionSyntax literal)
+    {
+        // We call GetTypeInfo to get the type for null literals
+        var typeInfo = _semanticModel.GetTypeInfo(literal);
+
+        return Constant(
+            literal.Token.Value,
+            ResolveType(
+                typeInfo.ConvertedType ?? throw new InvalidOperationException("No converted type for null literal")));
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitMemberAccessExpression(MemberAccessExpressionSyntax memberAccess)
+    {
+        // Identify DbSet property access on the user's context type
+        // TODO: support DbSet via DbContext.Set<T>() (and its STET counterpart)
+        // TODO: identify DbSet access on non-local context (e.g. new BlogContext().Blogs...
+        if (_semanticModel.GetSymbolInfo(memberAccess).Symbol is IPropertySymbol propertySymbol
+            && SymbolEqualityComparer.Default.Equals(propertySymbol.Type.OriginalDefinition, _dbSetSymbol)
+            && _semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol is ILocalSymbol contextTypeSymbol
+            && SymbolEqualityComparer.Default.Equals(contextTypeSymbol.Type.OriginalDefinition, _userDbContextSymbol))
+        {
+            // TODO: Cache these properties?
+
+            // We have a DbSet property access.
+            if (_userDbContextType.GetProperty(propertySymbol.Name) is not { CanRead: true } propertyInfo)
+            {
+                throw new InvalidOperationException(
+                    $"Couldn't find referenced property {propertySymbol.Name} on context type {_userDbContextType.Name}");
+            }
+
+            var dbSet = propertyInfo.GetMethod!.Invoke(_userDbContext, null)!;
+            var entityType = (IEntityType)dbSet.GetType().GetProperty(nameof(DbSet<object>.EntityType))!.GetMethod!
+                .Invoke(dbSet, null)!;
+
+            return new EntityQueryRootExpression(entityType);
+        }
+
+        var expression = Visit(memberAccess.Expression);
+
+        if (_semanticModel.GetSymbolInfo(memberAccess).Symbol is not ISymbol memberSymbol)
+        {
+            throw new InvalidOperationException($"MemberAccess: Couldn't find symbol for member: {memberAccess}");
+        }
+
+        var containingType = ResolveType(memberSymbol.ContainingType);
+        var memberInfo = memberSymbol switch
+        {
+            IPropertySymbol p => (MemberInfo?)containingType.GetProperty(p.Name),
+            IFieldSymbol f => containingType.GetField(f.Name),
+            INamedTypeSymbol t => containingType.GetNestedType(t.Name),
+
+            null => throw new InvalidOperationException($"MemberAccess: Couldn't find symbol for member: {memberAccess}"),
+            _ => throw new NotSupportedException($"MemberAccess: unsupported member symbol '{memberSymbol.GetType().Name}': {memberAccess}")
+        };
+
+        switch (memberInfo)
+        {
+            case Type nestedType:
+                return Constant(nestedType);
+
+            case null:
+                throw new InvalidOperationException($"MemberAccess: couldn't find member '{memberSymbol.Name}': {memberAccess}");
+        }
+
+        // Enum field constant
+        if (containingType.IsEnum)
+        {
+            return Constant(Enum.Parse(containingType, memberInfo.Name), containingType);
+        }
+
+        // array.Length
+        if (expression.Type.IsArray && memberInfo.Name == "Length")
+        {
+            if (expression.Type.GetArrayRank() != 1)
+            {
+                throw new NotImplementedException("MemberAccess on multi-dimensional array");
+            }
+
+            return ArrayLength(expression);
+        }
+
+        return MakeMemberAccess(
+            expression is ConstantExpression { Value: Type } ? null : expression,
+            memberInfo);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitObjectCreationExpression(ObjectCreationExpressionSyntax objectCreation)
+    {
+        if (_semanticModel.GetSymbolInfo(objectCreation).Symbol is not IMethodSymbol constructorSymbol)
+        {
+            throw new InvalidOperationException($"ObjectCreation: couldn't find IMethodSymbol for constructor: {objectCreation}");
+        }
+
+        Check.DebugAssert(constructorSymbol.MethodKind == MethodKind.Constructor, "constructorSymbol.MethodKind == MethodKind.Constructor");
+
+        var type = ResolveType(constructorSymbol.ContainingType);
+
+        // Find the reflection constructor that matches the constructor symbol's signature
+        var parameterTypes = constructorSymbol.Parameters.Select(ps => ResolveType(ps.Type)).ToArray();
+        var constructor = type.GetConstructor(parameterTypes);
+
+        var newExpression = constructor is not null
+            ? New(
+                constructor,
+                objectCreation.ArgumentList?.Arguments.Select(a => Visit(a)) ?? Array.Empty<Expression>())
+            : parameterTypes.Length == 0 // For structs, there's no actual parameterless constructor
+                ? New(type)
+                : throw new InvalidOperationException($"ObjectCreation: Missing constructor: {objectCreation}");
+
+        if (objectCreation.Initializer is null)
+        {
+            return newExpression;
+        }
+
+        var bindings =
+            objectCreation.Initializer.Expressions.Select(
+                e =>
+                {
+                    if (e is not AssignmentExpressionSyntax { Left: var lValue, Right: var value })
+                    {
+                        throw new NotSupportedException(
+                            $"ObjectCreation: non-assignment initializer expression of type '{e.GetType().Name}': {objectCreation}");
+                    }
+
+                    var lValueSymbol = _semanticModel.GetSymbolInfo(lValue).Symbol;
+                    var memberInfo = lValueSymbol switch
+                    {
+                        IPropertySymbol p => (MemberInfo?)type.GetProperty(p.Name),
+                        IFieldSymbol f => type.GetField(f.Name),
+
+                        _ => throw new InvalidOperationException(
+                            $"ObjectCreation: unsupported initializer for member of type '{lValueSymbol?.GetType().Name}': {e}")
+                    };
+
+                    if (memberInfo is null)
+                    {
+                        throw new InvalidOperationException($"ObjectCreation: couldn't find initialized member '{lValueSymbol.Name}': {e}");
+                    }
+
+                    return Bind(memberInfo, Visit(value));
+                });
+
+        return MemberInit(newExpression, bindings);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitParenthesizedExpression(ParenthesizedExpressionSyntax parenthesized)
+        => Visit(parenthesized.Expression);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitParenthesizedLambdaExpression(ParenthesizedLambdaExpressionSyntax lambda)
+    {
+        if (lambda.ExpressionBody is null)
+        {
+            throw new NotSupportedException("Lambda with null expression body");
+        }
+
+        if (lambda.Modifiers.Any())
+        {
+            throw new NotImplementedException("Lambda with modifiers: " + lambda.Modifiers);
+        }
+
+        if (!lambda.AsyncKeyword.IsKind(SyntaxKind.None))
+        {
+            throw new NotImplementedException("Async lambda");
+        }
+
+        var translatedParameters = new List<ParameterExpression>();
+        foreach (var parameter in lambda.ParameterList.Parameters)
+        {
+            if (_semanticModel.GetDeclaredSymbol(parameter) is not { } parameterSymbol ||
+                ResolveType(parameterSymbol.Type) is not { } parameterType)
+            {
+                throw new InvalidOperationException("Could not found symbol for parameter lambda: " + parameter);
+            }
+
+            translatedParameters.Add(Parameter(parameterType, parameter.Identifier.Text));
+        }
+
+        _parameterStack.Push(_parameterStack.Peek()
+            .AddRange(translatedParameters.Select(p => new KeyValuePair<string, ParameterExpression>(p.Name ?? throw new NotImplementedException(), p))));
+
+        try
+        {
+            var body = Visit(lambda.ExpressionBody);
+            return Lambda(body, translatedParameters);
+        }
+        finally
+        {
+            _parameterStack.Pop();
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitPredefinedType(PredefinedTypeSyntax predefinedType)
+        => Constant(ResolveType(predefinedType), typeof(Type));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitPrefixUnaryExpression(PrefixUnaryExpressionSyntax unary)
+    {
+        var operand = Visit(unary.Operand);
+
+        // https://learn.microsoft.com/dotnet/api/Microsoft.CodeAnalysis.CSharp.Syntax.PrefixUnaryExpressionSyntax
+
+        return unary.Kind() switch
+        {
+            SyntaxKind.UnaryPlusExpression => UnaryPlus(operand),
+            SyntaxKind.UnaryMinusExpression => Negate(operand),
+            SyntaxKind.BitwiseNotExpression => Not(operand),
+            SyntaxKind.LogicalNotExpression => Not(operand),
+
+            SyntaxKind.AddressOfExpression => throw NotSupported(),
+            SyntaxKind.IndexExpression => throw NotSupported(),
+            SyntaxKind.PointerIndirectionExpression => throw NotSupported(),
+            SyntaxKind.PreDecrementExpression => throw NotSupported(),
+            SyntaxKind.PreIncrementExpression => throw NotSupported(),
+
+            _ => throw new ArgumentOutOfRangeException(
+                $"Unexpected syntax kind '{unary.Kind()}' when visiting a {nameof(PrefixUnaryExpressionSyntax)}")
+        };
+
+        NotSupportedException NotSupported()
+            => throw new NotSupportedException(
+                $"Unary expression of type {unary.Kind()} is not supported in expression trees");
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitPostfixUnaryExpression(PostfixUnaryExpressionSyntax unary)
+    {
+        var operand = Visit(unary.Operand);
+
+        // https://learn.microsoft.com/dotnet/api/Microsoft.CodeAnalysis.CSharp.Syntax.PostfixUnaryExpressionSyntax
+
+        return unary.Kind() switch
+        {
+            SyntaxKind.SuppressNullableWarningExpression => operand,
+
+            SyntaxKind.PostIncrementExpression => throw NotSupported(),
+            SyntaxKind.PostDecrementExpression => throw NotSupported(),
+
+            _ => throw new InvalidOperationException($"Unexpected syntax kind '{unary.Kind()}' when visiting a {nameof(PostfixUnaryExpressionSyntax)}")
+        };
+
+        NotSupportedException NotSupported()
+            => throw new NotSupportedException(
+                $"Unary expression of type {unary.Kind()} is not supported in expression trees");
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax lambda)
+    {
+        if (lambda.ExpressionBody is null)
+        {
+            throw new NotSupportedException("SimpleLambda with null expression body");
+        }
+
+        if (lambda.Modifiers.Any())
+        {
+            throw new NotImplementedException("SimpleLambda with modifiers: " + lambda.Modifiers);
+        }
+
+        if (!lambda.AsyncKeyword.IsKind(SyntaxKind.None))
+        {
+            throw new NotImplementedException("SimpleLambda with async keyword");
+        }
+
+        var paramName = lambda.Parameter.Identifier.Text;
+        if (_semanticModel.GetDeclaredSymbol(lambda.Parameter) is not { } parameterSymbol ||
+            ResolveType(parameterSymbol.Type) is not { } parameterType)
+        {
+            throw new InvalidOperationException("Could not found symbol for parameter lambda: " + lambda.Parameter);
+        }
+
+        var parameter = Parameter(parameterType, paramName);
+        _parameterStack.Push(_parameterStack.Peek().SetItem(paramName, parameter));
+
+        try
+        {
+            var body = Visit(lambda.ExpressionBody);
+            return Lambda(body, parameter);
+        }
+        finally
+        {
+            _parameterStack.Pop();
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression VisitTypeOfExpression(TypeOfExpressionSyntax typeOf)
+    {
+        if (_semanticModel.GetSymbolInfo(typeOf.Type).Symbol is not ITypeSymbol typeSymbol)
+        {
+            throw new InvalidOperationException(
+                "Could not find symbol for typeof() expression: " + typeOf);
+        }
+
+        var type = ResolveType(typeSymbol);
+        return Constant(type, typeof(Type));
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Expression DefaultVisit(SyntaxNode node)
+        => throw new NotSupportedException($"Unsupported syntax node of type '{node.GetType()}': {node}");
+
+    private Type ResolveType(SyntaxNode node)
+        => _semanticModel.GetTypeInfo(node).Type is { } typeSymbol
+            ? ResolveType(typeSymbol)
+            : throw new InvalidOperationException("Could not find type symbol for: " + node);
+
+    private Type ResolveType(ITypeSymbol typeSymbol, Dictionary<string, Type>? genericParameterMap = null)
+    {
+        switch (typeSymbol)
+        {
+            case ITypeParameterSymbol typeParameterSymbol:
+                return genericParameterMap?.TryGetValue(typeParameterSymbol.Name, out var type) == true
+                    ? type
+                    : throw new InvalidOperationException($"Unknown generic type parameter symbol {typeParameterSymbol}");
+
+            case INamedTypeSymbol { IsGenericType: true } genericTypeSymbol:
+            {
+                var genericTypeName =
+                    genericTypeSymbol.OriginalDefinition.ToDisplayString(QualifiedTypeNameSymbolDisplayFormat)
+                    + '`' + genericTypeSymbol.Arity;
+
+                var definition = GetClrType(genericTypeName);
+                var typeArguments = genericTypeSymbol.TypeArguments.Select(a => ResolveType(a, genericParameterMap)).ToArray();
+                return definition.MakeGenericType(typeArguments);
+            }
+
+            // // Open generic type
+            // case INamedTypeSymbol { IsGenericType: true } genericTypeSymbol
+            //     // TODO: Hacky... Detect open type, to avoid trying MakeGenericType on it
+            //     when genericTypeSymbol.TypeArguments.Any(a => a is ITypeParameterSymbol):
+            // {
+            //     var genericTypeName = genericTypeSymbol.ToDisplayString(QualifiedTypeNameSymbolDisplayFormat)
+            //                           + '`' + genericTypeSymbol.Arity;
+            //
+            //     return GetClrType(genericTypeName);
+            // }
+            //
+            // // Closed generic type
+            // case INamedTypeSymbol { IsGenericType: true } genericTypeSymbol:
+            // {
+            //     var genericTypeName =
+            //         genericTypeSymbol.OriginalDefinition.ToDisplayString(QualifiedTypeNameSymbolDisplayFormat)
+            //         + '`' + genericTypeSymbol.Arity;
+            //
+            //     var definition = GetClrType(genericTypeName);
+            //     var typeArguments = genericTypeSymbol.TypeArguments.Select(ResolveType).ToArray();
+            //     return definition.MakeGenericType(typeArguments);
+            // }
+
+            case INamedTypeSymbol { IsAnonymousType: true } anonymousTypeSymbol:
+                _anonymousTypeDefinitions ??= LoadAnonymousTypes();
+                var properties = anonymousTypeSymbol.GetMembers().OfType<IPropertySymbol>().ToArray();
+                var found = _anonymousTypeDefinitions.TryGetValue(
+                    properties.Select(p => p.Name).OrderBy(p => p).ToArray(),
+                    out var anonymousTypeGenericDefinition);
+                Debug.Assert(found, "Anonymous type not found");
+
+                var constructorParameters = anonymousTypeGenericDefinition!.GetConstructors()[0].GetParameters();
+                var genericTypeArguments = new Type[constructorParameters.Length];
+
+                for (var i = 0; i < constructorParameters.Length; i++)
+                {
+                    genericTypeArguments[i] =
+                        ResolveType(properties.FirstOrDefault(p => p.Name == constructorParameters[i].Name)!.Type);
+                }
+
+                // TODO: Cache closed anonymous types
+
+                return anonymousTypeGenericDefinition!.MakeGenericType(genericTypeArguments);
+
+            case INamedTypeSymbol namedTypeSymbol:
+                if (typeSymbol.ContainingType is null)
+                {
+                    goto default;
+                }
+
+                var containingType = ResolveType(namedTypeSymbol.ContainingType);
+
+                var nestedType =
+                    containingType.GetNestedType(namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                if (nestedType is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Couldn't find nested type '{namedTypeSymbol.Name}' on containing type '{containingType.Name}'");
+                }
+
+                return nestedType;
+
+            default:
+                return GetClrType(typeSymbol.ToDisplayString(QualifiedTypeNameSymbolDisplayFormat));
+        }
+
+        Type GetClrType(string name)
+            => typeSymbol.ContainingAssembly is null
+                ? Type.GetType(name)!
+                : Type.GetType($"{name}, {typeSymbol.ContainingAssembly.Name}")!;
+
+        Dictionary<string[], Type> LoadAnonymousTypes()
+        {
+            // TODO
+            var assembly = Assembly.LoadFile("/home/roji/projects/test/EFTest/bin/Debug/net7.0/linux-x64/EFTest.dll");
+
+            return assembly.GetTypes()
+                .Where(t => t.IsAnonymousType())
+                .ToDictionary(
+                    t => t.GetProperties().Select(x => x.Name).OrderBy(p => p).ToArray(),
+                    t => t,
+                    new ArrayStructuralComparer<string>());
+        }
+    }
+
+    private class ArrayStructuralComparer<T> : IEqualityComparer<T[]>
+    {
+        public bool Equals(T[]? x, T[]? y)
+            => x is null ? y is null : y is not null && x.SequenceEqual(y);
+
+        public int GetHashCode(T[] obj)
+        {
+            var hashcode = new HashCode();
+
+            foreach (var value in obj)
+            {
+                hashcode.Add(value);
+            }
+
+            return hashcode.ToHashCode();
+        }
+    }
+
+    private Dictionary<string[], Type>? _anonymousTypeDefinitions;
+
+    [CompilerGenerated]
+    private class FakeClosureFrameClass
+    {
+    }
+
+    private class FakeFieldInfo : FieldInfo
+    {
+        public FakeFieldInfo(Type declaringType, Type fieldType, string name)
+        {
+            DeclaringType = declaringType;
+            FieldType = fieldType;
+            Name = name;
+        }
+
+        public override object[] GetCustomAttributes(bool inherit)
+            => Array.Empty<object>();
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+            => Array.Empty<object>();
+
+        public override bool IsDefined(Type attributeType, bool inherit)
+            => false;
+
+        public override Type DeclaringType { get; }
+
+        public override string Name { get; }
+
+        public override Type? ReflectedType => null;
+
+        // We implement GetValue since ParameterExtractingExpressionVisitor calls it to get the parameter value. In
+        // AOT generation time, we obviously have no parameter values, nor do we need them for the first part of the
+        // query pipeline.
+        public override object? GetValue(object? obj)
+            => FieldType.IsValueType ? Activator.CreateInstance(FieldType) : null;
+
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder,
+            CultureInfo? culture)
+            => throw new NotSupportedException();
+
+        public override FieldAttributes Attributes
+            => FieldAttributes.Public;
+
+        public override RuntimeFieldHandle FieldHandle
+            => throw new NotSupportedException();
+
+        public override Type FieldType { get; }
+    }
+
+    private class FakeConstructorInfo : ConstructorInfo
+    {
+        private readonly ParameterInfo[] _parameters;
+
+        public FakeConstructorInfo(Type type, ParameterInfo[] parameters)
+        {
+            DeclaringType = type;
+            _parameters = parameters;
+        }
+
+        public override object[] GetCustomAttributes(bool inherit)
+            => Array.Empty<object>();
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+            => Array.Empty<object>();
+
+        public override bool IsDefined(Type attributeType, bool inherit)
+            => false;
+
+        public override Type DeclaringType { get; }
+
+        public override string Name
+            => ".ctor";
+
+        public override Type ReflectedType
+            => DeclaringType;
+
+        public override MethodImplAttributes GetMethodImplementationFlags()
+            => MethodImplAttributes.Managed;
+
+        public override ParameterInfo[] GetParameters()
+            => _parameters;
+
+        public override MethodAttributes Attributes
+            => MethodAttributes.Public;
+
+        public override RuntimeMethodHandle MethodHandle
+            => throw new NotSupportedException();
+
+        public override object Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters,
+            CultureInfo? culture)
+            => throw new NotSupportedException();
+
+        public override object Invoke(BindingFlags invokeAttr, Binder? binder, object?[]? parameters,
+            CultureInfo? culture)
+            => throw new NotSupportedException();
+    }
+
+    private class FakeParameterInfo : ParameterInfo
+    {
+        public FakeParameterInfo(string name, Type parameterType, int position)
+            => (Name, ParameterType, Position) = (name, parameterType, position);
+
+        public override ParameterAttributes Attributes
+            => ParameterAttributes.In;
+
+        public override string? Name { get; }
+        public override Type ParameterType { get; }
+        public override int Position { get; }
+
+        public override MemberInfo Member
+            => throw new NotSupportedException();
+    }
+}

--- a/src/EFCore.Design/Query/Internal/ICSharpToLinqTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/ICSharpToLinqTranslator.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     Translates a Roslyn syntax tree into a LINQ expression tree.
+/// </summary>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public interface ICSharpToLinqTranslator
+{
+    /// <summary>
+    ///     Loads the given <see cref="Compilation" /> and prepares to translate queries using the given <see cref="DbContext" />.
+    /// </summary>
+    /// <param name="compilation">A <see cref="Compilation" /> containing the syntax nodes to be translated.</param>
+    /// <param name="userDbContext">An instance of the user's <see cref="DbContext" />.</param>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    void Load(Compilation compilation, DbContext userDbContext);
+
+    /// <summary>
+    ///     Translates a Roslyn syntax tree into a LINQ expression tree.
+    /// </summary>
+    /// <param name="node">The Roslyn syntax node to be translated.</param>
+    /// <param name="semanticModel">
+    /// The <see cref="SemanticModel" /> for the Roslyn <see cref="SyntaxTree" /> of which <paramref name="node" /> is a part.
+    /// </param>
+    /// <returns>A LINQ expression tree translated from the provided <paramref name="node"/>.</returns>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    Expression Translate(SyntaxNode node, SemanticModel semanticModel);
+}

--- a/src/EFCore.Design/Query/Internal/ILinqToCSharpTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/ILinqToCSharpTranslator.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     Translates a LINQ expression tree to a Roslyn syntax tree.
+/// </summary>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public interface ILinqToCSharpTranslator
+{
+    /// <summary>
+    ///     Translates a node representing a statement into a Roslyn syntax tree.
+    /// </summary>
+    /// <param name="node">The node to be translated.</param>
+    /// <param name="collectedNamespaces">Any namespaces required by the translated code will be added to this set.</param>
+    /// <returns>A Roslyn syntax tree representation of <paramref name="node" />.</returns>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    SyntaxNode TranslateStatement(Expression node, ISet<string> collectedNamespaces);
+
+    /// <summary>
+    ///     Translates a node representing an expression into a Roslyn syntax tree.
+    /// </summary>
+    /// <param name="node">The node to be translated.</param>
+    /// <param name="collectedNamespaces">Any namespaces required by the translated code will be added to this set.</param>
+    /// <returns>A Roslyn syntax tree representation of <paramref name="node" />.</returns>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    SyntaxNode TranslateExpression(Expression node, ISet<string> collectedNamespaces);
+
+    /// <summary>
+    ///     Returns the captured variables detected in the last translation.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    IReadOnlySet<ParameterExpression> CapturedVariables { get; }
+}

--- a/src/EFCore.Design/Query/Internal/IPrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/IPrecompiledQueryCodeGenerator.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable CS1591 // TODO
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+public interface IPrecompiledQueryCodeGenerator
+{
+    Task GeneratePrecompiledQueries(string projectDir, DbContext context, string outputDir, CancellationToken cancellationToken = default);
+}

--- a/src/EFCore.Design/Query/Internal/IQueryLocator.cs
+++ b/src/EFCore.Design/Query/Internal/IQueryLocator.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     Statically analyzes user code and locates EF LINQ queries within it, by identifying well-known terminating operators
+///     (e.g. <c>ToList</c>, <c>Single</c>).
+/// </summary>
+/// <remarks>
+///     After a <see cref="Compilation" /> is loaded via <see cref="LoadCompilation" />, <see cref="LocateQueries" /> is called repeatedly
+///     for all syntax trees in the compilation.
+/// </remarks>
+/// <remarks>
+///     <para>
+///         In some cases, the provided <see cref="SyntaxTree" /> must be rewritten (since async invocations such as <c>SingleAsync</c>
+///         inject a sync <c>Single</c> node). As a result, <see cref="LocateQueries" /> returns a possibly-rewritten
+///         <see cref="SyntaxTree" />.
+///     </para>
+///     <para>
+///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+///         any release. You should only use it directly in your code with extreme caution and knowing that
+///         doing so can result in application failures when updating to a new Entity Framework Core release.
+///     </para>
+/// </remarks>
+public interface IQueryLocator
+{
+    /// <summary>
+    ///     The <see cref="SyntaxAnnotation.Kind" /> of the the <see cref="SyntaxAnnotation" /> added to nodes which represent EF query
+    ///     LINQ candidates.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    const string EfQueryCandidateAnnotationKind = "EfQueryCandidate";
+
+    /// <summary>
+    ///     A list of syntax trees in which EF LINQ query candidates were located.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    IReadOnlyList<SyntaxTree> SyntaxTreesWithQueryCandidates { get; }
+
+    /// <summary>
+    ///     Loads a new <see cref="Compilation" />, representing a user project in which to locate queries.
+    /// </summary>
+    /// <param name="compilation">A <see cref="Compilation" /> representing a user project.</param>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    void LoadCompilation(Compilation compilation);
+
+    /// <summary>
+    ///     Locates EF LINQ queries within the given <see cref="SyntaxTree" />, which represents user code.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         In some cases, the provided <see cref="SyntaxTree" /> must be rewritten (since async invocations such as <c>SingleAsync</c>
+    ///         inject a sync <c>Single</c> node). As a result, this method returns a possibly-rewritten <see cref="SyntaxTree" />.
+    ///     </para>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    /// </remarks>
+    /// <param name="syntaxTree">A <see cref="SyntaxTree" /> in which to locate EF LINQ queries.</param>
+    /// <returns>A possibly rewritten <see cref="SyntaxTree" />.</returns>
+    SyntaxTree LocateQueries(SyntaxTree syntaxTree);
+}

--- a/src/EFCore.Design/Query/Internal/ISqlTreeQuoter.cs
+++ b/src/EFCore.Design/Query/Internal/ISqlTreeQuoter.cs
@@ -19,6 +19,8 @@ public interface ISqlTreeQuoter
     ///     Returns a LINQ expression tree that instantiates a faithful copy of <paramref name="expression" />.
     /// </summary>
     /// <param name="expression">The SQL tree to be quoted.</param>
+    /// <param name="rootSelectVariableName">The variable name to give to the top-most select expression.</param>
+    /// <param name="variableNames">A set of variable names already defined in the context, for uniquification.</param>
     /// <returns>A LINQ expression tree that instantiates a faithful copy of <paramref name="expression" />.</returns>
     /// <remarks>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -26,5 +28,5 @@ public interface ISqlTreeQuoter
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </remarks>
-    BlockExpression Quote(Expression expression);
+    public BlockExpression Quote(Expression expression, string rootSelectVariableName, HashSet<string> variableNames);
 }

--- a/src/EFCore.Design/Query/Internal/ISqlTreeQuoter.cs
+++ b/src/EFCore.Design/Query/Internal/ISqlTreeQuoter.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     Given a SQL expression tree, generates a LINQ expression tree that instantiates a copy of that tree. Can be used to render a C#
+///     representation of the SQL tree.
+/// </summary>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public interface ISqlTreeQuoter
+{
+    /// <summary>
+    ///     Returns a LINQ expression tree that instantiates a faithful copy of <paramref name="expression" />.
+    /// </summary>
+    /// <param name="expression">The SQL tree to be quoted.</param>
+    /// <returns>A LINQ expression tree that instantiates a faithful copy of <paramref name="expression" />.</returns>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    BlockExpression Quote(Expression expression);
+}

--- a/src/EFCore.Design/Query/Internal/LinqToCSharpTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/LinqToCSharpTranslator.cs
@@ -106,8 +106,7 @@ public class LinqToCSharpTranslator : ExpressionVisitor, ILinqToCSharpTranslator
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    [return: NotNullIfNotNull(nameof(node))]
-    protected virtual SyntaxNode? TranslateCore(Expression node, ISet<string> collectedNamespaces, bool statementContext = false)
+    protected virtual SyntaxNode TranslateCore(Expression node, ISet<string> collectedNamespaces, bool statementContext = false)
     {
         _capturedVariables.Clear();
         _collectedNamespaces = collectedNamespaces;

--- a/src/EFCore.Design/Query/Internal/LinqToCSharpTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/LinqToCSharpTranslator.cs
@@ -1,0 +1,1907 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using E = System.Linq.Expressions.Expression;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class LinqToCSharpTranslator : ExpressionVisitor, ILinqToCSharpTranslator
+{
+    private record StackFrame(
+        Dictionary<ParameterExpression, string> Variables,
+        HashSet<string> VariableNames,
+        Dictionary<LabelTarget, string> Labels,
+        HashSet<string> UnnamedLabelNames);
+
+    private readonly Stack<StackFrame> _stack
+        = new(new[] { new StackFrame(new(), new(), new(), new()) });
+
+    private int _unnamedParameterCounter;
+
+    private record LiftedState(
+        List<StatementSyntax> Statements,
+        Dictionary<ParameterExpression, string> Variables,
+        HashSet<string> VariableNames,
+        List<LocalDeclarationStatementSyntax> UnassignedVariableDeclarations);
+
+    private LiftedState _liftedState = new(new(), new(), new(), new());
+
+    private ExpressionContext _context;
+    private bool _onLastLambdaLine;
+
+    private readonly HashSet<ParameterExpression> _capturedVariables = new();
+    private ISet<string> _collectedNamespaces = null!;
+
+    private static MethodInfo? _activatorCreateInstanceMethod;
+    private static MethodInfo? _typeGetFieldMethod;
+    private static MethodInfo? _fieldGetValueMethod;
+    private static MethodInfo? _mathPowMethod;
+
+    private readonly SideEffectDetectionSyntaxWalker _sideEffectDetector = new();
+    private readonly ConstantDetectionSyntaxWalker _constantDetector = new();
+    private readonly SyntaxGenerator _g;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public LinqToCSharpTranslator(SyntaxGenerator syntaxGenerator)
+        => _g = syntaxGenerator;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IReadOnlySet<ParameterExpression> CapturedVariables
+        => _capturedVariables.ToHashSet();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected SyntaxNode Result { get; set; } = null!;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SyntaxNode TranslateStatement(Expression node, ISet<string> collectedNamespaces)
+        => TranslateCore(node, collectedNamespaces, statementContext: true);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SyntaxNode TranslateExpression(Expression node, ISet<string> collectedNamespaces)
+        => TranslateCore(node, collectedNamespaces, statementContext: false);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual SyntaxNode TranslateCore(Expression node, ISet<string> collectedNamespaces, bool statementContext = false)
+    {
+        _capturedVariables.Clear();
+        _collectedNamespaces = collectedNamespaces;
+        _unnamedParameterCounter = 0;
+        _context = statementContext ? ExpressionContext.Statement : ExpressionContext.Expression;
+        _onLastLambdaLine = true;
+
+        Visit(node);
+
+        if (_liftedState.Statements.Count > 0)
+        {
+            if (_context == ExpressionContext.Expression)
+            {
+                throw new NotSupportedException("Lifted expressions remaining at top-level in expression context");
+            }
+        }
+
+        Check.DebugAssert(_stack.Count == 1, "_parameterStack.Count == 1");
+        Check.DebugAssert(_stack.Peek().Variables.Count == 0, "_stack.Peek().Parameters.Count == 0");
+        Check.DebugAssert(_stack.Peek().VariableNames.Count == 0, "_stack.Peek().ParameterNames.Count == 0");
+        Check.DebugAssert(_stack.Peek().Labels.Count == 0, "_stack.Peek().Labels.Count == 0");
+        Check.DebugAssert(_stack.Peek().UnnamedLabelNames.Count == 0, "_stack.Peek().UnnamedLabelNames.Count == 0");
+
+        return Result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual SyntaxNode Translate(Expression? node)
+    {
+        Visit(node);
+
+        return Result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual T Translate<T>(Expression node) where T : CSharpSyntaxNode
+    {
+        Visit(node);
+
+        return Result as T
+               ?? throw new InvalidOperationException(
+                   $"Got translated node of type {Result?.GetType().Name} instead of the expected {typeof(T)}");
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual ExpressionSyntax Translate(Expression expression, IdentifierNameSyntax? lowerableAssignmentVariable)
+    {
+        Check.DebugAssert(
+            _context is ExpressionContext.Expression or ExpressionContext.ExpressionLambda,
+            "Cannot lower in statement context");
+
+        return expression switch
+        {
+            SwitchExpression switchExpression
+                => (ExpressionSyntax)TranslateSwitch(switchExpression, lowerableAssignmentVariable),
+
+            ConditionalExpression conditionalExpression
+                => (ExpressionSyntax)TranslateConditional(conditionalExpression, lowerableAssignmentVariable),
+
+            _ => Translate<ExpressionSyntax>(expression)
+        };
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [return: NotNullIfNotNull("node")]
+    public override Expression? Visit(Expression? node)
+        => node is null ? null : base.Visit(node);
+
+    /// <inheritdoc />
+    protected override Expression VisitBinary(BinaryExpression binary)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        // Handle some special cases
+        switch (binary.NodeType)
+        {
+            case ExpressionType.Assign:
+                return VisitAssignment(binary);
+
+            case ExpressionType.Power when binary.Left.Type == typeof(double) && binary.Right.Type == typeof(double):
+                return Visit(
+                    E.Call(
+                        _mathPowMethod ??= typeof(Math).GetMethod(
+                            nameof(Math.Pow), BindingFlags.Static | BindingFlags.Public, new[] { typeof(double), typeof(double) })!,
+                        binary.Left,
+                        binary.Right));
+
+            case ExpressionType.Power:
+                throw new NotImplementedException("Power over non-double operands");
+
+            case ExpressionType.PowerAssign:
+                return Visit(
+                    E.Assign(
+                        binary.Left,
+                        E.Power(
+                            binary.Left,
+                            binary.Right)));
+        }
+
+        var liftedStatementOrigPosition = _liftedState.Statements.Count;
+        var left = Translate<ExpressionSyntax>(binary.Left);
+        var liftedStatementLeftPosition = _liftedState.Statements.Count;
+        var right = Translate<ExpressionSyntax>(binary.Right);
+
+        // If both sides were lifted, we don't need to do anything special. Same if the left side was lifted.
+        // But if the right side was lifted and the left wasn't, then in order to preserve evaluation order we need to lift the left side
+        // out as well, otherwise the right side gets evaluated before the left.
+        if (_liftedState.Statements.Count > liftedStatementLeftPosition
+            && liftedStatementLeftPosition == liftedStatementOrigPosition
+            && _sideEffectDetector.MayHaveSideEffects(left))
+        {
+            var name = UniquifyVariableName("lifted");
+            _liftedState.Statements.Insert(
+                liftedStatementLeftPosition,
+                GenerateVarDeclaration(name, left));
+            _liftedState.VariableNames.Add(name);
+            left = IdentifierName(name);
+        }
+
+        if (binary.NodeType == ExpressionType.ArrayIndex)
+        {
+            Result = ElementAccessExpression(left, BracketedArgumentList(SingletonSeparatedList(Argument(right))));
+            return binary;
+        }
+
+        // TODO: Confirm what to do with the checked expression types
+
+        var syntaxKind = binary.NodeType switch
+        {
+            ExpressionType.Equal => SyntaxKind.EqualsExpression,
+            ExpressionType.NotEqual => SyntaxKind.NotEqualsExpression,
+
+            ExpressionType.Add => SyntaxKind.AddExpression,
+            ExpressionType.AddChecked => SyntaxKind.AddExpression,
+            ExpressionType.Subtract => SyntaxKind.SubtractExpression,
+            ExpressionType.SubtractChecked => SyntaxKind.SubtractExpression,
+            ExpressionType.Multiply => SyntaxKind.MultiplyExpression,
+            ExpressionType.MultiplyChecked => SyntaxKind.MultiplyExpression,
+            ExpressionType.Divide => SyntaxKind.DivideExpression,
+            ExpressionType.Modulo => SyntaxKind.ModuloExpression,
+            ExpressionType.AddAssign => SyntaxKind.AddAssignmentExpression,
+            ExpressionType.AddAssignChecked => SyntaxKind.AddAssignmentExpression,
+            ExpressionType.SubtractAssign => SyntaxKind.SubtractAssignmentExpression,
+            ExpressionType.SubtractAssignChecked => SyntaxKind.SubtractAssignmentExpression,
+            ExpressionType.MultiplyAssign => SyntaxKind.MultiplyAssignmentExpression,
+            ExpressionType.MultiplyAssignChecked => SyntaxKind.MultiplyAssignmentExpression,
+            ExpressionType.DivideAssign => SyntaxKind.DivideAssignmentExpression,
+            ExpressionType.ModuloAssign => SyntaxKind.ModuloAssignmentExpression,
+
+            ExpressionType.GreaterThan => SyntaxKind.GreaterThanExpression,
+            ExpressionType.GreaterThanOrEqual => SyntaxKind.GreaterThanOrEqualExpression,
+            ExpressionType.LessThan => SyntaxKind.LessThanExpression,
+            ExpressionType.LessThanOrEqual => SyntaxKind.LessThanOrEqualExpression,
+
+            ExpressionType.AndAlso => SyntaxKind.LogicalAndExpression,
+            ExpressionType.OrElse => SyntaxKind.LogicalOrExpression,
+            ExpressionType.AndAssign => SyntaxKind.AndAssignmentExpression,
+            ExpressionType.OrAssign => SyntaxKind.OrAssignmentExpression,
+
+            ExpressionType.And => SyntaxKind.BitwiseAndExpression,
+            ExpressionType.Or => SyntaxKind.BitwiseOrExpression,
+            ExpressionType.ExclusiveOr => SyntaxKind.ExclusiveOrExpression,
+            ExpressionType.LeftShift => SyntaxKind.LeftShiftExpression,
+            ExpressionType.RightShift => SyntaxKind.RightShiftExpression,
+            // TODO UnsignedRightShiftExpression
+            ExpressionType.ExclusiveOrAssign => SyntaxKind.ExclusiveOrAssignmentExpression,
+            ExpressionType.LeftShiftAssign => SyntaxKind.LeftShiftAssignmentExpression,
+            ExpressionType.RightShiftAssign => SyntaxKind.RightShiftAssignmentExpression,
+
+            ExpressionType.TypeIs => SyntaxKind.IsExpression,
+            ExpressionType.TypeAs => SyntaxKind.AsExpression,
+            ExpressionType.Coalesce => SyntaxKind.CoalesceExpression,
+
+            _ => throw new ArgumentOutOfRangeException("BinaryExpression with " + binary.NodeType)
+        };
+
+        Result = BinaryExpression(syntaxKind, left, right);
+
+        return binary;
+
+        Expression VisitAssignment(BinaryExpression assignment)
+        {
+            var translatedLeft = Translate<ExpressionSyntax>(assignment.Left);
+
+            ExpressionSyntax translatedRight;
+
+            // LINQ expression trees can directly access private members, but C# code cannot.
+            // If a private member is being set, VisitMember generated a reflection GetValue invocation for it; detect
+            // that here and replace it with SetValue instead.
+            // TODO: Replace this with a more efficient API for .NET 8.0.
+            // TODO: Private property
+            if (translatedLeft is InvocationExpressionSyntax
+                {
+                    Expression: MemberAccessExpressionSyntax
+                    {
+                        Name.Identifier.Text: nameof(FieldInfo.GetValue),
+                        Expression: var fieldInfoExpression
+                    },
+                    ArgumentList.Arguments: [var lValue]
+                })
+            {
+                translatedRight = Translate<ExpressionSyntax>(assignment.Right);
+
+                Result = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        fieldInfoExpression,
+                        IdentifierName(nameof(FieldInfo.SetValue))),
+                    ArgumentList(
+                        SeparatedList(new[] { lValue, Argument(translatedRight) })));
+            }
+            else
+            {
+                // Identify assignment where the RHS is a switch expression, and pass the LHS for possible lowering. If the switch
+                // expression is lifted out (e.g. because some arm contains a block), this will lower the variable to be assigned inside
+                // the resulting switch statement, rather then adding another useless temporary variable.
+                translatedRight = Translate(
+                    assignment.Right,
+                    lowerableAssignmentVariable: translatedLeft as IdentifierNameSyntax);
+
+                // If the RHS was lifted out and the assignment lowering succeeded, Translate above returns the lowered assignment variable;
+                // this would mean that we return a useless identity assignment (i = i). Instead, just return it.
+                if (translatedRight == translatedLeft)
+                {
+                    Result = translatedRight;
+                }
+                else
+                {
+                    Result = AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, translatedLeft, translatedRight);
+                }
+            }
+
+            return assignment;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitBlock(BlockExpression block)
+    {
+        var blockContext = _context;
+
+        var parentOnLastLambdaLine = _onLastLambdaLine;
+        var parentLiftedState = _liftedState;
+
+        // Expression blocks have no stack of their own, since they're lifted directly to their parent non-expression block.
+        StackFrame? ownStackFrame = null;
+        if (blockContext != ExpressionContext.Expression)
+        {
+            ownStackFrame = PushNewStackFrame();
+            _liftedState = new(new(), new(), new(), new());
+        }
+
+        var stackFrame = _stack.Peek();
+
+        // Do a 1st pass to identify and register any labels, since goto can appear before its label.
+        PreprocessLabels();
+
+        try
+        {
+            // Go over the block's variables, assign names to any unnamed ones and uniquify. Then add them to our stack frame, unless
+            // this is an expression block that will get lifted.
+            foreach (var parameter in block.Variables)
+            {
+                var (variables, variableNames) = (stackFrame.Variables, stackFrame.VariableNames);
+
+                var uniquifiedName = UniquifyVariableName(parameter.Name ?? "unnamed");
+
+                if (blockContext == ExpressionContext.Expression)
+                {
+                    _liftedState.Variables.Add(parameter, uniquifiedName);
+                    _liftedState.VariableNames.Add(uniquifiedName);
+                }
+                else
+                {
+                    variables.Add(parameter, uniquifiedName);
+                    variableNames.Add(uniquifiedName);
+                }
+            }
+
+            var unassignedVariables = block.Variables.ToList();
+
+            var statements = new List<StatementSyntax>();
+            LabeledStatementSyntax? pendingLabeledStatement = null;
+
+            // Now visit the expressions, applying any lifted expressions
+            for (var i = 0; i < block.Expressions.Count; i++)
+            {
+                var expression = block.Expressions[i];
+                var onLastBlockLine = i == block.Expressions.Count - 1;
+                _onLastLambdaLine = parentOnLastLambdaLine && onLastBlockLine;
+
+                // Any lines before the last are evaluated in statement context (they aren't returned); the last line is evaluated in the
+                // context of the block as a whole. _context now refers to the statement's context, blockContext to the block's.
+                var statementContext = onLastBlockLine ? _context : ExpressionContext.Statement;
+
+                SyntaxNode translated;
+                using (ChangeContext(onLastBlockLine ? _context : ExpressionContext.Statement))
+                {
+                    translated = Translate(expression);
+                }
+
+                // If we have a labeled statement, unwrap it and keep the label as pending. VisitLabel returns a dummy statement (since
+                // LINQ labels don't have a statement, unlike C#), so we'll skip that statement and add the label to the next real one.
+                if (translated is LabeledStatementSyntax labeledStatement)
+                {
+                    if (pendingLabeledStatement is not null)
+                    {
+                        throw new NotImplementedException("Multiple labels on the same statement");
+                    }
+
+                    pendingLabeledStatement = labeledStatement;
+                    translated = labeledStatement.Statement;
+                }
+
+                // Syntax optimization. This is an assignment of a block variable to some value. Render this as:
+                // var x = <expression>;
+                // ... instead of:
+                // int x;
+                // x = <expression>;
+                // ... except for the last line, where we just return the value if needed.
+                if (expression is BinaryExpression { NodeType: ExpressionType.Assign, Left: ParameterExpression lValue }
+                    && translated is AssignmentExpressionSyntax { Right: var valueSyntax }
+                    && (!onLastBlockLine || statementContext == ExpressionContext.Statement)
+                    && unassignedVariables.Remove(lValue))
+                {
+                    var useExplicitVariableType = valueSyntax.Kind() == SyntaxKind.NullLiteralExpression;
+
+                    translated = LocalDeclarationStatement(
+                        VariableDeclaration(
+                            useExplicitVariableType
+                                ? lValue.Type.GetTypeSyntax()
+                                : IdentifierName(Identifier(TriviaList(), SyntaxKind.VarKeyword, "var", "var", TriviaList())),
+                            SingletonSeparatedList(
+                                VariableDeclarator(Identifier(LookupVariableName(lValue)))
+                                    .WithInitializer(EqualsValueClause(valueSyntax)))));
+                }
+
+                if (statementContext == ExpressionContext.Expression)
+                {
+                    // We're on the last line of a block in expression context - the block is being lifted out.
+                    // All statements before the last line (this one) have already been added to _liftedStatements, just return the last
+                    // E.
+                    Check.DebugAssert(onLastBlockLine, "onLastBlockLine");
+                    Result = translated;
+                    break;
+                }
+
+                if (blockContext != ExpressionContext.Expression)
+                {
+                    if (_liftedState.Statements.Count > 0)
+                    {
+                        // If any expressions were lifted out of the current expression, flatten them into our own block, just before the
+                        // statement from which it was lifted. Note that we don't do this in Expression context, since our own block is
+                        // lifted out.
+                        statements.AddRange(_liftedState.Statements);
+                        _liftedState.Statements.Clear();
+                    }
+
+                    // Same for any variables being lifted out of the block; we add them to our own stack frame so that we can do proper
+                    // variable name uniquification etc.
+                    if (_liftedState.Variables.Count > 0)
+                    {
+                        foreach (var (parameter, name) in _liftedState.Variables)
+                        {
+                            stackFrame.Variables[parameter] = name;
+                            stackFrame.VariableNames.Add(name);
+                        }
+
+                        _liftedState.Variables.Clear();
+                    }
+                }
+
+                // Skip useless expressions with no side effects in statement context (these can be the result of switch/conditional lifting
+                // with assignment lowering)
+                if (statementContext == ExpressionContext.Statement && !_sideEffectDetector.MayHaveSideEffects(translated))
+                {
+                    continue;
+                }
+
+                var statement = translated switch
+                {
+                    StatementSyntax s => s,
+
+                    // If this is the last line in an expression lambda, wrap it in a return statement.
+                    ExpressionSyntax e when _onLastLambdaLine && statementContext == ExpressionContext.ExpressionLambda
+                        => ReturnStatement(e),
+
+                    // If we're in statement context and we have an expression that can't stand alone (e.g. literal), assign it to discard
+                    // TODO: We can also elide expressions with no side effects in stand-alone context
+                    ExpressionSyntax e
+                        when statementContext == ExpressionContext.Statement
+                        && !IsExpressionValidAsStatement(e)
+                        => ExpressionStatement(
+                            AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                IdentifierName(Identifier(TriviaList(), SyntaxKind.UnderscoreToken, "_", "_", TriviaList())),
+                                e)),
+
+                    ExpressionSyntax e => ExpressionStatement(e),
+
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+
+                if (blockContext == ExpressionContext.Expression)
+                {
+                    // This block is in expression context, and so will be lifted (we won't be returning a block).
+                    _liftedState.Statements.Add(statement);
+                }
+                else
+                {
+                    if (pendingLabeledStatement is not null)
+                    {
+                        statement = pendingLabeledStatement.WithStatement(statement);
+                        pendingLabeledStatement = null;
+                    }
+
+                    statements.Add(statement);
+                }
+            }
+
+            // If a label existed on the last line, add an empty statement (since C# requires it); for expression blocks we'd have to
+            // lift that, not supported for now.
+            if (pendingLabeledStatement is not null)
+            {
+                if (blockContext == ExpressionContext.Expression)
+                {
+                    throw new NotImplementedException("Label on last expression of an expression block");
+                }
+                else
+                {
+                    statements.Add(pendingLabeledStatement.WithStatement(EmptyStatement()));
+                }
+            }
+
+            // Above we transform top-level assignments (i = 8) to var-declarations with initializers (var i = 8); those variables have
+            // already been taken care of and removed from the list.
+            // But there may still be variables that get assigned inside nested blocks or other situations; prepare declarations for those
+            // and either add them to the block, or lift them if we're an expression block.
+            var unassignedVariableDeclarations =
+                unassignedVariables.Select(
+                    v => LocalDeclarationStatement(
+                        VariableDeclaration(
+                            v.Type.GetTypeSyntax(),
+                            SingletonSeparatedList(
+                                VariableDeclarator(Identifier(LookupVariableName(v)))))));
+
+            if (blockContext == ExpressionContext.Expression)
+            {
+                _liftedState.UnassignedVariableDeclarations.AddRange(unassignedVariableDeclarations);
+            }
+            else
+            {
+                statements.InsertRange(0, unassignedVariableDeclarations.Concat(_liftedState.UnassignedVariableDeclarations));
+                _liftedState.UnassignedVariableDeclarations.Clear();
+
+                // We're done. If the block is in an expression context, it needs to be lifted out; but not if it's in a lambda (in that case we
+                // just added return above).
+                Result = Block(statements);
+            }
+
+            return block;
+        }
+        finally
+        {
+            _onLastLambdaLine = parentOnLastLambdaLine;
+            _liftedState = parentLiftedState;
+
+            if (ownStackFrame is not null)
+            {
+                var popped = _stack.Pop();
+                Check.DebugAssert(popped.Equals(ownStackFrame), "popped.Equals(ownStackFrame)");
+            }
+        }
+
+        // Returns true for expressions which have side-effects, and can therefore appear alone as a statement
+        static bool IsExpressionValidAsStatement(ExpressionSyntax expression)
+            => expression.Kind() switch
+            {
+                SyntaxKind.InvocationExpression => true,
+
+                SyntaxKind.AddAssignmentExpression => true,
+                SyntaxKind.AndAssignmentExpression => true,
+                SyntaxKind.CoalesceAssignmentExpression => true,
+                SyntaxKind.DivideAssignmentExpression => true,
+                SyntaxKind.ModuloAssignmentExpression => true,
+                SyntaxKind.MultiplyAssignmentExpression => true,
+                SyntaxKind.OrAssignmentExpression => true,
+                SyntaxKind.SimpleAssignmentExpression => true,
+                SyntaxKind.SubtractAssignmentExpression => true,
+                SyntaxKind.ExclusiveOrAssignmentExpression => true,
+                SyntaxKind.LeftShiftAssignmentExpression => true,
+                SyntaxKind.RightShiftAssignmentExpression => true,
+
+                SyntaxKind.PostIncrementExpression => true,
+                SyntaxKind.PostDecrementExpression => true,
+                SyntaxKind.PreIncrementExpression => true,
+                SyntaxKind.PreDecrementExpression => true,
+
+                _ => false
+            };
+
+        void PreprocessLabels()
+        {
+            // LINQ label targets can be unnamed, so we need to generate names for unnamed ones and maintain a target->name mapping.
+            // We need to maintain this as a stack for every block which has labels.
+            // Normal blocks get their own labels stack frame, which gets popped when we leave the block. Expression labels add their
+            // labels to their parent's stack frame (since they get lifted).
+            var stackFrame = _stack.Peek();
+
+            foreach (var label in block.Expressions.OfType<LabelExpression>())
+            {
+                if (stackFrame.Labels.TryGetValue(label.Target, out var identifier))
+                {
+                    continue;
+                }
+
+                var (_, _, labels, unnamedLabelNames) = stackFrame;
+
+                // Generate names for unnamed label targets and uniquify
+                identifier = label.Target.Name ?? "unnamedLabel";
+                var identifierBase = identifier;
+                for (var i = 0; unnamedLabelNames.Contains(identifier); i++)
+                {
+                    identifier = identifierBase + i;
+                }
+
+                if (label.Target.Name is null)
+                {
+                    unnamedLabelNames.Add(identifier);
+                }
+                labels.Add(label.Target, identifier);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override CatchBlock VisitCatchBlock(CatchBlock node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitConditional(ConditionalExpression conditional)
+    {
+        Result = TranslateConditional(conditional, lowerableAssignmentVariable: null);
+
+        return conditional;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual CSharpSyntaxNode TranslateConditional(ConditionalExpression conditional, IdentifierNameSyntax? lowerableAssignmentVariable)
+    {
+        // ConditionalExpression can be an expression or an if/else statement.
+        var test = Translate<ExpressionSyntax>(conditional.Test);
+
+        var isFalseAbsent = conditional.IfFalse is DefaultExpression defaultIfFalse && defaultIfFalse.Type == typeof(void);
+
+        switch (_context)
+        {
+            case ExpressionContext.Statement:
+            {
+                var ifTrue = Translate(conditional.IfTrue);
+                var ifFalse = Translate(conditional.IfFalse);
+
+                var ifTrueStatement = ProcessArmBody(ifTrue, isTrueArm: true);
+
+                if (isFalseAbsent)
+                {
+                    return IfStatement(test, ifTrueStatement);
+                }
+
+                var ifFalseStatement = ProcessArmBody(ifFalse, isTrueArm: false);
+
+                return IfStatement(test, ifTrueStatement, ElseClause(ifFalseStatement));
+
+                StatementSyntax ProcessArmBody(SyntaxNode body, bool isTrueArm)
+                    => body switch
+                    {
+                        BlockSyntax b => b,
+
+                        // We want to specifically exempt IfStatementSyntax under the Else from being wrapped by a block, so as to get nice
+                        // else if syntax
+                        IfStatementSyntax i => isTrueArm ? Block(i) : i,
+
+                        ExpressionSyntax e => Block(ExpressionStatement(e)),
+                        StatementSyntax s => Block(s),
+
+                        _ => throw new ArgumentOutOfRangeException()
+                    };
+            }
+
+            case ExpressionContext.Expression:
+            case ExpressionContext.ExpressionLambda:
+            {
+                if (isFalseAbsent)
+                {
+                    throw new NotSupportedException(
+                        $"Missing {nameof(System.Linq.Expressions.ConditionalExpression.IfFalse)} in {nameof(ConditionalExpression)} in expression context");
+                }
+
+                var parentLiftedState = _liftedState;
+                _liftedState = new(new(), new(), new(), new());
+
+                var ifTrue = Translate(conditional.IfTrue);
+                var ifFalse = Translate(conditional.IfFalse);
+
+                if (ifTrue is not ExpressionSyntax ifTrueExpression
+                    || ifFalse is not ExpressionSyntax ifFalseExpression)
+                {
+                    throw new NotSupportedException("Trying to evaluate a non-expression condition in expression context");
+                }
+
+                // There were no lifted expressions inside either arm - we can translate directly to a C# conditional expression
+                if (_liftedState.Statements.Count == 0)
+                {
+                    _liftedState = parentLiftedState;
+                    return ConditionalExpression(test, ifTrueExpression, ifFalseExpression);
+                }
+
+                // There are lifted expressions inside one of the arms, we must lift the entire conditional expression, rewriting it to
+                // a an if/else statement.
+                _liftedState = new(new(), new(), new(), new());
+
+                IdentifierNameSyntax assignmentVariable;
+                TypeSyntax? loweredAssignmentVariableType = null;
+
+                if (lowerableAssignmentVariable is null)
+                {
+                    var name = UniquifyVariableName("liftedConditional");
+                    var parameter = E.Parameter(conditional.Type, name);
+                    assignmentVariable = IdentifierName(name);
+                    loweredAssignmentVariableType = parameter.Type.GetTypeSyntax();
+                }
+                else
+                {
+                    assignmentVariable = lowerableAssignmentVariable;
+                }
+
+                var ifTrueStatement = ProcessArmBody(conditional.IfTrue);
+                var ifFalseStatement = ProcessArmBody(conditional.IfFalse);
+
+                _liftedState = parentLiftedState;
+
+                if (lowerableAssignmentVariable is null)
+                {
+                    _liftedState.Statements.Add(
+                        LocalDeclarationStatement(
+                            VariableDeclaration(loweredAssignmentVariableType!)
+                                .WithVariables(
+                                    SingletonSeparatedList(
+                                        VariableDeclarator(assignmentVariable.Identifier.Text)))));
+                }
+                _liftedState.Statements.Add(IfStatement(test, ifTrueStatement, ElseClause(ifFalseStatement)));
+                return assignmentVariable;
+
+                StatementSyntax ProcessArmBody(Expression body)
+                {
+                    Check.DebugAssert(_liftedState.Statements.Count == 0, "_liftedExpressions.Count == 0");
+
+                    var translatedBody = Translate(body, assignmentVariable);
+
+                    // Usually we add an assignment for the variable.
+                    // The exception is if the body was itself lifted out and the assignment lowering succeeded (nested conditionals) -
+                    // in this case we get back the lowered assignment variable, and don't need the assignment (i = i)
+                    if (translatedBody != assignmentVariable)
+                    {
+                        _liftedState.Statements.Add(ExpressionStatement(
+                            AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                assignmentVariable,
+                                translatedBody)));
+                    }
+
+                    var block = Block(_liftedState.Statements);
+
+                    _liftedState.Statements.Clear();
+                    return block;
+                }
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitConstant(ConstantExpression constant)
+    {
+        Result = GenerateValue(constant.Value);
+
+        return constant;
+
+        ExpressionSyntax GenerateValue(object? value)
+            => value switch
+            {
+                int or long or uint or ulong or short or sbyte or ushort or byte or double or float or decimal
+                    => (ExpressionSyntax)_g.LiteralExpression(constant.Value),
+
+                string or bool or null => (ExpressionSyntax)_g.LiteralExpression(constant.Value),
+
+                Type t => TypeOfExpression(t.GetTypeSyntax()),
+                Enum e => HandleEnum(e),
+
+                ITuple tuple
+                    when tuple.GetType() is { IsGenericType: true } tupleType
+                         && tupleType.Name.StartsWith("ValueTuple`", StringComparison.Ordinal)
+                         && tupleType.Namespace == "System"
+                    => HandleValueTuple(tuple),
+
+                _ => throw new NotSupportedException(
+                    $"Encountered a constant of unsupported type '{value.GetType().Name}'. Only primitive constant nodes are supported.")
+            };
+
+        ExpressionSyntax HandleEnum(Enum e)
+        {
+            var enumType = e.GetType();
+
+            var formatted = Enum.Format(enumType, e, "G");
+            if (char.IsDigit(formatted[0]))
+            {
+                // Unknown value, render as a cast of the underlying integral value
+                if (!Enum.IsDefined(e.GetType(), e))
+                {
+                    var underlyingType = enumType.GetEnumUnderlyingType();
+
+                    return CastExpression(
+                        enumType.GetTypeSyntax(),
+                        LiteralExpression(
+                            SyntaxKind.NumericLiteralExpression,
+                            underlyingType == typeof(sbyte)
+                            || underlyingType == typeof(short)
+                            || underlyingType == typeof(int)
+                            || underlyingType == typeof(long)
+                                ? Literal(long.Parse(formatted))
+                                : Literal(ulong.Parse(formatted))));
+                }
+            }
+
+            var components = formatted.Split(", ");
+            Check.DebugAssert(components.Length > 0, "components.Length > 0");
+
+            return components.Aggregate(
+                (ExpressionSyntax?)null,
+                (last, next) => last is null
+                    ? MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName(enumType.Name),
+                        IdentifierName(next))
+                    : BinaryExpression(
+                        SyntaxKind.BitwiseOrExpression, last,
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName(enumType.Name),
+                            IdentifierName(next))))!;
+        }
+
+        ExpressionSyntax HandleValueTuple(ITuple tuple)
+        {
+            var arguments = new ArgumentSyntax[tuple.Length];
+            for (var i = 0; i < tuple.Length; i++)
+            {
+                arguments[i] = Argument(GenerateValue(tuple[i]!));
+            }
+
+            return TupleExpression(SeparatedList(arguments));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitDebugInfo(DebugInfoExpression node)
+        => throw new NotSupportedException("DebugInfo nodes are not supporting when translating expression trees to C#");
+
+    /// <inheritdoc />
+    protected override Expression VisitDefault(DefaultExpression node)
+    {
+        Result = DefaultExpression(node.Type.GetTypeSyntax());
+
+        return node;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitGoto(GotoExpression gotoNode)
+    {
+        Result = GotoStatement(SyntaxKind.GotoStatement, TranslateLabelTarget(gotoNode.Target));
+        return gotoNode;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitInvocation(InvocationExpression invocation)
+    {
+        var lambda = (LambdaExpression)invocation.Expression;
+
+        // We need to inline the lambda invocation into the tree, by replacing parameters in the lambda body with the invocation arguments.
+        // However, if an argument to the invocation can have side effects (e.g. a method call), and it's referenced multiple times from
+        // the body, then that would cause multiple evaluation, which is wrong (same if the arguments are evaluated only once but in reverse
+        // order.
+        // So we have to lift such arguments.
+        var arguments = new Expression[invocation.Arguments.Count];
+
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var argument = invocation.Arguments[i];
+            if (!MayHaveSideEffects(argument))
+            {
+                // No need to evaluate into a separate variable, just pass directly
+                arguments[i] = argument;
+                continue;
+            }
+
+            // Need to lift
+            var name = UniquifyVariableName(lambda.Parameters[i].Name ?? "lifted");
+            var parameter = E.Parameter(argument.Type, name);
+            _liftedState.Statements.Add(GenerateVarDeclaration(name, Translate<ExpressionSyntax>(argument)));
+            arguments[i] = parameter;
+        }
+
+        var replacedBody = new ReplacingExpressionVisitor(lambda.Parameters, arguments).Visit(lambda.Body);
+        Result = Translate(replacedBody);
+
+        return invocation;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitLabel(LabelExpression label)
+    {
+        // C# labels apply on a statement, but in LINQ they can appear anywhere (i.e. last thing in a block).
+        // So we apply the label to a dummy null literal statement, which we'll filter out of the block in statement context anyway.
+        Result = LabeledStatement(
+            TranslateLabelTarget(label.Target).Identifier.Text,
+            ExpressionStatement(LiteralExpression(SyntaxKind.NullLiteralExpression)));
+        return label;
+    }
+
+    /// <inheritdoc />
+    protected override LabelTarget VisitLabelTarget(LabelTarget? labelTarget)
+    {
+        if (labelTarget is null)
+        {
+            throw new NotImplementedException("Null argument in VisitLabelTarget");
+        }
+
+        Result = TranslateLabelTarget(labelTarget);
+        return labelTarget;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual IdentifierNameSyntax TranslateLabelTarget(LabelTarget labelTarget)
+    {
+        // In LINQ expression trees, label targets can have a return type (they're expressions), which means they return the last evaluated
+        // thing if e.g. they're the last expression in a block. This would require lifting out the last evaluation before the goto/break,
+        // assigning it to a temporary variable, and adding a variable evaluation after the label.
+        if (labelTarget.Type != typeof(void))
+        {
+            throw new NotImplementedException("Non-void label target");
+        }
+
+        // We did a processing pass on the block's labels, so any labels should already be found in our label stack frame
+        return IdentifierName(_stack.Peek().Labels[labelTarget]);
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitLambda<T>(Expression<T> lambda)
+    {
+        using var _ = ChangeContext(
+            lambda.ReturnType == typeof(void) ? ExpressionContext.Statement : ExpressionContext.ExpressionLambda);
+        var parentOnLastLambdaLine = _onLastLambdaLine;
+        _onLastLambdaLine = true;
+
+        var stackFrame = PushNewStackFrame();
+
+        var localUnnamedParameterCounter = 0;
+        foreach (var parameter in lambda.Parameters)
+        {
+            var name = parameter.Name ?? "unnamed" + (++localUnnamedParameterCounter);
+            stackFrame.Variables[parameter] = name;
+            stackFrame.VariableNames.Add(name);
+        }
+
+        var body = (CSharpSyntaxNode)Translate(lambda.Body);
+
+        // If the lambda body was an expression that had lifted statements (e.g. some block in expression context), we need to create
+        // a block to contain these statements
+        if (_liftedState.Statements.Count > 0)
+        {
+            Check.DebugAssert(lambda.ReturnType != typeof(void), "lambda.ReturnType != typeof(void)");
+
+            body = Block(_liftedState.Statements.Append(ReturnStatement((ExpressionSyntax)body)));
+            _liftedState.Statements.Clear();
+        }
+
+        Result = lambda.Parameters.Count switch
+        {
+            0 => ParenthesizedLambdaExpression(body),
+            1 => SimpleLambdaExpression(Parameter(Identifier(stackFrame.Variables[lambda.Parameters[0]])), body),
+            _ => ParenthesizedLambdaExpression(
+                ParameterList(SeparatedList(lambda.Parameters.Select(p => Parameter(Identifier(LookupVariableName(p)))))),
+                body)
+        };
+
+        var popped = _stack.Pop();
+        Check.DebugAssert(popped.Equals(stackFrame), "popped.Equals(stackFrame)");
+
+        _onLastLambdaLine = parentOnLastLambdaLine;
+
+        return lambda;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitLoop(LoopExpression loop)
+    {
+        if (_context == ExpressionContext.Expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        var rewrittenLoop1 = loop;
+
+        if (loop.ContinueLabel is not null)
+        {
+            var blockBody = loop.Body is BlockExpression b ? b : E.Block(loop.Body);
+            blockBody = blockBody.Update(
+                blockBody.Variables,
+                new[] { E.Label(loop.ContinueLabel) }.Concat(blockBody.Expressions));
+
+            rewrittenLoop1 = loop.Update(
+                loop.BreakLabel,
+                continueLabel: null,
+                blockBody);
+        }
+
+        Expression rewrittenLoop2 = rewrittenLoop1;
+
+        if (loop.BreakLabel is not null)
+        {
+            rewrittenLoop2 =
+                E.Block(
+                    rewrittenLoop1.Update(breakLabel: null, rewrittenLoop1.ContinueLabel, rewrittenLoop1.Body),
+                    E.Label(loop.BreakLabel));
+        }
+
+        if (rewrittenLoop2 != loop)
+        {
+            return Visit(rewrittenLoop2);
+        }
+
+        var translatedBody = Translate(loop.Body) switch
+        {
+            BlockSyntax b => b,
+            StatementSyntax s => Block(s),
+            ExpressionSyntax e => Block(ExpressionStatement(e)),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        StatementSyntax translated = WhileStatement(
+            LiteralExpression(SyntaxKind.TrueLiteralExpression),
+            translatedBody);
+
+        Result = translated;
+
+        return loop;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMember(MemberExpression member)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        // LINQ expression trees can directly access private members, but C# code cannot; render (slow) reflection code that does the same
+        // thing. Note that assignment to private members is handled in VisitBinary.
+        // TODO: Replace this with a more efficient API for .NET 8.0.
+        switch (member.Member)
+        {
+            case FieldInfo { IsPrivate: true } fieldInfo:
+                if (member.Expression is null)
+                {
+                    throw new NotImplementedException("Private static field access");
+                }
+
+                if (member.Member.DeclaringType is null)
+                {
+                    throw new NotSupportedException("Private field without a declaring type: " + member.Member.Name);
+                }
+
+                Result = Translate(
+                    E.Call(
+                        E.Call(
+                            E.Constant(member.Member.DeclaringType),
+                            _typeGetFieldMethod ??= typeof(Type).GetMethod(
+                                nameof(Type.GetField), new[] { typeof(string), typeof(BindingFlags) })!,
+                            E.Constant(fieldInfo.Name),
+                            E.Constant(BindingFlags.NonPublic | BindingFlags.Instance)),
+                        _fieldGetValueMethod ??= typeof(FieldInfo).GetMethod(nameof(FieldInfo.GetValue), new[] { typeof(object) })!,
+                        member.Expression));
+
+                break;
+
+            // TODO: private property
+            // TODO: private event
+
+            default:
+                Result = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    member.Expression is null
+                        ? member.Type.GetTypeSyntax() // static
+                        : Translate<ExpressionSyntax>(member.Expression),
+                    IdentifierName(member.Member.Name));
+                break;
+        }
+
+        return member;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitIndex(IndexExpression index)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        if (index.Arguments.Count > 1)
+        {
+            throw new NotImplementedException("IndexExpression with multiple arguments");
+        }
+
+        Result =
+            ElementAccessExpression(Translate<ExpressionSyntax>(index.Object!))
+                .WithArgumentList(
+                    BracketedArgumentList(
+                        SingletonSeparatedList(
+                            Argument(
+                                Translate<ExpressionSyntax>(index.Arguments.Single())))));
+
+        return index;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMethodCall(MethodCallExpression call)
+    {
+        if (call.Method.DeclaringType is null)
+        {
+            throw new NotSupportedException($"Can't translate method '{call.Method.Name}' which has no declaring type");
+        }
+
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        var parameters = call.Method.GetParameters();
+        var arguments = new ArgumentSyntax[parameters.Length];
+        var lastLiftedArgumentPosition = 0;
+
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var (argument, parameter) = (call.Arguments[i], parameters[i]);
+
+            var liftedStatementsPosition = _liftedState.Statements.Count;
+
+            var translated = Argument(Translate<ExpressionSyntax>(argument));
+
+            if (parameter.IsOut)
+            {
+                translated = translated.WithRefKindKeyword(Token(SyntaxKind.OutKeyword));
+            }
+            else if (parameter.IsIn)
+            {
+                translated = translated.WithRefKindKeyword(Token(SyntaxKind.InKeyword));
+            }
+            else if (parameter.ParameterType.IsByRef)
+            {
+                translated = translated.WithRefKindKeyword(Token(SyntaxKind.RefKeyword));
+            }
+
+            if (_liftedState.Statements.Count > liftedStatementsPosition)
+            {
+                // This argument contained lifted statements. In order to preserve evaluation order, we must also lift out all preceding
+                // arguments to before this argument's lifted statements.
+                for (; lastLiftedArgumentPosition < i; lastLiftedArgumentPosition++)
+                {
+                    var argumentExpression = arguments[lastLiftedArgumentPosition].Expression;
+
+                    if (_sideEffectDetector.MayHaveSideEffects(argumentExpression))
+                    {
+                        var name = UniquifyVariableName("liftedArg");
+
+                        _liftedState.Statements.Insert(
+                            liftedStatementsPosition++,
+                            GenerateVarDeclaration(name, argumentExpression));
+                        _liftedState.VariableNames.Add(name);
+
+                        arguments[lastLiftedArgumentPosition] = Argument(IdentifierName(name));
+                    }
+                }
+            }
+
+            arguments[i] = translated;
+        }
+
+        // TODO: don't specify generic parameters if they can all be inferred
+        SimpleNameSyntax methodIdentifier = call.Method.IsGenericMethod
+            ? GenericName(
+                Identifier(call.Method.Name),
+                TypeArgumentList(
+                    SeparatedList(
+                        call.Method.GetGenericArguments().Select(ga => ga.GetTypeSyntax()))))
+            : IdentifierName(call.Method.Name);
+
+        // Extension syntax
+        if (call.Method.IsDefined(typeof(ExtensionAttribute), inherit: false)
+            && !(arguments[0].Expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.NullLiteralExpression)))
+        {
+            Result = InvocationExpression(
+                MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    arguments[0].Expression,
+                    methodIdentifier),
+                ArgumentList(SeparatedList(arguments[1..])));
+        }
+        else
+        {
+            ExpressionSyntax expression;
+            if (call.Object is null)
+            {
+                // Static method call. Recursively add MemberAccessExpressions for all declaring types (for methods on nested types)
+                expression = GetMemberAccessesForAllDeclaringTypes(call.Method.DeclaringType);
+
+                static ExpressionSyntax GetMemberAccessesForAllDeclaringTypes(Type type)
+                {
+                    return type.DeclaringType is null
+                        ? type.GetTypeSyntax()
+                        : MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            GetMemberAccessesForAllDeclaringTypes(type.DeclaringType),
+                            IdentifierName(type.Name));
+                }
+            }
+            else
+            {
+                expression = Translate<ExpressionSyntax>(call.Object);
+            }
+
+            Result = InvocationExpression(
+                MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    expression,
+                    methodIdentifier),
+                ArgumentList(SeparatedList(arguments)));
+        }
+
+        if (call.Method.DeclaringType.Namespace is { } ns)
+        {
+            _collectedNamespaces.Add(ns);
+        }
+
+        return call;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitNewArray(NewArrayExpression newArray)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        Result =
+            ArrayCreationExpression(
+                    ArrayType(newArray.Type.GetElementType()!.GetTypeSyntax())
+                        .WithRankSpecifiers(
+                            SingletonList(
+                                ArrayRankSpecifier(
+                                    SingletonSeparatedList<ExpressionSyntax>(
+                                        OmittedArraySizeExpression())))))
+                .WithInitializer(
+                    InitializerExpression(
+                        SyntaxKind.ArrayInitializerExpression,
+                        SeparatedList(
+                            newArray.Expressions.Select(Translate<ExpressionSyntax>))));
+
+        return newArray;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitNew(NewExpression node)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        if (node.Type.IsAnonymousType())
+        {
+            if (node.Members is null)
+            {
+                throw new NotSupportedException("Anonymous type creation without members");
+            }
+
+            Result = AnonymousObjectCreationExpression(
+                SeparatedList(
+                    node.Arguments.Select((arg, i) =>
+                            AnonymousObjectMemberDeclarator(NameEquals(node.Members[i].Name), Translate<ExpressionSyntax>(arg)))
+                        .ToArray()));
+        }
+        else
+        {
+            // If the type has any required properties and the constructor doesn't have [SetsRequiredMembers], we can't just generate an
+            // instantiation E.
+            // TODO: Currently matching attributes by name since we target .NET 6.0. If/when we target .NET 7.0 and above, match the type.
+            if (node.Type.GetCustomAttributes(inherit: true)
+                    .Any(a => a.GetType().FullName == "System.Runtime.CompilerServices.RequiredMemberAttribute")
+                && node.Constructor is not null
+                && node.Constructor.GetCustomAttributes()
+                    .Any(a => a.GetType().FullName == "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute") != true)
+            {
+                // If the constructor is parameterless, we generate Activator.Create<T>() which is almost as fast (<10ns difference).
+                // For constructors with parameters, we currently throw as not supported (we can pass parameters, but boxing, probably
+                // speed degradation etc.).
+                if (node.Constructor.GetParameters().Length == 0)
+                {
+                    Result =
+                        Translate(
+                            E.Call(
+                                (_activatorCreateInstanceMethod ??= typeof(Activator).GetMethod(
+                                    nameof(Activator.CreateInstance), Array.Empty<Type>())!)
+                                .MakeGenericMethod(node.Type)));
+                }
+                else
+                {
+                    throw new NotImplementedException("Instantiation of type with required properties via constructor that has parameters");
+                }
+            }
+            else
+            {
+                // Normal case with plain old instantiation
+                Result = ObjectCreationExpression(node.Type.GetTypeSyntax())
+                    .WithArgumentList(
+                        ArgumentList(
+                            SeparatedList(
+                                node.Arguments.Select(arg => Argument(Translate<ExpressionSyntax>(arg))).ToArray())));
+            }
+
+            if (node.Constructor?.DeclaringType?.Namespace is not null)
+            {
+                _collectedNamespaces.Add(node.Constructor.DeclaringType.Namespace);
+            }
+        }
+
+        return node;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitParameter(ParameterExpression parameter)
+    {
+        // Note that the parameter in the lambda declaration is handled separately in VisitLambda
+        if (_stack.Peek().Variables.TryGetValue(parameter, out var name)
+            || _liftedState.Variables.TryGetValue(parameter, out name))
+        {
+            Result = IdentifierName(name);
+
+            return parameter;
+        }
+
+        // This parameter is unknown to us - it's captured from outside the entire expression tree.
+        // Simply return its name without worrying about uniquification, since the variable needs to correspond to the outside in any
+        // case (it's the callers responsibility).
+        _capturedVariables.Add(parameter);
+
+        if (parameter.Name is null)
+        {
+            throw new NotSupportedException("Unnamed captured variable");
+        }
+
+        Result = IdentifierName(parameter.Name);
+        return parameter;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitRuntimeVariables(RuntimeVariablesExpression node)
+        => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    protected override SwitchCase VisitSwitchCase(SwitchCase node)
+        => throw new NotSupportedException("Translation happens as part of VisitSwitch");
+
+    /// <inheritdoc />
+    protected override Expression VisitSwitch(SwitchExpression switchNode)
+    {
+        Result = TranslateSwitch(switchNode, lowerableAssignmentVariable: null);
+
+        return switchNode;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual CSharpSyntaxNode TranslateSwitch(SwitchExpression switchNode, IdentifierNameSyntax? lowerableAssignmentVariable)
+    {
+        if (switchNode.Comparison is not null)
+        {
+            throw new NotImplementedException("Switch with non-null comparison method");
+        }
+
+        var switchValue = Translate<ExpressionSyntax>(switchNode.SwitchValue);
+
+        switch (_context)
+        {
+            case ExpressionContext.Statement:
+            {
+                var parentLiftedState = _liftedState;
+                _liftedState = new(new(), new(), new(), new());
+
+                var cases = List(
+                    switchNode.Cases.Select(
+                        c => SwitchSection(
+                            labels: List<SwitchLabelSyntax>(
+                                c.TestValues.Select(tv => CaseSwitchLabel(Translate<ExpressionSyntax>(tv)))),
+                            statements: ProcessArmBody(c.Body))));
+
+                // LINQ SwitchExpression supports non-literal labels, which C# does not support. This rewrites the switch as a series of
+                // nested ConditionalExpressions.
+                if (cases.Any(c => c.Labels.Any(l => l is CaseSwitchLabelSyntax l2 && !_constantDetector.IsConstant(l2.Value))))
+                {
+                    _liftedState = parentLiftedState;
+                    return TranslateConditional(RewriteSwitchToConditionals(switchNode), lowerableAssignmentVariable);
+                }
+
+                if (switchNode.DefaultBody is not null)
+                {
+                    cases = cases.Add(
+                        SwitchSection(
+                            SingletonList<SwitchLabelSyntax>(DefaultSwitchLabel()),
+                            ProcessArmBody(switchNode.DefaultBody)));
+                }
+
+                return SwitchStatement(switchValue, cases);
+
+                SyntaxList<StatementSyntax> ProcessArmBody(Expression body)
+                {
+                    var translatedBody = Translate(body);
+
+                    var result = translatedBody switch
+                    {
+                        BlockSyntax block => SingletonList<StatementSyntax>(block.WithStatements(block.Statements.Add(BreakStatement()))),
+                        StatementSyntax s => List(new[] { s, BreakStatement() }),
+                        ExpressionSyntax e => List(new StatementSyntax[] { ExpressionStatement(e), BreakStatement() }),
+
+                        _ => throw new ArgumentOutOfRangeException()
+                    };
+
+                    return result;
+                }
+            }
+
+            case ExpressionContext.Expression:
+            case ExpressionContext.ExpressionLambda:
+            {
+                if (switchNode.DefaultBody is null)
+                {
+                    throw new NotSupportedException("Missing default arm for switch expression");
+                }
+
+                var parentLiftedState = _liftedState;
+                _liftedState = new(new(), new(), new(), new());
+
+                // Translate all arms
+                var arms = SeparatedList(
+                    switchNode.Cases.SelectMany(
+                            c => c.TestValues, (c, tv) => SwitchExpressionArm(
+                                ConstantPattern(Translate<ExpressionSyntax>(tv)),
+                                Translate<ExpressionSyntax>(c.Body)))
+                        .Append(SwitchExpressionArm(DiscardPattern(), Translate<ExpressionSyntax>(switchNode.DefaultBody))));
+
+                // LINQ SwitchExpression supports non-literal labels, which C# does not support. This rewrites the switch as a series of
+                // nested ConditionalExpressions.
+                if (arms.Any(a => a.Pattern is ConstantPatternSyntax cp && !_constantDetector.IsConstant(cp.Expression)))
+                {
+                    _liftedState = parentLiftedState;
+                    return TranslateConditional(RewriteSwitchToConditionals(switchNode), lowerableAssignmentVariable);
+                }
+
+                // If there were no lifted expressions inside any arm, we can translate directly to a C# switch expression
+                if (_liftedState.Statements.Count == 0)
+                {
+                    _liftedState = parentLiftedState;
+                    return SwitchExpression(switchValue, arms);
+                }
+
+                // There are lifted expressions inside some of the arms, we must lift the entire switch expression, rewriting it to
+                // a switch statement.
+                _liftedState = new(new(), new(), new(), new());
+
+                IdentifierNameSyntax assignmentVariable;
+                TypeSyntax? loweredAssignmentVariableType = null;
+
+                if (lowerableAssignmentVariable is null)
+                {
+                    var name = UniquifyVariableName("liftedSwitch");
+                    var parameter = E.Parameter(switchNode.Type, name);
+                    assignmentVariable = IdentifierName(name);
+                    loweredAssignmentVariableType = parameter.Type.GetTypeSyntax();
+                }
+                else
+                {
+                    assignmentVariable = lowerableAssignmentVariable;
+                }
+
+                var cases = List(
+                    switchNode.Cases.Select(
+                        c => SwitchSection(
+                            labels: List<SwitchLabelSyntax>(
+                                c.TestValues.Select(tv => CaseSwitchLabel(Translate<LiteralExpressionSyntax>(tv)))),
+                            statements: ProcessArmBody(c.Body)))
+                        .Append(SwitchSection(
+                            SingletonList<SwitchLabelSyntax>(DefaultSwitchLabel()),
+                            ProcessArmBody(switchNode.DefaultBody))));
+
+                _liftedState = parentLiftedState;
+
+                if (lowerableAssignmentVariable is null)
+                {
+                    _liftedState.Statements.Add(
+                        LocalDeclarationStatement(
+                            VariableDeclaration(loweredAssignmentVariableType!)
+                                .WithVariables(
+                                    SingletonSeparatedList(
+                                        VariableDeclarator(assignmentVariable.Identifier.Text)))));
+                }
+
+                _liftedState.Statements.Add(SwitchStatement(switchValue, cases));
+                return assignmentVariable;
+
+                SyntaxList<StatementSyntax> ProcessArmBody(Expression body)
+                {
+                    Check.DebugAssert(_liftedState.Statements.Count == 0, "_liftedExpressions.Count == 0");
+
+                    var translatedBody = Translate(body, assignmentVariable);
+
+                    var assignmentStatement = ExpressionStatement(
+                        AssignmentExpression(
+                            SyntaxKind.SimpleAssignmentExpression,
+                            assignmentVariable,
+                            translatedBody));
+
+                    if (_liftedState.Statements.Count == 0)
+                    {
+                        // Simple expression, can embed directly in the switch case
+                        return List(new StatementSyntax[] { assignmentStatement, BreakStatement() });
+                    }
+
+                    // Usually we add an assignment for the variable.
+                    // The exception is if the body was itself lifted out and the assignment lowering succeeded (nested conditionals) -
+                    // in this case we get back the lowered assignment variable, and don't need the assignment (i = i)
+                    if (translatedBody != assignmentVariable)
+                    {
+                        _liftedState.Statements.Add(ExpressionStatement(
+                            AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                assignmentVariable,
+                                translatedBody)));
+                    }
+
+                    _liftedState.Statements.Add(BreakStatement());
+                    var block = SingletonList<StatementSyntax>(Block(_liftedState.Statements));
+
+                    _liftedState.Statements.Clear();
+                    return block;
+                }
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        static ConditionalExpression RewriteSwitchToConditionals(SwitchExpression node)
+        {
+            if (node.Type == typeof(void))
+            {
+                return (ConditionalExpression)(node.Cases
+                           .SelectMany(c => c.TestValues, (c, tv) => new { c.Body, Label = tv })
+                           .Reverse()
+                           .Aggregate(
+                               node.DefaultBody,
+                               (expression, arm) => expression is null
+                                   ? E.IfThen(E.Equal(node.SwitchValue, arm.Label), arm.Body)
+                                   : E.IfThenElse(E.Equal(node.SwitchValue, arm.Label), arm.Body, expression))
+                       ?? throw new NotImplementedException("Empty switch statement"));
+            }
+
+            Check.DebugAssert(node.DefaultBody is not null, "Switch expression with non-void return type but no default body");
+
+            return (ConditionalExpression)node.Cases
+                .SelectMany(c => c.TestValues, (c, tv) => new { c.Body, Label = tv })
+                .Reverse()
+                .Aggregate(
+                    node.DefaultBody,
+                    (expression, arm) => E.Condition(
+                        E.Equal(node.SwitchValue, arm.Label),
+                        arm.Body,
+                        expression));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitTry(TryExpression node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitTypeBinary(TypeBinaryExpression node)
+    {
+        var visitedExpression = Translate<ExpressionSyntax>(node.Expression);
+
+        Result = node.NodeType switch
+        {
+            ExpressionType.TypeIs
+                => BinaryExpression(SyntaxKind.IsExpression, visitedExpression, node.TypeOperand.GetTypeSyntax()),
+
+            ExpressionType.TypeEqual
+                => BinaryExpression(SyntaxKind.EqualsExpression, visitedExpression, TypeOfExpression(node.TypeOperand.GetTypeSyntax())),
+
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        return node;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitUnary(UnaryExpression unary)
+    {
+        if (unary.Method is not null)
+        {
+            throw new NotImplementedException("Unary node with non-null method");
+        }
+
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        var operand = Translate<ExpressionSyntax>(unary.Operand);
+
+        // TODO: Confirm what to do with the checked expression types
+
+        Result = unary.NodeType switch
+        {
+            ExpressionType.Negate => _g.NegateExpression(operand),
+            ExpressionType.NegateChecked => _g.NegateExpression(operand),
+            ExpressionType.Not when unary.Type == typeof(bool) => _g.LogicalNotExpression(operand),
+            ExpressionType.Not => _g.BitwiseNotExpression(operand),
+            ExpressionType.OnesComplement => _g.BitwiseNotExpression(operand),
+            ExpressionType.IsFalse => _g.LogicalNotExpression(operand),
+            ExpressionType.IsTrue => operand,
+            ExpressionType.ArrayLength => _g.MemberAccessExpression(operand, "Length"),
+            ExpressionType.Convert => _g.ConvertExpression(unary.Type.GetTypeSyntax(), operand),
+            ExpressionType.ConvertChecked => _g.ConvertExpression(unary.Type.GetTypeSyntax(), operand),
+            ExpressionType.Throw when unary.Type == (typeof(void)) => _g.ThrowStatement(operand),
+            ExpressionType.Throw => _g.ThrowExpression(operand),
+            ExpressionType.TypeAs => BinaryExpression(SyntaxKind.AsExpression, operand, unary.Type.GetTypeSyntax()),
+            ExpressionType.Quote => operand,
+            ExpressionType.UnaryPlus => PrefixUnaryExpression(SyntaxKind.UnaryPlusExpression, operand),
+            ExpressionType.Unbox => operand,
+            ExpressionType.Increment => Translate(Expression.Add(unary.Operand, Expression.Constant(1))),
+            ExpressionType.Decrement => Translate(Expression.Subtract(unary.Operand, Expression.Constant(1))),
+            ExpressionType.PostIncrementAssign => PostfixUnaryExpression(SyntaxKind.PostIncrementExpression, operand),
+            ExpressionType.PostDecrementAssign => PostfixUnaryExpression(SyntaxKind.PostDecrementExpression, operand),
+            ExpressionType.PreIncrementAssign => PrefixUnaryExpression(SyntaxKind.PreIncrementExpression, operand),
+            ExpressionType.PreDecrementAssign => PrefixUnaryExpression(SyntaxKind.PreDecrementExpression, operand),
+
+            _ => throw new ArgumentOutOfRangeException("Unsupported LINQ unary node: " + unary.NodeType)
+        };
+
+        return unary;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMemberInit(MemberInitExpression node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitListInit(ListInitExpression node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override ElementInit VisitElementInit(ElementInit node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override MemberBinding VisitMemberBinding(MemberBinding node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override MemberAssignment VisitMemberAssignment(MemberAssignment node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override MemberMemberBinding VisitMemberMemberBinding(MemberMemberBinding node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override MemberListBinding VisitMemberListBinding(MemberListBinding node)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitExtension(Expression node)
+    {
+        // TODO: Remove any EF-specific code from this visitor (extend if needed)
+        // TODO: Hack mode. Visit the expression beforehand to replace EntityQueryRootExpression with context.Set<>(), or receive it in this visitor as a replacement or something.
+        if (node is EntityQueryRootExpression entityQueryRoot)
+        {
+            // TODO: STET
+            Result = ParseExpression($"context.Set<{entityQueryRoot.EntityType.ClrType.Name}>()");
+            return node;
+        }
+
+        throw new NotSupportedException(
+            $"Encountered non-quotable expression of type {node.GetType()} when translating expression tree to C#");
+    }
+
+    private static bool MayHaveSideEffects(Expression expression)
+        => expression is not ConstantExpression and not ParameterExpression;
+
+    private StackFrame PushNewStackFrame()
+    {
+        var previousFrame = _stack.Peek();
+        var newFrame = new StackFrame(
+            new(previousFrame.Variables),
+            new(previousFrame.VariableNames),
+            new(previousFrame.Labels),
+            new(previousFrame.UnnamedLabelNames));
+
+        _stack.Push(newFrame);
+
+        return newFrame;
+    }
+
+    private string LookupVariableName(ParameterExpression parameter)
+        => _stack.Peek().Variables.TryGetValue(parameter, out var name)
+            ? name
+            : _liftedState.Variables[parameter];
+
+    private string UniquifyVariableName(string? name)
+    {
+        var isUnnamed = name is null;
+        name ??= "unnamed";
+
+        var parameterNames = _stack.Peek().VariableNames;
+
+        if (parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name))
+        {
+            var baseName = name;
+            for (var j = isUnnamed ? _unnamedParameterCounter++ : 0;
+                 parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name);
+                 j++)
+            {
+                name = baseName + j;
+            }
+        }
+
+        return name;
+    }
+
+    private static LocalDeclarationStatementSyntax GenerateVarDeclaration(string variableIdentifier, ExpressionSyntax initializer)
+        => LocalDeclarationStatement(
+            VariableDeclaration(
+                IdentifierName(Identifier(TriviaList(), SyntaxKind.VarKeyword, "var", "var", TriviaList())),
+                SingletonSeparatedList(
+                    VariableDeclarator(Identifier(variableIdentifier))
+                        .WithInitializer(
+                            EqualsValueClause(
+                                initializer)))));
+
+    private ContextSwitcher ChangeContext(ExpressionContext newContext)
+        => new(this, newContext);
+
+    private readonly struct ContextSwitcher : IDisposable
+    {
+        private readonly LinqToCSharpTranslator _translator;
+        private readonly ExpressionContext _oldContext;
+
+        public ContextSwitcher(LinqToCSharpTranslator translator, ExpressionContext newContext)
+        {
+            _translator = translator;
+            _oldContext = translator._context;
+            translator._context = newContext;
+        }
+
+        public void Dispose()
+            => _translator._context = _oldContext;
+    }
+
+    private enum ExpressionContext
+    {
+        Expression,
+        Statement,
+        ExpressionLambda
+    }
+
+    private class ConstantDetectionSyntaxWalker : SyntaxWalker
+    {
+        private bool _isConstant;
+
+        public bool IsConstant(SyntaxNode node)
+        {
+            _isConstant = true;
+
+            Visit(node);
+
+            return _isConstant;
+        }
+
+        public override void Visit(SyntaxNode node)
+        {
+            _isConstant &= IsConstantCore(node);
+
+            base.Visit(node);
+        }
+
+        private static bool IsConstantCore(SyntaxNode node)
+            => node switch
+            {
+                LiteralExpressionSyntax => true,
+
+                // Binary/unary expressions over constants are also constant
+                BinaryExpressionSyntax or PrefixUnaryExpressionSyntax or PostfixUnaryExpressionSyntax => true,
+
+                _ => false
+            };
+    }
+
+    private class SideEffectDetectionSyntaxWalker : SyntaxWalker
+    {
+        private bool _mayHaveSideEffects;
+
+        public bool MayHaveSideEffects(SyntaxNode node)
+        {
+            _mayHaveSideEffects = false;
+
+            Visit(node);
+
+            return _mayHaveSideEffects;
+        }
+
+        public override void Visit(SyntaxNode node)
+        {
+            _mayHaveSideEffects |= MayHaveSideEffectsCore(node);
+
+            base.Visit(node);
+        }
+
+        private static bool MayHaveSideEffectsCore(SyntaxNode node)
+            => node switch
+            {
+                IdentifierNameSyntax or LiteralExpressionSyntax => false,
+                ExpressionStatementSyntax e => MayHaveSideEffectsCore(e.Expression),
+                EmptyStatementSyntax => false,
+
+                // TODO: we can exempt most binary and unary expressions as well, e.g. i + 5, but not anything involving assignment
+                _ => true
+            };
+    }
+}

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -1,0 +1,486 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+#pragma warning disable CS8602 // TODO
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+// TODO: Should extend ILanguageBasedService, go through IQueryCodeGeneratorSelector
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
+{
+    private readonly IQueryLocator _queryLocator;
+    private readonly ICSharpToLinqTranslator _csharpToLinqTranslator;
+    private readonly ISqlTreeQuoter _sqlTreeQuoter;
+
+    private const string OutputFileName = "EFPrecompiledQueryBootstrapper.cs";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public PrecompiledQueryCodeGenerator(
+        IQueryLocator queryLocator,
+        ICSharpToLinqTranslator csharpToLinqTranslator,
+        ISqlTreeQuoter sqlTreeQuoter)
+    {
+        _queryLocator = queryLocator;
+        _csharpToLinqTranslator = csharpToLinqTranslator;
+        _sqlTreeQuoter = sqlTreeQuoter;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public async Task GeneratePrecompiledQueries(string projectDir, DbContext context, string outputDir, CancellationToken cancellationToken = default)
+    {
+        // https://gist.github.com/DustinCampbell/32cd69d04ea1c08a16ae5c4cd21dd3a3
+        MSBuildLocator.RegisterDefaults();
+
+        Console.Error.WriteLine("Loading project...");
+        using var workspace = MSBuildWorkspace.Create();
+
+        // var project = await workspace.OpenProjectAsync("/home/roji/projects/test/EFTest/EFTest.csproj")
+        var project = await workspace.OpenProjectAsync(projectDir, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        Console.WriteLine("Compiling project...");
+        var compilation = await project.GetCompilationAsync(cancellationToken)
+            .ConfigureAwait(false);
+        Console.WriteLine($"Compiled assembly {compilation.Assembly.Name}");
+
+        // TODO: check reference to EF, bail early if not found?
+        _queryLocator.LoadCompilation(compilation);
+
+        Console.WriteLine("Locating EF LINQ queries...");
+
+        // TODO: Ignore our auto-generated code! Also compiled model... Recognize [CompilerGenerated]?
+        foreach (var syntaxTree in compilation.SyntaxTrees
+                     .Where(t => t.FilePath.Split(Path.DirectorySeparatorChar)[^1] != OutputFileName))
+        {
+            var newSyntaxTree = _queryLocator.LocateQueries(syntaxTree);
+            if (!ReferenceEquals(newSyntaxTree, syntaxTree))
+            {
+                compilation = compilation.ReplaceSyntaxTree(syntaxTree, newSyntaxTree);
+            }
+        }
+
+        Console.WriteLine("Generating precompiled queries...");
+        _csharpToLinqTranslator.Load(compilation, context);
+
+        var g = SyntaxGenerator.GetGenerator(project);
+        var linqToCSharpTranslator = new LinqToCSharpTranslator(g);
+        var liftableConstantProcessor = new LiftableConstantProcessor(null!);
+
+        var queryCompiler = context.GetService<IQueryCompiler>();
+        var queryCacheKeyGenerator = context.GetService<ICompiledQueryCacheKeyGenerator>();
+        var materializerLiftableConstantContext =
+            Expression.Parameter(typeof(RelationalMaterializerLiftableConstantContext), "materializerLiftableConstantContext");
+
+        var sqlExpressionPrinter = new ExpressionPrinter();
+        var stringBuilder = new StringBuilder();
+
+        var namespaces = new HashSet<string>();
+
+        var bootstrapBlock = Block(
+            AddLocalVariable("model", "context.Model"),
+            AddLocalVariable("dbSetToQueryRootReplacer", "new DbSetToQueryRootReplacer(model)"));
+
+        var variableNames = new HashSet<string> { "model", "dbSetToQueryRootReplacer" };
+
+        var queriesPrecompiled = 0;
+
+        foreach (var syntaxTree in _queryLocator.SyntaxTreesWithQueryCandidates)
+        {
+            var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+            foreach (var querySyntax in (await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false))
+                         .GetAnnotatedNodes(IQueryLocator.EfQueryCandidateAnnotationKind))
+            {
+                Console.WriteLine("*** " + querySyntax);
+
+                var async =
+                    querySyntax.GetAnnotations(IQueryLocator.EfQueryCandidateAnnotationKind).Single().Data switch
+                    {
+                        "Async" => true,
+                        "Sync" => false,
+                        _ => throw new InvalidOperationException(
+                            $"Invalid data for syntax annotation {IQueryLocator.EfQueryCandidateAnnotationKind}")
+                    };
+
+                // Convert the query's Roslyn syntax tree into a LINQ expression tree, and compile the query via EF's query pipeline.
+                // This returns:
+                // 1. The query after parameter extraction (this will become the cache key)
+                // 2. The query's executor function, which can produce an enumerable that invokes the query.
+                var (queryAfterParameterExtraction, queryExecutorExpression) = CompileQuery(querySyntax, semanticModel, async);
+
+                var queryBlock = Block();
+
+                queryBlock = queryBlock.AddStatements(
+                    GenerateQueryCacheKey(queryAfterParameterExtraction, namespaces, async));
+
+                var executorFactoryCode = GenerateExecutorFactory(queryExecutorExpression, namespaces, variableNames);
+
+                // factories[cacheKey] = context => { ... }
+                queryBlock = queryBlock.AddStatements(
+                    (StatementSyntax)g.ExpressionStatement(
+                        g.AssignmentStatement(
+                            g.ElementAccessExpression(g.IdentifierName("factories"), g.IdentifierName("cacheKey")),
+                            executorFactoryCode)));
+
+                queryBlock = queryBlock.WithLeadingTrivia(
+                    Comment(
+                        $"// Query from {syntaxTree.FilePath}:{syntaxTree.GetLineSpan(querySyntax.Span, cancellationToken).StartLinePosition}"));
+
+                bootstrapBlock = bootstrapBlock.AddStatements(queryBlock);
+                queriesPrecompiled++;
+            }
+        }
+
+        if (queriesPrecompiled == 0)
+        {
+            Console.WriteLine("Query precompilation complete, no queries processed.");
+            return;
+        }
+
+        bootstrapBlock = bootstrapBlock.AddStatements(
+            ParseStatement(@"Console.WriteLine(""Bootstrapped EF precompiled queries"");"));
+
+        var usingDirectives = List(namespaces
+            // In addition to the namespaces auto-detected by LinqToCSharpTranslator, we manually add these namespaces which are required
+            // by manually generated code above.
+            .Append("System")
+            .Append("System.Collections.Concurrent")
+            .Append("System.Runtime.CompilerServices")
+            .Append("System.Reflection")
+            .Append("System.Collections.Generic")
+            .Append("Microsoft.EntityFrameworkCore")
+            .Append("Microsoft.EntityFrameworkCore.ChangeTracking.Internal")
+            .Append("Microsoft.EntityFrameworkCore.Infrastructure")
+            .Append("Microsoft.EntityFrameworkCore.Infrastructure.Internal")
+            .Append("Microsoft.EntityFrameworkCore.Metadata")
+            .Append("Microsoft.Extensions.Caching.Memory")
+            .OrderBy(
+                ns => ns switch
+                {
+                    _ when ns.StartsWith("System.", StringComparison.Ordinal) => 10,
+                    _ when ns.StartsWith("Microsoft.", StringComparison.Ordinal) => 9,
+                    _ => 0
+                })
+            .ThenBy(ns => ns)
+            .Select(g.NamespaceImportDeclaration));
+
+        var dbSetMethodField =
+            ParseMemberDeclaration(
+                @"private static readonly MethodInfo DbSetMethod = typeof(DbContext).GetMethod(nameof(DbContext.Set), Array.Empty<Type>())!;")!;
+
+        var bootstrapMethod =
+            ((MethodDeclarationSyntax)ParseMemberDeclaration(
+                "public static void Bootstrap(DbContext context, ConcurrentDictionary<object, Func<DbContext, Delegate>> factories) {}")!)
+            .WithBody(bootstrapBlock);
+
+        var registerMethod =
+            ((MethodDeclarationSyntax)ParseMemberDeclaration(
+$"""
+[ModuleInitializer]
+public static void Register()
+    => PrecompiledQueryFactoryRegistry.RegisterBootstrapper(typeof({context.GetType().Name}), Bootstrap);
+""")!);
+
+        var dbSetToQueryRootReplacerClass =
+            ParseMemberDeclaration(
+"""
+class DbSetToQueryRootReplacer : ExpressionVisitor
+{
+    private readonly IModel _model;
+
+    public DbSetToQueryRootReplacer(IModel model)
+        => _model = model;
+
+    protected override Expression VisitMethodCall(MethodCallExpression node)
+    {
+        // TODO: SQL query
+        // TODO: STET
+        var method = node.Method;
+        if (method.IsGenericMethod && method.GetGenericMethodDefinition() == DbSetMethod)
+        {
+            var entityType = _model.FindEntityType(method.GetGenericArguments()[0])!;
+            return new EntityQueryRootExpression(entityType);
+        }
+
+        return base.VisitMethodCall(node);
+    }
+}
+""")!;
+
+        var bootstrapperSyntaxRoot = CompilationUnit()
+            .WithUsings(usingDirectives)
+            .WithMembers(
+                SingletonList<MemberDeclarationSyntax>(
+                    ClassDeclaration("EFPrecompiledQueryBootstrapper")
+                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
+                        .WithMembers(
+                            List(
+                                new[]
+                                {
+                                    dbSetMethodField,
+                                    bootstrapMethod,
+                                    registerMethod,
+                                    dbSetToQueryRootReplacerClass
+                                }))
+                        // TODO: Enable nullable reference types by inspecting Roslyn symbols of corresponding LINQ expression methods etc.
+                        .WithLeadingTrivia(Trivia(NullableDirectiveTrivia(Token(SyntaxKind.DisableKeyword), true)))));
+
+        // var document = project.AddDocument(OutputFileName, bootstrapperSyntaxRoot);
+
+        var bootstrapperText = bootstrapperSyntaxRoot.NormalizeWhitespace().ToFullString();
+        // var outputFilePath = Path.Combine(outputDir, OutputFileName);
+        // File.WriteAllText(outputFilePath, bootstrapperText);
+
+        var document = project.AddDocument(OutputFileName, bootstrapperText);
+
+        // document = await ImportAdder.AddImportsAsync(document, options: null, cancellationToken).ConfigureAwait(false);
+        // document = await ImportAdder.AddImportsFromSymbolAnnotationAsync(
+        //     document, Simplifier.AddImportsAnnotation, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // document = await ImportAdder.AddImportsAsync(document, options: null, cancellationToken).ConfigureAwait(false);
+
+        // Run the simplifier to e.g. get rid of unneeded parentheses
+        var syntaxRootFoo = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))!;
+        var annotatedDocument = document.WithSyntaxRoot(syntaxRootFoo.WithAdditionalAnnotations(Simplifier.Annotation));
+        document = await Simplifier.ReduceAsync(annotatedDocument, optionSet: null, cancellationToken).ConfigureAwait(false);
+
+        // format any node with explicit formatter annotation
+        // document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // format any elastic whitespace
+        // document = await Formatter.FormatAsync(document, SyntaxAnnotation.ElasticAnnotation, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        document = await Formatter.FormatAsync(document, options: null, cancellationToken).ConfigureAwait(false);
+
+        // document = await CaseCorrector.CaseCorrectAsync(document, CaseCorrector.Annotation, cancellationToken).ConfigureAwait(false);
+
+
+        var outputFilePath = Path.Combine(outputDir, OutputFileName);
+        var finalSyntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+        var finalText = await finalSyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        File.WriteAllText(outputFilePath, finalText.ToString());
+
+        // TODO: This is nicer - it adds the file to the project, but also adds a <Compile> node in the csproj for some reason.
+        // var applied = workspace.TryApplyChanges(document.Project.Solution);
+        // if (!applied)
+        // {
+        //     Console.WriteLine("Failed to apply changes to project");
+        // }
+
+        Console.WriteLine($"Query precompilation complete, processed {queriesPrecompiled} queries.");
+
+        (Expression QueryAfterParameterExtraction, Expression QueryExecutorExpression) CompileQuery(
+            SyntaxNode querySyntax,
+            SemanticModel semanticModel,
+            bool async)
+        {
+            // We have a query lambda, as a Roslyn syntax tree. Translate to LINQ expression tree.
+            // TODO: Add verification that this is an EF query over our user's context. If translation returns null the moment
+            // there's another query root (another context or another LINQ provider), that's fine.
+            var linqExpression = _csharpToLinqTranslator.Translate(querySyntax, semanticModel);
+
+            // We have the query as a LINQ expression tree.
+
+            // We now need to figure out the return type of the query's executor.
+            // Non-scalar query expressions return an IQueryable; the query executor will return an enumerable (sync or async).
+            // Scalar query expressions just return the scalar type, wrap that in a Task for async.
+            var returnType = linqExpression.Type;
+            if (returnType.IsGenericType
+                && returnType.GetGenericTypeDefinition().IsAssignableTo(typeof(IQueryable)))
+            {
+                returnType = (async ? typeof(IAsyncEnumerable<>) : typeof(IEnumerable<>))
+                    .MakeGenericType(returnType.GetGenericArguments()[0]);
+            }
+            else if (async)
+            {
+                returnType = typeof(Task<>).MakeGenericType(returnType);
+            }
+
+            // Compile the query, invoking CompileQueryToExpression on the IQueryCompiler from the user's context instance.
+            var resultTuple = (ITuple)queryCompiler.GetType()
+                .GetMethod(nameof(IQueryCompiler.CompileQueryToExpression))
+                .MakeGenericMethod(returnType)
+                .Invoke(queryCompiler, new object[] { linqExpression, async })!;
+
+            return ((Expression)resultTuple[0]!, (Expression)resultTuple[1]!);
+        }
+
+        StatementSyntax[] GenerateQueryCacheKey(Expression queryAfterParameterExtraction, HashSet<string> namespaces, bool async)
+        {
+            // We need to translate the query expression itself (after parameter extraction) to a Roslyn syntax tree as
+            // well - we'll be outputting that as the key for the compiled query cache.
+            // Note that this is different from the original query tree, since ParameterExtractingExpressionVisitor transforms it in various
+            // ways (e.g. captured variables are converted to parameters).
+            var querySyntaxTree = linqToCSharpTranslator.TranslateExpression(queryAfterParameterExtraction, namespaces);
+
+            // Wrap the query in a lambda accepting all the detected captured variables as lambda parameters. This ensures that the tree
+            // that will come out at runtime is identical to the one we have here - any difference will cause a cache miss.
+            var capturedVariables = linqToCSharpTranslator.CapturedVariables;
+            var lambdaParameters = new ParameterSyntax[capturedVariables.Count + 1];
+            lambdaParameters[0] = Parameter(Identifier("context")).WithType(IdentifierName("DbContext"));
+            var i = 1;
+            foreach (var capturedVariable in capturedVariables)
+            {
+                if (capturedVariable.Name is null)
+                {
+                    throw new NotSupportedException("Unnamed parameter in query syntax tree");
+                }
+
+                lambdaParameters[i++] = Parameter(Identifier(capturedVariable.Name))
+                    .WithType(capturedVariable.Type.GetTypeSyntax());
+            }
+
+            var lambdaWrappedQuerySyntaxTree =
+                ParenthesizedLambdaExpression(
+                        parameterList: ParameterList(SeparatedList(lambdaParameters)),
+                        body: (CSharpSyntaxNode)querySyntaxTree)
+                    .WithModifiers(TokenList(Token(SyntaxKind.StaticKeyword)));
+
+            var queryCacheKeyExpression =
+                queryCacheKeyGenerator.GenerateCacheKeyExpression(
+                    Expression.Parameter(typeof(Expression), "query"),
+                    Expression.Parameter(typeof(IModel), "model"),
+                    async);
+
+            // And translate the query cache key to a Roslyn syntax tree, replacing linqExpression with our already-translated
+            // query syntax tree
+            var queryCacheKeySyntaxTree =
+                (ExpressionSyntax)linqToCSharpTranslator.TranslateExpression(queryCacheKeyExpression, namespaces);
+
+            // We have a lambda wrapping the query, but its body is what's needed for the query cache key.
+            // Also, the expression tree contains context.Set<TEntity>(), but we need an EntityRootQueryExpression; replace.
+
+            // Expression query = (DbContext context, int __p_0) => context.Blogs.Where(...);
+            // query = dbSetToQueryRootReplacer.Visit(((LambdaExpression)query).Body);
+            // var cacheKey = new RelationalCompiledQueryCacheKey(...);
+            return new[]
+            {
+                (StatementSyntax)g.LocalDeclarationStatement(type: IdentifierName("Expression"), "query", lambdaWrappedQuerySyntaxTree),
+                ParseStatement("query = dbSetToQueryRootReplacer.Visit(((LambdaExpression)query).Body);"),
+                (StatementSyntax)g.LocalDeclarationStatement("cacheKey", queryCacheKeySyntaxTree)
+            };
+        }
+
+        SyntaxNode GenerateExecutorFactory(Expression queryExecutorExpression, HashSet<string> namespaces, HashSet<string> variableNames)
+        {
+            var statements = new List<StatementSyntax>();
+
+            statements.AddRange(new[] {
+                AddLocalVariable("relationalModel", "model.GetRelationalModel()"),
+                AddLocalVariable("relationalTypeMappingSource", "context.GetService<IRelationalTypeMappingSource>()"),
+                AddLocalVariable("materializerLiftableConstantContext",
+"""
+new RelationalMaterializerLiftableConstantContext(
+    context.GetService<ShapedQueryCompilingExpressionVisitorDependencies>(),
+    context.GetService<RelationalShapedQueryCompilingExpressionVisitorDependencies>())
+""") });
+            variableNames.UnionWith(new[] { "relationalModel", "relationalTypeMappingSource", "materializerLiftableConstantContext" });
+
+            // The materializer expression tree contains LiftedConstantExpression nodes, which contain instructions on how to resolve
+            // constant values which need to be lifted.
+            var queryExecutorAfterLiftingExpression =
+                liftableConstantProcessor.LiftConstants(queryExecutorExpression, materializerLiftableConstantContext, variableNames);
+
+            foreach (var liftedConstant in liftableConstantProcessor.LiftedConstants)
+            {
+                var (parameter, variableValue) = liftedConstant;
+
+                // TODO: Somewhat hacky, special handling for the SQL tree argument of RelationalCommandCache (since it requires
+                // very special rendering logic
+                if (parameter.Type == typeof(RelationalCommandCache))
+                {
+                    if (variableValue is NewExpression newRelationalCommandCacheExpression
+                        && newRelationalCommandCacheExpression.Arguments.FirstOrDefault(a => a.Type == typeof(SelectExpression)) is
+                            ConstantExpression { Value: SelectExpression selectExpression })
+                    {
+                        // Render out the SQL tree, preceded by an ExpressionPrinter dump of it in a comment for easier debugging.
+                        // Note that since the SQL tree is a graph (columns reference their SelectExpression's tables), rendering happens
+                        // in multiple statements.
+                        var sqlTreeBlock = _sqlTreeQuoter.Quote(selectExpression);
+                        var sqlTreeSyntaxStatements =
+                            ((BlockSyntax)linqToCSharpTranslator.TranslateStatement(sqlTreeBlock, namespaces)).Statements
+                            .ToArray();
+                        sqlTreeSyntaxStatements[0] = sqlTreeSyntaxStatements[0].WithLeadingTrivia(
+                            Comment(
+                                stringBuilder
+                                    .Clear()
+                                    .AppendLine("/*")
+                                    .AppendLine(sqlExpressionPrinter.PrintExpression(selectExpression))
+                                    .AppendLine("*/")
+                                    .ToString()));
+
+                        statements.AddRange(sqlTreeSyntaxStatements);
+
+                        // We've rendered the SQL tree, assigning it to variable "sqlTree". Update the RelationalCommandCache to point
+                        // to it
+                        variableValue = newRelationalCommandCacheExpression.Update(newRelationalCommandCacheExpression.Arguments
+                            .Select(a => a.Type == typeof(SelectExpression)
+                                ? Expression.Parameter(typeof(SelectExpression), "sqlTree")
+                                : a));
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Could not find SQL query in lifted {nameof(RelationalCommandCache)}");
+                    }
+                }
+
+                statements.Add(
+                    (StatementSyntax)g.LocalDeclarationStatement(
+                        parameter.Name!, linqToCSharpTranslator.TranslateExpression(variableValue, namespaces)));
+            }
+
+            // We compiled the query and now have an expression tree for invoking it. Translate that to a Roslyn syntax tree
+            // for outputting as C# code.
+            var queryExecutorSyntaxTree =
+                (SimpleLambdaExpressionSyntax)linqToCSharpTranslator.TranslateExpression(queryExecutorAfterLiftingExpression,
+                    namespaces);
+
+            // var executor = (QueryContext queryContext) => SingleQueryingEnumerable.Create(...)
+            statements.Add(
+                (StatementSyntax)g.ReturnStatement(
+                    ParenthesizedLambdaExpression(
+                        ParameterList(
+                            SingletonSeparatedList(
+                                Parameter(Identifier("queryContext")).WithType(IdentifierName("QueryContext")))),
+                        // The original executor expression was a lambda accepting the QueryContext, which is fine.
+                        // But when rendering to C#, we need a typed lambda parameter ((QueryContext queryContext) =>).
+                        body: queryExecutorSyntaxTree.Body)));
+
+            return g.ValueReturningLambdaExpression("context", statements);
+        }
+
+        StatementSyntax AddLocalVariable(string name, string initializerExpression)
+            => (StatementSyntax)g.LocalDeclarationStatement(name, ParseExpression(initializerExpression));
+    }
+}

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -57,7 +57,11 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public async Task GeneratePrecompiledQueries(string projectDir, DbContext context, string outputDir, CancellationToken cancellationToken = default)
+    public async Task GeneratePrecompiledQueries(
+        string projectFilePath,
+         DbContext context,
+        string outputDir,
+        CancellationToken cancellationToken = default)
     {
         // https://gist.github.com/DustinCampbell/32cd69d04ea1c08a16ae5c4cd21dd3a3
         MSBuildLocator.RegisterDefaults();
@@ -65,7 +69,7 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
         Console.Error.WriteLine("Loading project...");
         using var workspace = MSBuildWorkspace.Create();
 
-        var project = await workspace.OpenProjectAsync(projectDir, cancellationToken: cancellationToken)
+        var project = await workspace.OpenProjectAsync(projectFilePath, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         Console.WriteLine("Compiling project...");

--- a/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
+++ b/src/EFCore.Design/Query/Internal/PrecompiledQueryCodeGenerator.cs
@@ -188,6 +188,7 @@ public class PrecompiledQueryCodeGenerator : IPrecompiledQueryCodeGenerator
             // by manually generated code above.
             .Append("System")
             .Append("System.Collections.Concurrent")
+            .Append("System.Linq.Expressions")
             .Append("System.Runtime.CompilerServices")
             .Append("System.Reflection")
             .Append("System.Collections.Generic")

--- a/src/EFCore.Design/Query/Internal/QueryLocator.cs
+++ b/src/EFCore.Design/Query/Internal/QueryLocator.cs
@@ -1,0 +1,331 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class QueryLocator : CSharpSyntaxRewriter, IQueryLocator
+{
+    private Compilation? _compilation;
+
+#pragma warning disable CS8618 // Uninitialized non-nullable fields. We check _compilation to make sure LoadCompilation was invoked.
+    private ITypeSymbol _genericIQueryableSymbol, _nonGenericIQueryableSymbol, _dbSetSymbol;
+    private ITypeSymbol _efQueryableExtensionsSymbol, _enumerableSymbol, _queryableSymbol;
+    private ITypeSymbol _cancellationTokenSymbol;
+#pragma warning restore CS8618
+
+    private SemanticModel? _currentSemanticModel;
+    private bool _foundQueries;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IReadOnlyList<SyntaxTree> SyntaxTreesWithQueryCandidates => _syntaxTreesWithQueryCandidates;
+
+    private readonly List<SyntaxTree> _syntaxTreesWithQueryCandidates = new();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public void LoadCompilation(Compilation compilation)
+    {
+        _compilation = compilation;
+
+        _genericIQueryableSymbol = GetTypeSymbolOrThrow("System.Linq.IQueryable`1");
+        _nonGenericIQueryableSymbol = GetTypeSymbolOrThrow("System.Linq.IQueryable");
+        _dbSetSymbol = GetTypeSymbolOrThrow("Microsoft.EntityFrameworkCore.DbSet`1");
+
+        _efQueryableExtensionsSymbol =
+            GetTypeSymbolOrThrow("Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions");
+        _enumerableSymbol = GetTypeSymbolOrThrow("System.Linq.Enumerable");
+        _queryableSymbol = GetTypeSymbolOrThrow("System.Linq.Queryable");
+        _cancellationTokenSymbol = GetTypeSymbolOrThrow("System.Threading.CancellationToken");
+
+        _syntaxTreesWithQueryCandidates.Clear();
+
+        ITypeSymbol GetTypeSymbolOrThrow(string fullyQualifiedMetadataName)
+            => _compilation.GetTypeByMetadataName(fullyQualifiedMetadataName)
+               ?? throw new InvalidOperationException("Could not find type symbol for: " + fullyQualifiedMetadataName);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SyntaxTree LocateQueries(SyntaxTree syntaxTree)
+    {
+        if (_compilation is null)
+        {
+            throw new InvalidOperationException("A compilation must be loaded.");
+        }
+
+        Check.DebugAssert(_compilation.SyntaxTrees.Contains(syntaxTree), "Given syntax tree isn't part of the compilation.");
+
+        _foundQueries = false;
+
+        var oldRoot = syntaxTree.GetRoot();
+        var newRoot = Visit(oldRoot);
+
+        // Note that we rewrite the syntax tree for async methods, since SingleAsync inserts a sync Single node into
+        // the tree, not SingleAsync.
+        if (!ReferenceEquals(newRoot, oldRoot))
+        {
+            Debug.Assert(_foundQueries);
+            syntaxTree = syntaxTree.WithRootAndOptions(newRoot, syntaxTree.Options);
+        }
+
+        if (_foundQueries)
+        {
+            _syntaxTreesWithQueryCandidates.Add(syntaxTree);
+        }
+
+        return syntaxTree;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax invocation)
+    {
+        // TODO: Skip visiting identified candidates, there's no point.
+        var visitedInvocation = (InvocationExpressionSyntax)base.VisitInvocationExpression(invocation)!;
+
+        // TODO: Support non-extension invocation syntax: var blogs = ToList(ctx.Blogs);
+        if (visitedInvocation.Expression is not MemberAccessExpressionSyntax
+            {
+                Name: IdentifierNameSyntax { Identifier.Text : var identifier },
+                Expression: var innerExpression
+            } memberAccess)
+        {
+            return visitedInvocation;
+        }
+
+        // First, pattern-match on the method name as a string; this avoids accessing the semantic model for each and
+        // every invocation (more efficient).
+        //
+        // Some terminating operators need to go into the query tree (Single), others not (ToList).
+        // Note that checking whether the method's parameter is an IQueryable or not isn't sufficient (e.g.
+        // ToListAsync accepts an IQueryable parameter but should not be part of the query tree).
+        switch (identifier)
+        {
+            // Sync ToList, ToArray and AsEnumerable exist over IEnumerable only, so verify the actual argument is an
+            // IQueryable (otherwise this is just LINQ to Objects)
+            // Also, the terminating operator in these cases should not be part of the expression tree.
+            case nameof(Enumerable.ToList):
+            case nameof(Enumerable.ToArray):
+            case nameof(Enumerable.AsEnumerable):
+                return IsOnEnumerable() && IsQueryable(innerExpression)
+                    ? CheckAndAddQuery(innerExpression, async: false)
+                    : visitedInvocation;
+
+            case nameof(EntityFrameworkQueryableExtensions.ToListAsync):
+            case nameof(EntityFrameworkQueryableExtensions.ToArrayAsync):
+            case nameof(EntityFrameworkQueryableExtensions.AsAsyncEnumerable):
+                return IsOnEfQueryableExtensions()
+                    ? CheckAndAddQuery(innerExpression, async: true)
+                    : visitedInvocation;
+
+            case nameof(Queryable.All):
+            case nameof(Queryable.Any):
+            case nameof(Queryable.Average):
+            case nameof(Queryable.Contains):
+            case nameof(Queryable.Count):
+            case nameof(Queryable.DefaultIfEmpty):
+            case nameof(Queryable.ElementAt):
+            case nameof(Queryable.ElementAtOrDefault):
+            case nameof(Queryable.First):
+            case nameof(Queryable.FirstOrDefault):
+            case nameof(Queryable.Last):
+            case nameof(Queryable.LastOrDefault):
+            case nameof(Queryable.LongCount):
+            case nameof(Queryable.Max):
+            case nameof(Queryable.MaxBy):
+            case nameof(Queryable.Min):
+            case nameof(Queryable.MinBy):
+            case nameof(Queryable.Single):
+            case nameof(Queryable.SingleOrDefault):
+            case nameof(Queryable.Sum):
+                return IsOnQueryable()
+                    ? CheckAndAddQuery(visitedInvocation, async: false)
+                    : visitedInvocation;
+
+            case nameof(EntityFrameworkQueryableExtensions.AllAsync):
+            case nameof(EntityFrameworkQueryableExtensions.AnyAsync):
+            case nameof(EntityFrameworkQueryableExtensions.AverageAsync):
+            case nameof(EntityFrameworkQueryableExtensions.ContainsAsync):
+            case nameof(EntityFrameworkQueryableExtensions.CountAsync):
+            // case nameof(EntityFrameworkQueryableExtensions.DefaultIfEmptyAsync):
+            case nameof(EntityFrameworkQueryableExtensions.ElementAtAsync):
+            case nameof(EntityFrameworkQueryableExtensions.ElementAtOrDefaultAsync):
+            case nameof(EntityFrameworkQueryableExtensions.FirstAsync):
+            case nameof(EntityFrameworkQueryableExtensions.FirstOrDefaultAsync):
+            case nameof(EntityFrameworkQueryableExtensions.LastAsync):
+            case nameof(EntityFrameworkQueryableExtensions.LastOrDefaultAsync):
+            case nameof(EntityFrameworkQueryableExtensions.LongCountAsync):
+            case nameof(EntityFrameworkQueryableExtensions.MaxAsync):
+            // case nameof(EntityFrameworkQueryableExtensions.MaxByAsync):
+            case nameof(EntityFrameworkQueryableExtensions.MinAsync):
+            // case nameof(EntityFrameworkQueryableExtensions.MinByAsync):
+            case nameof(EntityFrameworkQueryableExtensions.SingleAsync):
+            case nameof(EntityFrameworkQueryableExtensions.SingleOrDefaultAsync):
+            case nameof(EntityFrameworkQueryableExtensions.SumAsync):
+                return IsOnEfQueryableExtensions() && TryRewriteInvocationToSync(out var rewrittenSyncInvocation)
+                    ? CheckAndAddQuery(rewrittenSyncInvocation, async: true)
+                    : visitedInvocation;
+
+            default:
+                return visitedInvocation;
+        }
+
+        bool IsOnEfQueryableExtensions()
+            => IsOnTypeSymbol(_efQueryableExtensionsSymbol);
+
+        bool IsOnEnumerable()
+            => IsOnTypeSymbol(_enumerableSymbol);
+
+        bool IsOnQueryable()
+            => IsOnTypeSymbol(_queryableSymbol);
+
+        bool IsOnTypeSymbol(ITypeSymbol typeSymbol)
+        {
+            if (GetSymbol(visitedInvocation) is not IMethodSymbol methodSymbol)
+            {
+                Console.WriteLine("Couldn't get method symbol for invocation: " + visitedInvocation);
+                return false;
+            }
+
+            return SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, typeSymbol);
+        }
+
+        bool TryRewriteInvocationToSync([NotNullWhen(true)] out InvocationExpressionSyntax? syncInvocation)
+        {
+            // Chop off the Async suffix
+            Debug.Assert(identifier.EndsWith("Async", StringComparison.Ordinal));
+            var syncMethodName = identifier.Substring(0, identifier.Length - "Async".Length);
+
+            // If the last argument is a cancellation token, chop it off
+            var arguments = visitedInvocation.ArgumentList.Arguments;
+            if (GetSymbol(visitedInvocation) is not IMethodSymbol methodSymbol)
+            {
+                syncInvocation = null;
+                return false;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[^1].Type, _cancellationTokenSymbol)
+                && visitedInvocation.ArgumentList.Arguments.Count == methodSymbol.Parameters.Length)
+            {
+                arguments = arguments.RemoveAt(arguments.Count - 1);
+            }
+
+            syncInvocation = visitedInvocation.Update(
+                    memberAccess.Update(
+                        memberAccess.Expression,
+                        memberAccess.OperatorToken,
+                        SyntaxFactory.IdentifierName(syncMethodName)),
+                    visitedInvocation.ArgumentList.WithArguments(arguments));
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override SyntaxNode? VisitForEachStatement(ForEachStatementSyntax forEach)
+    {
+        // Note: a LINQ queryable can't be placed directly inside await foreach, since IQueryable does not extend
+        // IAsyncEnumerable. So users need to add our AsAsyncEnumerable, which is detected above as a normal invocation.
+        var visited = base.VisitForEachStatement(forEach);
+
+        // TODO: Support DbSet directly inside await foreach
+        if (IsQueryable(forEach.Expression))
+        {
+            return forEach.WithExpression(CheckAndAddQuery(forEach.Expression, async: false));
+        }
+
+        return visited;
+    }
+
+    private ExpressionSyntax CheckAndAddQuery(ExpressionSyntax query, bool async)
+    {
+        // TODO: Drill down and see that there's a DbSet at the bottom (other LINQ providers may exist)
+
+        Console.WriteLine("Located EF query candidate: " + query);
+
+        _foundQueries = true;
+
+        // We annotate the expression as an EF query candidate, preserving the sync/async information.
+        // We'll search for nodes with these annotations later.
+        return query.WithAdditionalAnnotations(
+            new SyntaxAnnotation(IQueryLocator.EfQueryCandidateAnnotationKind, async ? "Async" : "Sync"));
+    }
+
+    private bool IsQueryable(ExpressionSyntax expression)
+    {
+        var symbol = GetSymbol(expression);
+        switch (symbol)
+        {
+            case IMethodSymbol methodSymbol:
+                return SymbolEqualityComparer.Default.Equals(methodSymbol.ReturnType.OriginalDefinition, _genericIQueryableSymbol) ||
+                       methodSymbol.ReturnType.OriginalDefinition.AllInterfaces.Contains(_nonGenericIQueryableSymbol, SymbolEqualityComparer.Default);
+
+            case IPropertySymbol propertySymbol:
+                return IsDbSet(propertySymbol.Type);
+
+            // TODO: Other cases of DbSet, e.g. field, local variable...
+
+            case null:
+                Console.WriteLine("Could not resolve symbol for query: " + expression);
+                return false;
+
+            default:
+                Console.WriteLine($"Unexpected symbol type '{symbol.GetType().Name} for symbol '{symbol}' for query: " + expression);
+                return false;
+        }
+    }
+
+    private ISymbol? GetSymbol(SyntaxNode node)
+    {
+        if (_currentSemanticModel?.SyntaxTree != node.SyntaxTree)
+        {
+            _currentSemanticModel = _compilation!.GetSemanticModel(node.SyntaxTree);
+        }
+
+        var symbol = _currentSemanticModel.GetSymbolInfo(node).Symbol;
+
+        if (symbol is null)
+        {
+            Console.WriteLine("Could not find symbol for: " + node);
+        }
+
+        return symbol;
+    }
+
+    // TODO: Handle DbSet subclasses which aren't InternalDbSet?
+    private bool IsDbSet(ITypeSymbol typeSymbol)
+        => SymbolEqualityComparer.Default.Equals(typeSymbol.OriginalDefinition, _dbSetSymbol);
+}

--- a/src/EFCore.Design/Query/Internal/QueryLocator.cs
+++ b/src/EFCore.Design/Query/Internal/QueryLocator.cs
@@ -303,7 +303,7 @@ public class QueryLocator : CSharpSyntaxRewriter, IQueryLocator
                 return false;
 
             default:
-                Console.WriteLine($"Unexpected symbol type '{symbol.GetType().Name} for symbol '{symbol}' for query: " + expression);
+                // Console.WriteLine($"Unexpected symbol type '{symbol.GetType().Name}' for symbol '{symbol}' for query: " + expression);
                 return false;
         }
     }

--- a/src/EFCore.Design/Query/Internal/SqlTreeQuoter.cs
+++ b/src/EFCore.Design/Query/Internal/SqlTreeQuoter.cs
@@ -14,12 +14,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SqlTreeQuoter : ISqlTreeQuoter
+public class SqlTreeQuoter : SqlExpressionVisitor, ISqlTreeQuoter
 {
     private readonly List<ParameterExpression> _blockVariables = new();
     private readonly List<Expression> _blockExpressions = new();
-    private readonly EmptySelectExpressionRenderer _emptySelectExpressionRenderer;
-    private readonly SelectExpressionPopulationRenderer _selectExpressionPopulationRenderer;
     private readonly Dictionary<SelectExpression, ParameterExpression> _selectExpressionMap = new();
 
     private ParameterExpression _relationalModelParameter = null!;
@@ -28,14 +26,66 @@ public class SqlTreeQuoter : ISqlTreeQuoter
     private string _rootSelectVariableName = null!;
     private HashSet<string> _variableNames = null!;
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public SqlTreeQuoter()
-        => (_emptySelectExpressionRenderer, _selectExpressionPopulationRenderer) = (new(this), new(this));
+    private bool _seenRootExpression;
+
+    #region Constructor and method infos
+
+    private static ConstructorInfo? _annotationConstructor;
+    private static ConstructorInfo? _atTimeZoneConstructor;
+    private static ConstructorInfo? _caseConstructorWithOperand;
+    private static ConstructorInfo? _caseConstructorWithoutOperand;
+    private static ConstructorInfo? _caseWhenClauseConstructor;
+    private static ConstructorInfo? _collateConstructor;
+    private static ConstructorInfo? _concreteColumnConstructor;
+    private static ConstructorInfo? _columnValueSetterConstructor;
+    private static MethodInfo? _constantFactoryMethod;
+    private static ConstructorInfo? _crossApplyConstructor;
+    private static ConstructorInfo? _crossJoinConstructor;
+    private static ConstructorInfo? _deleteConstructor;
+    private static ConstructorInfo? _distinctConstructor;
+    private static ConstructorInfo? _exceptConstructor;
+    private static ConstructorInfo? _existsConstructor;
+    // private static ConstructorInfo? _fromSqlConstructor;
+    private static ConstructorInfo? _inConstructorWithSubquery;
+    private static ConstructorInfo? _inConstructorWithValues;
+    private static ConstructorInfo? _intersectConstructor;
+    private static ConstructorInfo? _likeConstructor;
+    private static ConstructorInfo? _innerJoinConstructor;
+    private static ConstructorInfo? _leftJoinConstructor;
+    private static ConstructorInfo? _orderingConstructor;
+    private static ConstructorInfo? _outerApplyConstructor;
+    private static MethodInfo? _parameterFactoryMethod;
+    private static ConstructorInfo? _projectionConstructor;
+    // private static ConstructorInfo? _tableValuedFunctionConstructor;
+    private static MethodInfo? _relationalModelFindTableMethod;
+    private static ConstructorInfo? _rowNumberConstructor;
+    private static ConstructorInfo? _scalarSubqueryConstructor;
+    private static ConstructorInfo? _selectConstructor;
+    private static MethodInfo? _selectPopulateClausesMethod;
+    private static ConstructorInfo? _sqlBinaryConstructor;
+    private static ConstructorInfo? _sqlConstantConstructor;
+    private static ConstructorInfo? _sqlFragmentConstructor;
+    private static ConstructorInfo? _sqlFunctionConstructor;
+    private static ConstructorInfo? _sqlParameterConstructor;
+    private static ConstructorInfo? _sqlUnaryConstructor;
+    private static ConstructorInfo? _tableConstructor;
+    private static ConstructorInfo? _tableReferenceConstructor;
+    private static ConstructorInfo? _unionConstructor;
+    private static ConstructorInfo? _updateConstructor;
+    // private static ConstructorInfo? _jsonScalarConstructor;
+
+    private static MethodInfo? _hashSetAddMethod;
+
+    private static readonly MethodInfo RelationalTypeMappingSourceFindMappingMethod
+        = typeof(RelationalTypeMappingSource)
+            .GetMethod(nameof(RelationalTypeMappingSource.FindMapping),
+                new[]
+                {
+                    typeof(Type), typeof(string), typeof(bool), typeof(bool), typeof(int), typeof(bool), typeof(bool), typeof(int),
+                    typeof(int)
+                })!;
+
+    #endregion
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -47,6 +97,7 @@ public class SqlTreeQuoter : ISqlTreeQuoter
     {
         _rootSelectVariableName = rootSelectVariableName;
         _variableNames = variableNames;
+        _seenRootExpression = false;
 
         _blockVariables.Clear();
         _blockExpressions.Clear();
@@ -54,589 +105,553 @@ public class SqlTreeQuoter : ISqlTreeQuoter
         _relationalModelParameter = Parameter(typeof(RelationalModel), "relationalModel");
         _relationalTypeMappingSourceParameter = Parameter(typeof(RelationalTypeMappingSource), "relationalTypeMappingSource");
 
-        // First pass: locate all SelectExpressions and generate code to instantiate mostly empty versions of them.
-        _emptySelectExpressionRenderer.Render(expression);
-
-        // Second pass: generate code to populate the clauses of the empty SelectExpressions above.
-        _selectExpressionPopulationRenderer.Visit(expression);
+        Visit(expression);
 
         return Block(_blockVariables, _blockExpressions);
     }
 
-    private class EmptySelectExpressionRenderer : ExpressionVisitor
+    /// <inheritdoc />
+    protected override Expression VisitAtTimeZone(AtTimeZoneExpression atTimeZoneExpression)
+        => New(
+            _atTimeZoneConstructor ??= typeof(AtTimeZoneExpression).GetConstructor(
+                new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping) })!,
+            Visit(atTimeZoneExpression.Operand),
+            Visit(atTimeZoneExpression.TimeZone),
+            Constant(atTimeZoneExpression.Type),
+            RenderFindTypeMapping(atTimeZoneExpression.TypeMapping));
+
+    /// <inheritdoc />
+    protected override Expression VisitCase(CaseExpression caseExpression)
     {
-        private static readonly ConstructorInfo SelectExpressionConstructor
-            = typeof(SelectExpression).GetConstructor(new[] { typeof(string) })!;
+        var whenClauses = NewArrayInit(
+            typeof(CaseWhenClause),
+            initializers: caseExpression.WhenClauses
+                .Select(c => New(
+                    _caseWhenClauseConstructor ??=
+                        typeof(CaseWhenClause).GetConstructor(new[] { typeof(SqlExpression), typeof(SqlExpression) })!,
+                    Visit(c.Test),
+                    Visit(c.Result))));
 
-        private readonly SqlTreeQuoter _parentVisitor;
-
-        private bool _isFirstSelectExpression;
-
-        public EmptySelectExpressionRenderer(SqlTreeQuoter parentVisitor)
-            => _parentVisitor = parentVisitor;
-
-        public void Render(Expression expression)
-        {
-            _isFirstSelectExpression = true;
-
-            Visit(expression);
-        }
-
-        protected override Expression VisitExtension(Expression node)
-        {
-            if (node is SelectExpression selectExpression)
-            {
-                // Add code that instantiates an empty SelectExpression, with only the alias and tables.
-                // The rest of the clauses will be rendered in another pass, referencing the SelectExpression variables
-                // we create here.
-
-                // The very first SelectExpression we encounter is the root one, so we give it an externally given name (it needs to be
-                // referenced later from the outside).
-                // For other, nested select expressions, generate a uniquified name.
-                string selectExpressionVariableName;
-                if (_isFirstSelectExpression)
-                {
-                    selectExpressionVariableName = _parentVisitor._rootSelectVariableName;
-                    _isFirstSelectExpression = false;
-                }
-                else
-                {
-                    var baseName = "select";
-                    selectExpressionVariableName = baseName;
-                    for (var i = 0; _parentVisitor._variableNames.Contains(selectExpressionVariableName); i++)
-                    {
-                        selectExpressionVariableName = baseName + i;
-                    }
-
-                    _parentVisitor._variableNames.Add(selectExpressionVariableName);
-                }
-
-                var selectExpressionVariable = Parameter(typeof(SelectExpression), selectExpressionVariableName);
-                _parentVisitor._selectExpressionMap[selectExpression] = selectExpressionVariable;
-                _parentVisitor._blockVariables.Add(selectExpressionVariable);
-
-                _parentVisitor._blockExpressions.Add(
-                    Assign(
-                        selectExpressionVariable,
-                        New(
-                            SelectExpressionConstructor,
-                            Constant(selectExpression.Alias, typeof(string)))));
-            }
-
-            return base.VisitExtension(node);
-        }
+        return caseExpression.Operand is null
+            ? New(
+                _caseConstructorWithoutOperand ??=
+                    typeof(CaseExpression).GetConstructor(new[] { typeof(IReadOnlyList<CaseWhenClause>), typeof(SqlExpression) })!,
+                whenClauses,
+                VisitOrNull(caseExpression.ElseResult))
+            : New(
+                _caseConstructorWithOperand ??= typeof(CaseExpression).GetConstructor(
+                    new[] { typeof(SqlExpression), typeof(IReadOnlyList<CaseWhenClause>), typeof(SqlExpression) })!,
+                Visit(caseExpression.Operand),
+                whenClauses,
+                VisitOrNull(caseExpression.ElseResult));
     }
 
-    // TODO: This needs to be a design-time relational service that providers can override, to add support for their
-    // own expression types.
-    private class SelectExpressionPopulationRenderer : SqlExpressionVisitor
+    /// <inheritdoc />
+    protected override Expression VisitCollate(CollateExpression collateExpression)
+        => New(
+            _collateConstructor ??= typeof(CollateExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(string) })!,
+            Visit(collateExpression.Operand),
+            Constant(collateExpression.Collation));
+
+    /// <inheritdoc />
+    protected override Expression VisitColumn(ColumnExpression columnExpression)
     {
-        private static ConstructorInfo? _annotationConstructor;
-        private static ConstructorInfo? _atTimeZoneConstructor;
-        private static ConstructorInfo? _caseConstructorWithOperand;
-        private static ConstructorInfo? _caseConstructorWithoutOperand;
-        private static ConstructorInfo? _caseWhenClauseConstructor;
-        private static ConstructorInfo? _collateConstructor;
-        private static ConstructorInfo? _concreteColumnConstructor;
-        private static MethodInfo? _constantFactoryMethod;
-        private static ConstructorInfo? _crossApplyConstructor;
-        private static ConstructorInfo? _crossJoinConstructor;
-        private static ConstructorInfo? _deleteConstructor;
-        private static ConstructorInfo? _distinctConstructor;
-        private static ConstructorInfo? _exceptConstructor;
-        private static ConstructorInfo? _existsConstructor;
-        // private static ConstructorInfo? _fromSqlConstructor;
-        private static ConstructorInfo? _inConstructorWithSubquery;
-        private static ConstructorInfo? _inConstructorWithValues;
-        private static ConstructorInfo? _intersectConstructor;
-        private static ConstructorInfo? _likeConstructor;
-        private static ConstructorInfo? _innerJoinConstructor;
-        private static ConstructorInfo? _leftJoinConstructor;
-        private static ConstructorInfo? _orderingConstructor;
-        private static ConstructorInfo? _outerApplyConstructor;
-        private static MethodInfo? _parameterFactoryMethod;
-        private static ConstructorInfo? _projectionConstructor;
-        // private static ConstructorInfo? _tableValuedFunctionConstructor;
-        private static MethodInfo? _relationalModelFindTableMethod;
-        private static ConstructorInfo? _rowNumberConstructor;
-        private static ConstructorInfo? _scalarSubqueryConstructor;
-        private static MethodInfo? _selectPopulateClausesMethod;
-        private static ConstructorInfo? _sqlBinaryConstructor;
-        private static ConstructorInfo? _sqlConstantConstructor;
-        private static ConstructorInfo? _sqlFragmentConstructor;
-        private static ConstructorInfo? _sqlFunctionConstructor;
-        private static ConstructorInfo? _sqlParameterConstructor;
-        private static ConstructorInfo? _sqlUnaryConstructor;
-        private static ConstructorInfo? _tableConstructor;
-        private static ConstructorInfo? _tableReferenceConstructor;
-        private static ConstructorInfo? _unionConstructor;
-        private static ConstructorInfo? _updateConstructor;
-        // private static ConstructorInfo? _jsonScalarConstructor;
-
-        private static readonly MethodInfo RelationalTypeMappingSourceFindMappingMethod
-            = typeof(RelationalTypeMappingSource)
-                .GetMethod(nameof(RelationalTypeMappingSource.FindMapping),
-                    new[]
-                    {
-                        typeof(Type), typeof(string), typeof(bool), typeof(bool), typeof(int), typeof(bool),
-                        typeof(bool), typeof(int),
-                        typeof(int)
-                    })!;
-
-        private readonly SqlTreeQuoter _parentVisitor;
-
-        public SelectExpressionPopulationRenderer(SqlTreeQuoter parentVisitor)
-            => _parentVisitor = parentVisitor;
-
-        protected override Expression VisitAtTimeZone(AtTimeZoneExpression atTimeZoneExpression)
-            => New(
-                _atTimeZoneConstructor ??= typeof(AtTimeZoneExpression).GetConstructor(
-                    new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping) })!,
-                Visit(atTimeZoneExpression.Operand),
-                Visit(atTimeZoneExpression.TimeZone),
-                Constant(atTimeZoneExpression.Type),
-                RenderFindTypeMapping(atTimeZoneExpression.TypeMapping));
-
-        protected override Expression VisitCase(CaseExpression caseExpression)
+        if (columnExpression is not ConcreteColumnExpression concreteColumnExpression)
         {
-            var whenClauses = NewArrayInit(
-                typeof(CaseWhenClause),
-                initializers: caseExpression.WhenClauses
-                    .Select(c => New(
-                        _caseWhenClauseConstructor ??= typeof(CaseWhenClause).GetConstructor(new[] { typeof(SqlExpression), typeof(SqlExpression) })!,
-                        Visit(c.Test),
-                        Visit(c.Result))));
-
-            return caseExpression.Operand is null
-                ? New(
-                    _caseConstructorWithoutOperand ??=
-                        typeof(CaseExpression).GetConstructor(new[] { typeof(IReadOnlyList<CaseWhenClause>), typeof(SqlExpression) })!,
-                    whenClauses,
-                    VisitOrNull(caseExpression.ElseResult))
-                : New(
-                    _caseConstructorWithOperand ??= typeof(CaseExpression).GetConstructor(
-                        new[] { typeof(SqlExpression), typeof(IReadOnlyList<CaseWhenClause>), typeof(SqlExpression) })!,
-                    Visit(caseExpression.Operand),
-                    whenClauses,
-                    VisitOrNull(caseExpression.ElseResult));
+            throw new NotSupportedException("Unknown column type: " + columnExpression.GetType().Name);
         }
 
-        protected override Expression VisitCollate(CollateExpression collateExpression)
-            => New(
-                _collateConstructor ??= typeof(CollateExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(string) })!,
-                Visit(collateExpression.Operand),
-                Constant(collateExpression.Collation));
+        var found = _selectExpressionMap.TryGetValue(concreteColumnExpression.SelectExpression, out var selectExpressionVariable);
+        Debug.Assert(found, "Could not find SelectExpression in select expression map");
 
-        protected override Expression VisitColumn(ColumnExpression columnExpression)
+        return New(
+            _concreteColumnConstructor ??= typeof(ConcreteColumnExpression).GetConstructor(
+                new[] { typeof(string), typeof(TableReferenceExpression), typeof(Type), typeof(RelationalTypeMapping), typeof(bool) })!,
+            Constant(columnExpression.Name),
+            New(
+                _tableReferenceConstructor ??=
+                    typeof(TableReferenceExpression).GetConstructor(new[] { typeof(SelectExpression), typeof(string) })!,
+                selectExpressionVariable!,
+                Constant(columnExpression.TableAlias)),
+            Constant(columnExpression.Type),
+            RenderFindTypeMapping(columnExpression.TypeMapping),
+            Constant(columnExpression.IsNullable));
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitCrossApply(CrossApplyExpression crossApplyExpression)
+        => New(
+            _crossApplyConstructor ??=
+                typeof(CrossApplyExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
+            Visit(crossApplyExpression.Table),
+            RenderAnnotationArray(crossApplyExpression.GetAnnotations()));
+
+    /// <inheritdoc />
+    protected override Expression VisitCrossJoin(CrossJoinExpression crossJoinExpression)
+        => New(
+            _crossJoinConstructor ??=
+                typeof(CrossJoinExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
+            Visit(crossJoinExpression.Table),
+            RenderAnnotationArray(crossJoinExpression.GetAnnotations()));
+
+    /// <inheritdoc />
+    protected override Expression VisitDelete(DeleteExpression deleteExpression)
+    {
+        if (_seenRootExpression)
         {
-            if (columnExpression is not ConcreteColumnExpression concreteColumnExpression)
-            {
-                throw new NotSupportedException("Unknown column type: " + columnExpression.GetType().Name);
-            }
+            throw new NotSupportedException($"{nameof(DeleteExpression)} in non-root context");
+        }
 
-            var found = _parentVisitor._selectExpressionMap.TryGetValue(concreteColumnExpression.SelectExpression,
-                out var selectExpressionVariable);
-            Debug.Assert(found, "Could not find SelectExpression in select expression map");
+        _seenRootExpression = true;
 
-            return New(
-                _concreteColumnConstructor ??= typeof(ConcreteColumnExpression).GetConstructor(
-                    new[] { typeof(string), typeof(TableReferenceExpression), typeof(Type), typeof(RelationalTypeMapping), typeof(bool) })!,
-                Constant(columnExpression.Name),
+        var deleteExpressionVariable = Parameter(typeof(DeleteExpression), _rootSelectVariableName);
+        _blockVariables.Add(deleteExpressionVariable);
+        _blockExpressions.Add(
+            Assign(
+                deleteExpressionVariable,
                 New(
-                    _tableReferenceConstructor ??=
-                        typeof(TableReferenceExpression).GetConstructor(new[] { typeof(SelectExpression), typeof(string) })!,
-                    selectExpressionVariable!,
-                    Constant(columnExpression.TableAlias)),
-                Constant(columnExpression.Type),
-                RenderFindTypeMapping(columnExpression.TypeMapping),
-                Constant(columnExpression.IsNullable));
+                    _deleteConstructor ??= typeof(DeleteExpression).GetConstructor(
+                        new[] { typeof(TableExpression), typeof(SelectExpression), typeof(ISet<string>) })!,
+                    Visit(deleteExpression.Table),
+                    Visit(deleteExpression.SelectExpression),
+                    CreateTagsExpression(deleteExpression.Tags))));
+
+        return deleteExpressionVariable;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitDistinct(DistinctExpression distinctExpression)
+        => New(
+            _distinctConstructor ??= typeof(DistinctExpression).GetConstructor(new[] { typeof(SqlExpression) })!,
+            Visit(distinctExpression.Operand));
+
+    /// <inheritdoc />
+    protected override Expression VisitExcept(ExceptExpression exceptExpression)
+        => New(
+            _exceptConstructor ??= typeof(ExceptExpression).GetConstructor(
+                new[]
+                {
+                    typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool), typeof(IEnumerable<IAnnotatable>)
+                })!,
+            Constant(exceptExpression.Alias, typeof(string)),
+            Visit(exceptExpression.Source1),
+            Visit(exceptExpression.Source2),
+            Constant(exceptExpression.IsDistinct),
+            RenderAnnotationArray(exceptExpression.GetAnnotations()));
+
+    /// <inheritdoc />
+    protected override Expression VisitExists(ExistsExpression existsExpression)
+        => New(
+            _existsConstructor ??=
+                typeof(ExistsExpression).GetConstructor(new[] { typeof(SelectExpression), typeof(bool), typeof(RelationalTypeMapping) })!,
+            Visit(existsExpression.Subquery),
+            Constant(existsExpression),
+            RenderFindTypeMapping(existsExpression.TypeMapping));
+
+    /// <inheritdoc />
+    protected override Expression VisitFromSql(FromSqlExpression fromSqlExpression)
+        => throw new NotImplementedException();
+    // => New(
+    //     _fromSqlConstructor ??= typeof(FromSqlExpression).GetConstructor(new[] { typeof(string), typeof(ITableBase), typeof(string), typeof(Expression), typeof(IEnumerable<IAnnotation>) })!,
+    //     Constant(fromSqlExpression.Alias, typeof(string)),
+    //     fromSqlExpression.Table, // TODO
+    //     Constant(fromSqlExpression.Sql),
+    //     Visit(fromSqlExpression.Arguments),
+    //     Constant(fromSqlExpression.GetAnnotations().ToArray());
+
+    /// <inheritdoc />
+    protected override Expression VisitIn(InExpression inExpression)
+        => inExpression.Subquery is null
+            ? New(
+                _inConstructorWithValues ??= typeof(InExpression).GetConstructor(
+                    new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(bool), typeof(RelationalTypeMapping) })!,
+                Visit(inExpression.Item),
+                Visit(inExpression.Values!),
+                Constant(inExpression.IsNegated),
+                RenderFindTypeMapping(inExpression.TypeMapping))
+            : New(
+                _inConstructorWithSubquery ??= typeof(InExpression).GetConstructor(
+                    new[] { typeof(SqlExpression), typeof(SelectExpression), typeof(bool), typeof(RelationalTypeMapping) })!,
+                Visit(inExpression.Item),
+                Visit(inExpression.Subquery!),
+                Constant(inExpression.Negate()),
+                RenderFindTypeMapping(inExpression.TypeMapping));
+
+    /// <inheritdoc />
+    protected override Expression VisitIntersect(IntersectExpression intersectExpression)
+        => New(
+            _intersectConstructor ??= typeof(IntersectExpression).GetConstructor(
+                new[]
+                {
+                    typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool), typeof(IEnumerable<IAnnotation>)
+                })!,
+            Constant(intersectExpression.Alias, typeof(string)),
+            Visit(intersectExpression.Source1),
+            Visit(intersectExpression.Source2),
+            Constant(intersectExpression.IsDistinct),
+            RenderAnnotationArray(intersectExpression.GetAnnotations()));
+
+    /// <inheritdoc />
+    protected override Expression VisitLike(LikeExpression likeExpression)
+        => New(
+            _likeConstructor ??= typeof(LikeExpression).GetConstructor(
+                new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(SqlExpression), typeof(RelationalTypeMapping) })!,
+            Visit(likeExpression.Match),
+            Visit(likeExpression.Pattern),
+            VisitOrNull(likeExpression.EscapeChar),
+            RenderFindTypeMapping(likeExpression.TypeMapping));
+
+    /// <inheritdoc />
+    protected override Expression VisitInnerJoin(InnerJoinExpression innerJoinExpression)
+        => New(
+            _innerJoinConstructor ??= typeof(InnerJoinExpression).GetConstructor(
+                new[] { typeof(TableExpressionBase), typeof(SqlExpression), typeof(IEnumerable<IAnnotation>) })!,
+            Visit(innerJoinExpression.Table),
+            Visit(innerJoinExpression.JoinPredicate),
+            RenderAnnotationArray(innerJoinExpression.GetAnnotations()));
+
+    /// <inheritdoc />
+    protected override Expression VisitLeftJoin(LeftJoinExpression leftJoinExpression)
+        => New(
+            _leftJoinConstructor ??= typeof(LeftJoinExpression).GetConstructor(
+                new[] { typeof(TableExpressionBase), typeof(SqlExpression), typeof(IEnumerable<IAnnotation>) })!,
+            Visit(leftJoinExpression.Table),
+            Visit(leftJoinExpression.JoinPredicate),
+            RenderAnnotationArray(leftJoinExpression.GetAnnotations()));
+
+    /// <inheritdoc />
+    protected override Expression VisitOrdering(OrderingExpression orderingExpression)
+        => New(
+            _orderingConstructor ??= typeof(OrderingExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(bool) })!,
+            Visit(orderingExpression.Expression),
+            Constant(orderingExpression.IsAscending));
+
+    /// <inheritdoc />
+    protected override Expression VisitOuterApply(OuterApplyExpression outerApplyExpression)
+        => New(
+            _outerApplyConstructor ??=
+                typeof(OuterApplyExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
+            Visit(outerApplyExpression.Table),
+            RenderAnnotationArray(outerApplyExpression.GetAnnotations()));
+
+    /// <inheritdoc />
+    protected override Expression VisitProjection(ProjectionExpression projectionExpression)
+        => New(
+            _projectionConstructor ??=
+                typeof(ProjectionExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(string) })!,
+            Visit(projectionExpression.Expression),
+            Constant(projectionExpression.Alias));
+
+    /// <inheritdoc />
+    protected override Expression VisitTableValuedFunction(TableValuedFunctionExpression tableValuedFunctionExpression)
+        => throw new NotImplementedException();
+    // => New(
+    //     _tableValuedFunctionConstructor ??= typeof(TableValuedFunctionExpression).GetConstructor(
+    //         new[]
+    //         {
+    //             typeof(string), typeof(IStoreFunction), typeof(IReadOnlyList<SqlExpression>), typeof(IEnumerable<IAnnotation>)
+    //         })!,
+    //     Constant(tableValuedFunctionExpression.Alias, typeof(string)),
+    //     tableValuedFunctionExpression.StoreFunction,
+    //     Constant(tableValuedFunctionExpression.Arguments),
+    //     Constant(tableValuedFunctionExpression.GetAnnotations().ToArray());
+
+    /// <inheritdoc />
+    protected override Expression VisitRowNumber(RowNumberExpression rowNumberExpression)
+        => New(
+            _rowNumberConstructor ??= typeof(RowNumberExpression).GetConstructor(
+                new[] { typeof(IReadOnlyList<SqlExpression>), typeof(IReadOnlyList<OrderingExpression>), typeof(RelationalTypeMapping) })!,
+            NewArrayInit(typeof(SqlExpression), initializers: rowNumberExpression.Orderings.Select(Visit)!),
+            RenderFindTypeMapping(rowNumberExpression.TypeMapping));
+
+    /// <inheritdoc />
+    protected override Expression VisitScalarSubquery(ScalarSubqueryExpression scalarSubqueryExpression)
+        => New(
+            _scalarSubqueryConstructor ??= typeof(ScalarSubqueryExpression).GetConstructor(new[] { typeof(SelectExpression) })!,
+            Visit(scalarSubqueryExpression.Subquery));
+
+    /// <inheritdoc />
+    protected sealed override Expression VisitSelect(SelectExpression selectExpression)
+    {
+        // Select is rendered out in two steps:
+        // 1. Code that instantiates an empty SelectExpression - with only the alias and tables - assigning it to a variable.
+        // 2. A PopulateClauses call that populates all the other clauses, which is where we recursively visit them.
+        // This is necessary to allow subqueries to be referenced by their containing SelectExpressions, as well as by their contained
+        // columns).
+
+        // The very first SelectExpression we encounter is the root one, so we give it an externally given name (it needs to be
+        // referenced later from the outside).
+        // For other, nested select expressions, generate a uniquified name.
+        string selectExpressionVariableName;
+        if (_seenRootExpression)
+        {
+            var baseName = _rootSelectVariableName + "Subquery";
+            var i = 1;
+            do
+            {
+                selectExpressionVariableName = baseName + (i++);
+            } while (_variableNames.Contains(selectExpressionVariableName));
+
+            _variableNames.Add(selectExpressionVariableName);
+        }
+        else
+        {
+            selectExpressionVariableName = _rootSelectVariableName;
+            _seenRootExpression = true;
         }
 
-        protected override Expression VisitCrossApply(CrossApplyExpression crossApplyExpression)
-            => New(
-                _crossApplyConstructor ??=
-                    typeof(CrossApplyExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
-                Visit(crossApplyExpression.Table),
-                RenderAnnotationArray(crossApplyExpression.GetAnnotations()));
+        var selectExpressionVariable = Parameter(typeof(SelectExpression), selectExpressionVariableName);
+        _selectExpressionMap[selectExpression] = selectExpressionVariable;
+        _blockVariables.Add(selectExpressionVariable);
 
-        protected override Expression VisitCrossJoin(CrossJoinExpression crossJoinExpression)
-            => New(
-                _crossJoinConstructor ??=
-                    typeof(CrossJoinExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
-                Visit(crossJoinExpression.Table),
-                RenderAnnotationArray(crossJoinExpression.GetAnnotations()));
+        _blockExpressions.Add(
+            Assign(
+                selectExpressionVariable,
+                New(
+                    _selectConstructor ??= typeof(SelectExpression).GetConstructor(new[] { typeof(string) })!,
+                    Constant(selectExpression.Alias, typeof(string)))));
 
-        protected override Expression VisitDelete(DeleteExpression deleteExpression)
-            => New(
-                _deleteConstructor ??= typeof(DeleteExpression).GetConstructor(
-                    new[] { typeof(TableExpression), typeof(SelectExpression), typeof(ISet<string>) })!,
-                Visit(deleteExpression.Table),
-                Visit(deleteExpression.SelectExpression),
-                Constant(deleteExpression.Tags));
-
-        protected override Expression VisitDistinct(DistinctExpression distinctExpression)
-            => New(
-                _distinctConstructor ??= typeof(DistinctExpression).GetConstructor(new[] { typeof(SqlExpression) })!,
-                Visit(distinctExpression.Operand));
-
-        protected override Expression VisitExcept(ExceptExpression exceptExpression)
-            => New(
-                _exceptConstructor ??= typeof(ExceptExpression).GetConstructor(
+        _blockExpressions.Add(
+            Call(
+                selectExpressionVariable,
+                _selectPopulateClausesMethod ??= typeof(SelectExpression).GetMethod(
+                    nameof(SelectExpression.PopulateClauses),
                     new[]
                     {
-                        typeof(string),
-                        typeof(SelectExpression),
-                        typeof(SelectExpression),
-                        typeof(bool),
-                        typeof(IEnumerable<IAnnotatable>)
+                        typeof(IReadOnlyList<TableExpressionBase>), // tables
+                        typeof(SqlExpression), // predicate
+                        typeof(SqlExpression), // limit
+                        typeof(SqlExpression), // offset
+                        typeof(IReadOnlyList<SqlExpression>), // groupby
+                        typeof(SqlExpression), // having
+                        typeof(IReadOnlyList<OrderingExpression>), // orderings
+                        typeof(bool), // isDistinct
+                        typeof(IReadOnlyList<ProjectionExpression>), // projections
+                        typeof(ISet<string>), // tags
+                        // TODO:
+                        // typeof(SortedDictionary<string, IAnnotation>) // annotations
                     })!,
-                Constant(exceptExpression.Alias, typeof(string)),
-                Visit(exceptExpression.Source1),
-                Visit(exceptExpression.Source2),
-                Constant(exceptExpression.IsDistinct),
-                RenderAnnotationArray(exceptExpression.GetAnnotations()));
+                NewArrayInit(
+                    typeof(TableExpressionBase),
+                    initializers: selectExpression.Tables.Select(Visit)!),
+                VisitOrNull(selectExpression.Predicate),
+                VisitOrNull(selectExpression.Limit),
+                VisitOrNull(selectExpression.Offset),
+                NewArrayInit(typeof(SqlExpression), initializers: selectExpression.GroupBy.Select(Visit)!),
+                VisitOrNull(selectExpression.Having),
+                NewArrayInit(typeof(OrderingExpression), initializers: selectExpression.Orderings.Select(Visit)!),
+                Constant(selectExpression.IsDistinct),
+                NewArrayInit(typeof(ProjectionExpression), initializers: selectExpression.Projection.Select(Visit)!),
+                CreateTagsExpression(selectExpression.Tags)));
 
-        protected override Expression VisitExists(ExistsExpression existsExpression)
-            => New(
-                _existsConstructor ??= typeof(ExistsExpression).GetConstructor(new[] { typeof(SelectExpression), typeof(bool), typeof(RelationalTypeMapping)})!,
-                Visit(existsExpression.Subquery),
-                Constant(existsExpression),
-                RenderFindTypeMapping(existsExpression.TypeMapping));
+        return selectExpressionVariable;
+    }
 
-        protected override Expression VisitFromSql(FromSqlExpression fromSqlExpression)
-            => throw new NotImplementedException();
-            // => New(
-            //     _fromSqlConstructor ??= typeof(FromSqlExpression).GetConstructor(new[] { typeof(string), typeof(ITableBase), typeof(string), typeof(Expression), typeof(IEnumerable<IAnnotation>) })!,
-            //     Constant(fromSqlExpression.Alias, typeof(string)),
-            //     fromSqlExpression.Table, // TODO
-            //     Constant(fromSqlExpression.Sql),
-            //     Visit(fromSqlExpression.Arguments),
-            //     Constant(fromSqlExpression.GetAnnotations().ToArray());
+    /// <inheritdoc />
+    protected override Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression)
+        => New(
+            _sqlBinaryConstructor ??= typeof(SqlBinaryExpression).GetConstructor(
+                new[]
+                {
+                    typeof(ExpressionType), typeof(SqlExpression), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping)
+                })!,
+            Constant(sqlBinaryExpression.OperatorType),
+            Visit(sqlBinaryExpression.Left),
+            Visit(sqlBinaryExpression.Right),
+            Constant(sqlBinaryExpression.Type),
+            RenderFindTypeMapping(sqlBinaryExpression.TypeMapping));
 
-        protected override Expression VisitIn(InExpression inExpression)
-            => inExpression.Subquery is null
-                ? New(
-                    _inConstructorWithValues ??= typeof(InExpression).GetConstructor(
-                        new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(bool), typeof(RelationalTypeMapping) })!,
-                    Visit(inExpression.Item),
-                    Visit(inExpression.Values!),
-                    Constant(inExpression.IsNegated),
-                    RenderFindTypeMapping(inExpression.TypeMapping))
-                : New(
-                    _inConstructorWithSubquery ??= typeof(InExpression).GetConstructor(
-                        new[] { typeof(SqlExpression), typeof(SelectExpression), typeof(bool), typeof(RelationalTypeMapping) })!,
-                    Visit(inExpression.Item),
-                    Visit(inExpression.Subquery!),
-                    Constant(inExpression.Negate()),
-                    RenderFindTypeMapping(inExpression.TypeMapping));
+    /// <inheritdoc />
+    protected override Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression)
+        => New(
+            _sqlConstantConstructor ??= typeof(SqlConstantExpression).GetConstructor(
+                new[] { typeof(ConstantExpression), typeof(RelationalTypeMapping) })!,
+            Call(
+                _constantFactoryMethod ??= typeof(Expression)
+                    .GetMethod(nameof(Constant), new[] { typeof(object), typeof(Type) })!,
+                sqlConstantExpression.Type.IsValueType
+                    ? Convert(
+                        Constant(sqlConstantExpression.Value, sqlConstantExpression.Type), typeof(object))
+                    : Constant(sqlConstantExpression.Value, sqlConstantExpression.Type),
+                Constant(sqlConstantExpression.Type)),
+            RenderFindTypeMapping(sqlConstantExpression.TypeMapping));
 
-        protected override Expression VisitIntersect(IntersectExpression intersectExpression)
-            => New(
-                _intersectConstructor ??= typeof(IntersectExpression).GetConstructor(
-                    new[]
-                    {
-                        typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool),
-                        typeof(IEnumerable<IAnnotation>)
-                    })!,
-                Constant(intersectExpression.Alias, typeof(string)),
-                Visit(intersectExpression.Source1),
-                Visit(intersectExpression.Source2),
-                Constant(intersectExpression.IsDistinct),
-                RenderAnnotationArray(intersectExpression.GetAnnotations()));
+    /// <inheritdoc />
+    protected override Expression VisitSqlFragment(SqlFragmentExpression sqlFragmentExpression)
+        => New(
+            _sqlFragmentConstructor ??= typeof(SqlFragmentExpression).GetConstructor(new[] { typeof(string) })!,
+            Constant(sqlFragmentExpression.Sql));
 
-        protected override Expression VisitLike(LikeExpression likeExpression)
-            => New(
-                _likeConstructor ??= typeof(LikeExpression).GetConstructor(
-                    new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(SqlExpression), typeof(RelationalTypeMapping) })!,
-                Visit(likeExpression.Match),
-                Visit(likeExpression.Pattern),
-                VisitOrNull(likeExpression.EscapeChar),
-                RenderFindTypeMapping(likeExpression.TypeMapping));
+    /// <inheritdoc />
+    protected override Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
+        => New(
+            _sqlFunctionConstructor ??= typeof(SqlFunctionExpression).GetConstructor(
+                new[]
+                {
+                    typeof(SqlExpression), typeof(string), typeof(string), typeof(bool), typeof(IEnumerable<SqlExpression>),
+                    typeof(bool), typeof(bool), typeof(IEnumerable<bool>), typeof(bool), typeof(Type), typeof(RelationalTypeMapping)
+                })!,
+            VisitOrNull(sqlFunctionExpression.Instance),
+            Constant(sqlFunctionExpression.Schema, typeof(string)),
+            Constant(sqlFunctionExpression.Name),
+            Constant(sqlFunctionExpression.IsNiladic),
+            sqlFunctionExpression.Arguments is null
+                ? Constant(null, typeof(IEnumerable<SqlExpression>))
+                : NewArrayInit(typeof(SqlExpression), initializers: sqlFunctionExpression.Arguments.Select(Visit)!),
+            Constant(sqlFunctionExpression.IsNullable),
+            Constant(sqlFunctionExpression.InstancePropagatesNullability, typeof(bool?)),
+            sqlFunctionExpression.ArgumentsPropagateNullability is null
+                ? Constant(null, typeof(IEnumerable<bool>))
+                : NewArrayInit(
+                    typeof(bool), initializers: sqlFunctionExpression.ArgumentsPropagateNullability.Select(n => Constant(n))),
+            Constant(sqlFunctionExpression.IsBuiltIn),
+            Constant(sqlFunctionExpression.Type),
+            RenderFindTypeMapping(sqlFunctionExpression.TypeMapping));
 
-        protected override Expression VisitInnerJoin(InnerJoinExpression innerJoinExpression)
-            => New(
-                _innerJoinConstructor ??= typeof(InnerJoinExpression).GetConstructor(
-                    new[] { typeof(TableExpressionBase), typeof(SqlExpression), typeof(IEnumerable<IAnnotation>) })!,
-                Visit(innerJoinExpression.Table),
-                Visit(innerJoinExpression.JoinPredicate),
-                RenderAnnotationArray(innerJoinExpression.GetAnnotations()));
+    /// <inheritdoc />
+    protected override Expression VisitSqlParameter(SqlParameterExpression sqlParameterExpression)
+        => New(
+            _sqlParameterConstructor ??= typeof(SqlParameterExpression).GetConstructor(new[]
+            {
+                typeof(ParameterExpression), typeof(RelationalTypeMapping)
+            })!,
+            Call(
+                _parameterFactoryMethod ??= typeof(Expression)
+                    .GetMethod(nameof(Parameter), new[] { typeof(Type), typeof(string) })!,
+                Constant(sqlParameterExpression.Type),
+                Constant(sqlParameterExpression.Name, typeof(string))),
+            RenderFindTypeMapping(sqlParameterExpression.TypeMapping));
 
-        protected override Expression VisitLeftJoin(LeftJoinExpression leftJoinExpression)
-            => New(
-                _leftJoinConstructor ??= typeof(LeftJoinExpression).GetConstructor(
-                    new[] { typeof(TableExpressionBase), typeof(SqlExpression), typeof(IEnumerable<IAnnotation>) })!,
-                Visit(leftJoinExpression.Table),
-                Visit(leftJoinExpression.JoinPredicate),
-                RenderAnnotationArray(leftJoinExpression.GetAnnotations()));
+    /// <inheritdoc />
+    protected override Expression VisitSqlUnary(SqlUnaryExpression sqlUnaryExpression)
+        => New(
+            _sqlUnaryConstructor ??= typeof(SqlUnaryExpression).GetConstructor(new[]
+            {
+                typeof(ExpressionType), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping)
+            })!,
+            Constant(sqlUnaryExpression.OperatorType),
+            Visit(sqlUnaryExpression.Operand),
+            Constant(sqlUnaryExpression.Type),
+            RenderFindTypeMapping(sqlUnaryExpression.TypeMapping));
 
-        protected override Expression VisitOrdering(OrderingExpression orderingExpression)
-            => New(
-                _orderingConstructor ??= typeof(OrderingExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(bool) })!,
-                Visit(orderingExpression.Expression),
-                Constant(orderingExpression.IsAscending));
+    /// <inheritdoc />
+    protected override Expression VisitTable(TableExpression tableExpression)
+        => New(
+            _tableConstructor ??= typeof(TableExpression).GetConstructor(new[]
+            {
+                typeof(string), typeof(string), typeof(string), typeof(ITable)
+            })!,
+            Constant(tableExpression.Alias, typeof(string)),
+            Constant(tableExpression.Name, typeof(string)),
+            Constant(tableExpression.Schema, typeof(string)),
+            QuoteTableBase(tableExpression.Table));
 
-        protected override Expression VisitOuterApply(OuterApplyExpression outerApplyExpression)
-            => New(
-                _outerApplyConstructor ??=
-                    typeof(OuterApplyExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
-                Visit(outerApplyExpression.Table),
-                RenderAnnotationArray(outerApplyExpression.GetAnnotations()));
+    /// <inheritdoc />
+    protected override Expression VisitUnion(UnionExpression unionExpression)
+        => New(
+            _unionConstructor ??= typeof(UnionExpression).GetConstructor(
+                new[]
+                {
+                    typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool), typeof(IEnumerable<IAnnotation>)
+                })!,
+            Constant(unionExpression.Alias, typeof(string)),
+            Visit(unionExpression.Source1),
+            Visit(unionExpression.Source2),
+            Constant(unionExpression.IsDistinct),
+            RenderAnnotationArray(unionExpression.GetAnnotations()));
 
-        protected override Expression VisitProjection(ProjectionExpression projectionExpression)
-            => New(
-                _projectionConstructor ??=
-                    typeof(ProjectionExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(string) })!,
-                Visit(projectionExpression.Expression),
-                Constant(projectionExpression.Alias));
-
-        protected override Expression VisitTableValuedFunction(TableValuedFunctionExpression tableValuedFunctionExpression)
-            => throw new NotImplementedException();
-            // => New(
-            //     _tableValuedFunctionConstructor ??= typeof(TableValuedFunctionExpression).GetConstructor(
-            //         new[]
-            //         {
-            //             typeof(string), typeof(IStoreFunction), typeof(IReadOnlyList<SqlExpression>), typeof(IEnumerable<IAnnotation>)
-            //         })!,
-            //     Constant(tableValuedFunctionExpression.Alias, typeof(string)),
-            //     tableValuedFunctionExpression.StoreFunction,
-            //     Constant(tableValuedFunctionExpression.Arguments),
-            //     Constant(tableValuedFunctionExpression.GetAnnotations().ToArray());
-
-        protected override Expression VisitRowNumber(RowNumberExpression rowNumberExpression)
-            => New(
-                _rowNumberConstructor ??= typeof(RowNumberExpression).GetConstructor(
-                    new[] {
-                        typeof(IReadOnlyList<SqlExpression>),
-                        typeof(IReadOnlyList<OrderingExpression>),
-                        typeof(RelationalTypeMapping)
-                    })!,
-                NewArrayInit(typeof(SqlExpression), initializers: rowNumberExpression.Orderings.Select(Visit)!),
-                RenderFindTypeMapping(rowNumberExpression.TypeMapping));
-
-        protected override Expression VisitScalarSubquery(ScalarSubqueryExpression scalarSubqueryExpression)
-            => New(
-                _scalarSubqueryConstructor ??= typeof(ScalarSubqueryExpression).GetConstructor(new[] { typeof(SelectExpression) })!,
-                Visit(scalarSubqueryExpression.Subquery));
-
-        protected sealed override Expression VisitSelect(SelectExpression selectExpression)
+    /// <inheritdoc />
+    protected override Expression VisitUpdate(UpdateExpression updateExpression)
+    {
+        if (_seenRootExpression)
         {
-            var selectExpressionVariable = _parentVisitor._selectExpressionMap[selectExpression];
+            throw new NotSupportedException($"{nameof(UpdateExpression)} in non-root context");
+        }
 
-            _parentVisitor._blockExpressions.Add(
-                Call(
-                    selectExpressionVariable,
-                    _selectPopulateClausesMethod ??= typeof(SelectExpression).GetMethod(
-                        nameof(SelectExpression.PopulateClauses),
+        _seenRootExpression = true;
+
+        var updateExpressionVariable = Parameter(typeof(UpdateExpression), _rootSelectVariableName);
+        _blockVariables.Add(updateExpressionVariable);
+        _blockExpressions.Add(
+            Assign(
+                updateExpressionVariable,
+                New(
+                    _updateConstructor ??= typeof(UpdateExpression).GetConstructor(
                         new[]
                         {
-                            typeof(IReadOnlyList<TableExpressionBase>), // tables
-                            typeof(SqlExpression), // predicate
-                            typeof(SqlExpression), // limit
-                            typeof(SqlExpression), // offset
-                            typeof(IReadOnlyList<SqlExpression>), // groupby
-                            typeof(SqlExpression), // having
-                            typeof(IReadOnlyList<OrderingExpression>), // orderings
-                            typeof(bool), // isDistinct
-                            typeof(IReadOnlyList<ProjectionExpression>), // projections
-                            // TODO:
-                            // typeof(ISet<string>), // tags
-                            // typeof(SortedDictionary<string, IAnnotation>) // annotations
+                            typeof(TableExpression), typeof(SelectExpression), typeof(IReadOnlyList<ColumnValueSetter>),
+                            typeof(ISet<string>)
                         })!,
+                    Visit(updateExpression.Table),
+                    Visit(updateExpression.SelectExpression),
                     NewArrayInit(
-                        typeof(TableExpressionBase),
-                        initializers: selectExpression.Tables.Select(Visit)!),
-                    VisitOrNull(selectExpression.Predicate),
-                    VisitOrNull(selectExpression.Limit),
-                    VisitOrNull(selectExpression.Offset),
-                    NewArrayInit(typeof(SqlExpression), initializers: selectExpression.GroupBy.Select(Visit)!),
-                    VisitOrNull(selectExpression.Having),
-                    NewArrayInit(typeof(OrderingExpression), initializers: selectExpression.Orderings.Select(Visit)!),
-                    Constant(selectExpression.IsDistinct),
-                    NewArrayInit(typeof(ProjectionExpression), initializers: selectExpression.Projection.Select(Visit)!)));
+                        typeof(ColumnValueSetter),
+                        updateExpression.ColumnValueSetters
+                            .Select(s => New(
+                                _columnValueSetterConstructor ??=
+                                    typeof(ColumnValueSetter).GetConstructor(new[] { typeof(ColumnExpression), typeof(SqlExpression) })!,
+                                Visit(s.Column),
+                                Visit(s.Value)))),
+                    CreateTagsExpression(updateExpression.Tags))));
 
-            return selectExpressionVariable;
-        }
-
-        protected override Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression)
-            => New(
-                _sqlBinaryConstructor ??= typeof(SqlBinaryExpression).GetConstructor(
-                    new[]
-                    {
-                        typeof(ExpressionType),
-                        typeof(SqlExpression),
-                        typeof(SqlExpression),
-                        typeof(Type),
-                        typeof(RelationalTypeMapping)
-                    })!,
-                Constant(sqlBinaryExpression.OperatorType),
-                Visit(sqlBinaryExpression.Left),
-                Visit(sqlBinaryExpression.Right),
-                Constant(sqlBinaryExpression.Type),
-                RenderFindTypeMapping(sqlBinaryExpression.TypeMapping));
-
-        protected override Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression)
-            => New(
-                _sqlConstantConstructor ??= typeof(SqlConstantExpression).GetConstructor(
-                    new[] { typeof(ConstantExpression), typeof(RelationalTypeMapping) })!,
-                Call(
-                    _constantFactoryMethod ??= typeof(Expression)
-                        .GetMethod(nameof(Constant), new[] { typeof(object), typeof(Type) })!,
-                    sqlConstantExpression.Type.IsValueType
-                        ? Convert(
-                            Constant(sqlConstantExpression.Value, sqlConstantExpression.Type), typeof(object))
-                        : Constant(sqlConstantExpression.Value, sqlConstantExpression.Type),
-                    Constant(sqlConstantExpression.Type)),
-                RenderFindTypeMapping(sqlConstantExpression.TypeMapping));
-
-        protected override Expression VisitSqlFragment(SqlFragmentExpression sqlFragmentExpression)
-            => New(
-                _sqlFragmentConstructor ??= typeof(SqlFragmentExpression).GetConstructor(new[] { typeof(string) })!,
-                Constant(sqlFragmentExpression.Sql));
-
-        protected override Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
-            => New(
-                _sqlFunctionConstructor ??= typeof(SqlFunctionExpression).GetConstructor(
-                    new[]
-                    {
-                        typeof(SqlExpression),
-                        typeof(string),
-                        typeof(string),
-                        typeof(bool),
-                        typeof(IEnumerable<SqlExpression>),
-                        typeof(bool),
-                        typeof(bool),
-                        typeof(IEnumerable<bool>),
-                        typeof(bool),
-                        typeof(Type),
-                        typeof(RelationalTypeMapping)
-                    })!,
-                VisitOrNull(sqlFunctionExpression.Instance),
-                Constant(sqlFunctionExpression.Schema, typeof(string)),
-                Constant(sqlFunctionExpression.Name),
-                Constant(sqlFunctionExpression.IsNiladic),
-                sqlFunctionExpression.Arguments is null
-                    ? Constant(null, typeof(IEnumerable<SqlExpression>))
-                    : NewArrayInit(typeof(SqlExpression), initializers: sqlFunctionExpression.Arguments.Select(Visit)!),
-                Constant(sqlFunctionExpression.IsNullable),
-                Constant(sqlFunctionExpression.InstancePropagatesNullability, typeof(bool?)),
-                sqlFunctionExpression.ArgumentsPropagateNullability is null
-                    ? Constant(null, typeof(IEnumerable<bool>))
-                    : NewArrayInit(
-                        typeof(bool), initializers: sqlFunctionExpression.ArgumentsPropagateNullability.Select(n => Constant(n))),
-                Constant(sqlFunctionExpression.IsBuiltIn),
-                Constant(sqlFunctionExpression.Type),
-                RenderFindTypeMapping(sqlFunctionExpression.TypeMapping));
-
-        protected override Expression VisitSqlParameter(SqlParameterExpression sqlParameterExpression)
-            => New(
-                _sqlParameterConstructor ??= typeof(SqlParameterExpression).GetConstructor(new[]
-                {
-                    typeof(ParameterExpression), typeof(RelationalTypeMapping)
-                })!,
-                Call(
-                    _parameterFactoryMethod ??= typeof(Expression)
-                        .GetMethod(nameof(Parameter), new[] { typeof(Type), typeof(string) })!,
-                    Constant(sqlParameterExpression.Type),
-                    Constant(sqlParameterExpression.Name, typeof(string))),
-                RenderFindTypeMapping(sqlParameterExpression.TypeMapping));
-
-        protected override Expression VisitSqlUnary(SqlUnaryExpression sqlUnaryExpression)
-            => New(
-                _sqlUnaryConstructor ??= typeof(SqlUnaryExpression).GetConstructor(new[]
-                {
-                    typeof(ExpressionType), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping)
-                })!,
-                Constant(sqlUnaryExpression.OperatorType),
-                Visit(sqlUnaryExpression.Operand),
-                Constant(sqlUnaryExpression.Type),
-                RenderFindTypeMapping(sqlUnaryExpression.TypeMapping));
-
-        protected override Expression VisitTable(TableExpression tableExpression)
-            => New(
-                _tableConstructor ??= typeof(TableExpression).GetConstructor(new[]
-                {
-                    typeof(string), typeof(string), typeof(string), typeof(ITable)
-                })!,
-                Constant(tableExpression.Alias, typeof(string)),
-                Constant(tableExpression.Name, typeof(string)),
-                Constant(tableExpression.Schema, typeof(string)),
-                QuoteTableBase(tableExpression.Table));
-
-        protected override Expression VisitUnion(UnionExpression unionExpression)
-            => New(
-                _unionConstructor ??= typeof(UnionExpression).GetConstructor(
-                    new[]
-                    {
-                        typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool),
-                        typeof(IEnumerable<IAnnotation>)
-                    })!,
-                Constant(unionExpression.Alias, typeof(string)),
-                Visit(unionExpression.Source1),
-                Visit(unionExpression.Source2),
-                Constant(unionExpression.IsDistinct),
-                RenderAnnotationArray(unionExpression.GetAnnotations()));
-
-        protected override Expression VisitUpdate(UpdateExpression updateExpression)
-            => New(
-                _updateConstructor ??= typeof(UpdateExpression).GetConstructor(
-                    new[]
-                    {
-                        typeof(TableExpression),
-                        typeof(SelectExpression),
-                        typeof(IReadOnlyList<ColumnValueSetter>),
-                        typeof(ISet<string>)
-                    })!,
-                Visit(updateExpression.Table),
-                Visit(updateExpression.SelectExpression),
-                Constant(updateExpression.ColumnValueSetters),
-                Constant(updateExpression.Tags));
-
-        protected override Expression VisitJsonScalar(JsonScalarExpression jsonScalarExpression)
-            => throw new NotImplementedException();
-            // => New(
-            //     _jsonScalarConstructor ??= typeof(JsonScalarExpression).GetConstructor(new[] { typeof(ColumnExpression), typeof(IReadOnlyList<PathSegment>), typeof(Type), typeof(RelationalTypeMapping), typeof(bool) })!,
-            //     Visit(jsonScalarExpression.JsonColumn),
-            //     // TODO: Contains SqlExpression
-            //     Constant(jsonScalarExpression.Type),
-            //     RenderFindTypeMapping(jsonScalarExpression.TypeMapping),
-            //     Constant(jsonScalarExpression.IsNullable));
-
-        private Expression QuoteTableBase(ITableBase tableBase)
-            => tableBase switch
-            {
-                Table table => Call(
-                    _parentVisitor._relationalModelParameter,
-                    _relationalModelFindTableMethod ??= typeof(RelationalModel).GetMethod(nameof(RelationalModel.FindTable), new[] { typeof(string), typeof(string) })!,
-                    Constant(table.Name, typeof(string)),
-                    Constant(table.Schema, typeof(string))),
-
-                _ => throw new ArgumentOutOfRangeException($"Unsupported {nameof(ITableBase)} of type {tableBase.GetType().Name}")
-            };
-
-        private Expression RenderFindTypeMapping(RelationalTypeMapping? typeMapping)
-            => typeMapping is null
-                ? Constant(null, typeof(RelationalTypeMapping))
-                : Call(
-                    _parentVisitor._relationalTypeMappingSourceParameter,
-                    RelationalTypeMappingSourceFindMappingMethod,
-                    Constant(typeMapping.ClrType, typeof(Type)),
-                    Constant(typeMapping.StoreType, typeof(string)),
-                    Constant(false), // TODO: keyOrIndex not accessible
-                    Constant(typeMapping.IsUnicode, typeof(bool?)),
-                    Constant(typeMapping.Size, typeof(int?)),
-                    Constant(false, typeof(bool?)), // TODO: rowversion not accessible
-                    Constant(typeMapping.IsFixedLength, typeof(bool?)),
-                    Constant(typeMapping.Precision, typeof(int?)),
-                    Constant(typeMapping.Scale, typeof(int?)));
-
-        private Expression RenderAnnotationArray(IEnumerable<IAnnotation> annotations)
-            => NewArrayInit(typeof(Annotation), annotations.Select(a =>
-                New(
-                    _annotationConstructor ??= typeof(Annotation).GetConstructor(new[] { typeof(string), typeof(object) })!,
-                    Constant(a.Name),
-                    Constant(a.Value))));
-
-        private Expression VisitOrNull(Expression? expression)
-            => expression is null ? Constant(null, typeof(SqlExpression)) : Visit(expression);
+        return updateExpressionVariable;
     }
+
+    /// <inheritdoc />
+    protected override Expression VisitJsonScalar(JsonScalarExpression jsonScalarExpression)
+        => throw new NotImplementedException();
+    // => New(
+    //     _jsonScalarConstructor ??= typeof(JsonScalarExpression).GetConstructor(new[] { typeof(ColumnExpression), typeof(IReadOnlyList<PathSegment>), typeof(Type), typeof(RelationalTypeMapping), typeof(bool) })!,
+    //     Visit(jsonScalarExpression.JsonColumn),
+    //     // TODO: Contains SqlExpression
+    //     Constant(jsonScalarExpression.Type),
+    //     RenderFindTypeMapping(jsonScalarExpression.TypeMapping),
+    //     Constant(jsonScalarExpression.IsNullable));
+
+    private Expression QuoteTableBase(ITableBase tableBase)
+        => tableBase switch
+        {
+            Table table => Call(
+                _relationalModelParameter,
+                _relationalModelFindTableMethod ??=
+                    typeof(RelationalModel).GetMethod(nameof(RelationalModel.FindTable), new[] { typeof(string), typeof(string) })!,
+                Constant(table.Name, typeof(string)),
+                Constant(table.Schema, typeof(string))),
+
+            _ => throw new ArgumentOutOfRangeException($"Unsupported {nameof(ITableBase)} of type {tableBase.GetType().Name}")
+        };
+
+    private Expression RenderFindTypeMapping(RelationalTypeMapping? typeMapping)
+        => typeMapping is null
+            ? Constant(null, typeof(RelationalTypeMapping))
+            : Call(
+                _relationalTypeMappingSourceParameter,
+                RelationalTypeMappingSourceFindMappingMethod,
+                Constant(typeMapping.ClrType, typeof(Type)),
+                Constant(typeMapping.StoreType, typeof(string)),
+                Constant(false), // TODO: keyOrIndex not accessible
+                Constant(typeMapping.IsUnicode, typeof(bool?)),
+                Constant(typeMapping.Size, typeof(int?)),
+                Constant(false, typeof(bool?)), // TODO: rowversion not accessible
+                Constant(typeMapping.IsFixedLength, typeof(bool?)),
+                Constant(typeMapping.Precision, typeof(int?)),
+                Constant(typeMapping.Scale, typeof(int?)));
+
+    private Expression RenderAnnotationArray(IEnumerable<IAnnotation> annotations)
+        => NewArrayInit(typeof(Annotation), annotations.Select(a =>
+            New(
+                _annotationConstructor ??= typeof(Annotation).GetConstructor(new[] { typeof(string), typeof(object) })!,
+                Constant(a.Name),
+                Constant(a.Value))));
+
+    private Expression VisitOrNull(Expression? expression)
+        => expression is null ? Constant(null, typeof(SqlExpression)) : Visit(expression);
+
+    private static Expression CreateTagsExpression(ISet<string> tags)
+        => ListInit(
+            New(typeof(HashSet<string>)),
+            tags.Select(t =>
+                ElementInit(
+                    _hashSetAddMethod ??= typeof(HashSet<string>).GetMethod(nameof(HashSet<string>.Add))!,
+                    Constant(t))));
 }

--- a/src/EFCore.Design/Query/Internal/SqlTreeQuoter.cs
+++ b/src/EFCore.Design/Query/Internal/SqlTreeQuoter.cs
@@ -1,0 +1,619 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using static System.Linq.Expressions.Expression;
+using Constant = System.Reflection.Metadata.Constant;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqlTreeQuoter : ISqlTreeQuoter
+{
+    private readonly List<ParameterExpression> _blockVariables = new();
+    private readonly List<Expression> _blockExpressions = new();
+    private readonly EmptySelectExpressionRenderer _emptySelectExpressionRenderer;
+    private readonly SelectExpressionPopulationRenderer _selectExpressionPopulationRenderer;
+    private readonly Dictionary<SelectExpression, ParameterExpression> _selectExpressionMap = new();
+
+    private ParameterExpression _relationalModelParameter = null!;
+    private ParameterExpression _relationalTypeMappingSourceParameter = null!;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlTreeQuoter()
+        => (_emptySelectExpressionRenderer, _selectExpressionPopulationRenderer) = (new(this), new(this));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public BlockExpression Quote(Expression expression)
+    {
+        _blockVariables.Clear();
+        _blockExpressions.Clear();
+        _selectExpressionMap.Clear();
+        _relationalModelParameter = Parameter(typeof(RelationalModel), "relationalModel");
+        _relationalTypeMappingSourceParameter = Parameter(typeof(RelationalTypeMappingSource), "relationalTypeMappingSource");
+
+        // First pass: locate all SelectExpressions and generate code to instantiate mostly empty versions of them.
+        _emptySelectExpressionRenderer.Render(expression);
+
+        // Second pass: generate code to populate the clauses of the empty SelectExpressions above.
+        _selectExpressionPopulationRenderer.Visit(expression);
+
+        return Block(_blockVariables, _blockExpressions);
+    }
+
+    private class EmptySelectExpressionRenderer : ExpressionVisitor
+    {
+        private static readonly ConstructorInfo SelectExpressionConstructor
+            = typeof(SelectExpression).GetConstructor(new[] { typeof(string) })!;
+
+        private readonly SqlTreeQuoter _parentVisitor;
+
+        private int _selectExpressionCounter;
+
+        public EmptySelectExpressionRenderer(SqlTreeQuoter parentVisitor)
+            => _parentVisitor = parentVisitor;
+
+        public void Render(Expression expression)
+        {
+            _selectExpressionCounter = 0;
+
+            Visit(expression);
+        }
+
+        protected override Expression VisitExtension(Expression node)
+        {
+            if (node is SelectExpression selectExpression)
+            {
+                // Add code that instantiates an empty SelectExpression, with only the alias and tables.
+                // The rest of the clauses will be rendered in another pass, referencing the SelectExpression variables
+                // we create here.
+
+                // The very first SelectExpression we encounter is the root one, so we give it the special name sqlTree
+                var selectExpressionCounter = _selectExpressionCounter++;
+                var selectExpressionVariable = Parameter(
+                    typeof(SelectExpression),
+                    selectExpressionCounter == 0 ? "sqlTree" : $"select{selectExpressionCounter}");
+                _parentVisitor._selectExpressionMap[selectExpression] = selectExpressionVariable;
+                _parentVisitor._blockVariables.Add(selectExpressionVariable);
+
+                _parentVisitor._blockExpressions.Add(
+                    Assign(
+                        selectExpressionVariable,
+                        New(
+                            SelectExpressionConstructor,
+                            Constant(selectExpression.Alias, typeof(string)))));
+            }
+
+            return base.VisitExtension(node);
+        }
+    }
+
+    // TODO: This needs to be a design-time relational service that providers can override, to add support for their
+    // own expression types.
+    private class SelectExpressionPopulationRenderer : SqlExpressionVisitor
+    {
+        private static ConstructorInfo? _annotationConstructor;
+        private static ConstructorInfo? _atTimeZoneConstructor;
+        private static ConstructorInfo? _caseConstructorWithOperand;
+        private static ConstructorInfo? _caseConstructorWithoutOperand;
+        private static ConstructorInfo? _caseWhenClauseConstructor;
+        private static ConstructorInfo? _collateConstructor;
+        private static ConstructorInfo? _concreteColumnConstructor;
+        private static MethodInfo? _constantFactoryMethod;
+        private static ConstructorInfo? _crossApplyConstructor;
+        private static ConstructorInfo? _crossJoinConstructor;
+        private static ConstructorInfo? _deleteConstructor;
+        private static ConstructorInfo? _distinctConstructor;
+        private static ConstructorInfo? _exceptConstructor;
+        private static ConstructorInfo? _existsConstructor;
+        // private static ConstructorInfo? _fromSqlConstructor;
+        private static ConstructorInfo? _inConstructorWithSubquery;
+        private static ConstructorInfo? _inConstructorWithValues;
+        private static ConstructorInfo? _intersectConstructor;
+        private static ConstructorInfo? _likeConstructor;
+        private static ConstructorInfo? _innerJoinConstructor;
+        private static ConstructorInfo? _leftJoinConstructor;
+        private static ConstructorInfo? _orderingConstructor;
+        private static ConstructorInfo? _outerApplyConstructor;
+        private static MethodInfo? _parameterFactoryMethod;
+        private static ConstructorInfo? _projectionConstructor;
+        // private static ConstructorInfo? _tableValuedFunctionConstructor;
+        private static MethodInfo? _relationalModelFindTableMethod;
+        private static ConstructorInfo? _rowNumberConstructor;
+        private static ConstructorInfo? _scalarSubqueryConstructor;
+        private static MethodInfo? _selectPopulateClausesMethod;
+        private static ConstructorInfo? _sqlBinaryConstructor;
+        private static ConstructorInfo? _sqlConstantConstructor;
+        private static ConstructorInfo? _sqlFragmentConstructor;
+        private static ConstructorInfo? _sqlFunctionConstructor;
+        private static ConstructorInfo? _sqlParameterConstructor;
+        private static ConstructorInfo? _sqlUnaryConstructor;
+        private static ConstructorInfo? _tableConstructor;
+        private static ConstructorInfo? _tableReferenceConstructor;
+        private static ConstructorInfo? _unionConstructor;
+        private static ConstructorInfo? _updateConstructor;
+        // private static ConstructorInfo? _jsonScalarConstructor;
+
+        private static readonly MethodInfo RelationalTypeMappingSourceFindMappingMethod
+            = typeof(RelationalTypeMappingSource)
+                .GetMethod(nameof(RelationalTypeMappingSource.FindMapping),
+                    new[]
+                    {
+                        typeof(Type), typeof(string), typeof(bool), typeof(bool), typeof(int), typeof(bool),
+                        typeof(bool), typeof(int),
+                        typeof(int)
+                    })!;
+
+        private readonly SqlTreeQuoter _parentVisitor;
+
+        public SelectExpressionPopulationRenderer(SqlTreeQuoter parentVisitor)
+            => _parentVisitor = parentVisitor;
+
+        protected override Expression VisitAtTimeZone(AtTimeZoneExpression atTimeZoneExpression)
+            => New(
+                _atTimeZoneConstructor ??= typeof(AtTimeZoneExpression).GetConstructor(
+                    new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping) })!,
+                Visit(atTimeZoneExpression.Operand),
+                Visit(atTimeZoneExpression.TimeZone),
+                Constant(atTimeZoneExpression.Type),
+                RenderFindTypeMapping(atTimeZoneExpression.TypeMapping));
+
+        protected override Expression VisitCase(CaseExpression caseExpression)
+        {
+            var whenClauses = NewArrayInit(
+                typeof(CaseWhenClause),
+                initializers: caseExpression.WhenClauses
+                    .Select(c => New(
+                        _caseWhenClauseConstructor ??= typeof(CaseWhenClause).GetConstructor(new[] { typeof(SqlExpression), typeof(SqlExpression) })!,
+                        Visit(c.Test),
+                        Visit(c.Result))));
+
+            return caseExpression.Operand is null
+                ? New(
+                    _caseConstructorWithoutOperand ??=
+                        typeof(CaseExpression).GetConstructor(new[] { typeof(IReadOnlyList<CaseWhenClause>), typeof(SqlExpression) })!,
+                    whenClauses,
+                    VisitOrNull(caseExpression.ElseResult))
+                : New(
+                    _caseConstructorWithOperand ??= typeof(CaseExpression).GetConstructor(
+                        new[] { typeof(SqlExpression), typeof(IReadOnlyList<CaseWhenClause>), typeof(SqlExpression) })!,
+                    Visit(caseExpression.Operand),
+                    whenClauses,
+                    VisitOrNull(caseExpression.ElseResult));
+        }
+
+        protected override Expression VisitCollate(CollateExpression collateExpression)
+            => New(
+                _collateConstructor ??= typeof(CollateExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(string) })!,
+                Visit(collateExpression.Operand),
+                Constant(collateExpression.Collation));
+
+        protected override Expression VisitColumn(ColumnExpression columnExpression)
+        {
+            if (columnExpression is not ConcreteColumnExpression concreteColumnExpression)
+            {
+                throw new NotSupportedException("Unknown column type: " + columnExpression.GetType().Name);
+            }
+
+            var found = _parentVisitor._selectExpressionMap.TryGetValue(concreteColumnExpression.SelectExpression,
+                out var selectExpressionVariable);
+            Debug.Assert(found, "Could not find SelectExpression in select expression map");
+
+            return New(
+                _concreteColumnConstructor ??= typeof(ConcreteColumnExpression).GetConstructor(
+                    new[] { typeof(string), typeof(TableReferenceExpression), typeof(Type), typeof(RelationalTypeMapping), typeof(bool) })!,
+                Constant(columnExpression.Name),
+                New(
+                    _tableReferenceConstructor ??=
+                        typeof(TableReferenceExpression).GetConstructor(new[] { typeof(SelectExpression), typeof(string) })!,
+                    selectExpressionVariable!,
+                    Constant(columnExpression.TableAlias)),
+                Constant(columnExpression.Type),
+                RenderFindTypeMapping(columnExpression.TypeMapping),
+                Constant(columnExpression.IsNullable));
+        }
+
+        protected override Expression VisitCrossApply(CrossApplyExpression crossApplyExpression)
+            => New(
+                _crossApplyConstructor ??=
+                    typeof(CrossApplyExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
+                Visit(crossApplyExpression.Table),
+                RenderAnnotationArray(crossApplyExpression.GetAnnotations()));
+
+        protected override Expression VisitCrossJoin(CrossJoinExpression crossJoinExpression)
+            => New(
+                _crossJoinConstructor ??=
+                    typeof(CrossJoinExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
+                Visit(crossJoinExpression.Table),
+                RenderAnnotationArray(crossJoinExpression.GetAnnotations()));
+
+        protected override Expression VisitDelete(DeleteExpression deleteExpression)
+            => New(
+                _deleteConstructor ??= typeof(DeleteExpression).GetConstructor(
+                    new[] { typeof(TableExpression), typeof(SelectExpression), typeof(ISet<string>) })!,
+                Visit(deleteExpression.Table),
+                Visit(deleteExpression.SelectExpression),
+                Constant(deleteExpression.Tags));
+
+        protected override Expression VisitDistinct(DistinctExpression distinctExpression)
+            => New(
+                _distinctConstructor ??= typeof(DistinctExpression).GetConstructor(new[] { typeof(SqlExpression) })!,
+                Visit(distinctExpression.Operand));
+
+        protected override Expression VisitExcept(ExceptExpression exceptExpression)
+            => New(
+                _exceptConstructor ??= typeof(ExceptExpression).GetConstructor(
+                    new[]
+                    {
+                        typeof(string),
+                        typeof(SelectExpression),
+                        typeof(SelectExpression),
+                        typeof(bool),
+                        typeof(IEnumerable<IAnnotatable>)
+                    })!,
+                Constant(exceptExpression.Alias, typeof(string)),
+                Visit(exceptExpression.Source1),
+                Visit(exceptExpression.Source2),
+                Constant(exceptExpression.IsDistinct),
+                RenderAnnotationArray(exceptExpression.GetAnnotations()));
+
+        protected override Expression VisitExists(ExistsExpression existsExpression)
+            => New(
+                _existsConstructor ??= typeof(ExistsExpression).GetConstructor(new[] { typeof(SelectExpression), typeof(bool), typeof(RelationalTypeMapping)})!,
+                Visit(existsExpression.Subquery),
+                Constant(existsExpression),
+                RenderFindTypeMapping(existsExpression.TypeMapping));
+
+        protected override Expression VisitFromSql(FromSqlExpression fromSqlExpression)
+            => throw new NotImplementedException();
+            // => New(
+            //     _fromSqlConstructor ??= typeof(FromSqlExpression).GetConstructor(new[] { typeof(string), typeof(ITableBase), typeof(string), typeof(Expression), typeof(IEnumerable<IAnnotation>) })!,
+            //     Constant(fromSqlExpression.Alias, typeof(string)),
+            //     fromSqlExpression.Table, // TODO
+            //     Constant(fromSqlExpression.Sql),
+            //     Visit(fromSqlExpression.Arguments),
+            //     Constant(fromSqlExpression.GetAnnotations().ToArray());
+
+        protected override Expression VisitIn(InExpression inExpression)
+            => inExpression.Subquery is null
+                ? New(
+                    _inConstructorWithValues ??= typeof(InExpression).GetConstructor(
+                        new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(bool), typeof(RelationalTypeMapping) })!,
+                    Visit(inExpression.Item),
+                    Visit(inExpression.Values!),
+                    Constant(inExpression.IsNegated),
+                    RenderFindTypeMapping(inExpression.TypeMapping))
+                : New(
+                    _inConstructorWithSubquery ??= typeof(InExpression).GetConstructor(
+                        new[] { typeof(SqlExpression), typeof(SelectExpression), typeof(bool), typeof(RelationalTypeMapping) })!,
+                    Visit(inExpression.Item),
+                    Visit(inExpression.Subquery!),
+                    Constant(inExpression.Negate()),
+                    RenderFindTypeMapping(inExpression.TypeMapping));
+
+        protected override Expression VisitIntersect(IntersectExpression intersectExpression)
+            => New(
+                _intersectConstructor ??= typeof(IntersectExpression).GetConstructor(
+                    new[]
+                    {
+                        typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool),
+                        typeof(IEnumerable<IAnnotation>)
+                    })!,
+                Constant(intersectExpression.Alias, typeof(string)),
+                Visit(intersectExpression.Source1),
+                Visit(intersectExpression.Source2),
+                Constant(intersectExpression.IsDistinct),
+                RenderAnnotationArray(intersectExpression.GetAnnotations()));
+
+        protected override Expression VisitLike(LikeExpression likeExpression)
+            => New(
+                _likeConstructor ??= typeof(LikeExpression).GetConstructor(
+                    new[] { typeof(SqlExpression), typeof(SqlExpression), typeof(SqlExpression), typeof(RelationalTypeMapping) })!,
+                Visit(likeExpression.Match),
+                Visit(likeExpression.Pattern),
+                VisitOrNull(likeExpression.EscapeChar),
+                RenderFindTypeMapping(likeExpression.TypeMapping));
+
+        protected override Expression VisitInnerJoin(InnerJoinExpression innerJoinExpression)
+            => New(
+                _innerJoinConstructor ??= typeof(InnerJoinExpression).GetConstructor(
+                    new[] { typeof(TableExpressionBase), typeof(SqlExpression), typeof(IEnumerable<IAnnotation>) })!,
+                Visit(innerJoinExpression.Table),
+                Visit(innerJoinExpression.JoinPredicate),
+                RenderAnnotationArray(innerJoinExpression.GetAnnotations()));
+
+        protected override Expression VisitLeftJoin(LeftJoinExpression leftJoinExpression)
+            => New(
+                _leftJoinConstructor ??= typeof(LeftJoinExpression).GetConstructor(
+                    new[] { typeof(TableExpressionBase), typeof(SqlExpression), typeof(IEnumerable<IAnnotation>) })!,
+                Visit(leftJoinExpression.Table),
+                Visit(leftJoinExpression.JoinPredicate),
+                RenderAnnotationArray(leftJoinExpression.GetAnnotations()));
+
+        protected override Expression VisitOrdering(OrderingExpression orderingExpression)
+            => New(
+                _orderingConstructor ??= typeof(OrderingExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(bool) })!,
+                Visit(orderingExpression.Expression),
+                Constant(orderingExpression.IsAscending));
+
+        protected override Expression VisitOuterApply(OuterApplyExpression outerApplyExpression)
+            => New(
+                _outerApplyConstructor ??=
+                    typeof(OuterApplyExpression).GetConstructor(new[] { typeof(TableExpressionBase), typeof(IEnumerable<IAnnotation>) })!,
+                Visit(outerApplyExpression.Table),
+                RenderAnnotationArray(outerApplyExpression.GetAnnotations()));
+
+        protected override Expression VisitProjection(ProjectionExpression projectionExpression)
+            => New(
+                _projectionConstructor ??=
+                    typeof(ProjectionExpression).GetConstructor(new[] { typeof(SqlExpression), typeof(string) })!,
+                Visit(projectionExpression.Expression),
+                Constant(projectionExpression.Alias));
+
+        protected override Expression VisitTableValuedFunction(TableValuedFunctionExpression tableValuedFunctionExpression)
+            => throw new NotImplementedException();
+            // => New(
+            //     _tableValuedFunctionConstructor ??= typeof(TableValuedFunctionExpression).GetConstructor(
+            //         new[]
+            //         {
+            //             typeof(string), typeof(IStoreFunction), typeof(IReadOnlyList<SqlExpression>), typeof(IEnumerable<IAnnotation>)
+            //         })!,
+            //     Constant(tableValuedFunctionExpression.Alias, typeof(string)),
+            //     tableValuedFunctionExpression.StoreFunction,
+            //     Constant(tableValuedFunctionExpression.Arguments),
+            //     Constant(tableValuedFunctionExpression.GetAnnotations().ToArray());
+
+        protected override Expression VisitRowNumber(RowNumberExpression rowNumberExpression)
+            => New(
+                _rowNumberConstructor ??= typeof(RowNumberExpression).GetConstructor(
+                    new[] {
+                        typeof(IReadOnlyList<SqlExpression>),
+                        typeof(IReadOnlyList<OrderingExpression>),
+                        typeof(RelationalTypeMapping)
+                    })!,
+                NewArrayInit(typeof(SqlExpression), initializers: rowNumberExpression.Orderings.Select(Visit)!),
+                RenderFindTypeMapping(rowNumberExpression.TypeMapping));
+
+        protected override Expression VisitScalarSubquery(ScalarSubqueryExpression scalarSubqueryExpression)
+            => New(
+                _scalarSubqueryConstructor ??= typeof(ScalarSubqueryExpression).GetConstructor(new[] { typeof(SelectExpression) })!,
+                Visit(scalarSubqueryExpression.Subquery));
+
+        protected sealed override Expression VisitSelect(SelectExpression selectExpression)
+        {
+            var selectExpressionVariable = _parentVisitor._selectExpressionMap[selectExpression];
+
+            _parentVisitor._blockExpressions.Add(
+                Call(
+                    selectExpressionVariable,
+                    _selectPopulateClausesMethod ??= typeof(SelectExpression).GetMethod(
+                        nameof(SelectExpression.PopulateClauses),
+                        new[]
+                        {
+                            typeof(IReadOnlyList<TableExpressionBase>), // tables
+                            typeof(SqlExpression), // predicate
+                            typeof(SqlExpression), // limit
+                            typeof(SqlExpression), // offset
+                            typeof(IReadOnlyList<SqlExpression>), // groupby
+                            typeof(SqlExpression), // having
+                            typeof(IReadOnlyList<OrderingExpression>), // orderings
+                            typeof(bool), // isDistinct
+                            typeof(IReadOnlyList<ProjectionExpression>), // projections
+                            // TODO:
+                            // typeof(ISet<string>), // tags
+                            // typeof(SortedDictionary<string, IAnnotation>) // annotations
+                        })!,
+                    NewArrayInit(
+                        typeof(TableExpressionBase),
+                        initializers: selectExpression.Tables.Select(Visit)!),
+                    VisitOrNull(selectExpression.Predicate),
+                    VisitOrNull(selectExpression.Limit),
+                    VisitOrNull(selectExpression.Offset),
+                    NewArrayInit(typeof(SqlExpression), initializers: selectExpression.GroupBy.Select(Visit)!),
+                    VisitOrNull(selectExpression.Having),
+                    NewArrayInit(typeof(OrderingExpression), initializers: selectExpression.Orderings.Select(Visit)!),
+                    Constant(selectExpression.IsDistinct),
+                    NewArrayInit(typeof(ProjectionExpression), initializers: selectExpression.Projection.Select(Visit)!)));
+
+            return selectExpressionVariable;
+        }
+
+        protected override Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression)
+            => New(
+                _sqlBinaryConstructor ??= typeof(SqlBinaryExpression).GetConstructor(
+                    new[]
+                    {
+                        typeof(ExpressionType),
+                        typeof(SqlExpression),
+                        typeof(SqlExpression),
+                        typeof(Type),
+                        typeof(RelationalTypeMapping)
+                    })!,
+                Constant(sqlBinaryExpression.OperatorType),
+                Visit(sqlBinaryExpression.Left),
+                Visit(sqlBinaryExpression.Right),
+                Constant(sqlBinaryExpression.Type),
+                RenderFindTypeMapping(sqlBinaryExpression.TypeMapping));
+
+        protected override Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression)
+            => New(
+                _sqlConstantConstructor ??= typeof(SqlConstantExpression).GetConstructor(
+                    new[] { typeof(ConstantExpression), typeof(RelationalTypeMapping) })!,
+                Call(
+                    _constantFactoryMethod ??= typeof(Expression)
+                        .GetMethod(nameof(Constant), new[] { typeof(object), typeof(Type) })!,
+                    sqlConstantExpression.Type.IsValueType
+                        ? Convert(
+                            Constant(sqlConstantExpression.Value, sqlConstantExpression.Type), typeof(object))
+                        : Constant(sqlConstantExpression.Value, sqlConstantExpression.Type),
+                    Constant(sqlConstantExpression.Type)),
+                RenderFindTypeMapping(sqlConstantExpression.TypeMapping));
+
+        protected override Expression VisitSqlFragment(SqlFragmentExpression sqlFragmentExpression)
+            => New(
+                _sqlFragmentConstructor ??= typeof(SqlFragmentExpression).GetConstructor(new[] { typeof(string) })!,
+                Constant(sqlFragmentExpression.Sql));
+
+        protected override Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
+            => New(
+                _sqlFunctionConstructor ??= typeof(SqlFunctionExpression).GetConstructor(
+                    new[]
+                    {
+                        typeof(SqlExpression),
+                        typeof(string),
+                        typeof(string),
+                        typeof(bool),
+                        typeof(IEnumerable<SqlExpression>),
+                        typeof(bool),
+                        typeof(bool),
+                        typeof(IEnumerable<bool>),
+                        typeof(bool),
+                        typeof(Type),
+                        typeof(RelationalTypeMapping)
+                    })!,
+                VisitOrNull(sqlFunctionExpression.Instance),
+                Constant(sqlFunctionExpression.Schema, typeof(string)),
+                Constant(sqlFunctionExpression.Name),
+                Constant(sqlFunctionExpression.IsNiladic),
+                sqlFunctionExpression.Arguments is null
+                    ? Constant(null, typeof(IEnumerable<SqlExpression>))
+                    : NewArrayInit(typeof(SqlExpression), initializers: sqlFunctionExpression.Arguments.Select(Visit)!),
+                Constant(sqlFunctionExpression.IsNullable),
+                Constant(sqlFunctionExpression.InstancePropagatesNullability, typeof(bool?)),
+                sqlFunctionExpression.ArgumentsPropagateNullability is null
+                    ? Constant(null, typeof(IEnumerable<bool>))
+                    : NewArrayInit(
+                        typeof(bool), initializers: sqlFunctionExpression.ArgumentsPropagateNullability.Select(n => Constant(n))),
+                Constant(sqlFunctionExpression.IsBuiltIn),
+                Constant(sqlFunctionExpression.Type),
+                RenderFindTypeMapping(sqlFunctionExpression.TypeMapping));
+
+        protected override Expression VisitSqlParameter(SqlParameterExpression sqlParameterExpression)
+            => New(
+                _sqlParameterConstructor ??= typeof(SqlParameterExpression).GetConstructor(new[]
+                {
+                    typeof(ParameterExpression), typeof(RelationalTypeMapping)
+                })!,
+                Call(
+                    _parameterFactoryMethod ??= typeof(Expression)
+                        .GetMethod(nameof(Parameter), new[] { typeof(Type), typeof(string) })!,
+                    Constant(sqlParameterExpression.Type),
+                    Constant(sqlParameterExpression.Name, typeof(string))),
+                RenderFindTypeMapping(sqlParameterExpression.TypeMapping));
+
+        protected override Expression VisitSqlUnary(SqlUnaryExpression sqlUnaryExpression)
+            => New(
+                _sqlUnaryConstructor ??= typeof(SqlUnaryExpression).GetConstructor(new[]
+                {
+                    typeof(ExpressionType), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping)
+                })!,
+                Constant(sqlUnaryExpression.OperatorType),
+                Visit(sqlUnaryExpression.Operand),
+                Constant(sqlUnaryExpression.Type),
+                RenderFindTypeMapping(sqlUnaryExpression.TypeMapping));
+
+        protected override Expression VisitTable(TableExpression tableExpression)
+            => New(
+                _tableConstructor ??= typeof(TableExpression).GetConstructor(new[]
+                {
+                    typeof(string), typeof(string), typeof(string), typeof(ITable)
+                })!,
+                Constant(tableExpression.Alias, typeof(string)),
+                Constant(tableExpression.Name, typeof(string)),
+                Constant(tableExpression.Schema, typeof(string)),
+                QuoteTableBase(tableExpression.Table));
+
+        protected override Expression VisitUnion(UnionExpression unionExpression)
+            => New(
+                _unionConstructor ??= typeof(UnionExpression).GetConstructor(
+                    new[]
+                    {
+                        typeof(string), typeof(SelectExpression), typeof(SelectExpression), typeof(bool),
+                        typeof(IEnumerable<IAnnotation>)
+                    })!,
+                Constant(unionExpression.Alias, typeof(string)),
+                Visit(unionExpression.Source1),
+                Visit(unionExpression.Source2),
+                Constant(unionExpression.IsDistinct),
+                RenderAnnotationArray(unionExpression.GetAnnotations()));
+
+        protected override Expression VisitUpdate(UpdateExpression updateExpression)
+            => New(
+                _updateConstructor ??= typeof(UpdateExpression).GetConstructor(
+                    new[]
+                    {
+                        typeof(TableExpression),
+                        typeof(SelectExpression),
+                        typeof(IReadOnlyList<ColumnValueSetter>),
+                        typeof(ISet<string>)
+                    })!,
+                Visit(updateExpression.Table),
+                Visit(updateExpression.SelectExpression),
+                Constant(updateExpression.ColumnValueSetters),
+                Constant(updateExpression.Tags));
+
+        protected override Expression VisitJsonScalar(JsonScalarExpression jsonScalarExpression)
+            => throw new NotImplementedException();
+            // => New(
+            //     _jsonScalarConstructor ??= typeof(JsonScalarExpression).GetConstructor(new[] { typeof(ColumnExpression), typeof(IReadOnlyList<PathSegment>), typeof(Type), typeof(RelationalTypeMapping), typeof(bool) })!,
+            //     Visit(jsonScalarExpression.JsonColumn),
+            //     // TODO: Contains SqlExpression
+            //     Constant(jsonScalarExpression.Type),
+            //     RenderFindTypeMapping(jsonScalarExpression.TypeMapping),
+            //     Constant(jsonScalarExpression.IsNullable));
+
+        private Expression QuoteTableBase(ITableBase tableBase)
+            => tableBase switch
+            {
+                Table table => Call(
+                    _parentVisitor._relationalModelParameter,
+                    _relationalModelFindTableMethod ??= typeof(RelationalModel).GetMethod(nameof(RelationalModel.FindTable), new[] { typeof(string), typeof(string) })!,
+                    Constant(table.Name, typeof(string)),
+                    Constant(table.Schema, typeof(string))),
+
+                _ => throw new ArgumentOutOfRangeException($"Unsupported {nameof(ITableBase)} of type {tableBase.GetType().Name}")
+            };
+
+        private Expression RenderFindTypeMapping(RelationalTypeMapping? typeMapping)
+            => typeMapping is null
+                ? Constant(null, typeof(RelationalTypeMapping))
+                : Call(
+                    _parentVisitor._relationalTypeMappingSourceParameter,
+                    RelationalTypeMappingSourceFindMappingMethod,
+                    Constant(typeMapping.ClrType, typeof(Type)),
+                    Constant(typeMapping.StoreType, typeof(string)),
+                    Constant(false), // TODO: keyOrIndex not accessible
+                    Constant(typeMapping.IsUnicode, typeof(bool?)),
+                    Constant(typeMapping.Size, typeof(int?)),
+                    Constant(false, typeof(bool?)), // TODO: rowversion not accessible
+                    Constant(typeMapping.IsFixedLength, typeof(bool?)),
+                    Constant(typeMapping.Precision, typeof(int?)),
+                    Constant(typeMapping.Scale, typeof(int?)));
+
+        private Expression RenderAnnotationArray(IEnumerable<IAnnotation> annotations)
+            => NewArrayInit(typeof(Annotation), annotations.Select(a =>
+                New(
+                    _annotationConstructor ??= typeof(Annotation).GetConstructor(new[] { typeof(string), typeof(object) })!,
+                    Constant(a.Name),
+                    Constant(a.Value))));
+
+        private Expression VisitOrNull(Expression? expression)
+            => expression is null ? Constant(null, typeof(SqlExpression)) : Visit(expression);
+    }
+}

--- a/src/EFCore.Relational/EFCore.Relational.csproj
+++ b/src/EFCore.Relational/EFCore.Relational.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -62,6 +62,7 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
             { typeof(IRawSqlCommandBuilder), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IQuerySqlGeneratorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IModificationCommandFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(IRelationalLiftableConstantFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(ICommandBatchPreparer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IModificationCommandBatchFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IRelationalSqlTranslatingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -185,6 +186,9 @@ public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesB
         TryAdd<IRelationalParameterBasedSqlProcessorFactory, RelationalParameterBasedSqlProcessorFactory>();
         TryAdd<IRelationalQueryStringFactory, RelationalQueryStringFactory>();
         TryAdd<IQueryCompilationContextFactory, RelationalQueryCompilationContextFactory>();
+        TryAdd<ILiftableConstantFactory>(p => p.GetRequiredService<IRelationalLiftableConstantFactory>());
+        TryAdd<IRelationalLiftableConstantFactory, RelationalLiftableConstantFactory>();
+        TryAdd<ILiftableConstantProcessor, RelationalLiftableConstantProcessor>();
 
         ServiceCollectionMap.GetInfrastructure()
             .AddDependencySingleton<RelationalSqlGenerationHelperDependencies>()

--- a/src/EFCore.Relational/Query/IRelationalLiftableConstantFactory.cs
+++ b/src/EFCore.Relational/Query/IRelationalLiftableConstantFactory.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public interface IRelationalLiftableConstantFactory : ILiftableConstantFactory
+{
+    LiftableConstantExpression CreateLiftableConstant(
+        Expression<Func<RelationalMaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type);
+}

--- a/src/EFCore.Relational/Query/Internal/ConcreteColumnExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/ConcreteColumnExpression.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+public sealed class ConcreteColumnExpression : ColumnExpression
+{
+    private readonly TableReferenceExpression _table;
+
+    public ConcreteColumnExpression(IProperty property, IColumnBase column, TableReferenceExpression table, bool nullable)
+        : this(
+            column.Name,
+            table,
+            property.ClrType.UnwrapNullableType(),
+            column.PropertyMappings.First(m => m.Property == property).TypeMapping,
+            nullable || column.IsNullable)
+    {
+    }
+
+    public ConcreteColumnExpression(ProjectionExpression subqueryProjection, TableReferenceExpression table)
+        : this(
+            subqueryProjection.Alias, table,
+            subqueryProjection.Type, subqueryProjection.Expression.TypeMapping!,
+            IsNullableProjection(subqueryProjection))
+    {
+    }
+
+    private static bool IsNullableProjection(ProjectionExpression projectionExpression)
+        => projectionExpression.Expression switch
+        {
+            ColumnExpression columnExpression => columnExpression.IsNullable,
+            SqlConstantExpression sqlConstantExpression => sqlConstantExpression.Value == null,
+            _ => true
+        };
+
+    public ConcreteColumnExpression(
+        string name,
+        TableReferenceExpression table,
+        Type type,
+        RelationalTypeMapping typeMapping,
+        bool nullable)
+        : base(type, typeMapping)
+    {
+        Name = name;
+        _table = table;
+        IsNullable = nullable;
+    }
+
+    public override string Name { get; }
+
+    public override TableExpressionBase Table
+        => _table.Table;
+
+    public override string TableAlias
+        => _table.Alias;
+
+    public override bool IsNullable { get; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public SelectExpression SelectExpression => _table.SelectExpression;
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+        => this;
+
+    public override ConcreteColumnExpression MakeNullable()
+        => IsNullable ? this : new ConcreteColumnExpression(Name, _table, Type, TypeMapping!, true);
+
+    public void UpdateTableReference(SelectExpression oldSelect, SelectExpression newSelect)
+        => _table.UpdateTableReference(oldSelect, newSelect);
+
+    internal void Verify(IReadOnlyList<TableReferenceExpression> tableReferences)
+    {
+        if (!tableReferences.Contains(_table, ReferenceEqualityComparer.Instance))
+        {
+            throw new InvalidOperationException("Dangling column.");
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj != null
+           && (ReferenceEquals(this, obj)
+               || obj is ConcreteColumnExpression concreteColumnExpression
+               && Equals(concreteColumnExpression));
+
+    private bool Equals(ConcreteColumnExpression concreteColumnExpression)
+        => base.Equals(concreteColumnExpression)
+           && Name == concreteColumnExpression.Name
+           && _table.Equals(concreteColumnExpression._table)
+           && IsNullable == concreteColumnExpression.IsNullable;
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => HashCode.Combine(base.GetHashCode(), Name, _table, IsNullable);
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -29,6 +29,14 @@ public class RelationalCommandCache : IPrintableExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public Expression QueryExpression => _queryExpression;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public RelationalCommandCache(
         IMemoryCache memoryCache,
         IQuerySqlGeneratorFactory querySqlGeneratorFactory,

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -6,6 +6,28 @@ using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
+public static class SingleQueryingEnumerable
+{
+    public static SingleQueryingEnumerable<T> Create<T>(
+        RelationalQueryContext relationalQueryContext,
+        RelationalCommandCache relationalCommandCache,
+        IReadOnlyList<ReaderColumn?>? readerColumns,
+        Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, T> shaper,
+        Type contextType,
+        bool standAloneStateManager,
+        bool detailedErrorsEnabled,
+        bool threadSafetyChecksEnabled)
+        => new(
+            relationalQueryContext,
+            relationalCommandCache,
+            readerColumns,
+            shaper,
+            contextType,
+            standAloneStateManager,
+            detailedErrorsEnabled,
+            threadSafetyChecksEnabled);
+}
+
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
 ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.Relational/Query/Internal/TableReferenceExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/TableReferenceExpression.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+public sealed class TableReferenceExpression : Expression
+{
+    private SelectExpression _selectExpression;
+
+    public TableReferenceExpression(SelectExpression selectExpression, string alias)
+    {
+        _selectExpression = selectExpression;
+        Alias = alias;
+    }
+
+    public TableExpressionBase Table
+        => _selectExpression.Tables.Single(
+            e => string.Equals((e as JoinExpressionBase)?.Table.Alias ?? e.Alias, Alias, StringComparison.OrdinalIgnoreCase));
+
+    public string Alias { get; internal set; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public SelectExpression SelectExpression => _selectExpression;
+
+    public override Type Type
+        => typeof(object);
+
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
+
+    public void UpdateTableReference(SelectExpression oldSelect, SelectExpression newSelect)
+    {
+        if (ReferenceEquals(oldSelect, _selectExpression))
+        {
+            _selectExpression = newSelect;
+        }
+    }
+
+    internal void Verify(SelectExpression selectExpression)
+    {
+        if (!ReferenceEquals(selectExpression, _selectExpression))
+        {
+            throw new InvalidOperationException("Dangling TableReferenceExpression.");
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj != null
+           && (ReferenceEquals(this, obj)
+               || obj is TableReferenceExpression tableReferenceExpression
+               && Equals(tableReferenceExpression));
+
+    // Since table reference is owned by SelectExpression, the select expression should be the same reference if they are matching.
+    // That means we also don't need to compute the hashcode for it.
+    // This allows us to break the cycle in computation when traversing this graph.
+    private bool Equals(TableReferenceExpression tableReferenceExpression)
+        => string.Equals(Alias, tableReferenceExpression.Alias, StringComparison.OrdinalIgnoreCase)
+           && ReferenceEquals(_selectExpression, tableReferenceExpression._selectExpression);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => 0;
+}

--- a/src/EFCore.Relational/Query/RelationalLiftableConstantFactory.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantFactory.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class RelationalLiftableConstantFactory : LiftableConstantFactory, IRelationalLiftableConstantFactory
+{
+    public virtual LiftableConstantExpression CreateLiftableConstant(
+        Expression<Func<RelationalMaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type)
+        => new(resolverExpression, variableName, type);
+}

--- a/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalLiftableConstantProcessor.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+#pragma warning disable EF1001 // LiftableConstantProcessor is internal
+
+public class RelationalLiftableConstantProcessor : LiftableConstantProcessor
+{
+    private RelationalMaterializerLiftableConstantContext _relationalMaterializerLiftableConstantContext;
+
+    public RelationalLiftableConstantProcessor(
+        ShapedQueryCompilingExpressionVisitorDependencies dependencies,
+        RelationalShapedQueryCompilingExpressionVisitorDependencies relationalDependencies)
+        : base(dependencies)
+        => _relationalMaterializerLiftableConstantContext = new(dependencies, relationalDependencies);
+
+    protected override ConstantExpression InlineConstant(LiftableConstantExpression liftableConstant)
+    {
+        if (liftableConstant.ResolverExpression is Expression<Func<RelationalMaterializerLiftableConstantContext, object>>
+            resolverExpression)
+        {
+            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            var value = resolver(_relationalMaterializerLiftableConstantContext);
+            return Expression.Constant(value, liftableConstant.Type);
+        }
+
+        return base.InlineConstant(liftableConstant);
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalMaterializerLiftableConstantContext.cs
+++ b/src/EFCore.Relational/Query/RelationalMaterializerLiftableConstantContext.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public record RelationalMaterializerLiftableConstantContext(
+        ShapedQueryCompilingExpressionVisitorDependencies Dependencies,
+        RelationalShapedQueryCompilingExpressionVisitorDependencies RelationalDependencies)
+    : MaterializerLiftableConstantContext(Dependencies);

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -353,7 +353,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             }
         }
 
-        private static void InitializeSplitIncludeCollection<TParent, TNavigationEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void InitializeSplitIncludeCollection<TParent, TNavigationEntity>(
             int collectionId,
             QueryContext queryContext,
             DbDataReader parentDataReader,
@@ -392,7 +399,14 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             resultCoordinator.SetSplitQueryCollectionContext(collectionId, splitQueryCollectionContext);
         }
 
-        private static void PopulateSplitIncludeCollection<TIncludingEntity, TIncludedEntity>(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public static void PopulateSplitIncludeCollection<TIncludingEntity, TIncludedEntity>(
             int collectionId,
             RelationalQueryContext queryContext,
             IExecutionStrategy executionStrategy,
@@ -401,7 +415,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
             Func<QueryContext, DbDataReader, object[]> childIdentifier,
-            IReadOnlyList<ValueComparer> identifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> identifierValueComparers,
+            // IReadOnlyList<ValueComparer> identifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, TIncludedEntity> innerShaper,
             Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>? relatedDataLoaders,
             INavigationBase? inverseNavigation,
@@ -448,7 +463,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 while (dataReaderContext.HasNext ?? dbDataReader.Read())
                 {
-                    if (!CompareIdentifiers(
+                    if (!CompareIdentifiers2(
                             identifierValueComparers,
                             splitQueryCollectionContext.ParentIdentifier, childIdentifier(queryContext, dbDataReader)))
                     {
@@ -485,7 +500,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             bool detailedErrorsEnabled,
             SplitQueryResultCoordinator resultCoordinator,
             Func<QueryContext, DbDataReader, object[]> childIdentifier,
-            IReadOnlyList<ValueComparer> identifierValueComparers,
+            IReadOnlyList<Func<object, object, bool>> identifierValueComparers,
+            // IReadOnlyList<ValueComparer> identifierValueComparers,
             Func<QueryContext, DbDataReader, ResultContext, SplitQueryResultCoordinator, TIncludedEntity> innerShaper,
             Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>? relatedDataLoaders,
             INavigationBase? inverseNavigation,
@@ -540,7 +556,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             {
                 while (dataReaderContext.HasNext ?? await dbDataReader.ReadAsync(queryContext.CancellationToken).ConfigureAwait(false))
                 {
-                    if (!CompareIdentifiers(
+                    if (!CompareIdentifiers2(
                             identifierValueComparers,
                             splitQueryCollectionContext.ParentIdentifier, childIdentifier(queryContext, dbDataReader)))
                     {

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -707,7 +707,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 // Expression.Constant(navigation),
                                 _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
                                     c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!,
-                                    "navigation",
+                                    navigation.Name + "Navigation",
                                     typeof(INavigationBase)),
                                 // Expression.Constant(navigation.IsShadowProperty()
                                 //     ? null
@@ -717,7 +717,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     : _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
                                         c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!
                                             .GetCollectionAccessor()!,
-                                        "navigationCollectionAccessor",
+                                        navigation.Name + "NavigationCollectionAccessor",
                                         typeof(IClrCollectionAccessor)),
                                 Expression.Constant(_isTracking),
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -755,7 +755,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     ? Expression.Constant(null, typeof(INavigationBase))
                                     : _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
                                         c => c.Dependencies.Model.FindEntityType(inverseNavigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!,
-                                        "inverseNavigation",
+                                        navigation.Name + "InverseNavigation",
                                         typeof(INavigationBase)),
                                 GenerateFixup(includingEntityClrType, relatedEntityClrType, navigation, inverseNavigation),
                                 Expression.Constant(_isTracking)));
@@ -813,13 +813,13 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                 // Expression.Constant(navigation),
                                 _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
                                     c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!,
-                                    "navigation",
+                                    navigation.Name + "Navigation",
                                     typeof(INavigationBase)),
                                 // Expression.Constant(navigation.GetCollectionAccessor()),
                                 _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
                                     c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!
                                         .GetCollectionAccessor()!,
-                                    "navigationCollectionAccessor",
+                                    navigation.Name + "NavigationCollectionAccessor",
                                     typeof(IClrCollectionAccessor)),
                                 Expression.Constant(_isTracking),
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -860,7 +860,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     ? Expression.Constant(null, typeof(INavigationBase))
                                     : _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
                                         c => c.Dependencies.Model.FindEntityType(inverseNavigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!,
-                                        "inverseNavigation",
+                                        navigation.Name + "InverseNavigation",
                                         typeof(INavigationBase)),
                                 GenerateFixup(includingEntityClrType, relatedEntityClrType, navigation, inverseNavigation),
                                 Expression.Constant(_isTracking)));
@@ -1616,7 +1616,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 _parentVisitor.Dependencies.LiftableConstantFactory.CreateLiftableConstant(
                         c => c.Dependencies.Model.FindEntityType(navigation.DeclaringEntityType.Name)!.FindNavigation(navigation.Name)!
                             .GetCollectionAccessor()!,
-                        "navigationCollectionAccessor",
+                        navigation.Name + "NavigationCollectionAccessor",
                         typeof(IClrCollectionAccessor)),
 
                 CollectionAccessorAddMethodInfo,

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -281,7 +281,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 _expressions.Add(result);
                 result = Expression.Block(_variables, _expressions);
 
-                relationalCommandCache = CreateRelationalCommandCache();
+                relationalCommandCache = _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression);
                 readerColumns = CreateReaderColumnsExpression();
 
                 return Expression.Lambda(
@@ -303,7 +303,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 result = Expression.Block(_variables, _expressions);
 
                 relationalCommandCache = _generateCommandCache
-                    ? CreateRelationalCommandCache()
+                    ? _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression)
                     : Expression.Constant(null, typeof(RelationalCommandCache));
                 readerColumns = CreateReaderColumnsExpression();
 
@@ -386,7 +386,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 }
 
                 relationalCommandCache = _generateCommandCache
-                    ? CreateRelationalCommandCache()
+                    ? _parentVisitor.CreateRelationalCommandCacheExpression(_selectExpression)
                     : Expression.Constant(null, typeof(RelationalCommandCache));;
                 readerColumns = CreateReaderColumnsExpression();
 
@@ -399,17 +399,6 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     _resultContextParameter,
                     _resultCoordinatorParameter);
             }
-
-            LiftableConstantExpression CreateRelationalCommandCache()
-                => _parentVisitor.RelationalDependencies.RelationalLiftableConstantFactory.CreateLiftableConstant(
-                    c => new RelationalCommandCache(
-                        c.Dependencies.MemoryCache,
-                        c.RelationalDependencies.QuerySqlGeneratorFactory,
-                        c.RelationalDependencies.RelationalParameterBasedSqlProcessorFactory,
-                        _selectExpression,
-                        _parentVisitor._useRelationalNulls),
-                    "relationalCommandCache",
-                    typeof(RelationalCommandCache));
         }
 
         protected override Expression VisitBinary(BinaryExpression binaryExpression)

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -47,10 +47,12 @@ public sealed record RelationalShapedQueryCompilingExpressionVisitorDependencies
     [EntityFrameworkInternal]
     public RelationalShapedQueryCompilingExpressionVisitorDependencies(
         IQuerySqlGeneratorFactory querySqlGeneratorFactory,
-        IRelationalParameterBasedSqlProcessorFactory relationalParameterBasedSqlProcessorFactory)
+        IRelationalParameterBasedSqlProcessorFactory relationalParameterBasedSqlProcessorFactory,
+        IRelationalLiftableConstantFactory relationalLiftableConstantFactory)
     {
         QuerySqlGeneratorFactory = querySqlGeneratorFactory;
         RelationalParameterBasedSqlProcessorFactory = relationalParameterBasedSqlProcessorFactory;
+        RelationalLiftableConstantFactory = relationalLiftableConstantFactory;
     }
 
     /// <summary>
@@ -62,4 +64,9 @@ public sealed record RelationalShapedQueryCompilingExpressionVisitorDependencies
     ///     The SQL processor based on parameter values.
     /// </summary>
     public IRelationalParameterBasedSqlProcessorFactory RelationalParameterBasedSqlProcessorFactory { get; init; }
+
+    /// <summary>
+    ///     The liftable constant factory.
+    /// </summary>
+    public IRelationalLiftableConstantFactory RelationalLiftableConstantFactory { get; init; }
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/DeleteExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/DeleteExpression.cs
@@ -23,7 +23,14 @@ public sealed class DeleteExpression : Expression, IPrintableExpression
     {
     }
 
-    private DeleteExpression(TableExpression table, SelectExpression selectExpression, ISet<string> tags)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public DeleteExpression(TableExpression table, SelectExpression selectExpression, ISet<string> tags)
     {
         Table = table;
         SelectExpression = selectExpression;

--- a/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
@@ -30,7 +30,14 @@ public class ExceptExpression : SetOperationBase
     {
     }
 
-    private ExceptExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public ExceptExpression(
         string alias,
         SelectExpression source1,
         SelectExpression source2,

--- a/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
@@ -48,6 +48,13 @@ public class FromSqlExpression : TableExpressionBase, IClonableTableExpressionBa
     {
     }
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
     private FromSqlExpression(
         string alias,
         ITableBase? tableBase,

--- a/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
@@ -24,7 +24,14 @@ public class InnerJoinExpression : PredicateJoinExpressionBase
     {
     }
 
-    private InnerJoinExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public InnerJoinExpression(
         TableExpressionBase table,
         SqlExpression joinPredicate,
         IEnumerable<IAnnotation>? annotations)

--- a/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
@@ -30,7 +30,14 @@ public class IntersectExpression : SetOperationBase
     {
     }
 
-    private IntersectExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public IntersectExpression(
         string alias,
         SelectExpression source1,
         SelectExpression source2,

--- a/src/EFCore.Relational/Query/SqlExpressions/JsonScalarExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/JsonScalarExpression.cs
@@ -30,7 +30,14 @@ public class JsonScalarExpression : SqlExpression
     {
     }
 
-    internal JsonScalarExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public JsonScalarExpression(
         ColumnExpression jsonColumn,
         IReadOnlyList<PathSegment> path,
         Type type,

--- a/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
@@ -24,7 +24,14 @@ public class LeftJoinExpression : PredicateJoinExpressionBase
     {
     }
 
-    private LeftJoinExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public LeftJoinExpression(
         TableExpressionBase table,
         SqlExpression joinPredicate,
         IEnumerable<IAnnotation>? annotations)

--- a/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
@@ -23,7 +23,14 @@ public class OuterApplyExpression : JoinExpressionBase
     {
     }
 
-    private OuterApplyExpression(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public OuterApplyExpression(TableExpressionBase table, IEnumerable<IAnnotation>? annotations)
         : base(table, annotations)
     {
     }

--- a/src/EFCore.Relational/Query/SqlExpressions/ProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ProjectionExpression.cs
@@ -14,7 +14,14 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// </remarks>
 public sealed class ProjectionExpression : Expression, IPrintableExpression
 {
-    internal ProjectionExpression(SqlExpression expression, string alias)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public ProjectionExpression(SqlExpression expression, string alias)
     {
         Expression = expression;
         Alias = alias;

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -512,9 +512,8 @@ public sealed partial class SelectExpression : TableExpressionBase
         SqlExpression? having,
         IReadOnlyList<OrderingExpression> orderings,
         bool isDistinct,
-        IReadOnlyList<ProjectionExpression> projection)
-        // TODO
-        // ISet<string> tags,
+        IReadOnlyList<ProjectionExpression> projection,
+        ISet<string> tags)
         // SortedDictionary<string, IAnnotation> annotations)
     {
         _tables.AddRange(tables);
@@ -526,7 +525,7 @@ public sealed partial class SelectExpression : TableExpressionBase
         _orderings.AddRange(orderings);
         IsDistinct = isDistinct;
         _projection.AddRange(projection);
-        // Tags = tags;
+        Tags = tags;
         // _annotations = annotations;
 
         _mutable = false;

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -181,7 +181,14 @@ public class SqlFunctionExpression : SqlExpression
     {
     }
 
-    private SqlFunctionExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public SqlFunctionExpression(
         SqlExpression? instance,
         string? schema,
         string name,

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
@@ -17,7 +17,14 @@ public sealed class SqlParameterExpression : SqlExpression
     private readonly ParameterExpression _parameterExpression;
     private readonly string _name;
 
-    internal SqlParameterExpression(ParameterExpression parameterExpression, RelationalTypeMapping? typeMapping)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public SqlParameterExpression(ParameterExpression parameterExpression, RelationalTypeMapping? typeMapping)
         : base(parameterExpression.Type.UnwrapNullableType(), typeMapping)
     {
         Check.DebugAssert(parameterExpression.Name != null, "Parameter must have name.");
@@ -53,6 +60,7 @@ public sealed class SqlParameterExpression : SqlExpression
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
         => expressionPrinter.Append("@" + _parameterExpression.Name);
+
 
     /// <inheritdoc />
     public override bool Equals(object? obj)

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
@@ -28,6 +28,27 @@ public sealed class TableExpression : TableExpressionBase, IClonableTableExpress
         Table = table;
     }
 
+    // Constructor to be used solely for instantiation of the expression from AOT-generated code.
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public TableExpression(
+        string alias,
+        string name,
+        string? schema,
+        ITableBase table)
+        : base(alias, annotations: null) // TODO: Annotations
+    {
+        Name = table.Name;
+        Schema = table.Schema;
+        Table = table;
+    }
+
     /// <summary>
     ///     The alias assigned to this table source.
     /// </summary>

--- a/src/EFCore.Relational/Query/SqlExpressions/TableValuedFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableValuedFunctionExpression.cs
@@ -30,7 +30,14 @@ public class TableValuedFunctionExpression : TableExpressionBase, ITableBasedExp
     {
     }
 
-    private TableValuedFunctionExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public TableValuedFunctionExpression(
         string alias,
         IStoreFunction storeFunction,
         IReadOnlyList<SqlExpression> arguments,

--- a/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
@@ -30,7 +30,14 @@ public class UnionExpression : SetOperationBase
     {
     }
 
-    private UnionExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public UnionExpression(
         string alias,
         SelectExpression source1,
         SelectExpression source2,

--- a/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UpdateExpression.cs
@@ -28,7 +28,14 @@ public sealed class UpdateExpression : Expression, IPrintableExpression
     {
     }
 
-    private UpdateExpression(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public UpdateExpression(
         TableExpression table,
         SelectExpression selectExpression,
         IReadOnlyList<ColumnValueSetter> columnValueSetters,

--- a/src/EFCore.Relational/Storage/ReaderColumn`.cs
+++ b/src/EFCore.Relational/Storage/ReaderColumn`.cs
@@ -24,15 +24,15 @@ public class ReaderColumn<T> : ReaderColumn
     /// <param name="nullable">A value indicating if the column is nullable.</param>
     /// <param name="name">The name of the column.</param>
     /// <param name="property">The property being read if any, null otherwise.</param>
-    /// <param name="getFieldValue">A function to get field value for the column from the reader.</param>
+    /// <param name="getFieldValueExpression">A lambda expression to get field value for the column from the reader.</param>
     public ReaderColumn(
         bool nullable,
         string? name,
         IPropertyBase? property,
-        Func<DbDataReader, int[], T> getFieldValue)
-        : base(typeof(T), nullable, name, property)
+        Expression<Func<DbDataReader, int[], T>> getFieldValueExpression)
+        : base(typeof(T), nullable, name, property, getFieldValueExpression)
     {
-        GetFieldValue = getFieldValue;
+        GetFieldValue = getFieldValueExpression.Compile();
     }
 
     /// <summary>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -30,16 +30,18 @@ public class SqlServerCompiledQueryCacheKeyGenerator : RelationalCompiledQueryCa
         _sqlServerConnection = sqlServerConnection;
     }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public override object GenerateCacheKey(Expression query, bool async)
-        => new SqlServerCompiledQueryCacheKey(
-            GenerateCacheKeyCore(query, async),
-            _sqlServerConnection.IsMultipleActiveResultSetsEnabled);
+    // /// <summary>
+    // ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    // ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    // ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    // ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    // /// </summary>
+    // public override object GenerateCacheKey(Expression query, bool async)
+    //     => new SqlServerCompiledQueryCacheKey(
+    //         GenerateCacheKeyCore(query, async),
+    //         _sqlServerConnection.IsMultipleActiveResultSetsEnabled);
+
+    // TODO: Need to override relational GenerateCacheKeyExpression
 
     private readonly struct SqlServerCompiledQueryCacheKey : IEquatable<SqlServerCompiledQueryCacheKey>
     {

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -103,6 +103,8 @@ public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<objec
     /// </summary>
     public virtual LambdaExpression EqualsExpression { get; }
 
+    public abstract LambdaExpression ObjectEqualsExpression { get; }
+
     /// <summary>
     ///     The hash code expression.
     /// </summary>

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -269,6 +269,29 @@ public class ValueComparer
         return v1Null || v2Null ? v1Null && v2Null : Equals((T?)left, (T?)right);
     }
 
+    public override LambdaExpression ObjectEqualsExpression
+    {
+        get
+        {
+            // TODO: Cache this
+            var left = Expression.Parameter(typeof(object), "left");
+            var right = Expression.Parameter(typeof(object), "right");
+
+            return Expression.Lambda<Func<object?, object?, bool>>(
+                Expression.Condition(
+                    Expression.Equal(left, Expression.Constant(null)),
+                    Expression.Equal(right, Expression.Constant(null)),
+                    Expression.AndAlso(
+                        Expression.NotEqual(right, Expression.Constant(null)),
+                        Expression.Invoke(
+                            EqualsExpression,
+                            Expression.Convert(left, typeof(T)),
+                            Expression.Convert(right, typeof(T))))),
+                left,
+                right);
+        }
+    }
+
     /// <summary>
     ///     Returns the hash code for the given instance.
     /// </summary>

--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -13,6 +13,7 @@ Microsoft.EntityFrameworkCore.DbSet
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -82,6 +82,7 @@ public class EntityFrameworkServicesBuilder
             { typeof(IMemoryCache), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IEvaluatableExpressionFilter), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(INavigationExpansionExtensibilityHelper), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+            { typeof(ILiftableConstantFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IExceptionDetector), new ServiceCharacteristics(ServiceLifetime.Singleton) },
             { typeof(IProviderConventionSetBuilder), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IConventionSetBuilder), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -122,6 +123,7 @@ public class EntityFrameworkServicesBuilder
             { typeof(IQueryTranslationPostprocessorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IShapedQueryCompilingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(IDbContextLogger), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+            { typeof(ILiftableConstantProcessor), new ServiceCharacteristics(ServiceLifetime.Scoped) },
             { typeof(ILazyLoader), new ServiceCharacteristics(ServiceLifetime.Transient) },
             { typeof(IParameterBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
             { typeof(ITypeMappingSourcePlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
@@ -301,6 +303,8 @@ public class EntityFrameworkServicesBuilder
         TryAdd<IQueryTranslationPostprocessorFactory, QueryTranslationPostprocessorFactory>();
         TryAdd<INavigationExpansionExtensibilityHelper, NavigationExpansionExtensibilityHelper>();
         TryAdd<IExceptionDetector, ExceptionDetector>();
+        TryAdd<ILiftableConstantFactory, LiftableConstantFactory>();
+        TryAdd<ILiftableConstantProcessor, LiftableConstantProcessor>();
 
         TryAdd(
             p => p.GetService<IDbContextOptions>()?.FindExtension<CoreOptionsExtension>()?.DbContextLogger
@@ -321,7 +325,6 @@ public class EntityFrameworkServicesBuilder
             .AddDependencySingleton<ModelCacheKeyFactoryDependencies>()
             .AddDependencySingleton<ValueConverterSelectorDependencies>()
             .AddDependencySingleton<EntityMaterializerSourceDependencies>()
-            .AddDependencySingleton<ShapedQueryCompilingExpressionVisitorDependencies>()
             .AddDependencySingleton<EvaluatableExpressionFilterDependencies>()
             .AddDependencySingleton<RuntimeModelDependencies>()
             .AddDependencySingleton<ModelRuntimeInitializerDependencies>()
@@ -335,6 +338,7 @@ public class EntityFrameworkServicesBuilder
             .AddDependencyScoped<QueryableMethodTranslatingExpressionVisitorDependencies>()
             .AddDependencyScoped<QueryTranslationPreprocessorDependencies>()
             .AddDependencyScoped<QueryTranslationPostprocessorDependencies>()
+            .AddDependencyScoped<ShapedQueryCompilingExpressionVisitorDependencies>()
             .AddDependencyScoped<ValueGeneratorSelectorDependencies>()
             .AddDependencyScoped<DatabaseDependencies>()
             .AddDependencyScoped<ModelDependencies>()

--- a/src/EFCore/Infrastructure/Internal/PrecompiledQueryFactoryRegistry.cs
+++ b/src/EFCore/Infrastructure/Internal/PrecompiledQueryFactoryRegistry.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public static class PrecompiledQueryFactoryRegistry
+{
+    public static bool ArePrecompiledQueriesEnabled { get; private set; }
+
+    public static void RegisterBootstrapper(Type contextType, Action<DbContext, ConcurrentDictionary<object, Func<DbContext, Delegate>>> bootstrapper)
+    {
+        var contextTypeEntry = Registry.GetOrAdd(contextType, _ => new());
+
+        lock (contextTypeEntry.Bootstrappers)
+        {
+            contextTypeEntry.Bootstrappers.Add(bootstrapper);
+        }
+
+        ArePrecompiledQueriesEnabled = true;
+    }
+
+    private static readonly ConcurrentDictionary<Type, ContextTypeEntry> Registry = new();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool TryGetPrecompiledQueryFactory(
+        DbContext context,
+        object queryCacheKey,
+        [NotNullWhen(true)] out Func<DbContext, Delegate>? precompiledQueryFactory)
+    {
+        if (Registry.TryGetValue(context.GetType(), out var contextTypeEntry))
+        {
+            if (contextTypeEntry.Factories.TryGetValue(queryCacheKey, out precompiledQueryFactory))
+            {
+                return true;
+            }
+
+            // We haven't found a factory for the given cache key. Check if there are any un-applied boostrappers and apply them
+            // (startup flow)
+            if (contextTypeEntry.Bootstrappers.Count > 0)
+            {
+                lock (contextTypeEntry.Bootstrappers)
+                {
+                    foreach (var bootstrapper in contextTypeEntry.Bootstrappers)
+                    {
+                        bootstrapper(context, contextTypeEntry.Factories);
+                    }
+
+                    contextTypeEntry.Bootstrappers.Clear();
+                }
+
+                // And retry looking up the factory after bootstrapping
+                if (contextTypeEntry.Factories.TryGetValue(queryCacheKey, out precompiledQueryFactory))
+                {
+                    return true;
+                }
+            }
+        }
+
+
+        precompiledQueryFactory = null;
+        return false;
+    }
+
+    private readonly struct ContextTypeEntry
+    {
+        public ContextTypeEntry()
+        {
+        }
+
+        public List<Action<DbContext, ConcurrentDictionary<object, Func<DbContext, Delegate>>>> Bootstrappers { get; } = new();
+
+        /// <summary>
+        ///     Maps query cache keys to a factory method that can create a query executor given a context instance.
+        /// </summary>
+        public ConcurrentDictionary<object, Func<DbContext, Delegate>> Factories { get; } = new();
+    }
+}

--- a/src/EFCore/Query/CompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore/Query/CompiledQueryCacheKeyGenerator.cs
@@ -24,6 +24,15 @@ public class CompiledQueryCacheKeyGenerator : ICompiledQueryCacheKeyGenerator
     public virtual object GenerateCacheKey(Expression query, bool async)
         => GenerateCacheKeyCore(query, async);
 
+    /// <inheritdoc />
+    public virtual Expression GenerateCacheKeyExpression(Expression query, Expression model, bool async)
+        => Expression.New(
+            typeof(CompiledQueryCacheKey).GetConstructor(new[] { typeof(Expression), typeof(IModel), typeof(QueryTrackingBehavior), typeof(bool) })!,
+            query,
+            model,
+            Expression.Constant(Dependencies.CurrentContext.Context.ChangeTracker.QueryTrackingBehavior),
+            Expression.Constant(async));
+
     /// <summary>
     ///     Generates the cache key for the given query.
     /// </summary>
@@ -36,63 +45,64 @@ public class CompiledQueryCacheKeyGenerator : ICompiledQueryCacheKeyGenerator
             Dependencies.Model,
             Dependencies.CurrentContext.Context.ChangeTracker.QueryTrackingBehavior,
             async);
+}
+
+/// <summary>
+///     <para>
+///         A key that uniquely identifies a query. This is used to store and lookup
+///         compiled versions of a query in a cache.
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+public readonly struct CompiledQueryCacheKey : IEquatable<CompiledQueryCacheKey>
+{
+    private readonly Expression _query;
+    private readonly IModel _model;
+    private readonly QueryTrackingBehavior _queryTrackingBehavior;
+    private readonly bool _async;
 
     /// <summary>
-    ///     <para>
-    ///         A key that uniquely identifies a query. This is used to store and lookup
-    ///         compiled versions of a query in a cache.
-    ///     </para>
-    ///     <para>
-    ///         This type is typically used by database providers (and other extensions). It is generally
-    ///         not used in application code.
-    ///     </para>
+    ///     Initializes a new instance of the <see cref="CompiledQueryCacheKey" /> class.
     /// </summary>
-    protected readonly struct CompiledQueryCacheKey : IEquatable<CompiledQueryCacheKey>
+    /// <param name="query">The query to generate the key for.</param>
+    /// <param name="model">The model that queries is written against.</param>
+    /// <param name="queryTrackingBehavior">The tracking behavior for results of the query.</param>
+    /// <param name="async">A value indicating whether the query will be executed asynchronously.</param>
+    public CompiledQueryCacheKey(
+        Expression query,
+        IModel model,
+        QueryTrackingBehavior queryTrackingBehavior,
+        bool async)
     {
-        private readonly Expression _query;
-        private readonly IModel _model;
-        private readonly QueryTrackingBehavior _queryTrackingBehavior;
-        private readonly bool _async;
+        _query = query;
+        _model = model;
+        _queryTrackingBehavior = queryTrackingBehavior;
+        _async = async;
+    }
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="CompiledQueryCacheKey" /> class.
-        /// </summary>
-        /// <param name="query">The query to generate the key for.</param>
-        /// <param name="model">The model that queries is written against.</param>
-        /// <param name="queryTrackingBehavior">The tracking behavior for results of the query.</param>
-        /// <param name="async">A value indicating whether the query will be executed asynchronously.</param>
-        public CompiledQueryCacheKey(
-            Expression query,
-            IModel model,
-            QueryTrackingBehavior queryTrackingBehavior,
-            bool async)
-        {
-            _query = query;
-            _model = model;
-            _queryTrackingBehavior = queryTrackingBehavior;
-            _async = async;
-        }
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is CompiledQueryCacheKey other && Equals(other);
 
-        /// <inheritdoc />
-        public override bool Equals(object? obj)
-            => obj is CompiledQueryCacheKey other && Equals(other);
+    /// <inheritdoc />
+    public bool Equals(CompiledQueryCacheKey other)
+        => ReferenceEquals(_model, other._model)
+            && _queryTrackingBehavior == other._queryTrackingBehavior
+            && _async == other._async
+            && ExpressionEqualityComparer.Instance.Equals(_query, other._query);
 
-        /// <inheritdoc />
-        public bool Equals(CompiledQueryCacheKey other)
-            => ReferenceEquals(_model, other._model)
-                && _queryTrackingBehavior == other._queryTrackingBehavior
-                && _async == other._async
-                && ExpressionEqualityComparer.Instance.Equals(_query, other._query);
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            hash.Add(_query, ExpressionEqualityComparer.Instance);
-            hash.Add(_model);
-            hash.Add(_queryTrackingBehavior);
-            hash.Add(_async);
-            return hash.ToHashCode();
-        }
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(_query, ExpressionEqualityComparer.Instance);
+        hash.Add(_model);
+        hash.Add(_queryTrackingBehavior);
+        hash.Add(_async);
+        return hash.ToHashCode();
     }
 }
+

--- a/src/EFCore/Query/EntityShaperExpression.cs
+++ b/src/EFCore/Query/EntityShaperExpression.cs
@@ -185,7 +185,7 @@ public class EntityShaperExpression : Expression, IPrintableExpression
     public virtual bool IsNullable { get; }
 
     /// <summary>
-    ///     The materilization condition to use for shaping this entity.
+    ///     The materialization condition to use for shaping this entity.
     /// </summary>
     public virtual LambdaExpression MaterializationCondition { get; }
 

--- a/src/EFCore/Query/ICompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore/Query/ICompiledQueryCacheKeyGenerator.cs
@@ -32,4 +32,8 @@ public interface ICompiledQueryCacheKeyGenerator
     /// <param name="async"><see langword="true" /> if the query will be executed asynchronously.</param>
     /// <returns>An object representing a query cache key.</returns>
     object GenerateCacheKey(Expression query, bool async);
+
+#pragma warning disable CS1591
+    Expression GenerateCacheKeyExpression(Expression query, Expression model, bool async);
+#pragma warning restore CS1591
 }

--- a/src/EFCore/Query/ILiftableConstantFactory.cs
+++ b/src/EFCore/Query/ILiftableConstantFactory.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public interface ILiftableConstantFactory
+{
+    LiftableConstantExpression CreateLiftableConstant(
+        Expression<Func<MaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type);
+}

--- a/src/EFCore/Query/ILiftableConstantProcessor.cs
+++ b/src/EFCore/Query/ILiftableConstantProcessor.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public interface ILiftableConstantProcessor
+{
+    /// <summary>
+    ///     Exposes all constants that have been lifted during the last invocation of <see cref="LiftedConstants" />.
+    /// </summary>
+    IReadOnlyList<(ParameterExpression Parameter, Expression Expression)> LiftedConstants { get; }
+
+    /// <summary>
+    ///     Inlines all liftable constants as simple <see cref="ConstantExpression" /> nodes in the tree, containing the result of
+    ///     evaluating the liftable constants' resolvers.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ConstantExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     Liftable constant inlining is performed in the regular, non-precompiled query pipeline flow.
+    /// </remarks>
+    Expression InlineConstants(Expression expression);
+
+    /// <summary>
+    ///     Lifts all <see cref="LiftableConstantExpression" /> nodes, embedding <see cref="ParameterExpression" /> in their place and
+    ///     exposing the parameter and resolver via <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <param name="contextParameter">
+    ///     The <see cref="ParameterExpression" /> to be embedded in the liftable constant nodes' resolvers, instead of their lambda
+    ///     parameter.
+    /// </param>
+    /// <param name="variableNames">
+    ///     A set of variables already in use, for uniquification. Any generates variables will be added to this set.
+    /// </param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ParameterExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     Constant lifting is performed in the precompiled query pipeline flow.
+    /// </remarks>
+    Expression LiftConstants(Expression expression, ParameterExpression contextParameter, HashSet<string> variableNames);
+}

--- a/src/EFCore/Query/Internal/EntityQueryProvider.cs
+++ b/src/EFCore/Query/Internal/EntityQueryProvider.cs
@@ -30,7 +30,7 @@ public class EntityQueryProvider : IAsyncQueryProvider
         _queryCompiler = queryCompiler;
         _genericExecuteMethod = queryCompiler.GetType()
             .GetRuntimeMethods()
-            .Single(m => (m.Name == "Execute") && m.IsGenericMethod);
+            .Single(m => m is { Name: "Execute", IsGenericMethod: true });
     }
 
     /// <summary>

--- a/src/EFCore/Query/Internal/ICompiledQueryCache.cs
+++ b/src/EFCore/Query/Internal/ICompiledQueryCache.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.EntityFrameworkCore.Query.Internal;
 
 /// <summary>
@@ -16,6 +18,22 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 /// </remarks>
 public interface ICompiledQueryCache
 {
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    bool TryGetQuery<TResult>(object cacheKey, [NotNullWhen(true)] out Func<QueryContext, TResult>? compiledQuery);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    void AddQuery<TResult>(object cacheKey, Func<QueryContext, TResult> compiledQuery);
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore/Query/Internal/IQueryCompiler.cs
+++ b/src/EFCore/Query/Internal/IQueryCompiler.cs
@@ -48,4 +48,20 @@ public interface IQueryCompiler
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     Func<QueryContext, TResult> CreateCompiledAsyncQuery<TResult>(Expression query);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    (Expression, Expression<Func<QueryContext, TResult>>) CompileQueryToExpression<TResult>(Expression query, bool async);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    void CachePrecompiledQuery<TResult>(Expression query, Func<QueryContext, TResult> queryExecutor);
 }

--- a/src/EFCore/Query/LiftableConstantExpression.cs
+++ b/src/EFCore/Query/LiftableConstantExpression.cs
@@ -24,7 +24,7 @@ public class LiftableConstantExpression : Expression
         Type type)
     {
         ResolverExpression = resolverExpression;
-        VariableName = variableName;
+        VariableName = char.ToLower(variableName[0]) + variableName[1..];
         Type = type;
     }
 

--- a/src/EFCore/Query/LiftableConstantExpression.cs
+++ b/src/EFCore/Query/LiftableConstantExpression.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+/// <summary>
+///     A node containing an expression expressing how to obtain a constant value, which may get lifted out of an expression tree.
+/// </summary>
+/// <remarks>
+///     <para>
+///         When the expression tree is compiled, the constant value can simply be evaluated beforehand, and a
+///         <see cref="ConstantExpression" /> expression can directly reference the result.
+///     </para>
+///     <para>
+///         When the expression tree is translated to source code instead (in query pre-compilation), the expression can be rendered out
+///         separately, to be assigned to a variable, and this node is replaced by a reference to that variable.
+///     </para>
+/// </remarks>
+public class LiftableConstantExpression : Expression
+{
+    public LiftableConstantExpression(
+        LambdaExpression resolverExpression,
+        string variableName,
+        Type type)
+    {
+        ResolverExpression = resolverExpression;
+        VariableName = variableName;
+        Type = type;
+    }
+
+    public LambdaExpression ResolverExpression { get; }
+
+    public string VariableName { get; }
+
+    public override Type Type { get; }
+
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
+
+    // TODO: Complete other expression stuff (equality, etc.)
+}

--- a/src/EFCore/Query/LiftableConstantFactory.cs
+++ b/src/EFCore/Query/LiftableConstantFactory.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class LiftableConstantFactory : ILiftableConstantFactory
+{
+    public virtual LiftableConstantExpression CreateLiftableConstant(
+        Expression<Func<MaterializerLiftableConstantContext, object>> resolverExpression,
+        string variableName,
+        Type type)
+        => new(resolverExpression, variableName, type);
+}

--- a/src/EFCore/Query/LiftableConstantProcessor.cs
+++ b/src/EFCore/Query/LiftableConstantProcessor.cs
@@ -1,0 +1,444 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+#pragma warning disable CS1591
+
+public class LiftableConstantProcessor : ExpressionVisitor, ILiftableConstantProcessor
+{
+    private bool _inline;
+    private MaterializerLiftableConstantContext _materializerLiftableConstantContext;
+
+    /// <summary>
+    ///     Exposes all constants that have been lifted during the last invocation of <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual IReadOnlyList<(ParameterExpression Parameter, Expression Expression)> LiftedConstants { get; private set; }
+        = Array.Empty<(ParameterExpression Parameter, Expression Expression)>();
+
+    private record LiftedConstant(ParameterExpression Parameter, Expression Expression, ParameterExpression? ReplacingParameter = null);
+
+    private readonly List<LiftedConstant> _liftedConstants = new();
+    private readonly LiftedExpressionProcessor _liftedExpressionProcessor = new();
+    private readonly LiftedConstantOptimizer _liftedConstantOptimizer = new();
+
+    private ParameterExpression? _contextParameter;
+
+    public LiftableConstantProcessor(ShapedQueryCompilingExpressionVisitorDependencies dependencies)
+    {
+        _materializerLiftableConstantContext = new(dependencies);
+
+        _liftedConstants.Clear();
+    }
+
+    /// <summary>
+    ///     Inlines all liftable constants as simple <see cref="ConstantExpression" /> nodes in the tree, containing the result of
+    ///     evaluating the liftable constants' resolvers.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ConstantExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    /// <remarks>
+    ///     <para>
+    ///         Liftable constant inlining is performed in the regular, non-precompiled query pipeline flow.
+    ///     </para>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    /// </remarks>
+    public virtual Expression InlineConstants(Expression expression)
+    {
+        _liftedConstants.Clear();
+        _inline = true;
+
+        return Visit(expression);
+    }
+
+    /// <summary>
+    ///     Lifts all <see cref="LiftableConstantExpression" /> nodes, embedding <see cref="ParameterExpression" /> in their place and
+    ///     exposing the parameter and resolver via <see cref="LiftedConstants" />.
+    /// </summary>
+    /// <param name="expression">An expression containing <see cref="LiftableConstantExpression" /> nodes.</param>
+    /// <param name="contextParameter">
+    ///     The <see cref="ParameterExpression" /> to be embedded in the lifted constant nodes' resolvers, instead of their lambda
+    ///     parameter.
+    /// </param>
+    /// <param name="variableNames">
+    ///     A set of variables already in use, for uniquification. Any generates variables will be added to this set.
+    /// </param>
+    /// <returns>
+    ///     An expression tree containing <see cref="ParameterExpression" /> nodes instead of <see cref="LiftableConstantExpression" /> nodes.
+    /// </returns>
+    public virtual Expression LiftConstants(Expression expression, ParameterExpression contextParameter, HashSet<string> variableNames)
+    {
+        _liftedConstants.Clear();
+
+        _inline = false;
+        _contextParameter = contextParameter;
+
+        var expressionAfterLifting = Visit(expression);
+
+        // All liftable constant nodes have been lifted out.
+        // We'll now optimize them, looking for greatest common denominator tree fragments, in cases where e.g. two lifted constants look up
+        // the same entity type.
+        _liftedConstantOptimizer.Optimize(_liftedConstants);
+
+        // Uniquify all variable names, taking into account possible remapping done in the optimization phase above
+        var (originalParameters, newParameters) = (new List<Expression>(), new List<Expression>());
+        for (var i = 0; i < _liftedConstants.Count; i++)
+        {
+            var liftedConstant = _liftedConstants[i];
+
+            if (liftedConstant.ReplacingParameter is not null)
+            {
+                // This lifted constant is being removed, since it's a duplicate of another with the same expression.
+                // We still need to remap the parameter in the expression, but no uniquification etc.
+                originalParameters.Add(liftedConstant.Parameter);
+                newParameters.Add(liftedConstant.ReplacingParameter);
+                _liftedConstants.RemoveAt(i--);
+                continue;
+            }
+
+            var name = liftedConstant.Parameter.Name ?? "unknown";
+            var baseName = name;
+            for (var j = 0; variableNames.Contains(name); j++)
+            {
+                name = baseName + j;
+            }
+
+            variableNames.Add(name);
+
+            if (name != liftedConstant.Parameter.Name)
+            {
+                var newParameter = Expression.Parameter(liftedConstant.Parameter.Type, name);
+                _liftedConstants[i] = liftedConstant with { Parameter = newParameter };
+                originalParameters.Add(liftedConstant.Parameter);
+                newParameters.Add(newParameter);
+            }
+        }
+
+        // Finally, apply all remapping (optimization, uniquification) to both the expression tree and to the lifted constant variable
+        // themselves.
+        var (originalParametersArray, newParametersArray) = (originalParameters.ToArray(), newParameters.ToArray());
+        var remappedExpression = ReplacingExpressionVisitor.Replace(originalParametersArray, newParametersArray, expressionAfterLifting);
+        for (var i = 0; i < _liftedConstants.Count; i++)
+        {
+            var liftedConstant = _liftedConstants[i];
+            var remappedLiftedConstantExpression =
+                ReplacingExpressionVisitor.Replace(originalParametersArray, newParametersArray, liftedConstant.Expression);
+
+            if (remappedLiftedConstantExpression != liftedConstant.Expression)
+            {
+                _liftedConstants[i] = liftedConstant with { Expression = remappedLiftedConstantExpression };
+            }
+        }
+
+        LiftedConstants = _liftedConstants.Select(c => (c.Parameter, c.Expression)).ToArray();
+        return remappedExpression;
+    }
+
+    protected override Expression VisitExtension(Expression node)
+    {
+        if (node is LiftableConstantExpression liftedConstant)
+        {
+            return _inline
+                ? InlineConstant(liftedConstant)
+                : LiftConstant(liftedConstant);
+        }
+
+        return base.VisitExtension(node);
+    }
+
+    protected virtual ConstantExpression InlineConstant(LiftableConstantExpression liftableConstant)
+    {
+        if (liftableConstant.ResolverExpression is Expression<Func<MaterializerLiftableConstantContext, object>>
+            resolverExpression)
+        {
+            var resolver = resolverExpression.Compile(preferInterpretation: true);
+            var value = resolver(_materializerLiftableConstantContext);
+            return Expression.Constant(value, liftableConstant.Type);
+        }
+
+        throw new InvalidOperationException(
+            $"Unknown resolved expression of type {liftableConstant.ResolverExpression.GetType().Name} found on liftable constant expression");
+    }
+
+    protected virtual ParameterExpression LiftConstant(LiftableConstantExpression liftableConstant)
+    {
+        var resolverLambda = liftableConstant.ResolverExpression;
+        var parameter = resolverLambda.Parameters[0];
+
+        // Extract the lambda body, replacing the lambda parameter with our lifted constant context parameter, and also inline any captured
+        // literals
+        var body = _liftedExpressionProcessor.Process(resolverLambda.Body, parameter, _contextParameter!);
+
+        // If the lambda returns a value type, a Convert to object node gets needed that we need to unwrap
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } convertNode
+            && convertNode.Type == typeof(object))
+        {
+            body = convertNode.Operand;
+        }
+
+        // Register the lifted constant; note that the name will be uniquified later
+        var variableParameter = Expression.Parameter(liftableConstant.Type, liftableConstant.VariableName);
+        _liftedConstants.Add(new(variableParameter, body));
+
+        return variableParameter;
+    }
+
+    private class LiftedConstantOptimizer : ExpressionVisitor
+    {
+        private List<LiftedConstant> _liftedConstants = null!;
+
+        private record ExpressionInfo(ExpressionStatus Status, ParameterExpression? Parameter = null, string? PreferredName = null);
+        private readonly Dictionary<Expression, ExpressionInfo> _indexedExpressions = new(ExpressionEqualityComparer.Instance);
+        private LiftedConstant _currentLiftedConstant = null!;
+        private bool _firstPass;
+        private int _index;
+
+        public void Optimize(List<LiftedConstant> liftedConstants)
+        {
+            _liftedConstants = liftedConstants;
+            _indexedExpressions.Clear();
+
+            _firstPass = true;
+
+            // Phase 1: recursively seek out tree fragments which appear more than once across the lifted constants. These will be extracted
+            // out to separate variables.
+            foreach (var liftedConstant in liftedConstants)
+            {
+                _currentLiftedConstant = liftedConstant;
+                Visit(liftedConstant.Expression);
+            }
+
+            // Filter out fragments which don't appear at least once
+            foreach (var (expression, expressionInfo) in _indexedExpressions)
+            {
+                if (expressionInfo.Status == ExpressionStatus.SeenOnce)
+                {
+                    _indexedExpressions.Remove(expression);
+                    continue;
+                }
+
+                Check.DebugAssert(expressionInfo.Status == ExpressionStatus.SeenMultipleTimes,
+                    "expressionInfo.Status == ExpressionStatus.SeenMultipleTimes");
+            }
+
+            // Second pass: extract common denominator tree fragments to separate variables
+            _firstPass = false;
+            for (_index = 0; _index < liftedConstants.Count; _index++)
+            {
+                _currentLiftedConstant = _liftedConstants[_index];
+                if (_indexedExpressions.TryGetValue(_currentLiftedConstant.Expression, out var expressionInfo)
+                    && expressionInfo.Status == ExpressionStatus.Extracted)
+                {
+                    // This entire lifted constant has already been extracted before, so we no longer need it as a separate variable.
+                    _liftedConstants[_index] = _currentLiftedConstant with { ReplacingParameter = expressionInfo.Parameter };
+
+                    continue;
+                }
+
+                var optimizedExpression = Visit(_currentLiftedConstant.Expression);
+                if (optimizedExpression != _currentLiftedConstant.Expression)
+                {
+                    _liftedConstants[_index] = _currentLiftedConstant with { Expression = optimizedExpression };
+                }
+            }
+        }
+
+        [return: NotNullIfNotNull(nameof(node))]
+        public override Expression? Visit(Expression? node)
+        {
+            if (node is null)
+            {
+                return null;
+            }
+
+            if (node is ParameterExpression or ConstantExpression)
+            {
+                return node;
+            }
+
+            if (_firstPass)
+            {
+                var preferredName = ReferenceEquals(node, _currentLiftedConstant.Expression)
+                    ? _currentLiftedConstant.Parameter.Name
+                    : null;
+
+                if (!_indexedExpressions.TryGetValue(node, out var expressionInfo))
+                {
+                    // Unseen expression, add it to the dictionary with a null value, to indicate it's only a candidate at this point.
+                    _indexedExpressions[node] = new(ExpressionStatus.SeenOnce, PreferredName: preferredName);
+                    return base.Visit(node);
+                }
+
+                // We've already seen this expression.
+                if (expressionInfo.Status == ExpressionStatus.SeenOnce
+                    || expressionInfo.PreferredName is null && preferredName is not null)
+                {
+                    // This is the 2nd time we're seeing the expression - mark it as a common denominator
+                    _indexedExpressions[node] = _indexedExpressions[node] with
+                    {
+                        Status = ExpressionStatus.SeenMultipleTimes,
+                        PreferredName = preferredName
+                    };
+                }
+
+                // We've already seen and indexed this expression, no need to do it again
+                return node;
+            }
+            else
+            {
+                // 2nd pass
+                if (_indexedExpressions.TryGetValue(node, out var expressionInfo) && expressionInfo.Status != ExpressionStatus.SeenOnce)
+                {
+                    // This fragment is common across multiple lifted constants.
+                    if (expressionInfo.Status == ExpressionStatus.SeenMultipleTimes)
+                    {
+                        // This fragment hasn't yet been extracted out to its own variable in the 2nd pass.
+
+                        // If this happens to be a top-level node in the lifted constant, no need to extract an additional variable - just
+                        // use that as the "extracted" parameter further down.
+                        if (ReferenceEquals(node, _currentLiftedConstant.Expression))
+                        {
+                            _indexedExpressions[node] = new(ExpressionStatus.Extracted, _currentLiftedConstant.Parameter);
+                            return base.Visit(node);
+                        }
+
+                        // Otherwise, we need to extract a new variable, integrating it just before this one.
+                        var parameter = Expression.Parameter(node.Type, node switch
+                        {
+                            _ when expressionInfo.PreferredName is not null => expressionInfo.PreferredName,
+                            MemberExpression me => char.ToLowerInvariant(me.Member.Name[0]) + me.Member.Name[1..],
+                            MethodCallExpression mce => char.ToLowerInvariant(mce.Method.Name[0]) + mce.Method.Name[1..],
+                            _ => "unknown"
+                        });
+
+                        var visitedNode = base.Visit(node);
+                        _liftedConstants.Insert(_index++, new(parameter, visitedNode));
+
+                        // Mark this node as having been extracted, to prevent it from getting extracted again
+                        expressionInfo = _indexedExpressions[node] = new(ExpressionStatus.Extracted, parameter);
+                    }
+
+                    Check.DebugAssert(expressionInfo.Parameter is not null, "expressionInfo.Parameter is not null");
+
+                    return expressionInfo.Parameter;
+                }
+
+                // This specific fragment only appears once across the lifted constants; keep going down.
+                return base.Visit(node);
+            }
+        }
+
+        private enum ExpressionStatus
+        {
+            SeenOnce,
+            SeenMultipleTimes,
+            Extracted
+        }
+    }
+
+    private class LiftedExpressionProcessor : ExpressionVisitor
+    {
+        private ParameterExpression _originalParameter = null!;
+        private ParameterExpression _replacingParameter = null!;
+
+        public Expression Process(Expression expression, ParameterExpression originalParameter, ParameterExpression replacingParameter)
+        {
+            _originalParameter = originalParameter;
+            _replacingParameter = replacingParameter;
+
+            return Visit(expression);
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            // The expression to be lifted may contain a captured variable; for limited literal scenarios, inline that variable into the
+            // expression so we can render it out to C#.
+
+            // TODO: For the general case, this needs to be a full blown "evaluatable" identifier (like ParameterExtractingEV), which can
+            // identify any fragments of the tree which don't depend on the lambda parameter, and evaluate them.
+            // But for now we're doing a reduced version.
+
+            var visited = base.VisitMember(node);
+
+            if (visited is MemberExpression
+                {
+                    Expression: ConstantExpression { Value: var constant },
+                    Member: var member
+                })
+            {
+                return member switch
+                {
+                    FieldInfo fi => Expression.Constant(fi.GetValue(constant), node.Type),
+                    PropertyInfo pi => Expression.Constant(pi.GetValue(constant), node.Type),
+                    _ => visited
+                };
+            }
+
+            return visited;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+            => ReferenceEquals(node, _originalParameter)
+                ? _replacingParameter
+                : base.VisitParameter(node);
+    }
+
+#if DEBUG
+    protected override Expression VisitConstant(ConstantExpression node)
+    {
+        return IsLiteral(node.Value)
+            ? node
+            : throw new InvalidOperationException(
+                $"Materializer expression contains a non-literal constant of type '{node.Value!.GetType().Name}'. " +
+                $"Use a {nameof(LiftableConstantExpression)} to reference any constants.");
+
+        static bool IsLiteral(object? value)
+        {
+            return value switch
+            {
+                int or long or uint or ulong or short or sbyte or ushort or byte or double or float or decimal
+                    => true,
+
+                string or bool or Type or Enum or null => true,
+
+                ITuple tuple
+                    when tuple.GetType() is { IsGenericType: true } tupleType
+                         && tupleType.Name.StartsWith("ValueTuple`", StringComparison.Ordinal)
+                         && tupleType.Namespace == "System"
+                    => IsTupleLiteral(tuple),
+
+                _ => false
+            };
+
+            bool IsTupleLiteral(ITuple tuple)
+            {
+                for (var i = 0; i < tuple.Length; i++)
+                {
+                    if (!IsLiteral(tuple[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+#endif
+}

--- a/src/EFCore/Query/MaterializerLiftableConstantContext.cs
+++ b/src/EFCore/Query/MaterializerLiftableConstantContext.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public record MaterializerLiftableConstantContext(ShapedQueryCompilingExpressionVisitorDependencies Dependencies);

--- a/src/EFCore/Query/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/QueryCompilationContextDependencies.cs
@@ -53,6 +53,8 @@ public sealed record QueryCompilationContextDependencies
         IQueryableMethodTranslatingExpressionVisitorFactory queryableMethodTranslatingExpressionVisitorFactory,
         IQueryTranslationPostprocessorFactory queryTranslationPostprocessorFactory,
         IShapedQueryCompilingExpressionVisitorFactory shapedQueryCompilingExpressionVisitorFactory,
+        // ShapedQueryCompilingExpressionVisitorDependencies shapedQueryCompilingExpressionVisitorDependencies,
+        ILiftableConstantProcessor liftableConstantProcessor,
         IExecutionStrategy executionStrategy,
         ICurrentDbContext currentContext,
         IDbContextOptions contextOptions,
@@ -65,6 +67,9 @@ public sealed record QueryCompilationContextDependencies
         QueryableMethodTranslatingExpressionVisitorFactory = queryableMethodTranslatingExpressionVisitorFactory;
         QueryTranslationPostprocessorFactory = queryTranslationPostprocessorFactory;
         ShapedQueryCompilingExpressionVisitorFactory = shapedQueryCompilingExpressionVisitorFactory;
+        // ShapedQueryCompilingExpressionVisitorDependencies = shapedQueryCompilingExpressionVisitorDependencies;
+        LiftableConstantProcessor = liftableConstantProcessor;
+        ShapedQueryCompilingExpressionVisitorDependencies = null!;
         IsRetryingExecutionStrategy = executionStrategy.RetriesOnFailure;
         ContextOptions = contextOptions;
         Logger = logger;
@@ -113,6 +118,16 @@ public sealed record QueryCompilationContextDependencies
     ///     The shaped-query compiling expression visitor factory.
     /// </summary>
     public IShapedQueryCompilingExpressionVisitorFactory ShapedQueryCompilingExpressionVisitorFactory { get; init; }
+
+    /// <summary>
+    ///     The shaped query compiling expression visitor dependencies.
+    /// </summary>
+    public ShapedQueryCompilingExpressionVisitorDependencies ShapedQueryCompilingExpressionVisitorDependencies { get; init; }
+
+    /// <summary>
+    ///     The liftable constant processor.
+    /// </summary>
+    public ILiftableConstantProcessor LiftableConstantProcessor { get; init; }
 
     /// <summary>
     ///     Whether the configured execution strategy can retry.

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -58,10 +58,7 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
     [return: NotNullIfNotNull("expression")]
     public override Expression? Visit(Expression? expression)
     {
-        if (expression == null
-            || expression is ShapedQueryExpression
-            || expression is EntityShaperExpression
-            || expression is GroupByShaperExpression)
+        if (expression is null or ShapedQueryExpression or EntityShaperExpression or GroupByShaperExpression)
         {
             return expression;
         }

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -34,6 +34,16 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
         => new ReplacingExpressionVisitor(new[] { original }, new[] { replacement }).Visit(tree);
 
     /// <summary>
+    ///     Replaces one expression with another in given expression tree.
+    /// </summary>
+    /// <param name="originals">A list of original expressions to replace.</param>
+    /// <param name="replacements">A list of expressions to be used as replacements.</param>
+    /// <param name="tree">The expression tree in which replacement is going to be performed.</param>
+    /// <returns>An expression tree with replacements made.</returns>
+    public static Expression Replace(Expression[] originals, Expression[] replacements, Expression tree)
+        => new ReplacingExpressionVisitor(originals, replacements).Visit(tree);
+
+    /// <summary>
     ///     Creates a new instance of the <see cref="ReplacingExpressionVisitor" /> class.
     /// </summary>
     /// <param name="originals">A list of original expressions to replace.</param>

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -414,7 +414,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                             _liftableConstantFactory.CreateLiftableConstant(
                                 // TODO: Owned, STET
                                 c => c.Dependencies.Model.FindEntityType(entityType.Name)!.FindPrimaryKey()!,
-                                "key",
+                                entityType.Name + "Key",
                                 typeof(IKey)),
                             // Expression.Constant(primaryKey),
                             Expression.NewArrayInit(
@@ -546,7 +546,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             {
                 materializationConditionBody = _liftableConstantFactory.CreateLiftableConstant(
                     c => c.Dependencies.Model.FindEntityType(materializedEntityType.Name)!,
-                    "entityType",
+                    materializedEntityType.Name + "EntityType",
                     typeof(IEntityType));
             }
 
@@ -566,7 +566,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                     // Expression.Constant(concreteEntityTypes[i], typeof(IEntityType))
                     _liftableConstantFactory.CreateLiftableConstant(
                         c => c.Dependencies.Model.FindEntityType(concreteEntityType.Name)!,
-                        "entityType",
+                        concreteEntityType.Name + "EntityType",
                         typeof(IEntityType)));
             }
 

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -51,12 +51,16 @@ public sealed record ShapedQueryCompilingExpressionVisitorDependencies
         IEntityMaterializerSource entityMaterializerSource,
         ITypeMappingSource typeMappingSource,
         IMemoryCache memoryCache,
-        ICoreSingletonOptions coreSingletonOptions)
+        ICoreSingletonOptions coreSingletonOptions,
+        IModel model,
+        ILiftableConstantFactory liftableConstantFactory)
     {
         EntityMaterializerSource = entityMaterializerSource;
         TypeMappingSource = typeMappingSource;
         MemoryCache = memoryCache;
         CoreSingletonOptions = coreSingletonOptions;
+        Model = model;
+        LiftableConstantFactory = liftableConstantFactory;
     }
 
     /// <summary>
@@ -78,4 +82,14 @@ public sealed record ShapedQueryCompilingExpressionVisitorDependencies
     ///     Core singleton options.
     /// </summary>
     public ICoreSingletonOptions CoreSingletonOptions { get; init; }
+
+    /// <summary>
+    ///     The model.
+    /// </summary>
+    public IModel Model { get; init; }
+
+    /// <summary>
+    ///     The liftable constant factory.
+    /// </summary>
+    public ILiftableConstantFactory LiftableConstantFactory { get; init; }
 }

--- a/src/EFCore/Storage/Database.cs
+++ b/src/EFCore/Storage/Database.cs
@@ -66,4 +66,10 @@ public abstract class Database : IDatabase
         => Dependencies.QueryCompilationContextFactory
             .Create(async)
             .CreateQueryExecutor<TResult>(query);
+
+    /// <inheritdoc />
+    public virtual Expression<Func<QueryContext, TResult>> CompileQueryExpression<TResult>(Expression query, bool async)
+        => Dependencies.QueryCompilationContextFactory
+            .Create(async)
+            .CreateQueryExecutorExpression<TResult>(query);
 }

--- a/src/EFCore/Storage/IDatabase.cs
+++ b/src/EFCore/Storage/IDatabase.cs
@@ -55,4 +55,8 @@ public interface IDatabase
     /// <param name="async">A value indicating whether this is an async query.</param>
     /// <returns>A <see cref="Func{QueryContext, TResult}" /> which can be invoked to get results of the query.</returns>
     Func<QueryContext, TResult> CompileQuery<TResult>(Expression query, bool async);
+
+#pragma warning disable CS1591
+    Expression<Func<QueryContext, TResult>> CompileQueryExpression<TResult>(Expression query, bool async);
+#pragma warning restore CS1591
 }

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -140,6 +140,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("DbContextOptimizeDescription");
 
         /// <summary>
+        ///     Pre-compiles EF LINQ queries used by the DbContext.
+        /// </summary>
+        public static string DbContextPrecompileQueriesDescription
+            => GetString("DbContextPrecompileQueriesDescription");
+
+        /// <summary>
         ///     Scaffolds a DbContext and entity types for a database.
         /// </summary>
         public static string DbContextScaffoldDescription

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -177,6 +177,9 @@
   <data name="DbContextOptimizeDescription" xml:space="preserve">
     <value>Generates a compiled version of the model used by the DbContext.</value>
   </data>
+  <data name="DbContextPrecompileQueriesDescription" xml:space="preserve">
+    <value>Pre-compiles EF LINQ queries used by the DbContext.</value>
+  </data>
   <data name="DbContextScaffoldDescription" xml:space="preserve">
     <value>Scaffolds a DbContext and entity types for a database.</value>
   </data>

--- a/src/ef/Commands/DbContextCommand.cs
+++ b/src/ef/Commands/DbContextCommand.cs
@@ -15,6 +15,7 @@ internal class DbContextCommand : HelpCommandBase
         command.Command("info", new DbContextInfoCommand().Configure);
         command.Command("list", new DbContextListCommand().Configure);
         command.Command("optimize", new DbContextOptimizeCommand().Configure);
+        command.Command("precompile-queries", new PrecompileQueriesCommand().Configure);
         command.Command("scaffold", new DbContextScaffoldCommand().Configure);
         command.Command("script", new DbContextScriptCommand().Configure);
 

--- a/src/ef/Commands/PrecompileQueriesCommand.Configure.cs
+++ b/src/ef/Commands/PrecompileQueriesCommand.Configure.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.EntityFrameworkCore.Tools.Properties;
+
+namespace Microsoft.EntityFrameworkCore.Tools.Commands;
+
+internal partial class PrecompileQueriesCommand : ContextCommandBase
+{
+    private CommandOption? _outputDir;
+
+    public override void Configure(CommandLineApplication command)
+    {
+        command.Description = Resources.DbContextPrecompileQueriesDescription;
+
+        _outputDir = command.Option("-o|--output-dir <PATH>", Resources.OutputDirDescription);
+
+        base.Configure(command);
+    }
+}

--- a/src/ef/Commands/PrecompileQueriesCommand.cs
+++ b/src/ef/Commands/PrecompileQueriesCommand.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Tools.Properties;
+
+namespace Microsoft.EntityFrameworkCore.Tools.Commands;
+
+// ReSharper disable once ArrangeTypeModifiers
+internal partial class PrecompileQueriesCommand
+{
+    protected override int Execute(string[] args)
+    {
+        if (new SemanticVersionComparer().Compare(EFCoreVersion, "8.0.0") < 0)
+        {
+            throw new CommandException(Resources.VersionRequired("8.0.0"));
+        }
+
+        using var executor = CreateExecutor(args);
+        executor.PrecompileQueries(_outputDir!.Value());
+
+        return base.Execute(args);
+    }
+}

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -17,6 +17,7 @@ internal interface IOperationExecutor : IDisposable
     void UpdateDatabase(string? migration, string? connectionString, string? contextType);
     IEnumerable<IDictionary> GetContextTypes();
     void OptimizeContext(string? outputDir, string? modelNamespace, string? contextType);
+    void PrecompileQueries(string? outputDir);
 
     IDictionary ScaffoldContext(
         string provider,

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -150,6 +150,14 @@ internal abstract class OperationExecutorBase : IOperationExecutor
                 ["contextType"] = contextType
             });
 
+    public void PrecompileQueries(string? outputDir)
+        => InvokeOperation(
+            "PrecompileQueries",
+            new Dictionary<string, object?>
+            {
+                ["outputDir"] = outputDir
+            });
+
     public IDictionary ScaffoldContext(
         string provider,
         string connectionString,

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -192,6 +192,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("DbContextOptimizeDescription");
 
         /// <summary>
+        ///     Pre-compiles EF LINQ queries used by the DbContext.
+        /// </summary>
+        public static string DbContextPrecompileQueriesDescription
+            => GetString("DbContextPrecompileQueriesDescription");
+
+        /// <summary>
         ///     Scaffolds a DbContext and entity types for a database.
         /// </summary>
         public static string DbContextScaffoldDescription

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -198,6 +198,9 @@
   <data name="DbContextOptimizeDescription" xml:space="preserve">
     <value>Generates a compiled version of the model used by the DbContext.</value>
   </data>
+  <data name="DbContextPrecompileQueriesDescription" xml:space="preserve">
+    <value>Pre-compiles EF LINQ queries used by the DbContext.</value>
+  </data>
   <data name="DbContextScaffoldDescription" xml:space="preserve">
     <value>Scaffolds a DbContext and entity types for a database.</value>
   </data>

--- a/test/EFCore.Design.Tests/Query/CSharpToLinqTranslatorTest.cs
+++ b/test/EFCore.Design.Tests/Query/CSharpToLinqTranslatorTest.cs
@@ -1,0 +1,443 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable RedundantCast
+
+#nullable enable
+
+public class CSharpToLinqTranslatorTest
+{
+    [Fact]
+    public void ArrayCreation()
+        => AssertExpression(
+            "new int[3]",
+            () => new int[3]);
+
+    // ReSharper disable RedundantExplicitArrayCreation
+    [Fact]
+    public void ArrayCreation_with_initializer()
+        => AssertExpression(
+            "new int[] { 1, 2 }",
+            () => new int[] { 1, 2 });
+    // ReSharper restore RedundantExplicitArrayCreation
+
+    // ReSharper disable BuiltInTypeReferenceStyle
+    [Fact]
+    public void As()
+        => AssertExpression(
+            @"""foo"" as String",
+            () => "foo" as String);
+    // ReSharper restore BuiltInTypeReferenceStyle
+
+    [Fact]
+    public void As_with_predefined_type()
+        => AssertExpression(
+            @"""foo"" as string",
+            () => "foo" as string);
+
+    // TODO
+//     [Theory]
+//     [InlineData("=")]
+//     [InlineData("+=")]
+//     [InlineData("&=")]
+//     [InlineData("/=")]
+//     [InlineData("^=")]
+//     [InlineData("<<=")]
+//     [InlineData("%=")]
+//     [InlineData("*=")]
+//     [InlineData("|=")]
+//     [InlineData(">>=")]
+//     [InlineData("-=")]
+//     public void Assignment_not_supported(string op)
+//         => Assert.Throws<NotSupportedException>(
+//             () => AssertCodeOld(
+// $"""
+// var i = 3;
+// ~~~i {op} 2~~~;
+// """,
+//                 _ => {}));
+
+    [Theory]
+    [InlineData("1 + 2", ExpressionType.Add)]
+    [InlineData("1 - 2", ExpressionType.Subtract)]
+    [InlineData("1 * 2", ExpressionType.Multiply)]
+    [InlineData("1 / 2", ExpressionType.Divide)]
+    [InlineData("1 % 2", ExpressionType.Modulo)]
+    [InlineData("1 & 2", ExpressionType.And)]
+    [InlineData("1 | 2", ExpressionType.Or)]
+    [InlineData("1 ^ 2", ExpressionType.ExclusiveOr)]
+    [InlineData("1 >> 2", ExpressionType.RightShift)]
+    [InlineData("1 << 2", ExpressionType.LeftShift)]
+    [InlineData("1 < 2", ExpressionType.LessThan)]
+    [InlineData("1 <= 2", ExpressionType.LessThanOrEqual)]
+    [InlineData("1 > 2", ExpressionType.GreaterThan)]
+    [InlineData("1 >= 2", ExpressionType.GreaterThanOrEqual)]
+    [InlineData("1 == 2", ExpressionType.Equal)]
+    [InlineData("1 != 2", ExpressionType.NotEqual)]
+    public void Binary_int(string code, ExpressionType binaryType)
+        => AssertExpression(
+            code,
+            Expression.MakeBinary(binaryType, Expression.Constant(1), Expression.Constant(2)));
+
+    [Theory]
+    [InlineData("true && false", ExpressionType.AndAlso)]
+    [InlineData("true || false", ExpressionType.OrElse)]
+    [InlineData("true ^ false", ExpressionType.ExclusiveOr)]
+    public void Binary_bool(string code, ExpressionType binaryType)
+        => AssertExpression(
+            code,
+            Expression.Lambda<Func<bool>>(
+                Expression.MakeBinary(binaryType, Expression.Constant(true), Expression.Constant(false))));
+
+    [Fact]
+    public void Binary_add_string()
+        => AssertExpression(
+            @"new[] { ""foo"", ""bar"" }.Select(s => s + ""foo"")",
+            () => new[] { "foo", "bar" }.Select(s => s + "foo"));
+
+    [Fact]
+    public void Coalesce()
+        => AssertExpression(
+            @"(object?)""foo"" ?? (object)""bar""",
+            () => (object?)"foo" ?? (object)"bar");
+
+    [Fact]
+    public void Convert()
+        => AssertExpression(
+            @"(object)1",
+            () => (object)1);
+
+    [Fact]
+    public void ElementAccess_over_array()
+        => AssertExpression(
+            @"new[] { 1, 2, 3 } [1]",
+            () => new[] { 1, 2, 3 }[1]);
+
+    [Fact]
+    public void ElementAccess_over_list()
+        => AssertExpression(
+            @"new List<int> { 1, 2, 3 }[1]",
+            () => new List<int> { 1, 2, 3 }[1]);
+
+    [Fact]
+    public void IdentifierName_for_lambda_parameter()
+        => AssertExpression(
+            @"new[] { 1, 2, 3 }.Where(i => i == 2);",
+            () => new[] { 1, 2, 3 }.Where(i => i == 2));
+
+    [Fact]
+    public void IdentifierName_for_captured_variable()
+        => throw new NotImplementedException();
+
+    [Fact]
+    public void ImplicitArrayCreation()
+        => AssertExpression(
+            "new[] { 1, 2 }",
+            () => new[] { 1, 2 });
+
+    [Fact]
+    public void Invocation_instance_method()
+        => AssertExpression(
+            @"""foo"".Substring(2)",
+            () => "foo".Substring(2));
+
+    [Fact]
+    public void Invocation_method_with_optional_parameter()
+        => AssertExpression(
+            @"System.IO.File.ReadAllTextAsync(""/tmp/foo"")",
+            Expression.Call(
+                typeof(File).GetMethod(nameof(File.ReadAllTextAsync), new[] { typeof(string), typeof(CancellationToken) })!,
+                Expression.Constant("/tmp/foo"),
+                Expression.Constant(default(CancellationToken))));
+
+    [Fact]
+    public void Invocation_static_method()
+        => AssertExpression(
+            @"DateTime.Parse(""2020-01-01"")",
+            () => DateTime.Parse("2020-01-01"));
+
+    [Fact]
+    public void Invocation_extension_method()
+        => AssertExpression(
+            @"typeof(string).GetTypeInfo()",
+            () => typeof(string).GetTypeInfo());
+
+    // ReSharper disable InvokeAsExtensionMethod
+    [Fact]
+    public void Invocation_extension_method_with_non_extension_syntax()
+        => AssertExpression(
+            @"typeof(string).GetTypeInfo()",
+            () => IntrospectionExtensions.GetTypeInfo(typeof(string)));
+    // ReSharper restore InvokeAsExtensionMethod
+
+    [Fact]
+    public void Invocation_generic_method()
+        => AssertExpression(
+            @"Enumerable.Repeat(""foo"", 5)",
+            () => Enumerable.Repeat("foo", 5));
+
+    [Fact]
+    public void Invocation_generic_extension_method()
+        => AssertExpression(
+            @"new[] { 1, 2, 3 }.Where(i => i > 1)",
+            () => new[] { 1, 2, 3 }.Where(i => i > 1));
+
+    [Fact]
+    public void Invocation_generic_queryable_extension_method()
+        => AssertExpression(
+            @"new[] { 1, 2, 3 }.AsQueryable().Where(i => i > 1)",
+            () => new[] { 1, 2, 3 }.AsQueryable().Where(i => i > 1));
+
+    [Theory]
+    [InlineData(@"""hello""", "hello")]
+    [InlineData("1", 1)]
+    [InlineData("1L", 1L)]
+    [InlineData("1U", 1U)]
+    [InlineData("1UL", 1UL)]
+    [InlineData("1.5D", 1.5)]
+    [InlineData("1.5F", 1.5F)]
+    [InlineData("true", true)]
+    public void Literal(string csharpLiteral, object expectedValue)
+        => AssertExpression(csharpLiteral, Expression.Constant(expectedValue));
+
+    [Fact]
+    public void Literal_decimal()
+        => AssertExpression("1.5m", () => 1.5m);
+
+    // TODO
+    // public void Literal_null()
+    //     => AssertCodeOld(
+    //         "string s = ~~~null~~~;",
+    //         actual =>
+    //         {
+    //             var constantExpression = Assert.IsAssignableFrom<ConstantExpression>(actual);
+    //             Assert.Null(constantExpression.Value);
+    //             Assert.Same(typeof(string), constantExpression.Type);
+    //         });
+
+    [Fact]
+    public void Literal_enum()
+        => AssertExpression(
+            "CSharpToLinqTranslatorTest.SomeEnum.Two",
+            () => SomeEnum.Two);
+
+    [Fact]
+    public void Literal_enum_with_multiple_values()
+        => AssertExpression(
+            "CSharpToLinqTranslatorTest.SomeEnum.One | CSharpToLinqTranslatorTest.SomeEnum.Two",
+            () => SomeEnum.One | SomeEnum.Two);
+
+    // [Fact]
+    // public void Literal_enum_with_unknown_value()
+    //     => AssertExpression(Constant((SomeEnum)1000), "(SomeEnum)1000L");
+
+    [Fact]
+    public void MemberAccess_array_length()
+        => AssertExpression(
+            "new[] { 1, 2, 3 }.Length",
+            () => new[] { 1, 2, 3 }.Length);
+
+    [Fact]
+    public void MemberAccess_instance_property()
+        => AssertExpression(
+                @"""foo"".Length;",
+                () => "foo".Length);
+
+    [Fact]
+    public void MemberAccess_static_property()
+        => AssertExpression(
+            "DateTime.Now",
+            () => DateTime.Now);
+
+    // TODO: MemberAccess on fields
+
+    [Fact]
+    public void Nested_type()
+        => AssertExpression(
+            @"(object)new CSharpToLinqTranslatorTest.Blog()",
+            () => (object)new Blog());
+
+    [Fact]
+    public void Not_boolean()
+        => AssertExpression("!true", Expression.Not(Expression.Constant(true)));
+
+    [Fact]
+    public void ObjectCreation()
+        => AssertExpression(
+            @"new List<int>()",
+            () => new List<int>());
+
+    [Fact]
+    public void ObjectCreation_with_arguments()
+        => AssertExpression(
+            @"new List<int>(10)",
+            () => new List<int>(10));
+
+    [Fact]
+    public void ObjectCreation_with_initializers()
+        => AssertExpression(
+            @"new CSharpToLinqTranslatorTest.Blog(8) { Name = ""foo"" }",
+            () => new Blog(8) { Name = "foo" });
+
+    [Fact]
+    public void ObjectCreation_with_parameterless_struct_constructor()
+        => AssertExpression(
+            @"new DateTime()",
+            () => new DateTime());
+
+    [Fact]
+    public void Parenthesized()
+        => AssertExpression(@"(1)", () => 1);
+
+    [Theory]
+    [InlineData("+8", 8, ExpressionType.UnaryPlus)]
+    [InlineData("-8", 8, ExpressionType.Negate)]
+    [InlineData("~8", 8, ExpressionType.Not)]
+    public void PrefixUnary(string code, object operandValue, ExpressionType expectedNodeType)
+        => AssertExpression(
+            code,
+            Expression.MakeUnary(expectedNodeType, Expression.Constant(8), typeof(int)));
+
+    // ReSharper disable RedundantSuppressNullableWarningExpression
+    [Fact]
+    public void SuppressNullableWarningExpression()
+        => AssertExpression(
+            @"""foo""!",
+            () => "foo"!);
+    // ReSharper restore RedundantSuppressNullableWarningExpression
+
+    [ConditionalFact]
+    public void Typeof()
+        => AssertExpression(@"typeof(string)", () => typeof(string));
+
+    protected virtual void AssertExpression<T>(string code, Expression<Func<T>> expected)
+        => AssertExpression(code, expected.Body);
+
+    protected virtual void AssertExpression(string code, Expression expected)
+    {
+        code =
+            "using System;" + Environment.NewLine +
+            "using System.Collections.Generic;" + Environment.NewLine +
+            "using System.Linq;" + Environment.NewLine +
+            "using System.Reflection;" + Environment.NewLine +
+            "using Microsoft.EntityFrameworkCore.Query;" + Environment.NewLine +
+            Environment.NewLine +
+            $"_ = {code};";
+
+        var compilation = Compile(code);
+
+        var syntaxTree = compilation.SyntaxTrees.Single();
+
+        if (syntaxTree.GetRoot() is CompilationUnitSyntax { Members: [GlobalStatementSyntax globalStatement, ..] })
+        {
+            var expression = globalStatement switch
+            {
+                { Statement: ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax { Right: var e } } } => e,
+                { Statement: ExpressionStatementSyntax { Expression: var e } } => e,
+
+                _ => throw new InvalidOperationException("Could not find expression to assert on")
+            };
+
+            var actual = Translate(expression, compilation);
+
+            Assert.Equal(expected, actual, ExpressionEqualityComparer.Instance);
+        }
+        else
+        {
+            Assert.Fail("Could not find expression to assert on");
+        }
+    }
+
+    private Compilation Compile(string code)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(code);
+
+        var compilation = CSharpCompilation.Create(
+            "TestCompilation",
+            syntaxTrees: new[] { syntaxTree },
+            references: MetadataReferences);
+
+        var diagnostics = compilation.GetDiagnostics()
+            .Where(d => d.Severity is DiagnosticSeverity.Error)
+            .ToArray();
+
+        if (diagnostics.Any())
+        {
+            var stringBuilder = new StringBuilder()
+                .AppendLine("Compilation errors:");
+
+            foreach (var diagnostic in diagnostics)
+            {
+                stringBuilder.AppendLine(diagnostic.ToString());
+            }
+
+            Assert.Fail(stringBuilder.ToString());
+        }
+
+        return compilation;
+    }
+
+    private Expression Translate(SyntaxNode node, Compilation compilation)
+    {
+        var blogContext = new BlogContext();
+        var translator = new CSharpToLinqTranslator();
+        translator.Load(compilation, blogContext);
+        return translator.Translate(node, compilation.GetSemanticModel(node.SyntaxTree));
+    }
+
+    private static readonly MetadataReference[] MetadataReferences;
+
+    static CSharpToLinqTranslatorTest()
+    {
+        var metadataReferences = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Queryable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IQueryable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(DbContext).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(BlogContext).Assembly.Location)
+        };
+
+        var netAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(netAssemblyPath, "mscorlib.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(netAssemblyPath, "System.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(netAssemblyPath, "System.Core.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(netAssemblyPath, "System.Runtime.dll")));
+
+        MetadataReferences = metadataReferences.ToArray();
+    }
+
+    [Flags]
+    public enum SomeEnum
+    {
+        One = 1,
+        Two = 2
+    }
+
+    private class BlogContext : DbContext
+    {
+    }
+
+    public class Blog
+    {
+        public Blog()
+        {
+        }
+
+        public Blog(int id)
+            => Id = id;
+
+        public int Id { get; set; }
+        public string? Name { get; set; }
+    }
+}

--- a/test/EFCore.Design.Tests/Query/CSharpToLinqTranslatorTest.cs
+++ b/test/EFCore.Design.Tests/Query/CSharpToLinqTranslatorTest.cs
@@ -18,30 +18,30 @@ public class CSharpToLinqTranslatorTest
     [Fact]
     public void ArrayCreation()
         => AssertExpression(
-            "new int[3]",
-            () => new int[3]);
+            () => new int[3],
+            "new int[3]");
 
     // ReSharper disable RedundantExplicitArrayCreation
     [Fact]
     public void ArrayCreation_with_initializer()
         => AssertExpression(
-            "new int[] { 1, 2 }",
-            () => new int[] { 1, 2 });
+            () => new int[] { 1, 2 },
+            "new int[] { 1, 2 }");
     // ReSharper restore RedundantExplicitArrayCreation
 
     // ReSharper disable BuiltInTypeReferenceStyle
     [Fact]
     public void As()
         => AssertExpression(
-            @"""foo"" as String",
-            () => "foo" as String);
+            () => "foo" as String,
+            @"""foo"" as String");
     // ReSharper restore BuiltInTypeReferenceStyle
 
     [Fact]
     public void As_with_predefined_type()
         => AssertExpression(
-            @"""foo"" as string",
-            () => "foo" as string);
+            () => "foo" as string,
+            @"""foo"" as string");
 
     // TODO
 //     [Theory]
@@ -84,8 +84,8 @@ public class CSharpToLinqTranslatorTest
     [InlineData("1 != 2", ExpressionType.NotEqual)]
     public void Binary_int(string code, ExpressionType binaryType)
         => AssertExpression(
-            code,
-            Expression.MakeBinary(binaryType, Expression.Constant(1), Expression.Constant(2)));
+            Expression.MakeBinary(binaryType, Expression.Constant(1), Expression.Constant(2)),
+            code);
 
     [Theory]
     [InlineData("true && false", ExpressionType.AndAlso)]
@@ -93,45 +93,45 @@ public class CSharpToLinqTranslatorTest
     [InlineData("true ^ false", ExpressionType.ExclusiveOr)]
     public void Binary_bool(string code, ExpressionType binaryType)
         => AssertExpression(
-            code,
             Expression.Lambda<Func<bool>>(
-                Expression.MakeBinary(binaryType, Expression.Constant(true), Expression.Constant(false))));
+                Expression.MakeBinary(binaryType, Expression.Constant(true), Expression.Constant(false))),
+            code);
 
     [Fact]
     public void Binary_add_string()
         => AssertExpression(
-            @"new[] { ""foo"", ""bar"" }.Select(s => s + ""foo"")",
-            () => new[] { "foo", "bar" }.Select(s => s + "foo"));
+            () => new[] { "foo", "bar" }.Select(s => s + "foo"),
+            @"new[] { ""foo"", ""bar"" }.Select(s => s + ""foo"")");
 
     [Fact]
     public void Coalesce()
         => AssertExpression(
-            @"(object?)""foo"" ?? (object)""bar""",
-            () => (object?)"foo" ?? (object)"bar");
+            () => (object?)"foo" ?? (object)"bar",
+            @"(object?)""foo"" ?? (object)""bar""");
 
     [Fact]
     public void Convert()
         => AssertExpression(
-            @"(object)1",
-            () => (object)1);
+            () => (object)1,
+            @"(object)1");
 
     [Fact]
     public void ElementAccess_over_array()
         => AssertExpression(
-            @"new[] { 1, 2, 3 } [1]",
-            () => new[] { 1, 2, 3 }[1]);
+            () => new[] { 1, 2, 3 }[1],
+            @"new[] { 1, 2, 3 } [1]");
 
     [Fact]
     public void ElementAccess_over_list()
         => AssertExpression(
-            @"new List<int> { 1, 2, 3 }[1]",
-            () => new List<int> { 1, 2, 3 }[1]);
+            () => new List<int> { 1, 2, 3 }[1],
+            @"new List<int> { 1, 2, 3 }[1]");
 
     [Fact]
     public void IdentifierName_for_lambda_parameter()
         => AssertExpression(
-            @"new[] { 1, 2, 3 }.Where(i => i == 2);",
-            () => new[] { 1, 2, 3 }.Where(i => i == 2));
+            () => new[] { 1, 2, 3 }.Where(i => i == 2),
+            @"new[] { 1, 2, 3 }.Where(i => i == 2);");
 
     [Fact]
     public void IdentifierName_for_captured_variable()
@@ -140,61 +140,73 @@ public class CSharpToLinqTranslatorTest
     [Fact]
     public void ImplicitArrayCreation()
         => AssertExpression(
-            "new[] { 1, 2 }",
-            () => new[] { 1, 2 });
+            () => new[] { 1, 2 },
+            "new[] { 1, 2 }");
 
     [Fact]
     public void Invocation_instance_method()
         => AssertExpression(
-            @"""foo"".Substring(2)",
-            () => "foo".Substring(2));
+            () => "foo".Substring(2),
+            @"""foo"".Substring(2)");
 
     [Fact]
     public void Invocation_method_with_optional_parameter()
         => AssertExpression(
-            @"System.IO.File.ReadAllTextAsync(""/tmp/foo"")",
             Expression.Call(
                 typeof(File).GetMethod(nameof(File.ReadAllTextAsync), new[] { typeof(string), typeof(CancellationToken) })!,
                 Expression.Constant("/tmp/foo"),
-                Expression.Constant(default(CancellationToken))));
+                Expression.Constant(default(CancellationToken))),
+            @"System.IO.File.ReadAllTextAsync(""/tmp/foo"")");
 
     [Fact]
     public void Invocation_static_method()
         => AssertExpression(
-            @"DateTime.Parse(""2020-01-01"")",
-            () => DateTime.Parse("2020-01-01"));
+            () => DateTime.Parse("2020-01-01"),
+            @"DateTime.Parse(""2020-01-01"")");
 
     [Fact]
     public void Invocation_extension_method()
         => AssertExpression(
-            @"typeof(string).GetTypeInfo()",
-            () => typeof(string).GetTypeInfo());
+            () => typeof(string).GetTypeInfo(),
+            @"typeof(string).GetTypeInfo()");
 
     // ReSharper disable InvokeAsExtensionMethod
     [Fact]
     public void Invocation_extension_method_with_non_extension_syntax()
         => AssertExpression(
-            @"typeof(string).GetTypeInfo()",
-            () => IntrospectionExtensions.GetTypeInfo(typeof(string)));
+            () => IntrospectionExtensions.GetTypeInfo(typeof(string)),
+            @"typeof(string).GetTypeInfo()");
     // ReSharper restore InvokeAsExtensionMethod
 
     [Fact]
     public void Invocation_generic_method()
         => AssertExpression(
-            @"Enumerable.Repeat(""foo"", 5)",
-            () => Enumerable.Repeat("foo", 5));
+            () => Enumerable.Repeat("foo", 5),
+            @"Enumerable.Repeat(""foo"", 5)");
 
     [Fact]
     public void Invocation_generic_extension_method()
         => AssertExpression(
-            @"new[] { 1, 2, 3 }.Where(i => i > 1)",
-            () => new[] { 1, 2, 3 }.Where(i => i > 1));
+            () => new[] { 1, 2, 3 }.Where(i => i > 1),
+            @"new[] { 1, 2, 3 }.Where(i => i > 1)");
 
     [Fact]
     public void Invocation_generic_queryable_extension_method()
         => AssertExpression(
-            @"new[] { 1, 2, 3 }.AsQueryable().Where(i => i > 1)",
-            () => new[] { 1, 2, 3 }.AsQueryable().Where(i => i > 1));
+            () => new[] { 1, 2, 3 }.AsQueryable().Where(i => i > 1),
+            @"new[] { 1, 2, 3 }.AsQueryable().Where(i => i > 1)");
+
+    [Fact]
+    public void Invocation_non_generic_method_on_generic_type()
+        => AssertExpression(
+            () => SomeGenericType<int>.SomeFunction(1),
+            @"CSharpToLinqTranslatorTest.SomeGenericType<int>.SomeFunction(1)");
+
+    [Fact]
+    public void Invocation_generic_method_on_generic_type()
+        => AssertExpression(
+            () => SomeGenericType<int>.SomeGenericFunction<string>(1, "foo"),
+            @"CSharpToLinqTranslatorTest.SomeGenericType<int>.SomeGenericFunction<string>(1, ""foo"")");
 
     [Theory]
     [InlineData(@"""hello""", "hello")]
@@ -206,11 +218,15 @@ public class CSharpToLinqTranslatorTest
     [InlineData("1.5F", 1.5F)]
     [InlineData("true", true)]
     public void Literal(string csharpLiteral, object expectedValue)
-        => AssertExpression(csharpLiteral, Expression.Constant(expectedValue));
+        => AssertExpression(
+            Expression.Constant(expectedValue),
+            csharpLiteral);
 
     [Fact]
     public void Literal_decimal()
-        => AssertExpression("1.5m", () => 1.5m);
+        => AssertExpression(
+            () => 1.5m,
+            "1.5m");
 
     // TODO
     // public void Literal_null()
@@ -226,14 +242,14 @@ public class CSharpToLinqTranslatorTest
     [Fact]
     public void Literal_enum()
         => AssertExpression(
-            "CSharpToLinqTranslatorTest.SomeEnum.Two",
-            () => SomeEnum.Two);
+            () => SomeEnum.Two,
+            "CSharpToLinqTranslatorTest.SomeEnum.Two");
 
     [Fact]
     public void Literal_enum_with_multiple_values()
         => AssertExpression(
-            "CSharpToLinqTranslatorTest.SomeEnum.One | CSharpToLinqTranslatorTest.SomeEnum.Two",
-            () => SomeEnum.One | SomeEnum.Two);
+            () => SomeEnum.One | SomeEnum.Two,
+            "CSharpToLinqTranslatorTest.SomeEnum.One | CSharpToLinqTranslatorTest.SomeEnum.Two");
 
     // [Fact]
     // public void Literal_enum_with_unknown_value()
@@ -242,60 +258,64 @@ public class CSharpToLinqTranslatorTest
     [Fact]
     public void MemberAccess_array_length()
         => AssertExpression(
-            "new[] { 1, 2, 3 }.Length",
-            () => new[] { 1, 2, 3 }.Length);
+            () => new[] { 1, 2, 3 }.Length,
+            "new[] { 1, 2, 3 }.Length");
 
     [Fact]
     public void MemberAccess_instance_property()
         => AssertExpression(
-                @"""foo"".Length;",
-                () => "foo".Length);
+            () => "foo".Length,
+            @"""foo"".Length;");
 
     [Fact]
     public void MemberAccess_static_property()
         => AssertExpression(
-            "DateTime.Now",
-            () => DateTime.Now);
+            () => DateTime.Now,
+            "DateTime.Now");
 
     // TODO: MemberAccess on fields
 
     [Fact]
     public void Nested_type()
         => AssertExpression(
-            @"(object)new CSharpToLinqTranslatorTest.Blog()",
-            () => (object)new Blog());
+            () => (object)new Blog(),
+            @"(object)new CSharpToLinqTranslatorTest.Blog()");
 
     [Fact]
     public void Not_boolean()
-        => AssertExpression("!true", Expression.Not(Expression.Constant(true)));
+        => AssertExpression(
+            Expression.Not(Expression.Constant(true)),
+            "!true");
 
     [Fact]
     public void ObjectCreation()
         => AssertExpression(
-            @"new List<int>()",
-            () => new List<int>());
+            () => new List<int>(),
+            @"new List<int>()");
 
     [Fact]
     public void ObjectCreation_with_arguments()
         => AssertExpression(
-            @"new List<int>(10)",
-            () => new List<int>(10));
+            () => new List<int>(10),
+            @"new List<int>(10)");
 
     [Fact]
     public void ObjectCreation_with_initializers()
         => AssertExpression(
-            @"new CSharpToLinqTranslatorTest.Blog(8) { Name = ""foo"" }",
-            () => new Blog(8) { Name = "foo" });
+            () => new Blog(8) { Name = "foo" },
+            @"new CSharpToLinqTranslatorTest.Blog(8) { Name = ""foo"" }");
 
     [Fact]
     public void ObjectCreation_with_parameterless_struct_constructor()
         => AssertExpression(
-            @"new DateTime()",
-            () => new DateTime());
+            () => new DateTime(),
+            @"new DateTime()");
 
     [Fact]
     public void Parenthesized()
-        => AssertExpression(@"(1)", () => 1);
+        => AssertExpression(
+            () => 1,
+            @"(1)");
 
     [Theory]
     [InlineData("+8", 8, ExpressionType.UnaryPlus)]
@@ -303,25 +323,29 @@ public class CSharpToLinqTranslatorTest
     [InlineData("~8", 8, ExpressionType.Not)]
     public void PrefixUnary(string code, object operandValue, ExpressionType expectedNodeType)
         => AssertExpression(
-            code,
-            Expression.MakeUnary(expectedNodeType, Expression.Constant(8), typeof(int)));
+            Expression.MakeUnary(expectedNodeType, Expression.Constant(8), typeof(int)),
+            code);
 
     // ReSharper disable RedundantSuppressNullableWarningExpression
     [Fact]
     public void SuppressNullableWarningExpression()
         => AssertExpression(
-            @"""foo""!",
-            () => "foo"!);
+            () => "foo"!,
+            @"""foo""!");
     // ReSharper restore RedundantSuppressNullableWarningExpression
 
     [ConditionalFact]
     public void Typeof()
-        => AssertExpression(@"typeof(string)", () => typeof(string));
+        => AssertExpression(
+            () => typeof(string),
+            @"typeof(string)");
 
-    protected virtual void AssertExpression<T>(string code, Expression<Func<T>> expected)
-        => AssertExpression(code, expected.Body);
+    protected virtual void AssertExpression<T>(Expression<Func<T>> expected, string code)
+        => AssertExpression(
+            expected.Body,
+            code);
 
-    protected virtual void AssertExpression(string code, Expression expected)
+    protected virtual void AssertExpression(Expression expected, string code)
     {
         code =
             "using System;" + Environment.NewLine +
@@ -439,5 +463,14 @@ public class CSharpToLinqTranslatorTest
 
         public int Id { get; set; }
         public string? Name { get; set; }
+    }
+
+    public class SomeGenericType<T1>
+    {
+        public static int SomeFunction(T1 t1)
+            => 0;
+
+        public static int SomeGenericFunction<T2>(T1 t1, T2 t2)
+            => 0;
     }
 }

--- a/test/EFCore.Design.Tests/Query/LinqToCSharpTranslatorTest.cs
+++ b/test/EFCore.Design.Tests/Query/LinqToCSharpTranslatorTest.cs
@@ -339,7 +339,7 @@ new Blog("foo")
 """
 {
     var blog = new Blog();
-    LinqToCSharpTranslatorTest.GenericMethodImplementation<Blog>(blog);
+    LinqToCSharpTranslatorTest.GenericMethodImplementation(blog);
 }
 """);
     }

--- a/test/EFCore.Design.Tests/Query/LinqToCSharpTranslatorTest.cs
+++ b/test/EFCore.Design.Tests/Query/LinqToCSharpTranslatorTest.cs
@@ -1,0 +1,1703 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Xunit.Sdk;
+using static System.Linq.Expressions.Expression;
+using Assert = Xunit.Assert;
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class LinqToCSharpTranslatorTest
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public LinqToCSharpTranslatorTest(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+        _outputExpressionTrees = true;
+    }
+
+    [Theory]
+    [InlineData("hello", @"""hello""")]
+    [InlineData(1, "1")]
+    [InlineData(1L, "1L")]
+    [InlineData((short)1, "1")]
+    [InlineData((sbyte)1, "1")]
+    [InlineData(1U, "1U")]
+    [InlineData(1UL, "1UL")]
+    [InlineData((ushort)1, "1")]
+    [InlineData((byte)1, "1")]
+    [InlineData(1.5, "1.5D")]
+    [InlineData(1.5F, "1.5F")]
+    [InlineData(true, "true")]
+    [InlineData(typeof(string), "typeof(string)")]
+    public void Constant_values(object constantValue, string literalRepresentation)
+        => AssertExpression(
+            Constant(constantValue),
+            literalRepresentation);
+
+    [Fact]
+    public void Constant_decimal()
+        => AssertExpression(Constant(1.5m), "1.5M");
+
+    [Fact]
+    public void Constant_null()
+        => AssertExpression(Constant(null, typeof(string)), "null");
+
+    [Fact]
+    public void Constant_throws_on_unsupported_type()
+        => Assert.Throws<NotSupportedException>(() => AssertExpression(Constant(default(DateTime)), ""));
+
+    [Fact]
+    public void Enum()
+        => AssertExpression(Constant(SomeEnum.One), "SomeEnum.One");
+
+    [Fact]
+    public void Enum_with_multiple_values()
+        => AssertExpression(Constant(SomeEnum.One | SomeEnum.Two), "SomeEnum.One | SomeEnum.Two");
+
+    [Fact]
+    public void Enum_with_unknown_value()
+        => AssertExpression(Constant((SomeEnum)1000), "(SomeEnum)1000L");
+
+    [Theory]
+    [InlineData(ExpressionType.Add, "+")]
+    [InlineData(ExpressionType.Subtract, "-")]
+    // TODO: Complete
+    public void Binary_numeric(ExpressionType expressionType, string op)
+        => AssertExpression(
+            MakeBinary(expressionType, Constant(2), Constant(3)),
+            $"2 {op} 3");
+
+    [Fact]
+    public void Binary_ArrayIndex()
+        => AssertExpression(
+            ArrayIndex(Parameter(typeof(int[]), "i"), Constant(2)),
+            "i[2]");
+
+    [Fact]
+    public void Binary_Power()
+        => AssertExpression(
+            Power(Constant(2.0), Constant(3.0)),
+            "Math.Pow(2D, 3D)");
+
+    [Fact]
+    public void Binary_PowerAssign()
+        => AssertExpression(
+            PowerAssign(Parameter(typeof(double), "d"), Constant(3.0)),
+            "d = Math.Pow(d, 3D)");
+
+    [Theory]
+    [InlineData(ExpressionType.Negate, "-i")]
+    [InlineData(ExpressionType.NegateChecked, "-i")]
+    [InlineData(ExpressionType.Not, "~i")]
+    [InlineData(ExpressionType.OnesComplement, "~i")]
+    [InlineData(ExpressionType.UnaryPlus, "+i")]
+    [InlineData(ExpressionType.Increment, "i + 1")]
+    [InlineData(ExpressionType.Decrement, "i - 1")]
+    public void Unary_expression_int(ExpressionType expressionType, string expected)
+        => AssertExpression(
+            MakeUnary(expressionType, Parameter(typeof(int), "i"), typeof(int)),
+            expected);
+
+    [Theory]
+    [InlineData(ExpressionType.Not, "!b")]
+    [InlineData(ExpressionType.IsFalse, "!b")]
+    [InlineData(ExpressionType.IsTrue, "b")]
+    public void Unary_expression_bool(ExpressionType expressionType, string expected)
+        => AssertExpression(
+            MakeUnary(expressionType, Parameter(typeof(bool), "b"), typeof(bool)),
+            expected);
+
+    [Theory]
+    [InlineData(ExpressionType.PostIncrementAssign, "i++")]
+    [InlineData(ExpressionType.PostDecrementAssign, "i--")]
+    [InlineData(ExpressionType.PreIncrementAssign, "++i")]
+    [InlineData(ExpressionType.PreDecrementAssign, "--i")]
+    public void Unary_statement(ExpressionType expressionType, string expected)
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+            MakeUnary(expressionType, i, typeof(int))),
+$$"""
+{
+    int i;
+    {{expected}};
+}
+""");
+    }
+
+    [Fact]
+    public void Unary_ArrayLength()
+        => AssertExpression(
+            ArrayLength(Parameter(typeof(int[]), "i")),
+            "i.Length");
+
+    [Fact]
+    public void Unary_Convert()
+        => AssertExpression(
+            Convert(
+                Parameter(typeof(object), "i"),
+                typeof(string)),
+            "(string)i");
+
+    [Fact]
+    public void Unary_Throw()
+        => AssertStatement(
+            Throw(New(typeof(Exception))),
+            "throw new Exception();");
+
+    [Fact]
+    public void Unary_Unbox()
+        => AssertExpression(
+            Unbox(Parameter(typeof(object), "i"), typeof(int)),
+            "i");
+
+    [Fact]
+    public void Unary_Quote()
+    {
+        AssertExpression(
+            Quote((Expression<Func<string, int>>)(s => s.Length)),
+            "s => s.Length");
+    }
+
+    [Fact]
+    public void Unary_TypeAs()
+        => AssertExpression(
+            TypeAs(Parameter(typeof(object), "i"), typeof(string)),
+            "i as string");
+
+    [Fact]
+    public void Instance_property()
+        => AssertExpression(
+            Property(
+                Constant("hello"),
+                typeof(string).GetProperty(nameof(string.Length))!),
+            @"""hello"".Length");
+
+    [Fact]
+    public void Static_property()
+        => AssertExpression(
+            Property(
+                null,
+                typeof(DateTime).GetProperty(nameof(DateTime.Now))!),
+            "DateTime.Now");
+
+    [Fact]
+    public void Private_instance_field_read()
+        => AssertExpression(
+            Field(Parameter(typeof(Blog), "blog"), "_privateField"),
+            @"typeof(Blog).GetField(""_privateField"", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(blog)");
+
+    [Fact]
+    public void Private_instance_field_write()
+        => AssertStatement(
+            Assign(
+                Field(Parameter(typeof(Blog), "blog"), "_privateField"),
+                Constant(8)),
+            @"typeof(Blog).GetField(""_privateField"", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(blog, 8)");
+
+    [Fact]
+    public void Internal_instance_field_read()
+        => AssertExpression(
+            Field(Parameter(typeof(Blog), "blog"), "_internalField"),
+            @"typeof(Blog).GetField(""_internalField"", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(blog)");
+
+    [Fact]
+    public void Not()
+        => AssertExpression(
+            Expression.Not(Constant(true)),
+            "!true");
+
+    [Fact]
+    public void Method_call_instance()
+    {
+        var blog = Parameter(typeof(Blog), "blog");
+
+        AssertStatement(
+            Block(
+                variables: new[] { blog },
+                Assign(blog, New(Blog.Constructor)),
+                Call(
+                    blog,
+                    typeof(Blog).GetMethod(nameof(Blog.SomeInstanceMethod))!)),
+"""
+{
+    var blog = new Blog();
+    blog.SomeInstanceMethod();
+}
+""");
+    }
+
+    [Fact]
+    public void Method_call_static()
+        => AssertExpression(
+            Call(ReturnsIntWithParamMethod, Constant(8)),
+            "LinqToCSharpTranslatorTest.ReturnsIntWithParam(8)");
+
+    [Fact]
+    public void Method_call_static_on_nested_type()
+        => AssertExpression(
+            Call(typeof(Blog).GetMethod(nameof(Blog.Static_method_on_nested_type))!),
+            "LinqToCSharpTranslatorTest.Blog.Static_method_on_nested_type()");
+
+    [Fact]
+    public void Method_call_extension()
+    {
+        var blog = Parameter(typeof(LinqExpressionToRoslynTranslatorExtensionType), "someType");
+
+        AssertStatement(
+            Block(
+                variables: new[] { blog },
+                Assign(blog, New(LinqExpressionToRoslynTranslatorExtensionType.Constructor)),
+                Call(LinqExpressionToRoslynTranslatorExtensions.SomeExtensionMethod, blog)),
+"""
+{
+    var someType = new LinqExpressionToRoslynTranslatorExtensionType();
+    someType.SomeExtension();
+}
+""");
+    }
+
+    [Fact]
+    public void Method_call_extension_with_null_this()
+        => AssertExpression(
+            Call(
+                LinqExpressionToRoslynTranslatorExtensions.SomeExtensionMethod,
+                Constant(null, typeof(LinqExpressionToRoslynTranslatorExtensionType))),
+            "LinqExpressionToRoslynTranslatorExtensions.SomeExtension(null)");
+
+    [Fact]
+    public void Method_call_generic()
+    {
+        var blog = Parameter(typeof(Blog), "blog");
+
+        AssertStatement(
+            Block(
+                variables: new[] { blog },
+                Assign(blog, New(Blog.Constructor)),
+                Call(
+                    GenericMethod.MakeGenericMethod(typeof(Blog)),
+                    blog)),
+"""
+{
+    var blog = new Blog();
+    LinqToCSharpTranslatorTest.GenericMethodImplementation<Blog>(blog);
+}
+""");
+    }
+
+    [Fact]
+    public void Method_call_namespace_is_collected()
+    {
+        var (translator, _) = CreateTranslator();
+        var namespaces = new HashSet<string>();
+        _ = translator.TranslateExpression(Call(FooMethod), namespaces);
+        Assert.Collection(namespaces,
+            ns => Assert.Equal(typeof(LinqToCSharpTranslatorTest).Namespace, ns));
+    }
+
+    [Fact]
+    public void Method_call_with_in_out_ref_parameters()
+    {
+        var inParam = Parameter(typeof(int), "inParam");
+        var outParam = Parameter(typeof(int), "outParam");
+        var refParam = Parameter(typeof(int), "refParam");
+
+        AssertStatement(
+            Block(
+                variables: new[] { inParam, outParam, refParam },
+                Call(WithInOutRefParameterMethod, new[] { inParam, outParam, refParam })),
+"""
+{
+    int inParam;
+    int outParam;
+    int refParam;
+    LinqToCSharpTranslatorTest.WithInOutRefParameter(in inParam, out outParam, ref refParam);
+}
+""");
+    }
+
+    [Fact]
+    public void Instantiation()
+        => AssertExpression(
+            New(
+                typeof(Blog).GetConstructor(new[] { typeof(string) })!,
+                Constant("foo")),
+            @"new Blog(""foo"")");
+
+    [Fact]
+    public void Instantiation_with_required_properties_and_parameterless_constructor()
+        => AssertExpression(
+            New(
+                typeof(BlogWithRequiredProperties).GetConstructor(Array.Empty<Type>())!),
+"""
+Activator.CreateInstance<BlogWithRequiredProperties>()
+""");
+
+    [Fact]
+    public void Instantiation_with_required_properties_and_non_parameterless_constructor()
+        => Assert.Throws<NotImplementedException>(() => AssertExpression(
+            New(
+                typeof(BlogWithRequiredProperties).GetConstructor(new[] { typeof(string) })!,
+                Constant("foo")), ""));
+
+    [Fact]
+    public void Instantiation_with_required_properties_with_SetsRequiredMembers()
+        => AssertExpression(
+            New(
+                typeof(BlogWithRequiredProperties).GetConstructor(new[] { typeof(string), typeof(int) })!,
+                Constant("foo"), Constant(8)),
+            @"new BlogWithRequiredProperties(""foo"", 8)");
+
+    [Fact]
+    public void Lambda_with_expression_body()
+        => AssertExpression(
+            Lambda<Func<bool>>(Constant(true)),
+            "() => true");
+
+    [Fact]
+    public void Lambda_with_block_body()
+    {
+        var i = Parameter(typeof(int), "i");
+        var block = Block(
+            variables: new[] { i },
+            Assign(i, Constant(8)),
+            i);
+
+        AssertExpression(
+            Lambda<Func<int>>(block),
+"""
+() =>
+{
+    var i = 8;
+    return i;
+}
+""");
+    }
+
+    [Fact]
+    public void Lambda_with_no_parameters()
+        => AssertExpression(
+            Lambda<Func<bool>>(Constant(true)),
+            "() => true");
+
+    [Fact]
+    public void Lambda_with_one_parameter()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertExpression(
+            Lambda<Func<int, bool>>(Constant(true), i),
+            "i => true");
+    }
+
+    [Fact]
+    public void Lambda_with_two_parameters()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+
+        AssertExpression(
+            Lambda<Func<int, int, int>>(Add(i, j), i, j),
+            "(i, j) => i + j");
+    }
+
+    [Fact]
+    public void Invocation_simple()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertExpression(
+            AndAlso(
+                Constant(true),
+                Invoke((Expression<Func<int, bool>>)(f => f > 5), i)),
+            "true && i > 5");
+    }
+
+    [Fact]
+    public void Invocation_with_argument_that_has_side_effects()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(
+                    i,
+                    Add(
+                        Constant(5),
+                        Invoke((Expression<Func<int, int>>)(f => f + f), Call(FooMethod))))),
+"""
+{
+    var f = LinqToCSharpTranslatorTest.Foo();
+    var i = 5 + f + f;
+}
+""");
+    }
+
+    [Fact]
+    public void Condition_expression()
+        => AssertExpression(
+            Condition(Constant(true), Constant(1), Constant(2)),
+            "true ? 1 : 2");
+
+    [Fact]
+    public void Conditional_without_false_value_fails()
+        => Assert.Throws<NotSupportedException>(
+            () => AssertExpression(
+                IfThen(Constant(true), Constant(8)),
+                "true ? 1 : 2"));
+
+    [Fact]
+    public void Condition_statement()
+        => AssertStatement(
+            Block(
+                Condition(Constant(true), Call(FooMethod), Call(BarMethod)),
+                Constant(8)),
+"""
+{
+    if (true)
+    {
+        LinqToCSharpTranslatorTest.Foo();
+    }
+    else
+    {
+        LinqToCSharpTranslatorTest.Bar();
+    }
+}
+""");
+
+    [Fact]
+    public void IfThen_statement()
+    {
+        var parameter = Parameter(typeof(int), "i");
+        var block = Block(
+            variables: new[] { parameter },
+            expressions: Assign(parameter, Constant(8)));
+
+        AssertStatement(
+            Block(IfThen(Constant(true), block)),
+"""
+{
+    if (true)
+    {
+        var i = 8;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void IfThenElse_statement()
+    {
+        var parameter1 = Parameter(typeof(int), "i");
+        var block1 = Block(
+            variables: new[] { parameter1 },
+            expressions: Assign(parameter1, Constant(8)));
+
+        var parameter2 = Parameter(typeof(int), "j");
+        var block2 = Block(
+            variables: new[] { parameter2 },
+            expressions: Assign(parameter2, Constant(9)));
+
+        AssertStatement(
+            Block(IfThenElse(Constant(true), block1, block2)),
+"""
+{
+    if (true)
+    {
+        var i = 8;
+    }
+    else
+    {
+        var j = 9;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void IfThenElse_nested()
+    {
+        var variable = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { variable },
+                expressions: IfThenElse(
+                    Constant(true),
+                    Block(Assign(variable, Constant(1))),
+                    IfThenElse(
+                        Constant(false),
+                        Block(Assign(variable, Constant(2))),
+                        Block(Assign(variable, Constant(3)))))),
+"""
+{
+    int i;
+    if (true)
+    {
+        i = 1;
+    }
+    else if (false)
+    {
+        i = 2;
+    }
+    else
+    {
+        i = 3;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_expression()
+        => AssertExpression(
+            Switch(
+                Constant(8),
+                Constant(0),
+                SwitchCase(Constant(-9), Constant(9)),
+                SwitchCase(Constant(-10), Constant(10))),
+"""
+8 switch
+{
+    9 => -9,
+    10 => -10,
+    _ => 0
+}
+""");
+
+    [Fact]
+    public void Switch_expression_nested()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+        var k = Parameter(typeof(int), "k");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i, j, k },
+                Assign(j, Constant(8)),
+                Assign(
+                    i,
+                    Switch(
+                        j,
+                        defaultBody: Constant(0),
+                        SwitchCase(Constant(1), Constant(100)),
+                        SwitchCase(
+                            Switch(
+                                k,
+                                defaultBody: Constant(0),
+                                SwitchCase(Constant(2), Constant(200)),
+                                SwitchCase(Constant(3), Constant(300))),
+                            Constant(200))))),
+"""
+{
+    int k;
+    var j = 8;
+    var i = j switch
+    {
+        100 => 1,
+        200 => k switch
+        {
+            200 => 2,
+            300 => 3,
+            _ => 0
+        },
+        _ => 0
+    };
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_expression_non_constant_arm()
+        => AssertExpression(
+            Switch(
+                Parameter(typeof(Blog), "blog1"),
+                Constant(0),
+                SwitchCase(Constant(2), Parameter(typeof(Blog), "blog2")),
+                SwitchCase(Constant(3), Parameter(typeof(Blog), "blog3"))),
+            "blog1 == blog2 ? 2 : blog1 == blog3 ? 3 : 0");
+
+    [Fact]
+    public void Switch_statement_with_non_constant_label()
+    {
+        AssertStatement(
+            Switch(
+                Parameter(typeof(Blog), "blog1"),
+                Constant(0),
+                SwitchCase(Constant(2), Parameter(typeof(Blog), "blog2")),
+                SwitchCase(Constant(3), Parameter(typeof(Blog), "blog3"))),
+"""
+if (blog1 == blog2)
+{
+    2;
+}
+else if (blog1 == blog3)
+{
+    3;
+}
+else
+{
+    0;
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_statement_without_default()
+    {
+        var parameter = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { parameter },
+                expressions: Switch(
+                    Constant(7),
+                    SwitchCase(Block(typeof(void), Assign(parameter, Constant(9))), Constant(-9)),
+                    SwitchCase(Block(typeof(void), Assign(parameter, Constant(10))), Constant(-10)))),
+"""
+{
+    int i;
+    switch (7)
+    {
+        case -9:
+        {
+            i = 9;
+            break;
+        }
+
+        case -10:
+        {
+            i = 10;
+            break;
+        }
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_statement_with_default()
+    {
+        var parameter = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { parameter },
+                expressions: Switch(
+                    Constant(7),
+                    Assign(parameter, Constant(0)),
+                    SwitchCase(Assign(parameter, Constant(9)), Constant(-9)),
+                    SwitchCase(Assign(parameter, Constant(10)), Constant(-10)))),
+"""
+{
+    int i;
+    switch (7)
+    {
+        case -9:
+            i = 9;
+            break;
+        case -10:
+            i = 10;
+            break;
+        default:
+            i = 0;
+            break;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_statement_with_multiple_labels()
+    {
+        var parameter = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { parameter },
+                expressions: Switch(
+                    Constant(7),
+                    Assign(parameter, Constant(0)),
+                    SwitchCase(Assign(parameter, Constant(9)), Constant(-9), Constant(-8)),
+                    SwitchCase(Assign(parameter, Constant(10)), Constant(-10)))),
+"""
+{
+    int i;
+    switch (7)
+    {
+        case -9:
+        case -8:
+            i = 9;
+            break;
+        case -10:
+            i = 10;
+            break;
+        default:
+            i = 0;
+            break;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Variable_assignment_uses_var()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i, Constant(8))),
+"""
+{
+    var i = 8;
+}
+""");
+    }
+
+    [Fact]
+    public void Variable_assignment_to_null_does_not_use_var()
+    {
+        var s = Parameter(typeof(string), "s");
+
+        AssertStatement(
+            Block(
+                variables: new[] { s },
+                Assign(s, Constant(null, typeof(string)))),
+"""
+{
+    string s = null;
+}
+""");
+    }
+
+    [Fact]
+    public void Variables_with_same_name_in_sibling_blocks_do_not_get_renamed()
+    {
+        var i1 = Parameter(typeof(int), "i");
+        var i2 = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                Block(
+                    variables: new[] { i1 },
+                    Assign(i1, Constant(8)),
+                    Call(ReturnsIntWithParamMethod, i1)),
+                Block(
+                    variables: new[] { i2 },
+                    Assign(i2, Constant(8)),
+                    Call(ReturnsIntWithParamMethod, i2))),
+"""
+{
+    {
+        var i = 8;
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(i);
+    }
+
+    {
+        var i = 8;
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(i);
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Variable_with_same_name_in_child_block_gets_renamed()
+    {
+        var i1 = Parameter(typeof(int), "i");
+        var i2 = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i1 },
+                Assign(i1, Constant(8)),
+                Call(ReturnsIntWithParamMethod, i1),
+                Block(
+                    variables: new[] { i2 },
+                    Assign(i2, Constant(8)),
+                    Call(ReturnsIntWithParamMethod, i2),
+                    Call(ReturnsIntWithParamMethod, i1))),
+"""
+{
+    var i = 8;
+    LinqToCSharpTranslatorTest.ReturnsIntWithParam(i);
+    {
+        var i0 = 8;
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(i0);
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(i);
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Variable_with_same_name_in_lambda_does_not_get_renamed()
+    {
+        var i1 = Parameter(typeof(int), "i");
+        var i2 = Parameter(typeof(int), "i");
+        var f = Parameter(typeof(Func<int, bool>), "f");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i1 },
+                Assign(i1, Constant(8)),
+                Assign(
+                    f, Lambda<Func<int, bool>>(
+                        Equal(i2, Constant(5)),
+                        i2))),
+"""
+{
+    var i = 8;
+    f = i => i == 5;
+}
+""");
+    }
+
+    [Fact]
+    public void Same_parameter_instance_is_used_twice_in_nested_lambdas()
+    {
+        var f1 = Parameter(typeof(Func<int, bool>), "f1");
+        var f2 = Parameter(typeof(Func<int, bool>), "f2");
+        var i = Parameter(typeof(int), "i");
+
+        AssertExpression(
+            Assign(
+                f1,
+                Lambda<Func<int, bool>>(
+                    Block(
+                        Assign(
+                            f2,
+                            Lambda<Func<int, bool>>(
+                                Equal(i, Constant(5)),
+                                i)),
+                        Constant(true)),
+                    i)),
+"""
+f1 = i =>
+{
+    f2 = i => i == 5;
+    return true;
+}
+""");
+    }
+
+    [Fact]
+    public void Block_with_non_standalone_expression_as_statement()
+        => AssertStatement(
+            Block(Add(Constant(1), Constant(2))),
+"""
+{
+    _ = 1 + 2;
+}
+""");
+
+    [Fact]
+    public void Statement_condition_block_inside_expression_block_with_lifted_statements()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(
+                    i, Block(
+                        // We're in expression context. Do anything that will get lifted.
+                        Call(FooMethod),
+                        // Statement condition
+                        IfThen(
+                            Constant(true),
+                            Block(
+                                Call(BarMethod),
+                                Call(BazMethod))),
+                        // Last expression (to make the block above evaluate as statement
+                        Constant(8)))),
+"""
+{
+    LinqToCSharpTranslatorTest.Foo();
+    if (true)
+    {
+        LinqToCSharpTranslatorTest.Bar();
+        LinqToCSharpTranslatorTest.Baz();
+    }
+
+    var i = 8;
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_block_in_assignment_context()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i, Block(
+                    variables: new[] { j },
+                    Assign(j, Call(FooMethod)),
+                    Call(ReturnsIntWithParamMethod, j)))),
+"""
+{
+    var j = LinqToCSharpTranslatorTest.Foo();
+    var i = LinqToCSharpTranslatorTest.ReturnsIntWithParam(j);
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_block_in_method_call_context()
+    {
+        AssertStatement(
+            Block(
+                Call(
+                    ReturnsIntWithParamMethod,
+                    Block(
+                        Call(FooMethod),
+                        Call(BarMethod)))),
+"""
+{
+    LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.ReturnsIntWithParam(LinqToCSharpTranslatorTest.Bar());
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_nested_block()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+
+        AssertStatement(
+            Block(variables: new[] { i },
+            Assign(
+                i,
+                Block(
+                    variables: new[] { j },
+                    Assign(j, Call(FooMethod)),
+                    Block(
+                        Call(BarMethod),
+                        Call(ReturnsIntWithParamMethod, j))))),
+"""
+{
+    var j = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Bar();
+    var i = LinqToCSharpTranslatorTest.ReturnsIntWithParam(j);
+}
+""");
+    }
+
+    [Fact]
+    public void Binary_lifts_left_side_if_right_is_lifted()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i,
+                    Add(
+                        Call(FooMethod),
+                        Block(
+                            Call(BarMethod),
+                            Call(BazMethod))))),
+"""
+{
+    var lifted = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Bar();
+    var i = lifted + LinqToCSharpTranslatorTest.Baz();
+}
+""");
+    }
+
+    [Fact]
+    public void Binary_does_not_lift_left_side_if_it_has_no_side_effects()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i,
+                    Add(
+                        Constant(5),
+                        Block(
+                            Call(BarMethod),
+                            Call(BazMethod))))),
+"""
+{
+    LinqToCSharpTranslatorTest.Bar();
+    var i = 5 + LinqToCSharpTranslatorTest.Baz();
+}
+""");
+    }
+
+    [Fact]
+    public void Method_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i,
+                    Call(
+                        typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(MethodWithSixParams))!,
+                        Call(FooMethod),
+                        Constant(5),
+                        Block(Call(BarMethod), Call(BazMethod)),
+                        Call(FooMethod),
+                        Block(Call(BazMethod), Call(BarMethod)),
+                        Call(FooMethod)))),
+"""
+{
+    var liftedArg = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Bar();
+    var liftedArg0 = LinqToCSharpTranslatorTest.Baz();
+    var liftedArg1 = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Baz();
+    var i = LinqToCSharpTranslatorTest.MethodWithSixParams(liftedArg, 5, liftedArg0, liftedArg1, LinqToCSharpTranslatorTest.Bar(), LinqToCSharpTranslatorTest.Foo());
+}
+""");
+    }
+
+    [Fact]
+    public void New_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void Index_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void ListInit_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void NewArray_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void Lift_variable_in_expression_block()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i, Block(
+                    variables: new[] { j },
+                    Block(
+                        Call(FooMethod),
+                        Assign(j, Constant(8)),
+                        Constant(9))))),
+"""
+{
+    int j;
+    LinqToCSharpTranslatorTest.Foo();
+    j = 8;
+    var i = 9;
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_block_in_lambda_body_expression()
+    {
+        AssertExpression(
+            Lambda<Func<int>>(
+                Call(
+                    ReturnsIntWithParamMethod,
+                    Block(
+                        Call(FooMethod),
+                        Call(BarMethod))),
+                Array.Empty<ParameterExpression>()),
+"""
+() =>
+{
+    LinqToCSharpTranslatorTest.Foo();
+    return LinqToCSharpTranslatorTest.ReturnsIntWithParam(LinqToCSharpTranslatorTest.Bar());
+}
+""");
+    }
+
+    [Fact]
+    public void Do_not_lift_block_in_lambda_body()
+    {
+        AssertExpression(
+            Lambda<Func<int>>(
+                Block(Block(Constant(8))),
+                Array.Empty<ParameterExpression>()),
+"""
+() =>
+{
+    {
+        return 8;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Simplify_block_with_single_expression()
+        => AssertExpression(
+            Assign(Parameter(typeof(int), "i"), Block(Constant(8))),
+            "i = 8");
+
+    [Fact]
+    public void Cannot_lift_out_of_expression_context()
+        => Assert.Throws<NotSupportedException>(
+            () => AssertExpression(
+                Assign(
+                    Parameter(typeof(int), "i"),
+                    Block(
+                        Call(FooMethod),
+                        Constant(8))),
+                ""));
+
+    [Fact]
+    public void Lift_switch_expression()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+        var k = Parameter(typeof(int), "k");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i, j },
+                Assign(j, Constant(8)),
+                Assign(
+                    i,
+                    Switch(
+                        j,
+                        defaultBody: Block(Constant(0)),
+                        SwitchCase(
+                            Block(
+                                Block(
+                                    Assign(k, Call(FooMethod)),
+                                    Call(ReturnsIntWithParamMethod, k))),
+                            Constant(8)),
+                        SwitchCase(Constant(2), Constant(9))))),
+"""
+{
+    int i;
+    var j = 8;
+    switch (j)
+    {
+        case 8:
+        {
+            k = LinqToCSharpTranslatorTest.Foo();
+            i = LinqToCSharpTranslatorTest.ReturnsIntWithParam(k);
+            break;
+        }
+
+        case 9:
+            i = 2;
+            break;
+        default:
+            i = 0;
+            break;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_nested_switch_expression()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+        var k = Parameter(typeof(int), "k");
+        var l = Parameter(typeof(int), "l");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i, j, k },
+                Assign(j, Constant(8)),
+                Assign(
+                    i,
+                    Switch(
+                        j,
+                        defaultBody: Constant(0),
+                        SwitchCase(Constant(1), Constant(100)),
+                        SwitchCase(
+                            Switch(
+                                k,
+                                defaultBody: Constant(0),
+                                SwitchCase(
+                                    Block(
+                                        variables: new[] { l },
+                                        Assign(l, Call(FooMethod)),
+                                        Call(ReturnsIntWithParamMethod, l)),
+                                    Constant(200)),
+                                SwitchCase(Constant(3), Constant(300))),
+                            Constant(200))))),
+"""
+{
+    int i;
+    int k;
+    var j = 8;
+    switch (j)
+    {
+        case 100:
+            i = 1;
+            break;
+        case 200:
+        {
+            switch (k)
+            {
+                case 200:
+                {
+                    var l = LinqToCSharpTranslatorTest.Foo();
+                    i = LinqToCSharpTranslatorTest.ReturnsIntWithParam(l);
+                    break;
+                }
+
+                case 300:
+                    i = 3;
+                    break;
+                default:
+                    i = 0;
+                    break;
+            }
+
+            break;
+        }
+
+        default:
+            i = 0;
+            break;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_non_literal_switch_expression()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(
+                    i,
+                    Switch(
+                        Parameter(typeof(Blog), "blog1"),
+                        defaultBody: Block(Constant(0)),
+                        SwitchCase(
+                            Block(
+                                Call(ReturnsIntWithParamMethod, Constant(8)),
+                                Constant(1)),
+                            Parameter(typeof(Blog), "blog2")),
+                        SwitchCase(
+                            Block(
+                                Call(ReturnsIntWithParamMethod, Constant(9)),
+                                Constant(2)),
+                            Parameter(typeof(Blog), "blog3")),
+                        SwitchCase(Constant(3), Parameter(typeof(Blog), "blog4"))))),
+"""
+{
+    int i;
+    if (blog1 == blog2)
+    {
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(8);
+        i = 1;
+    }
+    else
+    {
+        if (blog1 == blog3)
+        {
+            LinqToCSharpTranslatorTest.ReturnsIntWithParam(9);
+            i = 2;
+        }
+        else
+        {
+            i = blog1 == blog4 ? 3 : 0;
+        }
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void TypeEqual_node()
+        => AssertExpression(
+            TypeEqual(Parameter(typeof(object), "p"), typeof(int)),
+            "p == typeof(int)");
+
+    [Fact]
+    public void TypeIs_node()
+        => AssertExpression(
+            TypeIs(Parameter(typeof(object), "p"), typeof(int)),
+            "p is int");
+
+    [Fact]
+    public void Goto_with_named_label()
+    {
+        var labelTarget = Label("label1");
+
+        AssertStatement(
+            Block(
+                Goto(labelTarget),
+                Label(labelTarget),
+                Call(FooMethod)),
+"""
+{
+    goto label1;
+    label1:
+        LinqToCSharpTranslatorTest.Foo();
+}
+""");
+    }
+
+    [Fact]
+    public void Goto_with_label_on_last_line()
+    {
+        var labelTarget = Label("label1");
+
+        AssertStatement(
+            Block(
+                Goto(labelTarget),
+                Label(labelTarget)),
+"""
+{
+    goto label1;
+    label1:
+        ;
+}
+""");
+    }
+
+    [Fact]
+    public void Goto_outside_label()
+    {
+        var labelTarget = Label();
+
+        AssertStatement(
+            Block(
+                IfThen(
+                    Constant(true),
+                    Block(
+                        Call(FooMethod),
+                        Goto(labelTarget))),
+                Label(labelTarget)),
+"""
+{
+    if (true)
+    {
+        LinqToCSharpTranslatorTest.Foo();
+        goto unnamedLabel;
+    }
+
+    unnamedLabel:
+        ;
+}
+""");
+    }
+
+    [Fact]
+    public void Goto_with_unnamed_labels_in_sibling_blocks()
+    {
+        var labelTarget1 = Label();
+        var labelTarget2 = Label();
+
+        AssertStatement(
+            Block(
+                Block(
+                    Goto(labelTarget1),
+                    Label(labelTarget1)),
+                Block(
+                    Goto(labelTarget2),
+                    Label(labelTarget2))),
+"""
+{
+    {
+        goto unnamedLabel;
+        unnamedLabel:
+            ;
+    }
+
+    {
+        goto unnamedLabel;
+        unnamedLabel:
+            ;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Loop_statement_infinite()
+        => AssertStatement(
+            Loop(Call(FooMethod)),
+"""
+while (true)
+{
+    LinqToCSharpTranslatorTest.Foo();
+}
+""");
+
+    [Fact]
+    public void Loop_statement_with_break_and_continue()
+    {
+        var i = Parameter(typeof(int), "i");
+        var breakLabel = Label();
+        var continueLabel = Label();
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i, Constant(0)),
+                Loop(
+                    Block(
+                        IfThen(
+                            Equal(i, Constant(100)),
+                            Break(breakLabel)),
+                        IfThen(
+                            Equal(Modulo(i, Constant(2)), Constant(0)),
+                            Continue(continueLabel)),
+                        PostIncrementAssign(i)),
+                    breakLabel,
+                    continueLabel)),
+"""
+{
+    var i = 0;
+    {
+        while (true)
+        {
+            unnamedLabel0:
+                if (i == 100)
+                {
+                    goto unnamedLabel;
+                }
+
+            if (i % 2 == 0)
+            {
+                goto unnamedLabel0;
+            }
+
+            i++;
+        }
+
+        unnamedLabel:
+            ;
+    }
+}
+""");
+    }
+
+    private void AssertStatement(Expression expression, string expected)
+        => AssertCore(expression, isStatement: true, expected);
+
+    private void AssertExpression(Expression expression, string expected)
+        => AssertCore(expression, isStatement: false, expected);
+
+    private void AssertCore(Expression expression, bool isStatement, string expected)
+    {
+        var (translator, workspace) = CreateTranslator();
+        var namespaces = new HashSet<string>();
+        var node = isStatement
+            ? translator.TranslateStatement(expression, namespaces)
+            : translator.TranslateExpression(expression, namespaces);
+
+        if (_outputExpressionTrees)
+        {
+            _testOutputHelper.WriteLine("---- Input LINQ expression tree:");
+            _testOutputHelper.WriteLine(_expressionPrinter.PrintExpression(expression));
+        }
+
+        // TODO: Actually compile the output C# code to make sure it's valid.
+        // TODO: For extra credit, execute both code representations and make sure the results are the same
+        // Simplifier.ReduceAsync(expression).Result
+
+        var code = node.NormalizeWhitespace().ToFullString();
+
+        var projectId = ProjectId.CreateNewId();
+        var versionStamp = VersionStamp.Create();
+        var projectInfo = ProjectInfo.Create(projectId, versionStamp, "TestProj", "TestProj", LanguageNames.CSharp);
+        workspace.AddProject(projectInfo);
+        var document = workspace.AddDocument(projectId, "Test.cs", SourceText.From(code));
+
+        var syntaxRootFoo = document.GetSyntaxRootAsync().Result!;
+        var annotatedDocument = document.WithSyntaxRoot(syntaxRootFoo.WithAdditionalAnnotations(Simplifier.Annotation));
+        document = Simplifier.ReduceAsync(annotatedDocument).Result;
+
+        var actual = document.GetTextAsync().Result.ToString();
+
+        try
+        {
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+
+            if (_outputExpressionTrees)
+            {
+                _testOutputHelper.WriteLine("---- Output Roslyn syntax tree:");
+                _testOutputHelper.WriteLine(actual);
+            }
+        }
+        catch (EqualException)
+        {
+            _testOutputHelper.WriteLine("---- Output Roslyn syntax tree:");
+            _testOutputHelper.WriteLine(actual);
+
+            throw;
+        }
+    }
+
+    private (LinqToCSharpTranslator, AdhocWorkspace) CreateTranslator()
+    {
+        var workspace = new AdhocWorkspace();
+        var syntaxGenerator = SyntaxGenerator.GetGenerator(workspace, LanguageNames.CSharp);
+        return (new LinqToCSharpTranslator(syntaxGenerator), workspace);
+    }
+
+    // ReSharper disable UnusedMember.Local
+    // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
+    // ReSharper disable UnusedParameter.Local
+    // ReSharper disable UnusedAutoPropertyAccessor.Local
+    // ReSharper disable MemberCanBePrivate.Local
+
+    private static readonly MethodInfo ReturnsIntWithParamMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(ReturnsIntWithParam))!;
+
+    public static int ReturnsIntWithParam(int i)
+        => i + 1;
+
+    private static readonly MethodInfo WithInOutRefParameterMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(WithInOutRefParameter))!;
+
+    public static void WithInOutRefParameter(in int inParam, out int outParam, ref int refParam)
+    {
+        outParam = 8;
+    }
+
+    private static readonly MethodInfo GenericMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethods().Single(m => m.Name == nameof(GenericMethodImplementation));
+
+    public static int GenericMethodImplementation<T>(T t)
+        => 0;
+
+    private static readonly MethodInfo FooMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(Foo))!;
+
+    public static int Foo()
+        => 1;
+
+    private static readonly MethodInfo BarMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(Bar))!;
+
+    public static int Bar()
+        => 1;
+
+    private static readonly MethodInfo BazMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(Baz))!;
+
+    public static int Baz()
+        => 1;
+
+    public static int MethodWithSixParams(int a, int b, int c, int d, int e, int f)
+        => a + b + c + d + e + f;
+
+    private class Blog
+    {
+#pragma warning disable CS0169
+        private int _privateField;
+        private int _internalField;
+#pragma warning restore CS0169
+        private int PrivateProperty { get; set; }
+        private int InternalProperty { get; set; }
+
+        public Blog() {}
+        public Blog(string name) {}
+
+        public int SomeInstanceMethod()
+            => 3;
+
+        public static readonly ConstructorInfo Constructor
+            = typeof(Blog).GetConstructor(Array.Empty<Type>())!;
+
+        public static int Static_method_on_nested_type()
+            => 3;
+    }
+
+    private class BlogWithRequiredProperties
+    {
+        public required string Name { get; set; }
+        public required int Rating { get; set; }
+
+        public BlogWithRequiredProperties() {}
+
+        public BlogWithRequiredProperties(string name)
+        {
+            Name = name;
+        }
+
+        [SetsRequiredMembers]
+        public BlogWithRequiredProperties(string name, int rating)
+        {
+            Name = name;
+            Rating = rating;
+        }
+    }
+
+    [Flags]
+    public enum SomeEnum
+    {
+        One = 1,
+        Two = 2
+    }
+
+    // ReSharper restore UnusedMember.Local
+    // ReSharper restore AutoPropertyCanBeMadeGetOnly.Local
+    // ReSharper restore UnusedParameter.Local
+    // ReSharper restore UnusedAutoPropertyAccessor.Local
+    // ReSharper restore MemberCanBePrivate.Local
+
+    private readonly ExpressionPrinter _expressionPrinter = new();
+    private readonly bool _outputExpressionTrees;
+}
+
+internal class LinqExpressionToRoslynTranslatorExtensionType
+{
+    public static readonly ConstructorInfo Constructor
+        = typeof(LinqExpressionToRoslynTranslatorExtensionType).GetConstructor(Array.Empty<Type>())!;
+}
+
+internal static class LinqExpressionToRoslynTranslatorExtensions
+{
+    public static readonly MethodInfo SomeExtensionMethod
+        = typeof(LinqExpressionToRoslynTranslatorExtensions).GetMethod(
+            nameof(SomeExtension), new[] { typeof(LinqExpressionToRoslynTranslatorExtensionType) })!;
+
+    public static int SomeExtension(this LinqExpressionToRoslynTranslatorExtensionType? someType)
+        => 3;
+}

--- a/test/EFCore.Relational.Tests/Query/Internal/BufferedDataReaderTest.cs
+++ b/test/EFCore.Relational.Tests/Query/Internal/BufferedDataReaderTest.cs
@@ -179,7 +179,7 @@ public class BufferedDataReaderTest
 
         var columns = new[]
         {
-            ReaderColumn.Create(columnType, true, null, null, (Func<DbDataReader, int[], T>)((r, _) => r.GetFieldValue<T>(0)))
+            ReaderColumn.Create(columnType, true, null, null, (Expression<Func<DbDataReader, int[], T>>)((r, _) => r.GetFieldValue<T>(0)))
         };
 
         var bufferedReader = new BufferedDataReader(reader, false);


### PR DESCRIPTION
Here's a first "semi-complete" working implementation of precompiled queries (#25009), for creating a feature branch. We can use this PR for first discussions.

To test this:

* Create a console program referencing this branch via `<ProjectReference>`, and run `dotnet ef dbcontext optimize` (I've replaced that to do precompiled querying, until we decide on the exact CLI switch (also to make it easier to test without needing a modified dotnet-ef tool)).
* Alternatively, you can do the precompiled query generation from your console app itself, which makes for a nice inner loop experience (you can debug into it etc.):

<details>
<summary>Triggering precompilation from your console app</summary>

```c#
if (args.Length > 0 && args[0] == "regenerate")
{
    var services = new ServiceCollection()
        .AddEntityFrameworkDesignTimeServices()
        .AddDbContextDesignTimeServices(ctx);
    var npgsqlDesignTimeServices = new SqlServerDesignTimeServices();
    npgsqlDesignTimeServices.ConfigureDesignTimeServices(services);
    var serviceProvider = services.BuildServiceProvider();
    var precompiledQueriesCodeGenerator = serviceProvider.GetRequiredService<IPrecompiledQueryCodeGenerator>();
    await precompiledQueriesCodeGenerator.GeneratePrecompiledQueries("/home/roji/projects/test/Test.csproj", ctx, outputDir: "/home/roji/projects/test");
    return;
}
```
</details>

* This builds the the project using Roslyn; note that this build is in additional to the regular build when invoking dotnet ef. Also, since you're referencing EF as a project reference, this will build EF too (long but only with this test setup).
* This reports the queries it identified, and generates an EFPrecompiledQueryBootstrapper into the project directory.
* When you run your console program, any query which was precompiled should be picked up, skipping runtime compilation.
* It can be useful to configure logging to show when query compilation and execution occur:

```c#
optionsBuilder.LogTo(Console.WriteLine, new[] { CoreEventId.QueryCompilationStarting, RelationalEventId.CommandExecuted })
```

</details>

This is by no means complete - I have a list of stuff that still needs to be done (split query, ExecuteUpdate/Delete, SQL queries, possibly some expression tree edge cases...).

To track issues you come across, I suggest posting them as a todo list in #25009  - no need for lots of different issues at this point).