### PR TITLE
[release/7.0] Fix split query over GroupBy over parameter (#30024)

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1280,6 +1280,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("NoDbCommand");
 
         /// <summary>
+        ///     Expression of type '{type}' isn't supported as the Values of an InExpression; only constants and parameters are supported.
+        /// </summary>
+        public static string NonConstantOrParameterAsInExpressionValues(object? type)
+            => string.Format(
+                GetString("NonConstantOrParameterAsInExpressionValues", nameof(type)),
+                type);
+
+        /// <summary>
         ///     'FindMapping' was called on a 'RelationalTypeMappingSource' with a non-relational 'TypeMappingInfo'.
         /// </summary>
         public static string NoneRelationalTypeMappingOnARelationalTypeMappingSource

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -899,6 +899,9 @@
   <data name="NoDbCommand" xml:space="preserve">
     <value>Cannot create a DbCommand for a non-relational query.</value>
   </data>
+  <data name="NonConstantOrParameterAsInExpressionValues" xml:space="preserve">
+    <value>Expression of type '{type}' isn't supported as the Values of an InExpression; only constants and parameters are supported.</value>
+  </data>
   <data name="NoneRelationalTypeMappingOnARelationalTypeMappingSource" xml:space="preserve">
     <value>'FindMapping' was called on a 'RelationalTypeMappingSource' with a non-relational 'TypeMappingInfo'.</value>
   </data>

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsCollectionsQueryTestBase.cs
@@ -2199,6 +2199,26 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture> : Que
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Collection_projection_over_GroupBy_over_parameter(bool async)
+    {
+        var validIds = new List<string> { "L1 01", "L1 02" };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Level1>()
+                .Where(l1 => validIds.Contains(l1.Name))
+                .GroupBy(l => l.Date)
+                .Select(g => new { g.Key, Ids = g.Select(e => e.Id) }),
+            elementSorter: e => e.Key,
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.Key, a.Key);
+                AssertCollection(e.Ids, a.Ids);
+            });
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task SelectMany_over_conditional_null_source(bool async)
         => AssertTranslationFailed(
             () => AssertQueryScalar(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -2319,6 +2319,28 @@ ORDER BY [l].[Id], [t2].[Date], [t2].[Date0], [t2].[Name]
 """);
     }
 
+    public override async Task Collection_projection_over_GroupBy_over_parameter(bool async)
+    {
+        await base.Collection_projection_over_GroupBy_over_parameter(async);
+
+        AssertSql(
+"""
+SELECT [t].[Date], [t0].[Id]
+FROM (
+    SELECT [l].[Date]
+    FROM [LevelOne] AS [l]
+    WHERE [l].[Name] IN (N'L1 01', N'L1 02')
+    GROUP BY [l].[Date]
+) AS [t]
+LEFT JOIN (
+    SELECT [l0].[Id], [l0].[Date]
+    FROM [LevelOne] AS [l0]
+    WHERE [l0].[Name] IN (N'L1 01', N'L1 02')
+) AS [t0] ON [t].[Date] = [t0].[Date]
+ORDER BY [t].[Date]
+""");
+    }
+
     public override async Task Include_partially_added_before_Where_and_then_build_upon(bool async)
     {
         await base.Include_partially_added_before_Where_and_then_build_upon(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -3003,6 +3003,28 @@ ORDER BY [l].[Id], [t2].[Date], [t2].[Date0], [t2].[Name]
 """);
     }
 
+    public override async Task Collection_projection_over_GroupBy_over_parameter(bool async)
+    {
+        await base.Collection_projection_over_GroupBy_over_parameter(async);
+
+        AssertSql(
+"""
+SELECT [t].[Date], [t0].[Id]
+FROM (
+    SELECT [l].[Date]
+    FROM [Level1] AS [l]
+    WHERE [l].[Name] IN (N'L1 01', N'L1 02')
+    GROUP BY [l].[Date]
+) AS [t]
+LEFT JOIN (
+    SELECT [l0].[Id], [l0].[Date]
+    FROM [Level1] AS [l0]
+    WHERE [l0].[Name] IN (N'L1 01', N'L1 02')
+) AS [t0] ON [t].[Date] = [t0].[Date]
+ORDER BY [t].[Date]
+""");
+    }
+
     public override async Task Filtered_include_is_considered_loaded(bool async)
     {
         await base.Filtered_include_is_considered_loaded(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
@@ -3728,6 +3728,36 @@ ORDER BY [l].[Id], [t].[Date], [t0].[Name], [t0].[Date]
 """);
     }
 
+    public override async Task Collection_projection_over_GroupBy_over_parameter(bool async)
+    {
+        await base.Collection_projection_over_GroupBy_over_parameter(async);
+
+        AssertSql(
+"""
+SELECT [l].[Date]
+FROM [LevelOne] AS [l]
+WHERE [l].[Name] IN (N'L1 01', N'L1 02')
+GROUP BY [l].[Date]
+ORDER BY [l].[Date]
+""",
+            //
+"""
+SELECT [t0].[Id], [t].[Date]
+FROM (
+    SELECT [l].[Date]
+    FROM [LevelOne] AS [l]
+    WHERE [l].[Name] IN (N'L1 01', N'L1 02')
+    GROUP BY [l].[Date]
+) AS [t]
+INNER JOIN (
+    SELECT [l0].[Id], [l0].[Date]
+    FROM [LevelOne] AS [l0]
+    WHERE [l0].[Name] IN (N'L1 01', N'L1 02')
+) AS [t0] ON [t].[Date] = [t0].[Date]
+ORDER BY [t].[Date]
+""");
+    }
+
     public override async Task Include_partially_added_before_Where_and_then_build_upon(bool async)
     {
         await base.Include_partially_added_before_Where_and_then_build_upon(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -2293,6 +2293,28 @@ ORDER BY [l].[Id], [t2].[Date], [t2].[Date0], [t2].[Name]
 """);
     }
 
+    public override async Task Collection_projection_over_GroupBy_over_parameter(bool async)
+    {
+        await base.Collection_projection_over_GroupBy_over_parameter(async);
+
+        AssertSql(
+"""
+SELECT [t].[Date], [t0].[Id]
+FROM (
+    SELECT [l].[Date]
+    FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
+    WHERE [l].[Name] IN (N'L1 01', N'L1 02')
+    GROUP BY [l].[Date]
+) AS [t]
+LEFT JOIN (
+    SELECT [l0].[Id], [l0].[Date]
+    FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
+    WHERE [l0].[Name] IN (N'L1 01', N'L1 02')
+) AS [t0] ON [t].[Date] = [t0].[Date]
+ORDER BY [t].[Date]
+""");
+    }
+
     public override async Task Multiple_SelectMany_navigation_property_followed_by_select_collection_navigation(bool async)
     {
         await base.Multiple_SelectMany_navigation_property_followed_by_select_collection_navigation(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -3021,6 +3021,28 @@ ORDER BY [l].[Id], [t2].[Date], [t2].[Date0], [t2].[Name]
 """);
     }
 
+    public override async Task Collection_projection_over_GroupBy_over_parameter(bool async)
+    {
+        await base.Collection_projection_over_GroupBy_over_parameter(async);
+
+        AssertSql(
+"""
+SELECT [t].[Date], [t0].[Id]
+FROM (
+    SELECT [l].[Date]
+    FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
+    WHERE [l].[Name] IN (N'L1 01', N'L1 02')
+    GROUP BY [l].[Date]
+) AS [t]
+LEFT JOIN (
+    SELECT [l0].[Id], [l0].[Date]
+    FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
+    WHERE [l0].[Name] IN (N'L1 01', N'L1 02')
+) AS [t0] ON [t].[Date] = [t0].[Date]
+ORDER BY [t].[Date]
+""");
+    }
+
     public override async Task Skip_Take_on_grouping_element_into_non_entity(bool async)
     {
         await base.Skip_Take_on_grouping_element_into_non_entity(async);


### PR DESCRIPTION
Fixes #30022, backports #30024

**Description**

A bug in split query handling results in an incorrect SQL query tree.

**Customer impact**

Valid LINQ queries involving split queries and GroupBy which worked in EF Core 6.0 throw NullReferenceException in 7.0.

**How found**

Customer report on 7.0.

**Regression**

Yes, from 6.0.

**Testing**

Added tests for the affected scenario.

**Risk**

Very low; the bug is very obvious and the fix is a one-liner.