### PR TITLE
[release/7.0] Move taking of lock earlier to avoid race in PruneCallback

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionFactory.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionFactory.cs
@@ -138,20 +138,21 @@ namespace Microsoft.Data.Sqlite
                 }
             }
 
-            for (var i = _idlePoolGroups.Count - 1; i >= 0; i--)
-            {
-                var poolGroup = _idlePoolGroups[i];
-
-                if (!poolGroup.Clear())
-                {
-                    _idlePoolGroups.Remove(poolGroup);
-                }
-            }
-
             _lock.EnterWriteLock();
 
             try
             {
+
+                for (var i = _idlePoolGroups.Count - 1; i >= 0; i--)
+                {
+                    var poolGroup = _idlePoolGroups[i];
+
+                    if (!poolGroup.Clear())
+                    {
+                        _idlePoolGroups.Remove(poolGroup);
+                    }
+                }
+
                 var activePoolGroups = new Dictionary<string, SqliteConnectionPoolGroup>();
                 foreach (var entry in _poolGroups)
                 {


### PR DESCRIPTION
This is a port of #30080
Fixes #29952

**Description**

The field `_idlePoolGroups` was being used outside the lock.

**Customer impact**

`ArgumentOutOfRangeException` exceptions when using Microsoft.Data.Sqlite, even without connection pooling.

**How found**

Multiple customer reports on 7.0.

**Regression**

No.

**Testing**

Manual testing.

**Risk**

Low; simple move of the lock area, and a quirk was added to revert back to older behavior.