### PR TITLE
[release/7.0] Fix to #29667 - Count after Take throws "No column name was specified for column 1 of 't'."

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -250,7 +250,7 @@ public class QuerySqlGenerator : SqlExpressionVisitor
             }
             else
             {
-                _relationalCommandBuilder.Append("1");
+                GenerateEmptyProjection(selectExpression);
             }
 
             if (selectExpression.Tables.Any())
@@ -307,6 +307,15 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     /// </summary>
     protected virtual void GeneratePseudoFromClause()
     {
+    }
+
+    /// <summary>
+    ///     Generates empty projection for a SelectExpression.
+    /// </summary>
+    /// <param name="selectExpression">SelectExpression for which the empty projection will be generated.</param>
+    protected virtual void GenerateEmptyProjection(SelectExpression selectExpression)
+    {
+        _relationalCommandBuilder.Append("1");
     }
 
     /// <inheritdoc />

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
@@ -171,6 +171,30 @@ WHERE (c["Discriminator"] = "Customer")
 """);
     }
 
+    public override async Task Count_over_keyless_entity(bool async)
+    {
+        await base.Count_over_keyless_entity(async);
+
+        AssertSql(
+"""
+SELECT COUNT(1) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
+    public override async Task Count_over_keyless_entity_with_pushdown(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Count_over_keyless_entity_with_pushdown(async));
+    }
+
+    public override async Task Count_over_keyless_entity_with_pushdown_empty_projection(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Count_over_keyless_entity_with_pushdown_empty_projection(async));
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindKeylessEntitiesQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindKeylessEntitiesQueryTestBase.cs
@@ -167,4 +167,25 @@ public abstract class NorthwindKeylessEntitiesQueryTestBase<TFixture> : QueryTes
                 .Select(pv => new { pv.City, pv.ContactName })
                 .OrderBy(x => x.ContactName)
                 .Take(2));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Count_over_keyless_entity(bool async)
+        => AssertCount(
+            async,
+            ss => ss.Set<CustomerQuery>());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Count_over_keyless_entity_with_pushdown(bool async)
+        => AssertCount(
+            async,
+            ss => ss.Set<CustomerQuery>().OrderBy(x => x.ContactTitle).Take(10));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Count_over_keyless_entity_with_pushdown_empty_projection(bool async)
+        => AssertCount(
+            async,
+            ss => ss.Set<CustomerQuery>().Take(10));
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
@@ -232,6 +232,56 @@ WHERE [m].[CustomerID] = N'ALFKI'
 """);
     }
 
+    public override async Task Count_over_keyless_entity(bool async)
+    {
+        await base.Count_over_keyless_entity(async);
+
+        AssertSql(
+"""
+SELECT COUNT(*)
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
+) AS [m]
+""");
+    }
+
+    public override async Task Count_over_keyless_entity_with_pushdown(bool async)
+    {
+        await base.Count_over_keyless_entity_with_pushdown(async);
+
+        AssertSql(
+"""
+@__p_0='10'
+
+SELECT COUNT(*)
+FROM (
+    SELECT TOP(@__p_0) [m].[ContactTitle]
+    FROM (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
+    ) AS [m]
+    ORDER BY [m].[ContactTitle]
+) AS [t]
+""");
+    }
+
+    public override async Task Count_over_keyless_entity_with_pushdown_empty_projection(bool async)
+    {
+        await base.Count_over_keyless_entity_with_pushdown_empty_projection(async);
+
+        AssertSql(
+"""
+@__p_0='10'
+
+SELECT COUNT(*)
+FROM (
+    SELECT TOP(@__p_0) 1 AS empty
+    FROM (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
+    ) AS [m]
+) AS [t]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Ported from https://github.com/dotnet/efcore/pull/30134
Fixes #29667

**Description**

Query using keyless entities that also uses Take and Count throws SqlException.

**Customer impact**

Query using keyless entities that also uses Take and Count throws SqlException. Scenario is not common, but it is a regression and there is no good workaround for it. Only options are to not use keyless entities or perform Count on the client (which can be a significant perf hit)

**How found**

Customer report on 7.0.

**Regression**

Yes. 

**Testing**

Added regression tests.

**Risk**

Low; Fix is very isolated, only affecting empty projection by adding an alias for it. Empty projection by definition can't be referenced in other parts of the query, so there is no risk of name clashes due to new alias. Also quirked.
