### PR TITLE
Avoid throwing relationship severed exceptions until DetectChanges is finished

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -568,6 +568,22 @@ public interface IStateManager : IResettableService
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    void HandleConceptualNulls(bool force);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    bool PostponeConceptualNullExceptions { get; set; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     void CascadeDelete(InternalEntityEntry entry, bool force, IEnumerable<IForeignKey>? foreignKeys = null);
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1708,26 +1708,27 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
 
             SetEntityState(cascadeState);
         }
-        else if (fks.Count > 0)
+        else if (!StateManager.PostponeConceptualNullExceptions)
         {
-            var foreignKey = fks.First();
-
-            if (sensitiveLoggingEnabled)
+            if (fks.Count > 0)
             {
+                var foreignKey = fks.First();
+
+                if (sensitiveLoggingEnabled)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.RelationshipConceptualNullSensitive(
+                            foreignKey.PrincipalEntityType.DisplayName(),
+                            EntityType.DisplayName(),
+                            this.BuildOriginalValuesString(foreignKey.Properties)));
+                }
+
                 throw new InvalidOperationException(
-                    CoreStrings.RelationshipConceptualNullSensitive(
+                    CoreStrings.RelationshipConceptualNull(
                         foreignKey.PrincipalEntityType.DisplayName(),
-                        EntityType.DisplayName(),
-                        this.BuildOriginalValuesString(foreignKey.Properties)));
+                        EntityType.DisplayName()));
             }
 
-            throw new InvalidOperationException(
-                CoreStrings.RelationshipConceptualNull(
-                    foreignKey.PrincipalEntityType.DisplayName(),
-                    EntityType.DisplayName()));
-        }
-        else
-        {
             var property = EntityType.GetProperties().FirstOrDefault(
                 p => (EntityState != EntityState.Modified
                         || IsModified(p))

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -1162,6 +1162,22 @@ public class StateManager : IStateManager
     {
         // Perf sensitive
 
+        HandleConceptualNulls(force);
+
+        foreach (var entry in this.ToListForState(deleted: true))
+        {
+            CascadeDelete(entry, force);
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual void HandleConceptualNulls(bool force)
+    {
         var toHandle = new List<InternalEntityEntry>();
 
         foreach (var entry in GetEntriesForState(modified: true, added: true))
@@ -1176,12 +1192,15 @@ public class StateManager : IStateManager
         {
             entry.HandleConceptualNulls(SensitiveLoggingEnabled, force, isCascadeDelete: false);
         }
-
-        foreach (var entry in this.ToListForState(deleted: true))
-        {
-            CascadeDelete(entry, force);
-        }
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool PostponeConceptualNullExceptions { get; set; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToMany.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToMany.cs
@@ -865,58 +865,42 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     child.ParentId = newParent.Id;
                 }
 
-                if (!Fixture.ForceClientNoAction
-                    || deleteOrphansTiming != CascadeTiming.Immediate
-                    || (changeMechanism & ChangeMechanism.Fk) != 0
-                    || changeMechanism == ChangeMechanism.Dependent)
-                {
-                    Assert.True(context.ChangeTracker.HasChanges());
+                Assert.True(context.ChangeTracker.HasChanges());
 
-                    Assert.DoesNotContain(child, oldParent.Children);
-                    Assert.Contains(child, newParent.Children);
-                    Assert.Equal(newParent.Id, child.ParentId);
-                    Assert.Equal(EntityState.Modified, context.Entry(child).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
+                Assert.DoesNotContain(child, oldParent.Children);
+                Assert.Contains(child, newParent.Children);
+                Assert.Equal(newParent.Id, child.ParentId);
+                Assert.Equal(EntityState.Modified, context.Entry(child).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
 
-                    context.SaveChanges();
+                context.SaveChanges();
 
-                    Assert.False(context.ChangeTracker.HasChanges());
+                Assert.False(context.ChangeTracker.HasChanges());
 
-                    Assert.DoesNotContain(child, oldParent.Children);
-                    Assert.Contains(child, newParent.Children);
-                    Assert.Equal(newParent.Id, child.ParentId);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(child).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges());
-                }
+                Assert.DoesNotContain(child, oldParent.Children);
+                Assert.Contains(child, newParent.Children);
+                Assert.Equal(newParent.Id, child.ParentId);
+                Assert.Equal(EntityState.Unchanged, context.Entry(child).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
             },
             context =>
             {
-                if (!Fixture.ForceClientNoAction
-                    || deleteOrphansTiming != CascadeTiming.Immediate
-                    || (changeMechanism & ChangeMechanism.Fk) != 0
-                    || changeMechanism == ChangeMechanism.Dependent)
-                {
-                    var root = LoadRequiredGraph(context);
+                var root = LoadRequiredGraph(context);
 
-                    Assert.False(context.ChangeTracker.HasChanges());
+                Assert.False(context.ChangeTracker.HasChanges());
 
-                    oldParent = root.RequiredChildren.First(e => e.Id == oldParent.Id);
-                    newParent = root.RequiredChildren.First(e => e.Id == newParent.Id);
-                    child = newParent.Children.First(e => e.Id == child.Id);
+                oldParent = root.RequiredChildren.First(e => e.Id == oldParent.Id);
+                newParent = root.RequiredChildren.First(e => e.Id == newParent.Id);
+                child = newParent.Children.First(e => e.Id == child.Id);
 
-                    Assert.DoesNotContain(child, oldParent.Children);
-                    Assert.Contains(child, newParent.Children);
-                    Assert.Equal(newParent.Id, child.ParentId);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(child).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
-                }
+                Assert.DoesNotContain(child, oldParent.Children);
+                Assert.Contains(child, newParent.Children);
+                Assert.Equal(newParent.Id, child.ParentId);
+                Assert.Equal(EntityState.Unchanged, context.Entry(child).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
             });
     }
 
@@ -984,58 +968,42 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     child.ParentId = newParent.AlternateId;
                 }
 
-                if (!Fixture.ForceClientNoAction
-                    || deleteOrphansTiming != CascadeTiming.Immediate
-                    || (changeMechanism & ChangeMechanism.Fk) != 0
-                    || changeMechanism == ChangeMechanism.Dependent)
-                {
-                    Assert.True(context.ChangeTracker.HasChanges());
+                Assert.True(context.ChangeTracker.HasChanges());
 
-                    Assert.DoesNotContain(child, oldParent.Children);
-                    Assert.Contains(child, newParent.Children);
-                    Assert.Equal(newParent.AlternateId, child.ParentId);
-                    Assert.Equal(EntityState.Modified, context.Entry(child).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
+                Assert.DoesNotContain(child, oldParent.Children);
+                Assert.Contains(child, newParent.Children);
+                Assert.Equal(newParent.AlternateId, child.ParentId);
+                Assert.Equal(EntityState.Modified, context.Entry(child).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
 
-                    context.SaveChanges();
+                context.SaveChanges();
 
-                    Assert.False(context.ChangeTracker.HasChanges());
+                Assert.False(context.ChangeTracker.HasChanges());
 
-                    Assert.DoesNotContain(child, oldParent.Children);
-                    Assert.Contains(child, newParent.Children);
-                    Assert.Equal(newParent.AlternateId, child.ParentId);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(child).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges());
-                }
+                Assert.DoesNotContain(child, oldParent.Children);
+                Assert.Contains(child, newParent.Children);
+                Assert.Equal(newParent.AlternateId, child.ParentId);
+                Assert.Equal(EntityState.Unchanged, context.Entry(child).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
             },
             context =>
             {
-                if (!Fixture.ForceClientNoAction
-                    || deleteOrphansTiming != CascadeTiming.Immediate
-                    || (changeMechanism & ChangeMechanism.Fk) != 0
-                    || changeMechanism == ChangeMechanism.Dependent)
-                {
-                    var root = LoadRequiredAkGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
-                    Assert.False(context.ChangeTracker.HasChanges());
+                Assert.False(context.ChangeTracker.HasChanges());
 
-                    oldParent = root.RequiredChildrenAk.First(e => e.Id == oldParent.Id);
-                    newParent = root.RequiredChildrenAk.First(e => e.Id == newParent.Id);
-                    child = newParent.Children.First(e => e.Id == child.Id);
+                oldParent = root.RequiredChildrenAk.First(e => e.Id == oldParent.Id);
+                newParent = root.RequiredChildrenAk.First(e => e.Id == newParent.Id);
+                child = newParent.Children.First(e => e.Id == child.Id);
 
-                    Assert.DoesNotContain(child, oldParent.Children);
-                    Assert.Contains(child, newParent.Children);
-                    Assert.Equal(newParent.AlternateId, child.ParentId);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(child).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
-                    Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
-                }
+                Assert.DoesNotContain(child, oldParent.Children);
+                Assert.Contains(child, newParent.Children);
+                Assert.Equal(newParent.AlternateId, child.ParentId);
+                Assert.Equal(EntityState.Unchanged, context.Entry(child).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(oldParent).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(newParent).State);
             });
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -10,6 +10,10 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
     {
     }
 
+    // No owned types
+    public override Task Sever_relationship_that_will_later_be_deleted(bool async)
+        => Task.CompletedTask;
+
     // Owned dependents are always loaded
     public override void Required_one_to_one_are_cascade_deleted_in_store(
         CascadeTiming? cascadeDeleteTiming,

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -247,6 +247,11 @@ public class FakeStateManager : IStateManager
     public void CascadeChanges(bool force)
         => throw new NotImplementedException();
 
+    public void HandleConceptualNulls(bool force)
+        => throw new NotImplementedException();
+
+    public bool PostponeConceptualNullExceptions { get; set; }
+
     public void CascadeDelete(InternalEntityEntry entry, bool force, IEnumerable<IForeignKey> foreignKeys = null)
         => throw new NotImplementedException();
 


### PR DESCRIPTION
Fixes #30122

Because the entities for which the relationship is being severed may end up being deleted later on in DetectChanges.
