### PR TITLE
Long and ULong properties marked as rowversion automatically convert to binary on SQL Server

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerLongTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerLongTypeMapping.cs
@@ -21,8 +21,15 @@ public class SqlServerLongTypeMapping : LongTypeMapping
     /// </summary>
     public SqlServerLongTypeMapping(
         string storeType,
+        ValueConverter? converter = null,
+        ValueComparer? comparer = null,
+        ValueComparer? providerValueComparer = null,
         DbType? dbType = System.Data.DbType.Int64)
-        : base(storeType, dbType)
+        : this(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(long), converter, comparer, providerValueComparer),
+                storeType,
+                dbType: dbType))
     {
     }
 

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -43,6 +43,26 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
                 v => v.ToArray()),
             storeTypePostfix: StoreTypePostfix.None);
 
+    private readonly SqlServerLongTypeMapping _longRowversion
+        = new(
+            "rowversion",
+            converter: new NumberToBytesConverter<long>(),
+            providerValueComparer: new ValueComparer<byte[]>(
+                (v1, v2) => StructuralComparisons.StructuralEqualityComparer.Equals(v1, v2),
+                v => StructuralComparisons.StructuralEqualityComparer.GetHashCode(v),
+                v => v.ToArray()),
+            dbType: DbType.Binary);
+
+    private readonly SqlServerLongTypeMapping _ulongRowversion
+        = new(
+            "rowversion",
+            converter: new NumberToBytesConverter<ulong>(),
+            providerValueComparer: new ValueComparer<byte[]>(
+                (v1, v2) => StructuralComparisons.StructuralEqualityComparer.Equals(v1, v2),
+                v => StructuralComparisons.StructuralEqualityComparer.GetHashCode(v),
+                v => v.ToArray()),
+            dbType: DbType.Binary);
+
     private readonly IntTypeMapping _int
         = new("int");
 
@@ -291,6 +311,16 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
             if (_clrTypeMappings.TryGetValue(clrType, out var mapping))
             {
                 return mapping;
+            }
+
+            if (clrType == typeof(ulong) && mappingInfo.IsRowVersion == true)
+            {
+                return _ulongRowversion;
+            }
+
+            if (clrType == typeof(long) && mappingInfo.IsRowVersion == true)
+            {
+                return _longRowversion;
             }
 
             if (clrType == typeof(string))

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -926,16 +926,16 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     public virtual IModel Timestamp_takes_precedence_over_MaxLength()
     {
         var modelBuilder = CreateModelBuilder();
-        modelBuilder.Entity<TimestampAndMaxlen>().Ignore(x => x.NonMaxTimestamp);
+        modelBuilder.Entity<TimestampAndMaxlength>().Ignore(x => x.NonMaxTimestamp);
 
         var model = Validate(modelBuilder);
 
-        Assert.Null(GetProperty<TimestampAndMaxlen>(model, "MaxTimestamp").GetMaxLength());
+        Assert.Null(GetProperty<TimestampAndMaxlength>(model, "MaxTimestamp").GetMaxLength());
 
         return model;
     }
 
-    protected class TimestampAndMaxlen
+    protected class TimestampAndMaxlength
     {
         public int Id { get; set; }
 

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -143,7 +143,7 @@ public class DataAnnotationSqlServerTest : DataAnnotationRelationalTestBase<Data
     {
         var model = base.Timestamp_takes_precedence_over_MaxLength();
 
-        var property = GetProperty<TimestampAndMaxlen>(model, "MaxTimestamp");
+        var property = GetProperty<TimestampAndMaxlength>(model, "MaxTimestamp");
 
         var storeType = property.GetRelationalTypeMapping().StoreType;
 

--- a/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
 namespace Microsoft.EntityFrameworkCore;
@@ -22,14 +23,10 @@ public class F1ULongSqlServerFixture : F1SqlServerFixtureBase<ulong>
             .OwnsOne(
                 s => s.Details, eb =>
                 {
-                    eb.Property<ulong>("Version").IsRowVersion().HasConversion<byte[]>();
+                    eb.Property<ulong>("Version").IsRowVersion();
                 });
 
-        modelBuilder
-            .Entity<OptimisticOptionalChild>()
-            .Property(x => x.Version)
-            .IsRowVersion()
-            .HasConversion<byte[]>();
+        modelBuilder.Entity<OptimisticOptionalChild>();
 
         modelBuilder
             .Entity<OptimisticParent>()
@@ -78,7 +75,9 @@ public class F1ULongSqlServerFixture : F1SqlServerFixtureBase<ulong>
     {
         public Guid Id { get; set; }
         public ICollection<OptimisticParent> Parents { get; set; }
-        public ulong Version { get; set; }
+
+        [Timestamp]
+        public long Version { get; set; }
     }
 
     public class OptimisticParent

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -69,7 +69,7 @@ public class DataAnnotationSqliteTest : DataAnnotationRelationalTestBase<DataAnn
     {
         var model = base.Timestamp_takes_precedence_over_MaxLength();
 
-        var property = GetProperty<TimestampAndMaxlen>(model, "MaxTimestamp");
+        var property = GetProperty<TimestampAndMaxlength>(model, "MaxTimestamp");
 
         var storeType = property.GetRelationalTypeMapping().StoreType;
 

--- a/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
@@ -471,12 +471,16 @@ public class PropertyAttributeConventionTest
 
     #region TimestampAttribute
 
-    [ConditionalFact]
-    public void TimestampAttribute_overrides_configuration_from_convention_source()
+    [ConditionalTheory]
+    [InlineData("Timestamp")]
+    [InlineData("LongTimestamp")]
+    [InlineData("ULongTimestamp")]
+    public void TimestampAttribute_overrides_configuration_from_convention_source(string propertyName)
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(byte[]), "Timestamp", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(
+            typeof(A).GetProperty(propertyName)!.PropertyType, propertyName, ConfigurationSource.Explicit)!;
 
         propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Convention);
         propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Convention);
@@ -487,12 +491,16 @@ public class PropertyAttributeConventionTest
         Assert.True(propertyBuilder.Metadata.IsConcurrencyToken);
     }
 
-    [ConditionalFact]
-    public void TimestampAttribute_does_not_override_configuration_from_explicit_source()
+    [ConditionalTheory]
+    [InlineData("Timestamp")]
+    [InlineData("LongTimestamp")]
+    [InlineData("ULongTimestamp")]
+    public void TimestampAttribute_does_not_override_configuration_from_explicit_source(string propertyName)
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(byte[]), "Timestamp", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(
+            typeof(A).GetProperty(propertyName)!.PropertyType, propertyName, ConfigurationSource.Explicit)!;
 
         propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
         propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Explicit);
@@ -782,6 +790,12 @@ public class PropertyAttributeConventionTest
         [Timestamp]
         public byte[] Timestamp { get; set; }
 
+        [Timestamp]
+        public long LongTimestamp { get; set; }
+
+        [Timestamp]
+        public ulong ULongTimestamp { get; set; }
+
         [Required]
         private int? PrivateProperty { get; set; }
 
@@ -854,7 +868,13 @@ public class PropertyAttributeConventionTest
         public string StringLengthProperty;
 
         [Timestamp]
-        public byte[] Timestamp;
+        public byte[] Timestamp { get; set; }
+
+        [Timestamp]
+        public long LongTimestamp { get; set; }
+
+        [Timestamp]
+        public ulong ULongTimestamp { get; set; }
     }
 
     private class BaseEntity


### PR DESCRIPTION
Fixes #12434
