### PR TITLE
[release/7.0] Take schema into account when comparing FK constraints.

### DIFF
--- a/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraintComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraintComparer.cs
@@ -12,6 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 // Sealed for perf
 public sealed class ForeignKeyConstraintComparer : IEqualityComparer<IForeignKeyConstraint>, IComparer<IForeignKeyConstraint>
 {
+    private static readonly bool QuirkEnabled29741
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29741", out var enabled) && enabled;
+
     private ForeignKeyConstraintComparer()
     {
     }
@@ -66,7 +69,24 @@ public sealed class ForeignKeyConstraintComparer : IEqualityComparer<IForeignKey
         }
 
         result = StringComparer.Ordinal.Compare(x.PrincipalTable.Name, y.PrincipalTable.Name);
-        return result != 0 ? result : StringComparer.Ordinal.Compare(x.Table.Name, y.Table.Name);
+        if (result != 0)
+        {
+            return result;
+        }
+
+        result = StringComparer.Ordinal.Compare(x.Table.Name, y.Table.Name);
+        if (result != 0 || QuirkEnabled29741)
+        {
+            return result;
+        }
+
+        result = StringComparer.Ordinal.Compare(x.PrincipalTable.Schema, y.PrincipalTable.Schema);
+        if (result != 0)
+        {
+            return result;
+        }
+
+        return result != 0 ? result : StringComparer.Ordinal.Compare(x.Table.Schema, y.Table.Schema);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #29741

### Customer Impact

A foreign key constraint is lost when the model contains two tables with the same name, but in different schemas with FKs referencing the same table. This causes exceptions during SaveChanges and invalid migrations. There are no known workarounds.

### Regression?

No.

### Risk

Low. This change is constrained to FK comparison and a quirk mode was added.

### Verification

Added a test for the affected scenario.
