### PR TITLE
Don't set table names from DbSet properties when Discriminator property is conflicted with the default but is then configured explicitly

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
@@ -145,14 +145,16 @@ public class TableNameFromDbSetConvention :
                     entityType.Builder.HasNoAnnotation(RelationalAnnotationNames.TableName);
                 }
 
-                if (entityType.GetMappingStrategy() == RelationalAnnotationNames.TpcMappingStrategy
+                var mappingStrategy = entityType.GetMappingStrategy();
+
+                if (mappingStrategy == RelationalAnnotationNames.TpcMappingStrategy
                     && entityType.IsAbstract())
                 {
                     // Undo the convention change if the entity type is mapped using TPC
                     entityType.Builder.HasNoAnnotation(RelationalAnnotationNames.TableName);
                 }
 
-                if (entityType.GetMappingStrategy() == RelationalAnnotationNames.TphMappingStrategy
+                if (mappingStrategy == RelationalAnnotationNames.TphMappingStrategy
                     && entityType.BaseType != null)
                 {
                     // Undo the convention change if the hierarchy ultimately ends up TPH

--- a/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
@@ -118,12 +118,12 @@ public class TableNameFromDbSetConvention :
             && (entityTypeBuilder.Metadata.GetMappingStrategy() ?? RelationalAnnotationNames.TphMappingStrategy)
             != RelationalAnnotationNames.TphMappingStrategy)
         {
-            foreach (var deriverEntityType in entityTypeBuilder.Metadata.GetDerivedTypesInclusive())
+            foreach (var derivedEntityType in entityTypeBuilder.Metadata.GetDerivedTypesInclusive())
             {
-                if (!deriverEntityType.HasSharedClrType
-                    && _sets.TryGetValue(deriverEntityType.ClrType, out var setName))
+                if (!derivedEntityType.HasSharedClrType
+                    && _sets.TryGetValue(derivedEntityType.ClrType, out var setName))
                 {
-                    deriverEntityType.Builder.ToTable(setName);
+                    derivedEntityType.Builder.ToTable(setName);
                 }
             }
         }
@@ -149,6 +149,13 @@ public class TableNameFromDbSetConvention :
                     && entityType.IsAbstract())
                 {
                     // Undo the convention change if the entity type is mapped using TPC
+                    entityType.Builder.HasNoAnnotation(RelationalAnnotationNames.TableName);
+                }
+
+                if (entityType.GetMappingStrategy() == RelationalAnnotationNames.TphMappingStrategy
+                    && entityType.BaseType != null)
+                {
+                    // Undo the convention change if the hierarchy ultimately ends up TPH
                     entityType.Builder.HasNoAnnotation(RelationalAnnotationNames.TableName);
                 }
             }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
@@ -20,21 +20,21 @@ public class InheritanceQueryCosmosTest : InheritanceQueryTestBase<InheritanceQu
 """
 SELECT c
 FROM root c
-WHERE (c["Discriminator"] = "Coke")
+WHERE (c["Discriminator"] = 1)
 OFFSET 0 LIMIT 2
 """,
                 //
 """
 SELECT c
 FROM root c
-WHERE (c["Discriminator"] = "Lilt")
+WHERE (c["Discriminator"] = 2)
 OFFSET 0 LIMIT 2
 """,
                 //
 """
 SELECT c
 FROM root c
-WHERE (c["Discriminator"] = "Tea")
+WHERE (c["Discriminator"] = 3)
 OFFSET 0 LIMIT 2
 """);
     }
@@ -47,7 +47,7 @@ OFFSET 0 LIMIT 2
 """
 SELECT c
 FROM root c
-WHERE c["Discriminator"] IN ("Drink", "Coke", "Lilt", "Tea")
+WHERE c["Discriminator"] IN (0, 1, 2, 3)
 """);
     }
 

--- a/test/EFCore.Specification.Tests/Query/InheritanceQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceQueryFixtureBase.cs
@@ -384,7 +384,18 @@ public abstract class InheritanceQueryFixtureBase : SharedStoreFixtureBase<Inher
         if (HasDiscriminator)
         {
             modelBuilder.Entity<Bird>().HasDiscriminator<string>("Discriminator").IsComplete(IsDiscriminatorMappingComplete);
-            modelBuilder.Entity<Drink>().HasDiscriminator().IsComplete(IsDiscriminatorMappingComplete);
+
+            modelBuilder.Entity<Drink>()
+                .HasDiscriminator(e => e.Discriminator)
+                .HasValue<Drink>(DrinkType.Drink)
+                .HasValue<Coke>(DrinkType.Coke)
+                .HasValue<Lilt>(DrinkType.Lilt)
+                .HasValue<Tea>(DrinkType.Tea)
+                .IsComplete(IsDiscriminatorMappingComplete);
+        }
+        else
+        {
+            modelBuilder.Entity<Drink>().Ignore(e => e.Discriminator);
         }
 
         modelBuilder.Entity<KiwiQuery>().HasDiscriminator().IsComplete(IsDiscriminatorMappingComplete);

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/DrinkType.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/DrinkType.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
-public class Drink
+public enum DrinkType
 {
-    public int Id { get; set; }
-    public int SortIndex { get; set; }
-    public DrinkType Discriminator { get; set; }
+    Drink,
+    Coke,
+    Lilt,
+    Tea
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/InheritanceContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/InheritanceContext.cs
@@ -14,6 +14,9 @@ public class InheritanceContext : PoolableDbContext
     public DbSet<AnimalQuery> AnimalQueries { get; set; }
     public DbSet<Country> Countries { get; set; }
     public DbSet<Drink> Drinks { get; set; }
+    public DbSet<Coke> Coke { get; set; }
+    public DbSet<Lilt> Lilt { get; set; }
+    public DbSet<Tea> Tea { get; set; }
     public DbSet<Plant> Plants { get; set; }
 
     public static void Seed(InheritanceContext context, bool useGeneratedKeys)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqlServerTest.cs
@@ -218,7 +218,7 @@ WHERE (
 UPDATE [d]
 SET [d].[SugarGrams] = 0
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] = N'Coke'
+WHERE [d].[Discriminator] = 1
 """);
     }
 
@@ -231,7 +231,7 @@ WHERE [d].[Discriminator] = N'Coke'
 UPDATE [d]
 SET [d].[SugarGrams] = 0
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] = N'Coke'
+WHERE [d].[Discriminator] = 1
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
@@ -51,19 +51,19 @@ public class IncompleteMappingInheritanceQuerySqlServerTest : InheritanceRelatio
 """
 SELECT TOP(2) [d].[Id], [d].[Discriminator], [d].[SortIndex], [d].[CaffeineGrams], [d].[CokeCO2], [d].[SugarGrams]
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] = N'Coke'
+WHERE [d].[Discriminator] = 1
 """,
             //
 """
 SELECT TOP(2) [d].[Id], [d].[Discriminator], [d].[SortIndex], [d].[LiltCO2], [d].[SugarGrams]
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] = N'Lilt'
+WHERE [d].[Discriminator] = 2
 """,
             //
 """
 SELECT TOP(2) [d].[Id], [d].[Discriminator], [d].[SortIndex], [d].[CaffeineGrams], [d].[HasMilk]
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] = N'Tea'
+WHERE [d].[Discriminator] = 3
 """);
     }
 
@@ -103,7 +103,7 @@ WHERE [m].[Discriminator] = N'Eagle'
 """
 SELECT [d].[Id], [d].[Discriminator], [d].[SortIndex], [d].[CaffeineGrams], [d].[CokeCO2], [d].[SugarGrams], [d].[LiltCO2], [d].[HasMilk]
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] IN (N'Drink', N'Coke', N'Lilt', N'Tea')
+WHERE [d].[Discriminator] IN (0, 1, 2, 3)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceQuerySqlServerTest.cs
@@ -48,19 +48,19 @@ public class InheritanceQuerySqlServerTest : InheritanceRelationalQueryTestBase<
 """
 SELECT TOP(2) [d].[Id], [d].[Discriminator], [d].[SortIndex], [d].[CaffeineGrams], [d].[CokeCO2], [d].[SugarGrams]
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] = N'Coke'
+WHERE [d].[Discriminator] = 1
 """,
             //
 """
 SELECT TOP(2) [d].[Id], [d].[Discriminator], [d].[SortIndex], [d].[LiltCO2], [d].[SugarGrams]
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] = N'Lilt'
+WHERE [d].[Discriminator] = 2
 """,
             //
 """
 SELECT TOP(2) [d].[Id], [d].[Discriminator], [d].[SortIndex], [d].[CaffeineGrams], [d].[HasMilk]
 FROM [Drinks] AS [d]
-WHERE [d].[Discriminator] = N'Tea'
+WHERE [d].[Discriminator] = 3
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqliteTest.cs
@@ -207,7 +207,7 @@ WHERE (
 """
 UPDATE "Drinks" AS "d"
 SET "SugarGrams" = 0
-WHERE "d"."Discriminator" = 'Coke'
+WHERE "d"."Discriminator" = 1
 """);
     }
 
@@ -219,7 +219,7 @@ WHERE "d"."Discriminator" = 'Coke'
 """
 UPDATE "Drinks" AS "d"
 SET "SugarGrams" = 0
-WHERE "d"."Discriminator" = 'Coke'
+WHERE "d"."Discriminator" = 1
 """);
     }
 


### PR DESCRIPTION
Fixes #29993
