### PR TITLE
Support resolving application services from singleton internal services

### DIFF
--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -447,6 +447,41 @@ public class DbContextOptionsBuilder : IDbContextOptionsBuilderInfrastructure
         => WithOption(e => e.WithApplicationServiceProvider(serviceProvider));
 
     /// <summary>
+    ///     Sets the root <see cref="IServiceProvider" /> from which singleton application services can be obtained from singleton
+    ///     internal services.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is an advanced option that is rarely needed by normal applications. Calling this method will result in a new internal
+    ///         service provider being created for every different root application service provider.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="rootServiceProvider">The service provider to be used.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual DbContextOptionsBuilder UseRootApplicationServiceProvider(IServiceProvider? rootServiceProvider)
+        => WithOption(e => e.WithRootApplicationServiceProvider(rootServiceProvider));
+
+    /// <summary>
+    ///     Resolves the root <see cref="IServiceProvider" /> from from the scoped application service provider. The root provider can
+    ///     be used to obtain singleton application services from singleton internal services.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is an advanced option that is rarely needed by normal applications. Calling this method will result in a new internal
+    ///         service provider being created for every different root application service provider.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual DbContextOptionsBuilder ResolveRootApplicationServiceProvider()
+        => WithOption(e => e.WithAutoResolveRootApplicationServiceProvider(true));
+
+    /// <summary>
     ///     Enables application data to be included in exception messages, logging, etc. This can include the
     ///     values assigned to properties of your entity instances, parameter values for commands being sent
     ///     to the database, and other such data. You should only enable this flag if you have the appropriate

--- a/src/EFCore/DbContextOptionsBuilder`.cs
+++ b/src/EFCore/DbContextOptionsBuilder`.cs
@@ -366,6 +366,41 @@ public class DbContextOptionsBuilder<TContext> : DbContextOptionsBuilder
         => (DbContextOptionsBuilder<TContext>)base.UseApplicationServiceProvider(serviceProvider);
 
     /// <summary>
+    ///     Sets the root <see cref="IServiceProvider" /> from which singleton application services can be obtained from singleton
+    ///     internal services.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is an advanced option that is rarely needed by normal applications. Calling this method will result in a new internal
+    ///         service provider being created for every different root application service provider.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="rootServiceProvider">The service provider to be used.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public new virtual DbContextOptionsBuilder<TContext> UseRootApplicationServiceProvider(IServiceProvider? rootServiceProvider)
+        => (DbContextOptionsBuilder<TContext>)base.UseRootApplicationServiceProvider(rootServiceProvider);
+
+    /// <summary>
+    ///     Resolves the root <see cref="IServiceProvider" /> from from the scoped application service provider. The root provider can
+    ///     be used to obtain singleton application services from singleton internal services.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is an advanced option that is rarely needed by normal applications. Calling this method will result in a new internal
+    ///         service provider being created for every different root application service provider.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-dbcontext-options">Using DbContextOptions</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public new virtual DbContextOptionsBuilder<TContext> ResolveRootApplicationServiceProvider()
+        => (DbContextOptionsBuilder<TContext>)base.ResolveRootApplicationServiceProvider();
+
+    /// <summary>
     ///     Enables application data to be included in exception messages, logging, etc. This can include the
     ///     values assigned to properties of your entity instances, parameter values for commands being sent
     ///     to the database, and other such data. You should only enable this flag if you have the appropriate

--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -1040,6 +1040,8 @@ public static class EntityFrameworkServiceCollectionExtensions
         ServiceLifetime optionsLifetime)
         where TContextImplementation : DbContext
     {
+        serviceCollection.TryAddSingleton<ServiceProviderAccessor>();
+
         serviceCollection.TryAdd(
             new ServiceDescriptor(
                 typeof(DbContextOptions<TContextImplementation>),

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -130,6 +130,9 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
         var clone = Clone();
 
         clone._applicationServiceProvider = applicationServiceProvider;
+        clone._rootApplicationServiceProvider ??= _autoResolveResolveRootProvider
+            ? applicationServiceProvider?.GetService<ServiceProviderAccessor>()?.RootServiceProvider
+            : null;
 
         return clone;
     }
@@ -160,6 +163,9 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
         var clone = Clone();
 
         clone._autoResolveResolveRootProvider = autoResolve;
+        clone._rootApplicationServiceProvider ??= autoResolve
+            ? _applicationServiceProvider?.GetService<ServiceProviderAccessor>()?.RootServiceProvider
+            : null;
 
         return clone;
     }
@@ -458,10 +464,7 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
     ///     The option set from the <see cref="DbContextOptionsBuilder.UseRootApplicationServiceProvider" /> method.
     /// </summary>
     public virtual IServiceProvider? RootApplicationServiceProvider
-        => _rootApplicationServiceProvider
-            ?? (_autoResolveResolveRootProvider
-                ? _applicationServiceProvider?.GetService<ServiceProviderAccessor>()?.RootServiceProvider
-                : null);
+        => _rootApplicationServiceProvider;
 
     /// <summary>
     ///     The option set from the <see cref="DbContextOptionsBuilder.UseRootApplicationServiceProvider" /> method.

--- a/src/EFCore/Infrastructure/ICoreSingletonOptions.cs
+++ b/src/EFCore/Infrastructure/ICoreSingletonOptions.cs
@@ -28,4 +28,9 @@ public interface ICoreSingletonOptions : ISingletonOptions
     ///     Reflects the option set by <see cref="DbContextOptionsBuilder.EnableThreadSafetyChecks" />.
     /// </summary>
     bool AreThreadSafetyChecksEnabled { get; }
+
+    /// <summary>
+    ///     The root service provider for the application, if available. />.
+    /// </summary>
+    IServiceProvider? RootApplicationServiceProvider { get; }
 }

--- a/src/EFCore/Infrastructure/Internal/CoreSingletonOptions.cs
+++ b/src/EFCore/Infrastructure/Internal/CoreSingletonOptions.cs
@@ -23,6 +23,7 @@ public class CoreSingletonOptions : ICoreSingletonOptions
 
         AreDetailedErrorsEnabled = coreOptions.DetailedErrorsEnabled;
         AreThreadSafetyChecksEnabled = coreOptions.ThreadSafetyChecksEnabled;
+        RootApplicationServiceProvider = coreOptions.RootApplicationServiceProvider;
     }
 
     /// <summary>
@@ -54,6 +55,14 @@ public class CoreSingletonOptions : ICoreSingletonOptions
                     nameof(DbContextOptionsBuilder.EnableThreadSafetyChecks),
                     nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
         }
+
+        if (RootApplicationServiceProvider != coreOptions.RootApplicationServiceProvider)
+        {
+            throw new InvalidOperationException(
+                CoreStrings.SingletonOptionChanged(
+                    nameof(DbContextOptionsBuilder.UseRootApplicationServiceProvider),
+                    nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
+        }
     }
 
     /// <summary>
@@ -71,4 +80,12 @@ public class CoreSingletonOptions : ICoreSingletonOptions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool AreThreadSafetyChecksEnabled { get; private set; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual IServiceProvider? RootApplicationServiceProvider { get; private set; }
 }

--- a/src/EFCore/Infrastructure/ServiceProviderAccessor.cs
+++ b/src/EFCore/Infrastructure/ServiceProviderAccessor.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure;
+
+/// <summary>
+///     This type is added as a singleton service to the application service provider to provide access to the
+///     root service provider.
+/// </summary>
+public class ServiceProviderAccessor
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ServiceProviderAccessor" /> class.
+    /// </summary>
+    /// <param name="rootServiceProvider">The injected service provider.</param>
+    public ServiceProviderAccessor(IServiceProvider rootServiceProvider)
+    {
+        RootServiceProvider = rootServiceProvider;
+    }
+
+    /// <summary>
+    ///     The injected service provider.
+    /// </summary>
+    public virtual IServiceProvider RootServiceProvider { get; }
+}


### PR DESCRIPTION
Fixes #13540

Scoped and transient internal services can obtain application services using the `DbContext` as a service locator. Singleton services cannot do this since they do not have access to the `DbContext`. This change allows the root application service provider to be registered as an `ISingletonOption` such that singleton internal services can resolve singleton and transient application services.

