### PR TITLE
[SMALL] Fix to #30073 - JSON query regression in EF8

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1539,7 +1539,7 @@ public sealed partial class SelectExpression : TableExpressionBase
 
                         remappedConstant = Constant(
                             new JsonProjectionInfo(
-                                jsonProjectionInfo.JsonColumnIndex,
+                                projectionIndexMap[jsonProjectionInfo.JsonColumnIndex],
                                 newKeyAccessInfo,
                                 jsonProjectionInfo.AdditionalPath));
                     }

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryFixtureBase.cs
@@ -377,6 +377,7 @@ public abstract class JsonQueryFixtureBase : SharedStoreFixtureBase<JsonQueryCon
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
         modelBuilder.Entity<JsonEntityBasic>().Property(x => x.Id).ValueGeneratedNever();
+        modelBuilder.Entity<EntityBasic>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<JsonEntityBasicForReference>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<JsonEntityBasicForCollection>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<JsonEntityBasic>().OwnsOne(

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
@@ -22,9 +22,10 @@ public class JsonQueryContext : DbContext
     public static void Seed(JsonQueryContext context)
     {
         var jsonEntitiesBasic = JsonQueryData.CreateJsonEntitiesBasic();
+        var entitiesBasic = JsonQueryData.CreateEntitiesBasic();
         var jsonEntitiesBasicForReference = JsonQueryData.CreateJsonEntitiesBasicForReference();
         var jsonEntitiesBasicForCollection = JsonQueryData.CreateJsonEntitiesBasicForCollection();
-        JsonQueryData.WireUp(jsonEntitiesBasic, jsonEntitiesBasicForReference, jsonEntitiesBasicForCollection);
+        JsonQueryData.WireUp(jsonEntitiesBasic, entitiesBasic, jsonEntitiesBasicForReference, jsonEntitiesBasicForCollection);
 
         var jsonEntitiesCustomNaming = JsonQueryData.CreateJsonEntitiesCustomNaming();
         var jsonEntitiesSingleOwned = JsonQueryData.CreateJsonEntitiesSingleOwned();
@@ -32,6 +33,7 @@ public class JsonQueryContext : DbContext
         var jsonEntitiesAllTypes = JsonQueryData.CreateJsonEntitiesAllTypes();
 
         context.JsonEntitiesBasic.AddRange(jsonEntitiesBasic);
+        context.EntitiesBasic.AddRange(entitiesBasic);
         context.JsonEntitiesBasicForReference.AddRange(jsonEntitiesBasicForReference);
         context.JsonEntitiesBasicForCollection.AddRange(jsonEntitiesBasicForCollection);
         context.JsonEntitiesCustomNaming.AddRange(jsonEntitiesCustomNaming);

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
@@ -7,11 +7,11 @@ public class JsonQueryData : ISetSource
 {
     public JsonQueryData()
     {
-        EntitiesBasic = new List<EntityBasic>();
         JsonEntitiesBasic = CreateJsonEntitiesBasic();
+        EntitiesBasic = CreateEntitiesBasic();
         JsonEntitiesBasicForReference = CreateJsonEntitiesBasicForReference();
         JsonEntitiesBasicForCollection = CreateJsonEntitiesBasicForCollection();
-        WireUp(JsonEntitiesBasic, JsonEntitiesBasicForReference, JsonEntitiesBasicForCollection);
+        WireUp(JsonEntitiesBasic, EntitiesBasic, JsonEntitiesBasicForReference, JsonEntitiesBasicForCollection);
 
         JsonEntitiesCustomNaming = CreateJsonEntitiesCustomNaming();
         JsonEntitiesSingleOwned = CreateJsonEntitiesSingleOwned();
@@ -292,6 +292,13 @@ public class JsonQueryData : ISetSource
         return new List<JsonEntityBasic> { entity1 };
     }
 
+    public static IReadOnlyList<EntityBasic> CreateEntitiesBasic()
+    {
+        var entity1 = new EntityBasic { Id = 1, Name = "eb 1" };
+
+        return new List<EntityBasic> { entity1 };
+    }
+
     public static IReadOnlyList<JsonEntityBasicForReference> CreateJsonEntitiesBasicForReference()
     {
         var entity1 = new JsonEntityBasicForReference { Id = 1, Name = "EntityReference1" };
@@ -314,27 +321,30 @@ public class JsonQueryData : ISetSource
     }
 
     public static void WireUp(
-        IReadOnlyList<JsonEntityBasic> entitiesBasic,
+        IReadOnlyList<JsonEntityBasic> jsonEntitiesBasic,
+        IReadOnlyList<EntityBasic> entitiesBasic,
         IReadOnlyList<JsonEntityBasicForReference> entitiesBasicForReference,
         IReadOnlyList<JsonEntityBasicForCollection> entitiesBasicForCollection)
     {
-        entitiesBasic[0].EntityReference = entitiesBasicForReference[0];
-        entitiesBasicForReference[0].Parent = entitiesBasic[0];
-        entitiesBasicForReference[0].ParentId = entitiesBasic[0].Id;
+        entitiesBasic[0].JsonEntityBasics = new List<JsonEntityBasic> { jsonEntitiesBasic[0] };
 
-        entitiesBasic[0].EntityCollection = new List<JsonEntityBasicForCollection>
+        jsonEntitiesBasic[0].EntityReference = entitiesBasicForReference[0];
+        entitiesBasicForReference[0].Parent = jsonEntitiesBasic[0];
+        entitiesBasicForReference[0].ParentId = jsonEntitiesBasic[0].Id;
+
+        jsonEntitiesBasic[0].EntityCollection = new List<JsonEntityBasicForCollection>
         {
             entitiesBasicForCollection[0],
             entitiesBasicForCollection[1],
             entitiesBasicForCollection[2]
         };
 
-        entitiesBasicForCollection[0].Parent = entitiesBasic[0];
-        entitiesBasicForCollection[0].ParentId = entitiesBasic[0].Id;
-        entitiesBasicForCollection[1].Parent = entitiesBasic[0];
-        entitiesBasicForCollection[1].ParentId = entitiesBasic[0].Id;
-        entitiesBasicForCollection[2].Parent = entitiesBasic[0];
-        entitiesBasicForCollection[2].ParentId = entitiesBasic[0].Id;
+        entitiesBasicForCollection[0].Parent = jsonEntitiesBasic[0];
+        entitiesBasicForCollection[0].ParentId = jsonEntitiesBasic[0].Id;
+        entitiesBasicForCollection[1].Parent = jsonEntitiesBasic[0];
+        entitiesBasicForCollection[1].ParentId = jsonEntitiesBasic[0].Id;
+        entitiesBasicForCollection[2].Parent = jsonEntitiesBasic[0];
+        entitiesBasicForCollection[2].ParentId = jsonEntitiesBasic[0].Id;
     }
 
     public static IReadOnlyList<JsonEntityCustomNaming> CreateJsonEntitiesCustomNaming()
@@ -799,6 +809,16 @@ public class JsonQueryData : ISetSource
         if (typeof(TEntity) == typeof(JsonEntityAllTypes))
         {
             return (IQueryable<TEntity>)JsonEntitiesAllTypes.OfType<JsonEntityAllTypes>().AsQueryable();
+        }
+
+        if (typeof(TEntity) == typeof(JsonEntityBasicForReference))
+        {
+            return (IQueryable<TEntity>)JsonEntitiesBasicForReference.AsQueryable();
+        }
+
+        if (typeof(TEntity) == typeof(JsonEntityBasicForCollection))
+        {
+            return (IQueryable<TEntity>)JsonEntitiesBasicForCollection.AsQueryable();
         }
 
         throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -435,6 +435,30 @@ LEFT JOIN [JsonEntitiesBasic] AS [j0] ON [j].[Id] = [j0].[Id]
 """);
     }
 
+    public override async Task Left_join_json_entities_json_being_inner(bool async)
+    {
+        await base.Left_join_json_entities_json_being_inner(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j0].[Id], [j0].[Name], [j0].[OwnedCollection]
+FROM [JsonEntitiesBasic] AS [j]
+LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
+""");
+    }
+
+    public override async Task Left_join_json_entities_complex_projection_json_being_inner(bool async)
+    {
+        await base.Left_join_json_entities_complex_projection_json_being_inner(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j0].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j0].[Name], [j0].[OwnedCollection]
+FROM [JsonEntitiesBasic] AS [j]
+LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
+""");
+    }
+
     public override async Task Project_json_entity_FirstOrDefault_subquery(bool async)
     {
         await base.Project_json_entity_FirstOrDefault_subquery(async);


### PR DESCRIPTION
Problem was that when we were translating join, combining two SelectExpressions together, we were not remapping JSON column indexes stored in the inner select. This later result in shaper trying to read JSON column data from the wrong index and throwing the exception.

We already had a test that would have caught that, but it didn't return any data so the mismatch was never detected - fixed the data issue and added few more tests for good measure.

Fixes #30073
