### PR TITLE
Allow field navigations in proxies when lazy-loading is disabled for the navigation

### DIFF
--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
@@ -79,28 +79,37 @@ public class ProxyBindingRewriter : IModelFinalizingConvention
                 {
                     if (!navigationBase.IsShadowProperty())
                     {
-                        if (navigationBase.PropertyInfo == null)
+                        if (_options.UseChangeTrackingProxies)
                         {
-                            throw new InvalidOperationException(
-                                ProxiesStrings.FieldProperty(navigationBase.Name, entityType.DisplayName()));
-                        }
+                            if (navigationBase.PropertyInfo == null)
+                            {
+                                throw new InvalidOperationException(
+                                    ProxiesStrings.FieldProperty(navigationBase.Name, entityType.DisplayName()));
+                            }
 
-                        if (_options.UseChangeTrackingProxies
-                            && navigationBase.PropertyInfo.SetMethod?.IsReallyVirtual() == false)
-                        {
-                            throw new InvalidOperationException(
-                                ProxiesStrings.NonVirtualProperty(navigationBase.Name, entityType.DisplayName()));
+                            if (navigationBase.PropertyInfo.SetMethod?.IsReallyVirtual() == false)
+                            {
+                                throw new InvalidOperationException(
+                                    ProxiesStrings.NonVirtualProperty(navigationBase.Name, entityType.DisplayName()));
+                            }
                         }
 
                         if (_options.UseLazyLoadingProxies
                             && navigationBase.LazyLoadingEnabled)
                         {
-                            if (!navigationBase.PropertyInfo.GetMethod!.IsReallyVirtual())
+                            if (navigationBase.PropertyInfo == null
+                                || !navigationBase.PropertyInfo.GetMethod!.IsReallyVirtual())
                             {
                                 if (!_options.IgnoreNonVirtualNavigations
                                     && !(navigationBase is INavigation navigation
                                         && navigation.ForeignKey.IsOwnership))
                                 {
+                                    if (navigationBase.PropertyInfo == null)
+                                    {
+                                        throw new InvalidOperationException(
+                                            ProxiesStrings.FieldProperty(navigationBase.Name, entityType.DisplayName()));
+                                    }
+
                                     throw new InvalidOperationException(
                                         ProxiesStrings.NonVirtualProperty(navigationBase.Name, entityType.DisplayName()));
                                 }

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -37,6 +37,14 @@ public class LazyLoadingProxyTests
     }
 
     [ConditionalFact]
+    public void Does_not_throw_if_field_navigation_to_non_owned_type_is_allowed()
+    {
+        using var context = new LazyContextAllowingFieldNavigation();
+        Assert.NotNull(
+            context.Model.FindEntityType(typeof(LazyFieldNavEntity))!.FindNavigation(nameof(LazyFieldNavEntity.SelfRef)));
+    }
+
+    [ConditionalFact]
     public void Does_not_throw_if_non_virtual_navigation_is_set_to_not_eager_load()
     {
         using var context = new LazyContextDisabledNavigation();
@@ -45,10 +53,27 @@ public class LazyLoadingProxyTests
     }
 
     [ConditionalFact]
+    public void Does_not_throw_if_field_navigation_is_set_to_not_eager_load()
+    {
+        using var context = new LazyContextDisabledFieldNavigation();
+        Assert.NotNull(
+            context.Model.FindEntityType(typeof(LazyFieldNavEntity))!.FindNavigation(nameof(LazyFieldNavEntity.SelfRef)));
+    }
+
+    [ConditionalFact]
     public void Does_not_throw_if_non_virtual_navigation_to_owned_type()
     {
         using var context = new LazyContext<LazyNonVirtualOwnedNavEntity>();
-        var model = context.Model;
+        Assert.NotNull(
+            context.Model.FindEntityType(typeof(LazyNonVirtualOwnedNavEntity))!.FindNavigation(nameof(LazyNonVirtualOwnedNavEntity.NavigationToOwned)));
+    }
+
+    [ConditionalFact]
+    public void Does_not_throw_if_field_navigation_to_owned_type()
+    {
+        using var context = new LazyContextOwnedFieldNavigation();
+        Assert.NotNull(
+            context.Model.FindEntityType(typeof(LazyFieldOwnedNavEntity))!.FindNavigation(nameof(LazyFieldOwnedNavEntity.NavigationToOwned)));
     }
 
     [ConditionalFact]
@@ -131,6 +156,52 @@ public class LazyLoadingProxyTests
         }
     }
 
+    private class LazyContextAllowingFieldNavigation : TestContext<LazyFieldNavEntity>
+    {
+        public LazyContextAllowingFieldNavigation()
+            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false, ignoreNonVirtualNavigations: true)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<LazyFieldNavEntity>().HasOne(e => e.SelfRef).WithOne();
+        }
+    }
+
+    private class LazyContextDisabledFieldNavigation : TestContext<LazyFieldNavEntity>
+    {
+        public LazyContextDisabledFieldNavigation()
+            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<LazyFieldNavEntity>().HasOne(e => e.SelfRef).WithOne();
+            modelBuilder.Entity<LazyFieldNavEntity>().Navigation(e => e.SelfRef).EnableLazyLoading(false);
+        }
+    }
+
+    private class LazyContextOwnedFieldNavigation : TestContext<LazyFieldOwnedNavEntity>
+    {
+        public LazyContextOwnedFieldNavigation()
+            : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<LazyFieldOwnedNavEntity>().OwnsOne(e => e.NavigationToOwned).WithOwner(e => e.Owner);
+        }
+    }
+
     public sealed class LazySealedEntity
     {
         public int Id { get; set; }
@@ -141,6 +212,13 @@ public class LazyLoadingProxyTests
         public int Id { get; set; }
 
         public LazyNonVirtualNavEntity SelfRef { get; set; }
+    }
+
+    public class LazyFieldNavEntity
+    {
+        public int Id { get; set; }
+
+        public LazyFieldNavEntity SelfRef;
     }
 
     public class LazyNonVirtualOwnedNavEntity
@@ -158,6 +236,23 @@ public class LazyLoadingProxyTests
         public string Name { get; set; }
 
         public LazyNonVirtualOwnedNavEntity Owner { get; set; }
+    }
+
+    public class LazyFieldOwnedNavEntity
+    {
+        public int Id { get; set; }
+
+        public OwnedFieldNavEntity NavigationToOwned;
+    }
+
+    [Owned]
+    public class OwnedFieldNavEntity
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public LazyFieldOwnedNavEntity Owner;
     }
 
     public class LazyHiddenFieldEntity


### PR DESCRIPTION
Also when non-virtual navigations are allowed.

Fixes https://github.com/dotnet/efcore/issues/10787#issuecomment-1385422910
