### PR TITLE
[release/7.0] Use correct provider type for nullable value type with converter

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -1393,6 +1393,8 @@ public class RelationalModelValidator : ModelValidator
                     storeObject.DisplayName()));
         }
 
+        var typeMapping = property.GetRelationalTypeMapping();
+        var duplicateTypeMapping = duplicateProperty.GetRelationalTypeMapping();
         var currentTypeString = property.GetColumnType(storeObject);
         var previousTypeString = duplicateProperty.GetColumnType(storeObject);
         if (!string.Equals(currentTypeString, previousTypeString, StringComparison.OrdinalIgnoreCase))
@@ -1408,9 +1410,6 @@ public class RelationalModelValidator : ModelValidator
                     previousTypeString,
                     currentTypeString));
         }
-
-        var typeMapping = property.GetRelationalTypeMapping();
-        var duplicateTypeMapping = duplicateProperty.GetRelationalTypeMapping();
 
         Type currentProviderType, previousProviderType;
         if (QuirkEnabled29531)

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -1393,8 +1393,6 @@ public class RelationalModelValidator : ModelValidator
                     storeObject.DisplayName()));
         }
 
-        var typeMapping = property.GetRelationalTypeMapping();
-        var duplicateTypeMapping = duplicateProperty.GetRelationalTypeMapping();
         var currentTypeString = property.GetColumnType(storeObject);
         var previousTypeString = duplicateProperty.GetColumnType(storeObject);
         if (!string.Equals(currentTypeString, previousTypeString, StringComparison.OrdinalIgnoreCase))
@@ -1410,6 +1408,9 @@ public class RelationalModelValidator : ModelValidator
                     previousTypeString,
                     currentTypeString));
         }
+
+        var typeMapping = property.GetRelationalTypeMapping();
+        var duplicateTypeMapping = duplicateProperty.GetRelationalTypeMapping();
 
         Type currentProviderType, previousProviderType;
         if (QuirkEnabled29531)

--- a/src/EFCore.Relational/Metadata/Internal/ColumnBase.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnBase.cs
@@ -12,6 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 public class ColumnBase<TColumnMappingBase> : Annotatable, IColumnBase
     where TColumnMappingBase : class, IColumnMappingBase
 {
+    private static readonly bool QuirkEnabled29985
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29985", out var enabled) && enabled;
+
     private Type? _providerClrType;
 
     /// <summary>
@@ -84,7 +87,9 @@ public class ColumnBase<TColumnMappingBase> : Annotatable, IColumnBase
             }
 
             var typeMapping = StoreTypeMapping;
-            var providerType = typeMapping.Converter?.ProviderClrType ?? typeMapping.ClrType;
+            var providerType = QuirkEnabled29985
+                ? typeMapping.Converter?.ProviderClrType ?? typeMapping.ClrType
+                : typeMapping.Converter?.ProviderClrType.UnwrapNullableType() ?? typeMapping.ClrType;
 
             return _providerClrType = providerType;
         }

--- a/src/EFCore.Relational/Update/Internal/ColumnAccessorsFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/ColumnAccessorsFactory.cs
@@ -13,6 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal;
 /// </summary>
 public static class ColumnAccessorsFactory
 {
+    private static readonly bool QuirkEnabled29985
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29985", out var enabled) && enabled;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -51,7 +54,7 @@ public static class ColumnAccessorsFactory
 
                     var providerValue = entry.GetCurrentProviderValue(property);
                     if (providerValue == null
-                        && !typeof(TColumn).IsNullableType())
+                        && (!QuirkEnabled29985 || !typeof(TColumn).IsNullableType()))
                     {
                         return (value!, valueFound);
                     }
@@ -94,7 +97,7 @@ public static class ColumnAccessorsFactory
 
                     var providerValue = entry.GetOriginalProviderValue(property);
                     if (providerValue == null
-                        && !typeof(TColumn).IsNullableType())
+                        && (!QuirkEnabled29985 || !typeof(TColumn).IsNullableType()))
                     {
                         return (value!, valueFound);
                     }

--- a/src/EFCore.Relational/Update/Internal/RowForeignKeyValueFactoryFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/RowForeignKeyValueFactoryFactory.cs
@@ -80,9 +80,11 @@ public class RowForeignKeyValueFactoryFactory : IRowForeignKeyValueFactoryFactor
             return principalType.IsNullableType()
                 ? (IRowForeignKeyValueFactory<TKey>)Activator.CreateInstance(
                     typeof(SimpleNullablePrincipalRowForeignKeyValueFactory<,,>).MakeGenericType(
-                        typeof(TKey), typeof(TKey).UnwrapNullableType(), typeof(TForeignKey)), foreignKey, dependentColumn, columnAccessors)!
+                        typeof(TKey), typeof(TKey).UnwrapNullableType(), typeof(TForeignKey)), foreignKey, dependentColumn,
+                    columnAccessors)!
                 : new SimpleNonNullableRowForeignKeyValueFactory<TKey, TForeignKey>(
-                    foreignKey, dependentColumn, columnAccessors, valueConverterSelector);        }
+                    foreignKey, dependentColumn, columnAccessors, valueConverterSelector);
+        }
         else
         {
             var dependentColumn = foreignKey.Columns.First();
@@ -107,7 +109,8 @@ public class RowForeignKeyValueFactoryFactory : IRowForeignKeyValueFactoryFactor
             return principalColumn.IsNullable
                 ? (IRowForeignKeyValueFactory<TKey>)Activator.CreateInstance(
                     typeof(SimpleNullablePrincipalRowForeignKeyValueFactory<,,>).MakeGenericType(
-                        typeof(TKey), typeof(TKey).UnwrapNullableType(), typeof(TKey), typeof(TForeignKey)), foreignKey, dependentColumn, columnAccessors)!
+                        typeof(TKey), typeof(TKey).UnwrapNullableType(), typeof(TKey), typeof(TForeignKey)), foreignKey, dependentColumn,
+                    columnAccessors)!
                 : new SimpleNonNullableRowForeignKeyValueFactory<TKey, TForeignKey>(
                     foreignKey, dependentColumn, columnAccessors, valueConverterSelector);
         }

--- a/src/EFCore.Relational/Update/Internal/RowForeignKeyValueFactoryFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/RowForeignKeyValueFactoryFactory.cs
@@ -14,6 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal;
 /// </summary>
 public class RowForeignKeyValueFactoryFactory : IRowForeignKeyValueFactoryFactory
 {
+    private static readonly bool QuirkEnabled29985
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29985", out var enabled) && enabled;
+
     private readonly IValueConverterSelector _valueConverterSelector;
 
     /// <summary>
@@ -53,30 +56,60 @@ public class RowForeignKeyValueFactoryFactory : IRowForeignKeyValueFactoryFactor
         IValueConverterSelector valueConverterSelector)
         where TKey : notnull
     {
-        var dependentColumn = foreignKey.Columns.Single();
-        var dependentType = dependentColumn.ProviderClrType;
-        var principalType = foreignKey.PrincipalColumns.Single().ProviderClrType;
-        var columnAccessors = ((Column)dependentColumn).Accessors;
-
-        if (dependentType.IsNullableType()
-            && principalType.IsNullableType())
+        if (QuirkEnabled29985)
         {
-            return new SimpleFullyNullableRowForeignKeyValueFactory<TKey, TForeignKey>(
-                foreignKey, dependentColumn, columnAccessors, valueConverterSelector);
-        }
+            var dependentColumn = foreignKey.Columns.Single();
+            var dependentType = dependentColumn.ProviderClrType;
+            var principalType = foreignKey.PrincipalColumns.Single().ProviderClrType;
+            var columnAccessors = ((Column)dependentColumn).Accessors;
 
-        if (dependentType.IsNullableType())
+            if (dependentType.IsNullableType()
+                && principalType.IsNullableType())
+            {
+                return new SimpleFullyNullableRowForeignKeyValueFactory<TKey, TForeignKey>(
+                    foreignKey, dependentColumn, columnAccessors, valueConverterSelector);
+            }
+
+            if (dependentType.IsNullableType())
+            {
+                return (IRowForeignKeyValueFactory<TKey>)Activator.CreateInstance(
+                    typeof(SimpleNullableRowForeignKeyValueFactory<,>).MakeGenericType(
+                        typeof(TKey), typeof(TForeignKey)), foreignKey, dependentColumn, columnAccessors, valueConverterSelector)!;
+            }
+
+            return principalType.IsNullableType()
+                ? (IRowForeignKeyValueFactory<TKey>)Activator.CreateInstance(
+                    typeof(SimpleNullablePrincipalRowForeignKeyValueFactory<,,>).MakeGenericType(
+                        typeof(TKey), typeof(TKey).UnwrapNullableType(), typeof(TForeignKey)), foreignKey, dependentColumn, columnAccessors)!
+                : new SimpleNonNullableRowForeignKeyValueFactory<TKey, TForeignKey>(
+                    foreignKey, dependentColumn, columnAccessors, valueConverterSelector);        }
+        else
         {
-            return (IRowForeignKeyValueFactory<TKey>)Activator.CreateInstance(
-                typeof(SimpleNullableRowForeignKeyValueFactory<,>).MakeGenericType(
-                    typeof(TKey), typeof(TForeignKey)), foreignKey, dependentColumn, columnAccessors, valueConverterSelector)!;
-        }
+            var dependentColumn = foreignKey.Columns.First();
+            var principalColumn = foreignKey.PrincipalColumns.First();
+            var columnAccessors = ((Column)dependentColumn).Accessors;
 
-        return principalType.IsNullableType()
-            ? (IRowForeignKeyValueFactory<TKey>)Activator.CreateInstance(
-                typeof(SimpleNullablePrincipalRowForeignKeyValueFactory<,,>).MakeGenericType(
-                    typeof(TKey), typeof(TKey).UnwrapNullableType(), typeof(TForeignKey)), foreignKey, dependentColumn, columnAccessors)!
-            : new SimpleNonNullableRowForeignKeyValueFactory<TKey, TForeignKey>(
-                foreignKey, dependentColumn, columnAccessors, valueConverterSelector);
+            if (principalColumn.ProviderClrType.IsNullableType()
+                || (dependentColumn.IsNullable
+                    && principalColumn.IsNullable))
+            {
+                return new SimpleFullyNullableRowForeignKeyValueFactory<TKey, TForeignKey>(
+                    foreignKey, dependentColumn, columnAccessors, valueConverterSelector);
+            }
+
+            if (dependentColumn.IsNullable)
+            {
+                return (IRowForeignKeyValueFactory<TKey>)Activator.CreateInstance(
+                    typeof(SimpleNullableRowForeignKeyValueFactory<,>).MakeGenericType(
+                        typeof(TKey), typeof(TForeignKey)), foreignKey, dependentColumn, columnAccessors, valueConverterSelector)!;
+            }
+
+            return principalColumn.IsNullable
+                ? (IRowForeignKeyValueFactory<TKey>)Activator.CreateInstance(
+                    typeof(SimpleNullablePrincipalRowForeignKeyValueFactory<,,>).MakeGenericType(
+                        typeof(TKey), typeof(TKey).UnwrapNullableType(), typeof(TKey), typeof(TForeignKey)), foreignKey, dependentColumn, columnAccessors)!
+                : new SimpleNonNullableRowForeignKeyValueFactory<TKey, TForeignKey>(
+                    foreignKey, dependentColumn, columnAccessors, valueConverterSelector);
+        }
     }
 }

--- a/src/EFCore.Relational/Update/Internal/SimpleNullablePrincipalRowForeignKeyValueFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/SimpleNullablePrincipalRowForeignKeyValueFactory.cs
@@ -13,7 +13,6 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal;
 /// </summary>
 public class SimpleNullablePrincipalRowForeignKeyValueFactory<TKey, TNonNullableKey, TForeignKey>
     : RowForeignKeyValueFactory<TKey, TForeignKey>
-    where TNonNullableKey : struct
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -186,7 +186,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
         CancellationToken cancellationToken = default)
     {
         var oldState = _stateData.EntityState;
-        bool adding;
+        var adding = false;
         await SetupAsync().ConfigureAwait(false);
 
         if ((adding || oldState is EntityState.Detached)

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -117,8 +117,7 @@ public class ValueComparer
             || unwrappedType == typeof(Guid)
             || unwrappedType == typeof(bool)
             || unwrappedType == typeof(decimal)
-            || unwrappedType == typeof(object)
-           )
+            || unwrappedType == typeof(object))
         {
             return Expression.Lambda<Func<T?, T?, bool>>(
                 Expression.Equal(param1, param2),

--- a/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EFCore.Analyzers\EFCore.Analyzers.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Design\EFCore.Design.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Relational\EFCore.Relational.csproj" />
     <ProjectReference Include="..\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -421,22 +421,26 @@ public partial class RelationalModelValidatorTest : ModelValidatorTest
     }
 
     [ConditionalFact]
-    public virtual void Passes_on_not_configured_shared_columns_with_shared_table()
+    public virtual void Passes_on_shared_columns_with_shared_table()
     {
         var modelBuilder = CreateConventionModelBuilder();
 
         modelBuilder.Entity<A>().HasOne<B>().WithOne(b => b.A).HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
         modelBuilder.Entity<A>().Property(a => a.P0).HasColumnName(nameof(A.P0));
+        modelBuilder.Entity<A>().Property(a => a.P3).HasColumnName(nameof(A.P3))
+            .HasConversion(e => (long?)e, e => (int?)e);
         modelBuilder.Entity<A>().Property(a => a.P1).IsRequired();
         modelBuilder.Entity<A>().ToTable("Table");
         modelBuilder.Entity<B>().Property(b => b.P0).HasColumnName(nameof(A.P0)).HasColumnType("someInt");
+        modelBuilder.Entity<B>().Property(b => b.P3).HasColumnName(nameof(A.P3))
+            .HasConversion(e => (long)e, e => (int?)e);
         modelBuilder.Entity<B>().ToTable("Table");
 
         Validate(modelBuilder);
     }
 
     [ConditionalFact]
-    public virtual void Throws_on_not_configured_shared_columns_with_shared_table_with_dependents()
+    public virtual void Throws_on_nullable_shared_columns_with_shared_table_with_dependents()
     {
         var modelBuilder = CreateConventionModelBuilder();
 
@@ -450,7 +454,7 @@ public partial class RelationalModelValidatorTest : ModelValidatorTest
     }
 
     [ConditionalFact]
-    public virtual void Warns_on_not_configured_shared_columns_with_shared_table()
+    public virtual void Warns_on_no_required_columns_with_shared_table()
     {
         var modelBuilder = CreateConventionModelBuilder();
 

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -10281,6 +10281,36 @@ public class MigrationsModelDifferTest : MigrationsModelDifferTestBase
             Assert.Empty,
             Assert.Empty);
 
+    [ConditionalFact] // Issue #29985
+    public void SeedData_value_conversion_nullable_datetime()
+        => Execute(
+            common => common.Entity(
+                "EntityWithOneProperty",
+                x =>
+                {
+                    x.Property<int>("Id");
+                    x.HasData(new { Id = 42 });
+                }),
+            source => source.Entity(
+                "EntityWithOneProperty",
+                x =>
+                {
+                    x.Property<DateTime?>("Value1")
+                        .HasColumnType("datetime2")
+                        .HasConversion(
+                            p => p,
+                            p => p != null ? DateTime.SpecifyKind(p.Value, DateTimeKind.Utc) : null);
+                }),
+            target => target.Entity(
+                "EntityWithOneProperty",
+                x =>
+                {
+                    x.Property<DateTime?>("Value1")
+                        .HasColumnType("datetime2");
+                }),
+            Assert.Empty,
+            Assert.Empty);
+
     [ConditionalFact]
     public void SeedData_change_enum_conversion()
         => Execute(

--- a/test/EFCore.Specification.Tests/UpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/UpdatesTestBase.cs
@@ -430,7 +430,11 @@ public abstract class UpdatesTestBase<TFixture> : IClassFixture<TFixture>
         => ExecuteWithStrategyInTransaction(
             context =>
             {
-                var person = new Person("1", null) { Address = new Address { Country = Country.Eswatini, City = "Bulembu" }, Country = "Eswatini" };
+                var person = new Person("1", null)
+                {
+                    Address = new Address { Country = Country.Eswatini, City = "Bulembu" },
+                    Country = "Eswatini"
+                };
 
                 context.Add(person);
 
@@ -439,8 +443,9 @@ public abstract class UpdatesTestBase<TFixture> : IClassFixture<TFixture>
             context =>
             {
                 var person = context.Set<Person>().Single();
-                person.Address = new Address { Country = Country.Türkiye, City = "Konya" };
+                person.Address = new Address { Country = Country.Türkiye, City = "Konya", ZipCode = 42100 };
                 person.Country = "Türkiye";
+                person.ZipCode = "42100";
 
                 context.SaveChanges();
             },
@@ -450,7 +455,9 @@ public abstract class UpdatesTestBase<TFixture> : IClassFixture<TFixture>
 
                 Assert.Equal(Country.Türkiye, person.Address!.Country);
                 Assert.Equal("Konya", person.Address.City);
+                Assert.Equal(42100, person.Address.ZipCode);
                 Assert.Equal("Türkiye", person.Country);
+                Assert.Equal("42100", person.ZipCode);
             });
 
     [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Update/MismatchedKeyTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/MismatchedKeyTypesSqlServerTest.cs
@@ -361,7 +361,7 @@ public class MismatchedKeyTypesSqlServerTest : IClassFixture<MismatchedKeyTypesS
         Assert.Equal(
             RelationalStrings.StoredKeyTypesNotConvertable(
                 nameof(OptionalSingleBad.PrincipalId), "uniqueidentifier", "bigint", nameof(PrincipalBad.Id)),
-            Assert.Throws<TargetInvocationException>(() => context.SaveChanges()).InnerException!.Message);
+            Assert.Throws<TargetInvocationException>(() => context.SaveChanges()).InnerException!.InnerException!.Message);
     }
 
     protected class MismatchedKeyTypesContextNoFks : MismatchedKeyTypesContext

--- a/test/ef.Tests/ef.Tests.csproj
+++ b/test/ef.Tests/ef.Tests.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\..\src\ef\ef.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Design\EFCore.Design.csproj" />
     <ProjectReference Include="..\..\src\EFCore.SqlServer\EFCore.SqlServer.csproj" />
+    <ProjectReference Include="..\..\src\EFCore.Analyzers\EFCore.Analyzers.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Port of #29746
Fixes #29985

**Description**

In EF7, processing seed data in the model snapshot could result in an incorrect provider type when the property has a converter. This change ports a fix already in EF8 to ensure provider types are used correctly.

**Customer impact**

Many customers reporting that models with seed data will continually update this data on every migration, even though the data never changes. This means every generated migration contains Up and Down steps, even when the migration should be empty. No reasonable workaround.

**How found**

Multiple customer reports on 7.0.

**Regression**

Yes.

**Testing**

New tests added for this kind of seed data in the model snapshot.

**Risk**

Medium. Significant code changes, but these changes have been in the 8.0 code for several months now, and they are quirked here.
