### PR TITLE
Stop allowing identifying relationships from overriding cascade behavior

### DIFF
--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -548,6 +548,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture> : IClassFixture<TFi
             modelBuilder.Entity<Bayaz>();
             modelBuilder.Entity<SecondLaw>();
             modelBuilder.Entity<ThirdLaw>();
+
+            modelBuilder.Entity<SneakyChild>(
+                b =>
+                {
+                    b.HasOne(x => x.Parent).WithMany(x => x.Children).OnDelete(DeleteBehavior.Restrict);
+                    b.HasAlternateKey(x => new { x.Id, x.ParentId });
+                });
         }
 
         protected virtual object CreateFullGraph()
@@ -3980,6 +3987,46 @@ public abstract partial class GraphUpdatesTestBase<TFixture> : IClassFixture<TFi
         {
             get => _secondLaw;
             set => SetWithNotify(value, ref _secondLaw);
+        }
+    }
+
+    protected class NaiveParent : NotifyingEntity
+    {
+        private Guid _id;
+        private readonly ICollection<SneakyChild> _children = new ObservableHashSet<SneakyChild>();
+
+        public Guid Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public virtual ICollection<SneakyChild> Children
+            => _children;
+    }
+
+    protected class SneakyChild : NotifyingEntity
+    {
+        private Guid _id;
+        private Guid _parentId;
+        private NaiveParent _parent = null!;
+
+        public Guid Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public Guid ParentId
+        {
+            get => _parentId;
+            set => SetWithNotify(value, ref _parentId);
+        }
+
+        public virtual NaiveParent Parent
+        {
+            get => _parent;
+            set => SetWithNotify(value, ref _parent);
         }
     }
 

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
@@ -857,7 +857,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if (Fixture.ForceClientNoAction)
                 {
-                    Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+                    Assert.Equal(
+                        CoreStrings.KeyReadOnly(nameof(RequiredSingle1.Id), nameof(RequiredSingle1)),
+                        Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                 }
                 else
                 {
@@ -1199,16 +1201,18 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     throw new ArgumentOutOfRangeException(nameof(changeMechanism));
                 }
 
-                Assert.False(context.Entry(root).Reference(e => e.RequiredSingle).IsLoaded);
-                Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
-                Assert.True(context.ChangeTracker.HasChanges());
-
                 if (Fixture.ForceClientNoAction)
                 {
-                    Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+                    Assert.Equal(
+                        CoreStrings.KeyReadOnly(nameof(RequiredSingle1.Id), nameof(RequiredSingle1)),
+                        Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                 }
                 else
                 {
+                    Assert.False(context.Entry(root).Reference(e => e.RequiredSingle).IsLoaded);
+                    Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
+                    Assert.True(context.ChangeTracker.HasChanges());
+
                     context.SaveChanges();
 
                     Assert.False(context.ChangeTracker.HasChanges());

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -38,6 +38,10 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
     public override Task Sever_relationship_that_will_later_be_deleted(bool async)
         => Task.CompletedTask;
 
+    // No owned types
+    public override Task Alternate_key_over_foreign_key_doesnt_bypass_delete_behavior(bool async)
+        => Task.CompletedTask;
+
     // Owned dependents are always loaded
     public override void Required_one_to_one_are_cascade_deleted_in_store(
         CascadeTiming? cascadeDeleteTiming,


### PR DESCRIPTION
Fixes #28961

In the issue, an alternate key was added over the the foreign key to make it effectively an identifying relationship. That is, changing the relationship changes the identity of the dependent. This resulted in the special handling for identifying relationships to kick in, which didn't respect the configured DeleteBehavior. This change fixes that.
