### PR TITLE
Remove unnecessary dependency on MS.CA.VB package

### DIFF
--- a/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
+++ b/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
@@ -40,7 +40,6 @@
     <ProjectReference Include="..\..\src\EFCore.Relational\EFCore.Relational.csproj" />
     <ProjectReference Include="..\EFCore.Tests\EFCore.Tests.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR does not fix any bugs or add new features and is very small in size, so I think, it doesn't need an issue to be opened first. I just notecied, that for whatever reason analyzer tests have a dependency on a VB package, while the analyzers themselves are for C# only. I verified, that removing this dependency doesn't break test execution locally. If there is some mysterious sense in having this dependency, I won't regret if the PR gets closed. It actually took more time to setup EF repo on my machine than the time taken by the actual change...