### PR TITLE
Use case-insensitive string comparisons by default on SQL Server

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -252,6 +252,15 @@ public readonly record struct RelationalTypeMappingInfo
     }
 
     /// <summary>
+    ///     Indicates whether or not the mapping should be compared, etc. as if it is a key.
+    /// </summary>
+    public bool HasKeySemantics
+    {
+        get => _coreTypeMappingInfo.HasKeySemantics;
+        init => _coreTypeMappingInfo = _coreTypeMappingInfo with { HasKeySemantics = value };
+    }
+
+    /// <summary>
     ///     Indicates whether or not the mapping supports Unicode, or <see langword="null" /> if not defined.
     /// </summary>
     public bool? IsUnicode

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
@@ -18,6 +18,8 @@ public class SqlServerStringTypeMapping : StringTypeMapping
     private const int UnicodeMax = 4000;
     private const int AnsiMax = 8000;
 
+    private static readonly CaseInsensitiveValueComparer CaseInsensitiveValueComparer = new();
+
     private readonly bool _isUtf16;
     private readonly SqlDbType? _sqlDbType;
     private readonly int _maxSpecificSize;
@@ -35,10 +37,14 @@ public class SqlServerStringTypeMapping : StringTypeMapping
         int? size = null,
         bool fixedLength = false,
         SqlDbType? sqlDbType = null,
-        StoreTypePostfix? storeTypePostfix = null)
+        StoreTypePostfix? storeTypePostfix = null,
+        bool useKeyComparison = false)
         : this(
             new RelationalTypeMappingParameters(
-                new CoreTypeMappingParameters(typeof(string)),
+                new CoreTypeMappingParameters(
+                    typeof(string),
+                    comparer: useKeyComparison ? CaseInsensitiveValueComparer : null,
+                    keyComparer: useKeyComparison ? CaseInsensitiveValueComparer : null),
                 storeType ?? GetDefaultStoreName(unicode, fixedLength),
                 storeTypePostfix ?? StoreTypePostfix.Size,
                 GetDbType(unicode, fixedLength),

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -336,7 +336,8 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
                 }
 
                 if (size == null
-                    && storeTypeName == null)
+                    && storeTypeName == null
+                    && !mappingInfo.HasKeySemantics)
                 {
                     return isAnsi
                         ? isFixedLength
@@ -351,7 +352,8 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
                     unicode: !isAnsi,
                     size: size,
                     fixedLength: isFixedLength,
-                    storeTypePostfix: storeTypeName == null ? StoreTypePostfix.Size : StoreTypePostfix.None);
+                    storeTypePostfix: storeTypeName == null ? StoreTypePostfix.Size : StoreTypePostfix.None,
+                    useKeyComparison: mappingInfo.HasKeySemantics);
             }
 
             if (clrType == typeof(byte[]))

--- a/src/EFCore/ChangeTracking/CaseInsensitiveValueComparer.cs
+++ b/src/EFCore/ChangeTracking/CaseInsensitiveValueComparer.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking;
+
+/// <summary>
+///     Case-insensitive value comparison for strings.
+/// </summary>
+public class CaseInsensitiveValueComparer : ValueComparer<string?>
+{
+    /// <summary>
+    ///    Creates a value comparer instance.
+    /// </summary>
+    public CaseInsensitiveValueComparer()
+        : base(
+            (l, r) => string.Equals(l, r, StringComparison.OrdinalIgnoreCase),
+            v => v == null ? 0 : v.ToUpper().GetHashCode())
+    {
+    }
+}

--- a/src/EFCore/ChangeTracking/CaseInsensitiveValueComparer.cs
+++ b/src/EFCore/ChangeTracking/CaseInsensitiveValueComparer.cs
@@ -14,7 +14,7 @@ public class CaseInsensitiveValueComparer : ValueComparer<string?>
     public CaseInsensitiveValueComparer()
         : base(
             (l, r) => string.Equals(l, r, StringComparison.OrdinalIgnoreCase),
-            v => v == null ? 0 : v.ToUpper().GetHashCode())
+            v => v == null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(v))
     {
     }
 }

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -97,7 +97,8 @@ public readonly record struct TypeMappingInfo
         var mappingHints = customConverter?.MappingHints;
         var property = principals[0];
 
-        IsKeyOrIndex = property.IsKey() || property.IsForeignKey() || property.IsIndex();
+        HasKeySemantics = property.IsKey() || property.IsForeignKey();
+        IsKeyOrIndex = HasKeySemantics || property.IsIndex();
         Size = fallbackSize ?? mappingHints?.Size;
         IsUnicode = fallbackUnicode ?? mappingHints?.IsUnicode;
         IsRowVersion = property.IsConcurrencyToken && property.ValueGenerated == ValueGenerated.OnAddOrUpdate;
@@ -138,6 +139,7 @@ public readonly record struct TypeMappingInfo
     /// <param name="rowVersion">Specifies a row-version, or <see langword="null" /> for default.</param>
     /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
+    /// <param name="keySemantics">If <see langword="true" />, then a special mapping for a key or foreign key may be returned.</param>
     public TypeMappingInfo(
         Type? type = null,
         bool keyOrIndex = false,
@@ -145,11 +147,13 @@ public readonly record struct TypeMappingInfo
         int? size = null,
         bool? rowVersion = null,
         int? precision = null,
-        int? scale = null)
+        int? scale = null,
+        bool keySemantics = false)
     {
         ClrType = type?.UnwrapNullableType();
 
         IsKeyOrIndex = keyOrIndex;
+        HasKeySemantics = keySemantics;
         Size = size;
         IsUnicode = unicode;
         IsRowVersion = rowVersion;
@@ -176,6 +180,7 @@ public readonly record struct TypeMappingInfo
     {
         IsRowVersion = source.IsRowVersion;
         IsKeyOrIndex = source.IsKeyOrIndex;
+        HasKeySemantics = source.HasKeySemantics;
 
         var mappingHints = converter.MappingHints;
 
@@ -199,6 +204,11 @@ public readonly record struct TypeMappingInfo
     ///     Indicates whether or not the mapping is part of a key or index.
     /// </summary>
     public bool IsKeyOrIndex { get; init; }
+
+    /// <summary>
+    ///     Indicates whether or not the mapping should be compared, etc. as if it is a key.
+    /// </summary>
+    public bool HasKeySemantics { get; init; }
 
     /// <summary>
     ///     Indicates the store-size to use for the mapping, or null if none.

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -1141,18 +1141,11 @@ public abstract class CustomConvertersTestBase<TFixture> : BuiltInDataTypesTestB
                         v => v.Skip(3).ToArray());
                 });
 
-            var caseInsensitiveComparer = new ValueComparer<string>(
-                (l, r) => (l == null || r == null) ? (l == r) : l.Equals(r, StringComparison.InvariantCultureIgnoreCase),
-                v => StringComparer.InvariantCultureIgnoreCase.GetHashCode(v),
-                v => v);
-
             modelBuilder.Entity<StringKeyDataType>(
                 b =>
                 {
                     var property = b.Property(e => e.Id)
                         .HasConversion(v => "KeyValue=" + v, v => v.Substring(9)).Metadata;
-
-                    property.SetValueComparer(caseInsensitiveComparer);
                 });
 
             modelBuilder.Entity<StringForeignKeyDataType>(
@@ -1161,8 +1154,7 @@ public abstract class CustomConvertersTestBase<TFixture> : BuiltInDataTypesTestB
                     b.Property(e => e.StringKeyDataTypeId)
                         .HasConversion(
                             v => "KeyValue=" + v,
-                            v => v.Substring(9),
-                            caseInsensitiveComparer);
+                            v => v.Substring(9));
                 });
 
             modelBuilder.Entity<MaxLengthDataTypes>(


### PR DESCRIPTION
Fixes #27526


