### PR TITLE
Use precision/scale facets instead of store type when reverse engineering

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -401,10 +401,9 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
 
         property.HasColumnName(column.Name);
 
-        if (!typeScaffoldingInfo.IsInferred
-            && !string.IsNullOrWhiteSpace(column.StoreType))
+        if (!string.IsNullOrWhiteSpace(typeScaffoldingInfo.ScaffoldColumnType))
         {
-            property.HasColumnType(column.StoreType);
+            property.HasColumnType(typeScaffoldingInfo.ScaffoldColumnType);
         }
 
         if (typeScaffoldingInfo.ScaffoldUnicode.HasValue)

--- a/src/EFCore.Design/Scaffolding/Internal/TypeScaffoldingInfo.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/TypeScaffoldingInfo.cs
@@ -19,14 +19,14 @@ public class TypeScaffoldingInfo
     /// </summary>
     public TypeScaffoldingInfo(
         Type clrType,
-        bool inferred,
+        string? scaffoldColumnType,
         bool? scaffoldUnicode,
         int? scaffoldMaxLength,
         bool? scaffoldFixedLength,
         int? scaffoldPrecision,
         int? scaffoldScale)
     {
-        IsInferred = inferred;
+        ScaffoldColumnType = scaffoldColumnType;
         ScaffoldUnicode = scaffoldUnicode;
         ScaffoldMaxLength = scaffoldMaxLength;
         ScaffoldPrecision = scaffoldPrecision;
@@ -49,7 +49,7 @@ public class TypeScaffoldingInfo
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool IsInferred { get; }
+    public virtual string? ScaffoldColumnType { get; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -467,7 +467,7 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
                     + "("
                     + (scale == null || parameters.StoreTypePostfix == StoreTypePostfix.Precision
                         ? precision.ToString()
-                        : precision + "," + scale)
+                        : precision + ", " + scale)
                     + ")";
             }
         }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -4174,7 +4174,7 @@ namespace RootNamespace
 
                     b.Property<decimal>("Price")
                         .HasPrecision(7)
-                        .HasColumnType("decimal(7,2)");
+                        .HasColumnType("decimal(7, 2)");
 
                     b.HasKey("Id");
 
@@ -4208,7 +4208,7 @@ namespace RootNamespace
 
                     b.Property<decimal>("Price")
                         .HasPrecision(7, 3)
-                        .HasColumnType("decimal(7,3)");
+                        .HasColumnType("decimal(7, 3)");
 
                     b.HasKey("Id");
 
@@ -6904,7 +6904,7 @@ namespace RootNamespace
                         .HasColumnType("datetimeoffset");
 
                     b.Property<decimal>("Decimal")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(18, 2)");
 
                     b.Property<double>("Double")
                         .HasColumnType("float");
@@ -6931,7 +6931,7 @@ namespace RootNamespace
                         .HasColumnType("bigint");
 
                     b.Property<decimal>("EnumU64")
-                        .HasColumnType("decimal(20,0)");
+                        .HasColumnType("decimal(20, 0)");
 
                     b.Property<short>("Int16")
                         .HasColumnType("smallint");
@@ -6943,7 +6943,7 @@ namespace RootNamespace
                         .HasColumnType("bigint");
 
                     b.Property<decimal?>("OptionalProperty")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(18, 2)");
 
                     b.Property<short>("SignedByte")
                         .HasColumnType("smallint");
@@ -7006,7 +7006,7 @@ namespace RootNamespace
                         .HasColumnType("bigint");
 
                     b.Property<decimal>("UnsignedInt64")
-                        .HasColumnType("decimal(20,0)");
+                        .HasColumnType("decimal(20, 0)");
 
                     b.HasKey("Id");
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -2182,7 +2182,7 @@ namespace TestNamespace
                     Assert.False(dependentMoney.IsConcurrencyToken);
                     Assert.Equal(ValueGenerated.Never, dependentMoney.ValueGenerated);
                     Assert.Equal("Money", dependentMoney.GetColumnName());
-                    Assert.Equal("decimal(9,3)", dependentMoney.GetColumnType());
+                    Assert.Equal("decimal(9, 3)", dependentMoney.GetColumnType());
                     Assert.Null(dependentMoney.GetMaxLength());
                     Assert.Null(dependentMoney.IsUnicode());
                     Assert.Null(dependentMoney.IsFixedLength());

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -358,7 +358,7 @@ public class RelationalScaffoldingModelFactoryTest
     [ConditionalTheory]
     [InlineData("nvarchar(450)", null)]
     [InlineData("datetime2(4)", null)]
-    [InlineData("DateTime2(4)", "DateTime2(4)")]
+    [InlineData("DateTime2(4)", null)]
     public void Column_type_annotation(string storeType, string expectedColumnType)
     {
         var column = new DatabaseColumn

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqlServerTest.cs
@@ -17,7 +17,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("int", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<int>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<int>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalTheory]
@@ -27,7 +27,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("bigint", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<long>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<long>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalTheory]
@@ -35,10 +35,10 @@ public class ScaffoldingTypeMapperSqlServerTest
     [InlineData(true)]
     public void Maps_default_decimal_column(bool isKeyOrIndex)
     {
-        var mapping = CreateMapper().FindMapping("decimal(18,2)", isKeyOrIndex, rowVersion: false);
+        var mapping = CreateMapper().FindMapping("decimal(18, 2)", isKeyOrIndex, rowVersion: false);
 
         AssertMapping<decimal>(
-            mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalTheory]
@@ -46,9 +46,9 @@ public class ScaffoldingTypeMapperSqlServerTest
     [InlineData(true)]
     public void Maps_non_default_decimal_column(bool isKeyOrIndex)
     {
-        var mapping = CreateMapper().FindMapping("decimal(14,3)", isKeyOrIndex, rowVersion: false);
+        var mapping = CreateMapper().FindMapping("decimal(14, 3)", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<decimal>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: 14, scale: 3);
+        AssertMapping<decimal>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: 14, scale: 3);
     }
 
     [ConditionalTheory]
@@ -59,7 +59,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("numeric(17,4)", isKeyOrIndex, rowVersion: false);
 
         AssertMapping<decimal>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "numeric", maxLength: null, unicode: null, fixedLength: null, precision: 17, scale: 4);
     }
 
     [ConditionalTheory]
@@ -69,7 +69,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("bit", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<bool>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<bool>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalTheory]
@@ -80,7 +80,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("datetime", isKeyOrIndex, rowVersion: false);
 
         AssertMapping<DateTime>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "datetime", maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalTheory]
@@ -91,7 +91,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("datetime2", isKeyOrIndex, rowVersion: false);
 
         AssertMapping<DateTime>(
-            mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -99,7 +99,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -107,7 +107,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -115,7 +115,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -124,7 +124,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: true, rowVersion: false);
 
         AssertMapping<byte[]>(
-            mapping, inferred: true, maxLength: -1, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: null, maxLength: -1, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -132,7 +132,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -140,7 +140,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(900)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -148,7 +148,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -156,7 +156,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("binary(900)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: true, precision: null, scale: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -164,7 +164,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("rowversion", keyOrIndex: false, rowVersion: true);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -173,7 +173,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: false, rowVersion: true);
 
         AssertMapping<byte[]>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "varbinary", maxLength: -1, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -182,7 +182,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: false, rowVersion: true);
 
         AssertMapping<byte[]>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "varbinary", maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -191,7 +191,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("varbinary(8)", keyOrIndex: false, rowVersion: true);
 
         AssertMapping<byte[]>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -200,7 +200,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("binary(max)", keyOrIndex: false, rowVersion: true);
 
         AssertMapping<byte[]>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "binary", maxLength: -1, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -209,7 +209,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: false, rowVersion: true);
 
         AssertMapping<byte[]>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "binary", maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -218,7 +218,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("binary(8)", keyOrIndex: false, rowVersion: true);
 
         AssertMapping<byte[]>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "binary", maxLength: null, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -226,7 +226,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(max)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -234,7 +234,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -243,7 +243,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("varchar(max)", keyOrIndex: false, rowVersion: false);
 
         AssertMapping<string>(
-            mapping, inferred: true, maxLength: null, unicode: false, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: null, maxLength: null, unicode: false, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -251,7 +251,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("varchar(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: 200, unicode: false, fixedLength: null, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: 200, unicode: false, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -260,7 +260,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("nvarchar(max)", keyOrIndex: true, rowVersion: false);
 
         AssertMapping<string>(
-            mapping, inferred: true, maxLength: -1, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: null, maxLength: -1, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -268,7 +268,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: 200, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -277,7 +277,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("varchar(max)", keyOrIndex: true, rowVersion: false);
 
         AssertMapping<string>(
-            mapping, inferred: true, maxLength: -1, unicode: false, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: null, maxLength: -1, unicode: false, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -285,7 +285,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("varchar(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: 200, unicode: false, fixedLength: null, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: 200, unicode: false, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -293,7 +293,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(450)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -302,7 +302,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("varchar(900)", keyOrIndex: true, rowVersion: false);
 
         AssertMapping<string>(
-            mapping, inferred: true, maxLength: null, unicode: false, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: null, maxLength: null, unicode: false, fixedLength: null, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -310,7 +310,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("nchar(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -318,7 +318,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("char(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: 200, unicode: false, fixedLength: true, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: 200, unicode: false, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -327,7 +327,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("nchar(max)", keyOrIndex: true, rowVersion: false);
 
         AssertMapping<string>(
-            mapping, inferred: true, maxLength: -1, unicode: null, fixedLength: true, precision: null, scale: null);
+            mapping, columnType: null, maxLength: -1, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -335,7 +335,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("nchar(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: 200, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -344,7 +344,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("char(max)", keyOrIndex: true, rowVersion: false);
 
         AssertMapping<string>(
-            mapping, inferred: true, maxLength: -1, unicode: false, fixedLength: true, precision: null, scale: null);
+            mapping, columnType: null, maxLength: -1, unicode: false, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -352,7 +352,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("char(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: 200, unicode: false, fixedLength: true, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: 200, unicode: false, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -360,7 +360,7 @@ public class ScaffoldingTypeMapperSqlServerTest
     {
         var mapping = CreateMapper().FindMapping("nchar(450)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: true, precision: null, scale: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -369,7 +369,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("char(900)", keyOrIndex: true, rowVersion: false);
 
         AssertMapping<string>(
-            mapping, inferred: true, maxLength: null, unicode: false, fixedLength: true, precision: null, scale: null);
+            mapping, columnType: null, maxLength: null, unicode: false, fixedLength: true, precision: null, scale: null);
     }
 
     [ConditionalFact]
@@ -378,12 +378,12 @@ public class ScaffoldingTypeMapperSqlServerTest
         var mapping = CreateMapper().FindMapping("text", keyOrIndex: true, rowVersion: false);
 
         AssertMapping<string>(
-            mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null, precision: null, scale: null);
+            mapping, columnType: "text", maxLength: null, unicode: false, fixedLength: null, precision: null, scale: null);
     }
 
     private static void AssertMapping<T>(
         TypeScaffoldingInfo mapping,
-        bool inferred,
+        string columnType,
         int? maxLength,
         bool? unicode,
         bool? fixedLength,
@@ -391,7 +391,7 @@ public class ScaffoldingTypeMapperSqlServerTest
         int? scale)
     {
         Assert.Same(typeof(T), mapping.ClrType);
-        Assert.Equal(inferred, mapping.IsInferred);
+        Assert.Equal(columnType, mapping.ScaffoldColumnType);
         Assert.Equal(maxLength, mapping.ScaffoldMaxLength);
         Assert.Equal(unicode, mapping.ScaffoldUnicode);
         Assert.Equal(fixedLength, mapping.ScaffoldFixedLength);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqliteTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqliteTest.cs
@@ -19,7 +19,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("text", keyOrIndex, rowVersion);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -31,7 +31,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("integer", keyOrIndex, rowVersion);
 
-        AssertMapping<long>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<long>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -43,7 +43,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("blob", keyOrIndex, rowVersion);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -55,7 +55,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("real", keyOrIndex, rowVersion);
 
-        AssertMapping<double>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<double>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -67,7 +67,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("TEXT", keyOrIndex, rowVersion);
 
-        AssertMapping<string>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -79,7 +79,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("INTEGER", keyOrIndex, rowVersion);
 
-        AssertMapping<long>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<long>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -91,7 +91,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("BLOB", keyOrIndex, rowVersion);
 
-        AssertMapping<byte[]>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -103,7 +103,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("REAL", keyOrIndex, rowVersion);
 
-        AssertMapping<double>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<double>(mapping, columnType: null, maxLength: null, unicode: null, fixedLength: null);
     }
 
     // Type affinity cases...
@@ -115,7 +115,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("int", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<long>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<long>(mapping, columnType: "int", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -125,7 +125,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("bigint", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<long>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<long>(mapping, columnType: "bigint", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -133,7 +133,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -141,7 +141,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -149,7 +149,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "binary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -157,7 +157,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -165,7 +165,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -173,7 +173,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(900)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -181,15 +181,15 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "binary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
     public void Maps_key_binary_default_sized_column()
     {
-        var mapping = CreateMapper().FindMapping("binary(900)", keyOrIndex: true, rowVersion: false);
+        var mapping = CreateMapper().FindMapping("binary", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "binary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -197,7 +197,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(max)", keyOrIndex: false, rowVersion: true);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -205,7 +205,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(200)", keyOrIndex: false, rowVersion: true);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -213,7 +213,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varbinary(8)", keyOrIndex: false, rowVersion: true);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "varbinary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -221,7 +221,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("binary(max)", keyOrIndex: false, rowVersion: true);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "binary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -229,7 +229,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("binary(200)", keyOrIndex: false, rowVersion: true);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "binary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -237,7 +237,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("binary(8)", keyOrIndex: false, rowVersion: true);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "binary", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -245,7 +245,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(max)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nvarchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -253,7 +253,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nvarchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -261,7 +261,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varchar(max)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "varchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -269,7 +269,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varchar(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "varchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -277,7 +277,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(max)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nvarchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -285,7 +285,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nvarchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -293,7 +293,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varchar(max)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "varchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -301,7 +301,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varchar(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "varchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -309,7 +309,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nvarchar(450)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nvarchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -317,7 +317,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("varchar(900)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "varchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -325,7 +325,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nchar(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -333,7 +333,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("char(200)", keyOrIndex: false, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "char", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -341,7 +341,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nchar(max)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -349,7 +349,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nchar(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -357,7 +357,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("char(max)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "char", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -365,7 +365,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("char(200)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "char", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -373,7 +373,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("nchar(450)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "nchar", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -381,7 +381,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("char(900)", keyOrIndex: true, rowVersion: false);
 
-        AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<string>(mapping, columnType: "char", maxLength: null, unicode: null, fixedLength: null);
     }
 
     // Unknown type cases...
@@ -395,7 +395,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("", keyOrIndex, rowVersion);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalFact]
@@ -403,7 +403,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("rowversion", keyOrIndex: false, rowVersion: true);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "rowversion", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -413,7 +413,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("decimal(18, 2)", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "decimal", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -423,7 +423,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("bit", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "bit", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -433,7 +433,7 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("datetime", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "datetime", maxLength: null, unicode: null, fixedLength: null);
     }
 
     [ConditionalTheory]
@@ -443,13 +443,13 @@ public class ScaffoldingTypeMapperSqliteTest
     {
         var mapping = CreateMapper().FindMapping("datetime2", isKeyOrIndex, rowVersion: false);
 
-        AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        AssertMapping<byte[]>(mapping, columnType: "datetime2", maxLength: null, unicode: null, fixedLength: null);
     }
 
-    private static void AssertMapping<T>(TypeScaffoldingInfo mapping, bool inferred, int? maxLength, bool? unicode, bool? fixedLength)
+    private static void AssertMapping<T>(TypeScaffoldingInfo mapping, string columnType, int? maxLength, bool? unicode, bool? fixedLength)
     {
         Assert.Same(typeof(T), mapping.ClrType);
-        Assert.Equal(inferred, mapping.IsInferred);
+        Assert.Equal(columnType, mapping.ScaffoldColumnType);
         Assert.Equal(maxLength, mapping.ScaffoldMaxLength);
         Assert.Equal(unicode, mapping.ScaffoldUnicode);
         Assert.Equal(fixedLength, mapping.ScaffoldFixedLength);

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -107,7 +107,7 @@ ALTER TABLE [Person] ADD [Name] nvarchar(32) NULL;
 
         AssertSql(
 """
-ALTER TABLE [Person] ADD [Pi] decimal(15,10) NOT NULL;
+ALTER TABLE [Person] ADD [Pi] decimal(15, 10) NOT NULL;
 """);
     }
 
@@ -117,7 +117,7 @@ ALTER TABLE [Person] ADD [Pi] decimal(15,10) NOT NULL;
 
         AssertSql(
 """
-ALTER TABLE [Person] ADD [Pi] decimal(20,7) NOT NULL;
+ALTER TABLE [Person] ADD [Pi] decimal(20, 7) NOT NULL;
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -179,7 +179,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.Fraction') AS decimal(18,2)) < 20.5
+WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.Fraction') AS decimal(18, 2)) < 20.5
 """);
     }
 
@@ -1329,7 +1329,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
 
         AssertSql(
 """
-SELECT JSON_VALUE([j].[Reference],'$.TestDefaultString') AS [TestDefaultString], JSON_VALUE([j].[Reference],'$.TestMaxLengthString') AS [TestMaxLengthString], CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) AS [TestBoolean], CAST(JSON_VALUE([j].[Reference],'$.TestByte') AS tinyint) AS [TestByte], JSON_VALUE([j].[Reference],'$.TestCharacter') AS [TestCharacter], CAST(JSON_VALUE([j].[Reference],'$.TestDateTime') AS datetime2) AS [TestDateTime], CAST(JSON_VALUE([j].[Reference],'$.TestDateTimeOffset') AS datetimeoffset) AS [TestDateTimeOffset], CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18,3)) AS [TestDecimal], CAST(JSON_VALUE([j].[Reference],'$.TestDouble') AS float) AS [TestDouble], CAST(JSON_VALUE([j].[Reference],'$.TestGuid') AS uniqueidentifier) AS [TestGuid], CAST(JSON_VALUE([j].[Reference],'$.TestInt16') AS smallint) AS [TestInt16], CAST(JSON_VALUE([j].[Reference],'$.TestInt32') AS int) AS [TestInt32], CAST(JSON_VALUE([j].[Reference],'$.TestInt64') AS bigint) AS [TestInt64], CAST(JSON_VALUE([j].[Reference],'$.TestSignedByte') AS smallint) AS [TestSignedByte], CAST(JSON_VALUE([j].[Reference],'$.TestSingle') AS real) AS [TestSingle], CAST(JSON_VALUE([j].[Reference],'$.TestTimeSpan') AS time) AS [TestTimeSpan], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt16') AS int) AS [TestUnsignedInt16], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt32') AS bigint) AS [TestUnsignedInt32], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20,0)) AS [TestUnsignedInt64], JSON_VALUE([j].[Reference],'$.TestEnum') AS [TestEnum], CAST(JSON_VALUE([j].[Reference],'$.TestEnumWithIntConverter') AS int) AS [TestEnumWithIntConverter], JSON_VALUE([j].[Reference],'$.TestNullableEnum') AS [TestNullableEnum], CAST(JSON_VALUE([j].[Reference],'$.TestNullableEnumWithIntConverter') AS int) AS [TestNullableEnumWithIntConverter], JSON_VALUE([j].[Reference],'$.TestNullableEnumWithConverterThatHandlesNulls') AS [TestNullableEnumWithConverterThatHandlesNulls]
+SELECT JSON_VALUE([j].[Reference],'$.TestDefaultString') AS [TestDefaultString], JSON_VALUE([j].[Reference],'$.TestMaxLengthString') AS [TestMaxLengthString], CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) AS [TestBoolean], CAST(JSON_VALUE([j].[Reference],'$.TestByte') AS tinyint) AS [TestByte], JSON_VALUE([j].[Reference],'$.TestCharacter') AS [TestCharacter], CAST(JSON_VALUE([j].[Reference],'$.TestDateTime') AS datetime2) AS [TestDateTime], CAST(JSON_VALUE([j].[Reference],'$.TestDateTimeOffset') AS datetimeoffset) AS [TestDateTimeOffset], CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18, 3)) AS [TestDecimal], CAST(JSON_VALUE([j].[Reference],'$.TestDouble') AS float) AS [TestDouble], CAST(JSON_VALUE([j].[Reference],'$.TestGuid') AS uniqueidentifier) AS [TestGuid], CAST(JSON_VALUE([j].[Reference],'$.TestInt16') AS smallint) AS [TestInt16], CAST(JSON_VALUE([j].[Reference],'$.TestInt32') AS int) AS [TestInt32], CAST(JSON_VALUE([j].[Reference],'$.TestInt64') AS bigint) AS [TestInt64], CAST(JSON_VALUE([j].[Reference],'$.TestSignedByte') AS smallint) AS [TestSignedByte], CAST(JSON_VALUE([j].[Reference],'$.TestSingle') AS real) AS [TestSingle], CAST(JSON_VALUE([j].[Reference],'$.TestTimeSpan') AS time) AS [TestTimeSpan], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt16') AS int) AS [TestUnsignedInt16], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt32') AS bigint) AS [TestUnsignedInt32], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20, 0)) AS [TestUnsignedInt64], JSON_VALUE([j].[Reference],'$.TestEnum') AS [TestEnum], CAST(JSON_VALUE([j].[Reference],'$.TestEnumWithIntConverter') AS int) AS [TestEnumWithIntConverter], JSON_VALUE([j].[Reference],'$.TestNullableEnum') AS [TestNullableEnum], CAST(JSON_VALUE([j].[Reference],'$.TestNullableEnumWithIntConverter') AS int) AS [TestNullableEnumWithIntConverter], JSON_VALUE([j].[Reference],'$.TestNullableEnumWithConverterThatHandlesNulls') AS [TestNullableEnumWithConverterThatHandlesNulls]
 FROM [JsonEntitiesAllTypes] AS [j]
 """);
     }
@@ -1478,7 +1478,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDateTimeOffset') AS datetimeoffset)
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18,3)) <> 1.35 OR (CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18,3)) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18, 3)) <> 1.35 OR (CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18, 3)) IS NULL)
 """);
     }
 
@@ -1728,7 +1728,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt32') AS bigint) <> CAST(
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20,0)) <> 10000.0 OR (CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20,0)) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20, 0)) <> 10000.0 OR (CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20, 0)) IS NULL)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -673,7 +673,7 @@ FROM [Orders] AS [o]
 
         AssertSql(
 """
-SELECT COALESCE(SUM(CAST([o].[Quantity] AS decimal(18,2)) / 2.09), 0.0)
+SELECT COALESCE(SUM(CAST([o].[Quantity] AS decimal(18, 2)) / 2.09), 0.0)
 FROM [Order Details] AS [o]
 """);
     }
@@ -684,7 +684,7 @@ FROM [Order Details] AS [o]
 
         AssertSql(
 """
-SELECT COALESCE(SUM(CAST([o].[Quantity] AS decimal(18,2)) / 2.0), 0.0)
+SELECT COALESCE(SUM(CAST([o].[Quantity] AS decimal(18, 2)) / 2.0), 0.0)
 FROM [Order Details] AS [o]
 """);
     }
@@ -838,7 +838,7 @@ FROM [Orders] AS [o]
 
         AssertSql(
 """
-SELECT AVG(CAST([o].[Quantity] AS decimal(18,2)) / 2.09)
+SELECT AVG(CAST([o].[Quantity] AS decimal(18, 2)) / 2.09)
 FROM [Order Details] AS [o]
 """);
     }
@@ -849,7 +849,7 @@ FROM [Order Details] AS [o]
 
         AssertSql(
 """
-SELECT AVG(CAST([o].[Quantity] AS decimal(18,2)) / 2.0)
+SELECT AVG(CAST([o].[Quantity] AS decimal(18, 2)) / 2.0)
 FROM [Order Details] AS [o]
 """);
     }
@@ -902,7 +902,7 @@ SELECT AVG(CAST((
         FROM [Order Details] AS [o0]
         WHERE [o].[OrderID] = [o0].[OrderID]))
     FROM [Orders] AS [o]
-    WHERE [t].[CustomerID] = [o].[CustomerID]) AS decimal(18,2)))
+    WHERE [t].[CustomerID] = [o].[CustomerID]) AS decimal(18, 2)))
 FROM (
     SELECT TOP(@__p_0) [c].[CustomerID]
     FROM [Customers] AS [c]
@@ -929,7 +929,7 @@ SELECT AVG(CAST((
         FROM [Order Details] AS [o0]
         WHERE [o].[OrderID] = [o0].[OrderID])) AS float))
     FROM [Orders] AS [o]
-    WHERE [t].[CustomerID] = [o].[CustomerID]) AS decimal(18,2)))
+    WHERE [t].[CustomerID] = [o].[CustomerID]) AS decimal(18, 2)))
 FROM (
     SELECT TOP(@__p_0) [c].[CustomerID]
     FROM [Customers] AS [c]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2804,7 +2804,7 @@ ORDER BY [o].[OrderDate]
 
         AssertSql(
 """
-SELECT N'TotalAmount' AS [Name], COALESCE(SUM(CAST([t].[OrderID] AS decimal(18,2))), 0.0) AS [Value]
+SELECT N'TotalAmount' AS [Name], COALESCE(SUM(CAST([t].[OrderID] AS decimal(18, 2))), 0.0) AS [Value]
 FROM (
     SELECT [o].[OrderID], 1 AS [Key]
     FROM [Orders] AS [o]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1430,7 +1430,7 @@ WHERE [o].[CustomerID] = N'ALFKI'
 
         AssertSql(
 """
-SELECT CAST([o].[OrderID] AS decimal(18,2)) / CAST(([o].[OrderID] + 1000) AS decimal(18,2))
+SELECT CAST([o].[OrderID] AS decimal(18, 2)) / CAST(([o].[OrderID] + 1000) AS decimal(18, 2))
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] = 10243
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -4140,7 +4140,7 @@ VALUES (@p0);
 
             AssertSql(
 """
-SELECT COALESCE(SUM(CAST([i].[Quantity] AS decimal(18,2))), 0.0)
+SELECT COALESCE(SUM(CAST([i].[Quantity] AS decimal(18, 2))), 0.0)
 FROM [InventoryPools] AS [i]
 """);
         }
@@ -8276,10 +8276,10 @@ ORDER BY [t].[Id], [t].[MasterTrunk22340Id], [t].[MasterTrunk22340Id0], [f0].[Cu
 
         public class Currency22340
         {
-            [Column(TypeName = "decimal(18,2)")]
+            [Column(TypeName = "decimal(18, 2)")]
             public decimal Amount { get; set; }
 
-            [Column(TypeName = "decimal(18,2)")]
+            [Column(TypeName = "decimal(18, 2)")]
             public decimal Code { get; set; }
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Update/JsonUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/JsonUpdateSqlServerTest.cs
@@ -630,7 +630,7 @@ WHERE [j].[Id] = 1
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDecimal', CAST(JSON_VALUE(@p0, '$[0]') AS decimal(18,3))), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDecimal', CAST(JSON_VALUE(@p1, '$[0]') AS decimal(18,3)))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDecimal', CAST(JSON_VALUE(@p0, '$[0]') AS decimal(18, 3))), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDecimal', CAST(JSON_VALUE(@p1, '$[0]') AS decimal(18, 3)))
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -894,7 +894,7 @@ WHERE [j].[Id] = 1
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt64', CAST(JSON_VALUE(@p0, '$[0]') AS decimal(20,0))), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt64', CAST(JSON_VALUE(@p1, '$[0]') AS decimal(20,0)))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt64', CAST(JSON_VALUE(@p0, '$[0]') AS decimal(20, 0))), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt64', CAST(JSON_VALUE(@p1, '$[0]') AS decimal(20, 0)))
 OUTPUT 1
 WHERE [Id] = @p2;
 """,

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingSourceTest.cs
@@ -106,7 +106,7 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMapperTestBase
         var typeMapping = GetTypeMapping(typeof(decimal));
 
         Assert.Equal(DbType.Decimal, typeMapping.DbType);
-        Assert.Equal("decimal(18,2)", typeMapping.StoreType);
+        Assert.Equal("decimal(18, 2)", typeMapping.StoreType);
     }
 
     [ConditionalFact]
@@ -115,7 +115,7 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMapperTestBase
         var typeMapping = GetTypeMapping(typeof(decimal?));
 
         Assert.Equal(DbType.Decimal, typeMapping.DbType);
-        Assert.Equal("decimal(18,2)", typeMapping.StoreType);
+        Assert.Equal("decimal(18, 2)", typeMapping.StoreType);
     }
 
     [ConditionalTheory]
@@ -993,8 +993,8 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMapperTestBase
     [InlineData("datetime", typeof(DateTime), null, false, false)]
     [InlineData("datetime2", typeof(DateTime), null, false, false)]
     [InlineData("datetimeoffset", typeof(DateTimeOffset), null, false, false)]
-    [InlineData("dec", typeof(decimal), null, false, false, "dec(18,0)")]
-    [InlineData("decimal", typeof(decimal), null, false, false, "decimal(18,0)")]
+    [InlineData("dec", typeof(decimal), null, false, false, "dec(18, 0)")]
+    [InlineData("decimal", typeof(decimal), null, false, false, "decimal(18, 0)")]
     [InlineData("float", typeof(double), null, false, false)] // This is correct. SQL Server 'float' type maps to C# double
     [InlineData("float(10)", typeof(double), null, false, false)]
     [InlineData("image", typeof(byte[]), null, false, false)]
@@ -1007,7 +1007,7 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMapperTestBase
     [InlineData("national character(333)", typeof(string), 333, true, true)]
     [InlineData("nchar(333)", typeof(string), 333, true, true)]
     [InlineData("ntext", typeof(string), null, true, false)]
-    [InlineData("numeric", typeof(decimal), null, false, false, "numeric(18,0)")]
+    [InlineData("numeric", typeof(decimal), null, false, false, "numeric(18, 0)")]
     [InlineData("nvarchar(333)", typeof(string), 333, true, false)]
     [InlineData("nvarchar(max)", typeof(string), -1, true, false)]
     [InlineData("real", typeof(float), null, false, false)]
@@ -1336,7 +1336,7 @@ public class SqlServerTypeMappingSourceTest : RelationalTypeMapperTestBase
             mapper.GetMapping(model.FindEntityType(typeof(MyType)).FindProperty("Id")).StoreType);
 
         Assert.Equal(
-            "dec(6,1)",
+            "dec(6, 1)",
             mapper.GetMapping(model.FindEntityType(typeof(MyRelatedType1)).FindProperty("Relationship2Id")).StoreType);
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/29711

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

