### PR TITLE
Fix typo in ApplyConfigurationsFromAssembly XML doc

### DIFF
--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -493,7 +493,7 @@ public class ModelBuilder : IInfrastructure<IConventionModelBuilder>
     }
 
     /// <summary>
-    ///     Applies configuration from all <see cref="IEntityTypeConfiguration{TEntity}" /> />
+    ///     Applies configuration from all <see cref="IEntityTypeConfiguration{TEntity}" />
     ///     instances that are defined in provided assembly.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

