### PR TITLE
[release/7.0] Use default schema for TPC tables (#30214)

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -145,8 +145,8 @@ public static class RelationalEntityTypeExtensions
             return (string?)schemaAnnotation.Value ?? GetDefaultSchema(entityType);
         }
 
-        return entityType.BaseType != null
-            ? entityType.GetRootType().GetSchema()
+        return entityType.BaseType != null && entityType.BaseType.GetTableName() != null
+            ? entityType.BaseType.GetSchema()
             : GetDefaultSchema(entityType);
     }
 

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -14,6 +14,9 @@ namespace Microsoft.EntityFrameworkCore;
 /// </remarks>
 public static class RelationalEntityTypeExtensions
 {
+    private static readonly bool QuirkEnabled29899
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29899", out var enabled) && enabled;
+
     /// <summary>
     ///     Gets the name used for the <see cref="ISqlQuery" /> mapped using
     ///     <see cref="O:RelationalEntityTypeBuilderExtensions.ToSqlQuery" />.
@@ -145,8 +148,8 @@ public static class RelationalEntityTypeExtensions
             return (string?)schemaAnnotation.Value ?? GetDefaultSchema(entityType);
         }
 
-        return entityType.BaseType != null && entityType.BaseType.GetTableName() != null
-            ? entityType.BaseType.GetSchema()
+        return entityType.BaseType != null
+            ? entityType.GetRootType().GetSchema() ?? (QuirkEnabled29899 ? null : GetDefaultSchema(entityType))
             : GetDefaultSchema(entityType);
     }
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -331,6 +331,7 @@ public class ModelSnapshotSqlServerTest
             AddBoilerPlate(
                 @"
             modelBuilder
+                .HasDefaultSchema("DefaultSchema")
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
@@ -340,7 +341,7 @@ public class ModelSnapshotSqlServerTest
             SqlServerModelBuilderExtensions.HasPerformanceLevelSql(modelBuilder, ""'S0'"");"),
             o =>
             {
-                Assert.Equal(8, o.GetAnnotations().Count());
+                Assert.Equal(9, o.GetAnnotations().Count());
                 Assert.Equal("AnnotationValue", o["AnnotationName"]);
             });
 
@@ -355,7 +356,9 @@ public class ModelSnapshotSqlServerTest
             },
             AddBoilerPlate(
                 @"
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseHiLo(modelBuilder, ""EntityFrameworkHiLoSequence"");
 
@@ -372,7 +375,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -393,7 +396,9 @@ public class ModelSnapshotSqlServerTest
             },
             AddBoilerPlate(
                 @"
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseKeySequences(modelBuilder, ""Sequence"");
 
@@ -404,13 +409,13 @@ public class ModelSnapshotSqlServerTest
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasDefaultValueSql(""NEXT VALUE FOR [EntityWithOnePropertySequence]"");
+                        .HasDefaultValueSql(""NEXT VALUE FOR [DefaultSchema].[EntityWithOnePropertySequence]"");
 
                     SqlServerPropertyBuilderExtensions.UseSequence(b.Property<int>(""Id""));
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -464,7 +469,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -480,8 +485,9 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
-                });"),
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
+                });
+"""),
             o =>
             {
                 Assert.Equal(2, o.GetEntityTypes().Count());
@@ -516,7 +522,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""AbstractBase"");
+                    b.ToTable("AbstractBase", ""DefaultSchema"");
 
                     b.UseTptMappingStrategy();
                 });
@@ -525,7 +531,7 @@ public class ModelSnapshotSqlServerTest
                 {
                     b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AbstractBase"");
 
-                    b.ToTable(""BaseEntity"");
+                    b.ToTable("BaseEntity", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity"", b =>
@@ -548,7 +554,7 @@ public class ModelSnapshotSqlServerTest
                 });"),
             model =>
             {
-                Assert.Equal(4, model.GetAnnotations().Count());
+                Assert.Equal(5, model.GetAnnotations().Count());
                 Assert.Equal(3, model.GetEntityTypes().Count());
 
                 var abstractBase = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AbstractBase");
@@ -557,6 +563,7 @@ public class ModelSnapshotSqlServerTest
 
                 var baseType = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity");
                 Assert.Equal("BaseEntity", baseType.GetTableName());
+                Assert.Equal("DefaultSchema", baseType.GetSchema());
 
                 var derived = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity");
                 Assert.Equal("DerivedEntity", derived.GetTableName());
@@ -588,7 +595,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""BaseEntity"");
+                    b.ToTable(""BaseEntity"", ""DefaultSchema"");
 
                     b.UseTptMappingStrategy();
                 });
@@ -616,7 +623,7 @@ public class ModelSnapshotSqlServerTest
                 });"),
             o =>
             {
-                Assert.Equal(4, o.GetAnnotations().Count());
+                Assert.Equal(5, o.GetAnnotations().Count());
 
                 Assert.Equal(
                     "DerivedEntity",
@@ -640,7 +647,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.ToTable((string)null);
 
-                    b.ToView(""EntityWithOneProperty"", (string)null);
+                    b.ToView(""EntityWithOneProperty"", "DefaultSchema");
                 });"),
             o => Assert.Equal("EntityWithOneProperty", o.GetEntityTypes().Single().GetViewName()));
 
@@ -691,7 +698,7 @@ public class ModelSnapshotSqlServerTest
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasDefaultValueSql(""NEXT VALUE FOR [AbstractBaseSequence]"");
+                        .HasDefaultValueSql(""NEXT VALUE FOR [DefaultSchema].[AbstractBaseSequence]"");
 
                     SqlServerPropertyBuilderExtensions.UseSequence(b.Property<int>(""Id""));
 
@@ -706,7 +713,7 @@ public class ModelSnapshotSqlServerTest
                 {
                     b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AbstractBase"");
 
-                    b.ToTable(""BaseEntity"");
+                    b.ToTable(""BaseEntity"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity"", b =>
@@ -722,7 +729,7 @@ public class ModelSnapshotSqlServerTest
                 });"),
             model =>
             {
-                Assert.Equal(5, model.GetAnnotations().Count());
+                Assert.Equal(6, model.GetAnnotations().Count());
                 Assert.Equal(3, model.GetEntityTypes().Count());
 
                 var abstractBase = model.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AbstractBase");
@@ -751,13 +758,13 @@ public class ModelSnapshotSqlServerTest
 
                         b.Property<int>("Shadow").HasColumnName("Shadow");
                         b.ToTable(
-                            "Order", tb =>
+                            "Order", "DefaultSchema", tb =>
                             {
                                 tb.Property(e => e.Id).UseIdentityColumn(2, 3).HasAnnotation("fii", "arr");
                                 tb.Property("Shadow");
                             });
                         b.SplitToTable(
-                            "SplitOrder", sb =>
+                            "SplitOrder", "DefaultSchema", sb =>
                             {
                                 sb.Property("Shadow");
                                 sb.HasTrigger("splitTrigger").HasAnnotation("oof", "rab");
@@ -771,12 +778,12 @@ public class ModelSnapshotSqlServerTest
 
                                 od.Property<int>("BillingShadow");
                                 od.ToTable(
-                                    "SplitOrder", tb =>
+                                    "SplitOrder", "DefaultSchema", tb =>
                                     {
                                         tb.Property("BillingShadow").HasColumnName("Shadow");
                                     });
                                 od.SplitToTable(
-                                    "BillingDetails", sb =>
+                                    "BillingDetails", "DefaultSchema", sb =>
                                     {
                                         sb.Property("BillingShadow").HasColumnName("Shadow");
                                     });
@@ -789,12 +796,12 @@ public class ModelSnapshotSqlServerTest
 
                                 od.Property<int>("ShippingShadow");
                                 od.ToTable(
-                                    "Order", tb =>
+                                    "Order", "DefaultSchema", tb =>
                                     {
                                         tb.Property("ShippingShadow").HasColumnName("Shadow");
                                     });
                                 od.SplitToTable(
-                                    "ShippingDetails", sb =>
+                                    "ShippingDetails", "DefaultSchema", sb =>
                                     {
                                         sb.Property("ShippingShadow");
                                     });
@@ -818,7 +825,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Order"", null, t =>
+                    b.ToTable(""Order"", "DefaultSchema", t =>
                         {
                             t.Property(""Id"")
                                 .HasAnnotation(""fii"", ""arr"")
@@ -829,7 +836,7 @@ public class ModelSnapshotSqlServerTest
                             t.Property(""Shadow"");
                         });
 
-                    b.SplitToTable(""SplitOrder"", null, t =>
+                    b.SplitToTable(""SplitOrder"", "DefaultSchema", t =>
                         {
                             t.HasTrigger(""splitTrigger"")
                                 .HasAnnotation(""oof"", ""rab"");
@@ -858,13 +865,13 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasKey(""OrderId"");
 
-                            b1.ToTable(""SplitOrder"", null, t =>
+                            b1.ToTable(""SplitOrder"", "DefaultSchema", t =>
                                 {
                                     t.Property(""BillingShadow"")
                                         .HasColumnName(""Shadow"");
                                 });
 
-                            b1.SplitToTable(""BillingDetails"", null, t =>
+                            b1.SplitToTable(""BillingDetails"", "DefaultSchema", t =>
                                 {
                                     t.Property(""BillingShadow"")
                                         .HasColumnName(""Shadow"");
@@ -889,7 +896,7 @@ public class ModelSnapshotSqlServerTest
 
                                     b2.HasKey(""OrderDetailsOrderId"");
 
-                                    b2.ToTable(""SplitOrder"");
+                                    b2.ToTable(""SplitOrder"", ""DefaultSchema"");
 
                                     b2.WithOwner()
                                         .HasForeignKey(""OrderDetailsOrderId"");
@@ -908,13 +915,13 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasKey(""OrderId"");
 
-                            b1.ToTable(""Order"", null, t =>
+                            b1.ToTable(""Order"", "DefaultSchema", t =>
                                 {
                                     t.Property(""ShippingShadow"")
                                         .HasColumnName(""Shadow"");
                                 });
 
-                            b1.SplitToTable(""ShippingDetails"", null, t =>
+                            b1.SplitToTable(""ShippingDetails"", "DefaultSchema", t =>
                                 {
                                     t.Property(""ShippingShadow"");
                                 });
@@ -938,7 +945,7 @@ public class ModelSnapshotSqlServerTest
 
                                     b2.HasKey(""OrderDetailsOrderId"");
 
-                                    b2.ToTable(""ShippingDetails"", (string)null);
+                                    b2.ToTable(""ShippingDetails"", "DefaultSchema");
 
                                     b2.WithOwner()
                                         .HasForeignKey(""OrderDetailsOrderId"");
@@ -1081,12 +1088,12 @@ public class ModelSnapshotSqlServerTest
 
                     b.ToTable((string)null);
 
-                    b.ToView(""EntityWithOneProperty"", null, v =>
+                    b.ToView(""EntityWithOneProperty"", "DefaultSchema", v =>
                         {
                             v.Property(""Shadow"");
                         });
 
-                    b.SplitToView(""SplitView"", null, v =>
+                    b.SplitToView(""SplitView"", "DefaultSchema", v =>
                         {
                             v.Property(""Shadow"");
                         });
@@ -1106,13 +1113,13 @@ public class ModelSnapshotSqlServerTest
 
                             b1.ToTable((string)null);
 
-                            b1.ToView(""EntityWithOneProperty"", null, v =>
+                            b1.ToView(""EntityWithOneProperty"", "DefaultSchema", v =>
                                 {
                                     v.Property(""AlternateId"")
                                         .HasColumnName(""SomeId"");
                                 });
 
-                            b1.SplitToView(""SplitView"", null, v =>
+                            b1.SplitToView(""SplitView"", "DefaultSchema", v =>
                                 {
                                     v.Property(""AlternateId"")
                                         .HasColumnName(""SomeOtherId"");
@@ -1141,7 +1148,7 @@ public class ModelSnapshotSqlServerTest
                 Assert.Empty(relationalModel.Tables);
                 Assert.Equal(2, relationalModel.Views.Count());
 
-                var mainView = relationalModel.FindView(entityWithOneProperty.GetViewName(), entityWithOneProperty.GetSchema());
+                var mainView = relationalModel.FindView(entityWithOneProperty.GetViewName(), "DefaultSchema");
 
                 var fragment = entityWithOneProperty.GetMappingFragments().Single();
                 var splitView = relationalModel.FindView(fragment.StoreObject.Name, fragment.StoreObject.Schema);
@@ -1288,7 +1295,7 @@ public class ModelSnapshotSqlServerTest
                 .HasAnnotation(""foo"", ""bar"");"),
             model =>
             {
-                Assert.Equal(5, model.GetAnnotations().Count());
+                Assert.Equal(6, model.GetAnnotations().Count());
 
                 var sequence = model.GetSequences().Single();
                 Assert.Equal(2, sequence.StartValue);
@@ -1364,7 +1371,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"", t =>
+                    b.ToTable(""EntityWithTwoProperties"", "DefaultSchema", t =>
                         {
                             t.HasCheckConstraint(""AlternateId"", ""AlternateId > Id"")
                                 .HasName(""CK_Customer_AlternateId"")
@@ -1404,7 +1411,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""BaseEntity"");
+                    b.ToTable(""BaseEntity"", ""DefaultSchema"");
 
                     b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseEntity"");
 
@@ -1453,7 +1460,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"", t =>
+                    b.ToTable(""EntityWithOneProperty"", "DefaultSchema", t =>
                         {
                             t.HasTrigger(""SomeTrigger"")
                                 .HasDatabaseName(""SomeTrg"")
@@ -1495,7 +1502,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"", t =>
+                    b.ToTable(""EntityWithOneProperty"", "DefaultSchema", t =>
                         {
                             t.ExcludeFromMigrations();
 
@@ -1534,12 +1541,14 @@ public class ModelSnapshotSqlServerTest
             builder => builder.UseIdentityColumns(),
             AddBoilerPlate(
                 @"
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);"),
             o =>
             {
-                Assert.Equal(4, o.GetAnnotations().Count());
+                Assert.Equal(5, o.GetAnnotations().Count());
                 Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, o.GetValueGenerationStrategy());
                 Assert.Equal(1, o.GetIdentitySeed());
                 Assert.Equal(1, o.GetIdentityIncrement());
@@ -1551,12 +1560,14 @@ public class ModelSnapshotSqlServerTest
             builder => builder.UseIdentityColumns(5),
             AddBoilerPlate(
                 @"
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 5L);"),
             o =>
             {
-                Assert.Equal(4, o.GetAnnotations().Count());
+                Assert.Equal(5, o.GetAnnotations().Count());
                 Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, o.GetValueGenerationStrategy());
                 Assert.Equal(5, o.GetIdentitySeed());
                 Assert.Equal(1, o.GetIdentityIncrement());
@@ -1568,12 +1579,14 @@ public class ModelSnapshotSqlServerTest
             builder => builder.UseIdentityColumns(increment: 5),
             AddBoilerPlate(
                 @"
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 5);"),
             o =>
             {
-                Assert.Equal(4, o.GetAnnotations().Count());
+                Assert.Equal(5, o.GetAnnotations().Count());
                 Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, o.GetValueGenerationStrategy());
                 Assert.Equal(1, o.GetIdentitySeed());
                 Assert.Equal(5, o.GetIdentityIncrement());
@@ -1592,12 +1605,14 @@ public class ModelSnapshotSqlServerTest
 
                         b.HasKey("Id");
 
-                        b.ToTable("Buildings");
+                        b.ToTable("Buildings", "DefaultSchema");
                     });
             },
             AddBoilerPlate(
                 @"
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 9223372036854775807L, 5);
 
@@ -1611,11 +1626,11 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", (string)null);
+                    b.ToTable(""Buildings"", "DefaultSchema");
                 });"),
             o =>
             {
-                Assert.Equal(4, o.GetAnnotations().Count());
+                Assert.Equal(5, o.GetAnnotations().Count());
                 Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, o.GetValueGenerationStrategy());
                 Assert.Equal(long.MaxValue, o.GetIdentitySeed());
                 Assert.Equal(5, o.GetIdentityIncrement());
@@ -1651,7 +1666,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
 
                     b.HasAnnotation(""AnnotationName"", ""AnnotationValue"");
                 });"),
@@ -1684,7 +1699,7 @@ public class ModelSnapshotSqlServerTest
 
                     SqlServerKeyBuilderExtensions.IsClustered(b.HasKey(""Id""), false);
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
 
                     SqlServerEntityTypeBuilderExtensions.IsMemoryOptimized(b);
                 });"),
@@ -1715,7 +1730,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""BaseEntity"");
+                    b.ToTable(""BaseEntity"", ""DefaultSchema"");
 
                     b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseEntity"");
 
@@ -1784,7 +1799,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""BaseEntity"");
+                    b.ToTable(""BaseEntity"", ""DefaultSchema"");
 
                     b.HasDiscriminator<string>(""Discriminator"").IsComplete(true).HasValue(""BaseEntity"");
 
@@ -1859,7 +1874,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""BaseEntityWithStructDiscriminator"");
+                    b.ToTable(""BaseEntityWithStructDiscriminator"", ""DefaultSchema"");
 
                     b.HasDiscriminator<string>(""Discriminator"").IsComplete(true).HasValue(""Base"");
 
@@ -1928,7 +1943,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -1962,7 +1977,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"", ""AlternateId"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -1986,7 +2001,7 @@ public class ModelSnapshotSqlServerTest
                     b.Property<int>(""Id"")
                         .HasColumnType(""int"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -2023,7 +2038,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasAlternateKey(""Id"", ""AlternateId"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -2060,7 +2075,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasIndex(""AlternateId"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -2095,7 +2110,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasIndex(""Id"", ""AlternateId"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -2130,7 +2145,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -2149,7 +2164,7 @@ public class ModelSnapshotSqlServerTest
                     b.HasIndex(""AlternateId"")
                         .IsUnique();
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -2349,7 +2364,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasIndex(""RightsId"");
 
-                    b.ToTable(""MyJoinTable"", (string)null);
+                    b.ToTable(""MyJoinTable"", "DefaultSchema");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyLeft"", b =>
@@ -2365,7 +2380,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""ManyToManyLeft"");
+                    b.ToTable(""ManyToManyLeft"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyRight"", b =>
@@ -2381,7 +2396,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""ManyToManyRight"");
+                    b.ToTable(""ManyToManyRight"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""ManyToManyLeftManyToManyRight"", b =>
@@ -2490,7 +2505,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithGenericKey<Guid>"");
+                    b.ToTable(""EntityWithGenericKey<Guid>"", ""DefaultSchema"");
                 });", usingSystem: true),
             model =>
             {
@@ -2540,7 +2555,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithProperties"", (string)null);
+                    b.ToTable(""EntityWithProperties"", "DefaultSchema");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -2555,7 +2570,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithProperties"", (string)null);
+                    b.ToTable(""EntityWithProperties"", "DefaultSchema");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -2603,7 +2618,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithGenericKey<Guid>"");
+                    b.ToTable(""EntityWithGenericKey<Guid>"", ""DefaultSchema"");
                 });", usingSystem: true),
             model =>
             {
@@ -2648,7 +2663,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasAlternateKey(""Property"");
 
-                    b.ToTable(""EntityWithGenericProperty<Guid>"");
+                    b.ToTable(""EntityWithGenericProperty<Guid>"", ""DefaultSchema"");
                 });", usingSystem: true),
             model =>
             {
@@ -2683,7 +2698,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"", ""DefaultSchema"");
 
                     b.HasDiscriminator<long>(""Day"");
                 });"),
@@ -2715,7 +2730,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"", ""DefaultSchema"");
 
                     b.HasDiscriminator<string>(""Day"");
                 });"),
@@ -2763,7 +2778,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
 
                     b.ToTable(tb => tb.IsTemporal(ttb =>
                             {
@@ -2824,11 +2839,11 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
 
                     b.ToTable(tb => tb.IsTemporal(ttb =>
                             {
-                                ttb.UseHistoryTable(""EntityWithStringPropertyHistory"");
+                                ttb.UseHistoryTable(""EntityWithStringPropertyHistory"", ""DefaultSchema"");
                                 ttb
                                     .HasPeriodStart(""PeriodStart"")
                                     .HasColumnName(""PeriodStart"");
@@ -2909,7 +2924,7 @@ public class ModelSnapshotSqlServerTest
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
 
                     b.HasData(
                         new
@@ -2925,7 +2940,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringKey"");
+                    b.ToTable(""EntityWithStringKey"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -2952,7 +2967,7 @@ public class ModelSnapshotSqlServerTest
 
                             SqlServerIndexBuilderExtensions.IncludeProperties(b1.HasIndex(""Id""), new[] { ""AlternateId"" });
 
-                            b1.ToTable(""EntityWithOneProperty"");
+                            b1.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
 
                             b1.WithOwner(""EntityWithOneProperty"")
                                 .HasForeignKey(""AlternateId"")
@@ -3005,7 +3020,7 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasIndex(""EntityWithStringKeyId"");
 
-                            b1.ToTable(""EntityWithStringProperty"");
+                            b1.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
 
                             b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
                                 .WithOne()
@@ -3105,7 +3120,7 @@ public class ModelSnapshotSqlServerTest
                         b.HasData(
                             new EntityWithOneProperty { Id = 1 });
 
-                        b.ToTable("EntityWithOneProperty", e => e.ExcludeFromMigrations());
+                        b.ToTable("EntityWithOneProperty", "DefaultSchema", e => e.ExcludeFromMigrations());
                     });
 
                 builder.Entity<EntityWithStringKey>(
@@ -3137,7 +3152,7 @@ public class ModelSnapshotSqlServerTest
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
 
-                    b.ToTable(""EntityWithOneProperty"", null, t =>
+                    b.ToTable(""EntityWithOneProperty"", "DefaultSchema", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -3156,7 +3171,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringKey"", null, t =>
+                    b.ToTable(""EntityWithStringKey"", "DefaultSchema", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -3184,7 +3199,7 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasIndex(""Id"");
 
-                            b1.ToTable(""EntityWithOneProperty"");
+                            b1.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
 
                             b1.WithOwner(""EntityWithOneProperty"")
                                 .HasForeignKey(""AlternateId"")
@@ -3237,7 +3252,7 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasIndex(""EntityWithStringKeyId"");
 
-                            b1.ToTable(""EntityWithStringProperty"", null, t =>
+                            b1.ToTable(""EntityWithStringProperty"", "DefaultSchema", t =>
                                 {
                                     t.ExcludeFromMigrations();
                                 });
@@ -3333,7 +3348,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Order"");
+                    b.ToTable(""Order"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"", b =>
@@ -3345,7 +3360,7 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasKey(""OrderId"");
 
-                            b1.ToTable(""Order"");
+                            b1.ToTable(""Order"", ""DefaultSchema"");
 
                             b1.WithOwner()
                                 .HasForeignKey(""OrderId"");
@@ -3360,7 +3375,7 @@ public class ModelSnapshotSqlServerTest
 
                                     b2.HasKey(""OrderDetailsOrderId"");
 
-                                    b2.ToTable(""Order"");
+                                    b2.ToTable(""Order"", ""DefaultSchema"");
 
                                     b2.WithOwner()
                                         .HasForeignKey(""OrderDetailsOrderId"");
@@ -3376,7 +3391,7 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasKey(""OrderId"");
 
-                            b1.ToTable(""Order"");
+                            b1.ToTable(""Order"", ""DefaultSchema"");
 
                             b1.WithOwner()
                                 .HasForeignKey(""OrderId"");
@@ -3391,7 +3406,7 @@ public class ModelSnapshotSqlServerTest
 
                                     b2.HasKey(""OrderDetailsOrderId"");
 
-                                    b2.ToTable(""Order"");
+                                    b2.ToTable(""Order"", ""DefaultSchema"");
 
                                     b2.WithOwner()
                                         .HasForeignKey(""OrderDetailsOrderId"");
@@ -3407,7 +3422,7 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasKey(""OrderId"");
 
-                            b1.ToTable(""Order"");
+                            b1.ToTable(""Order"", ""DefaultSchema"");
 
                             b1.WithOwner()
                                 .HasForeignKey(""OrderId"");
@@ -3422,7 +3437,7 @@ public class ModelSnapshotSqlServerTest
 
                                     b2.HasKey(""OrderInfoOrderId"");
 
-                                    b2.ToTable(""Order"");
+                                    b2.ToTable(""Order"", ""DefaultSchema"");
 
                                     b2.WithOwner()
                                         .HasForeignKey(""OrderInfoOrderId"");
@@ -3491,7 +3506,9 @@ namespace RootNamespace
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
@@ -3505,7 +3522,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""TestOwner"");
+                    b.ToTable(""TestOwner"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+TestOwner"", b =>
@@ -3525,7 +3542,7 @@ namespace RootNamespace
 
                             b1.ToTable((string)null);
 
-                            b1.ToView(""OwnedView"", (string)null);
+                            b1.ToView(""OwnedView"", "DefaultSchema");
 
                             b1.WithOwner()
                                 .HasForeignKey(""TestOwnerId"");
@@ -3575,7 +3592,9 @@ namespace RootNamespace
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
@@ -3589,7 +3608,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""TestOwner"");
+                    b.ToTable(""TestOwner"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+TestOwner"", b =>
@@ -3610,7 +3629,7 @@ namespace RootNamespace
 
                             b1.HasKey(""TestOwnerId"", ""Id"");
 
-                            b1.ToTable(""TestOwnee"", t =>
+                            b1.ToTable(""TestOwnee"", "DefaultSchema", t =>
                                 {
                                     t.HasCheckConstraint(""CK_TestOwnee_TestEnum_Enum_Constraint"", ""[TestEnum] IN (0, 1, 2)"");
                                 });
@@ -3676,7 +3695,7 @@ namespace RootNamespace
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -3692,7 +3711,7 @@ namespace RootNamespace
 
                             b1.HasKey(""EntityWithOnePropertyId"");
 
-                            b1.ToTable(""EntityWithOneProperty"");
+                            b1.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
 
                             b1.ToJson(""EntityWithTwoProperties"");
 
@@ -3706,7 +3725,7 @@ namespace RootNamespace
 
                                     b2.HasKey(""EntityWithTwoPropertiesEntityWithOnePropertyId"");
 
-                                    b2.ToTable(""EntityWithOneProperty"");
+                                    b2.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
 
                                     b2.WithOwner()
                                         .HasForeignKey(""EntityWithTwoPropertiesEntityWithOnePropertyId"");
@@ -3725,7 +3744,7 @@ namespace RootNamespace
 
                                             b3.HasKey(""EntityWithStringKeyEntityWithTwoPropertiesEntityWithOnePropertyId"", ""Id"");
 
-                                            b3.ToTable(""EntityWithOneProperty"");
+                                            b3.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
 
                                             b3.HasAnnotation(""Relational:JsonPropertyName"", ""JsonProps"");
 
@@ -3852,7 +3871,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal("AnnotationValue", o.GetEntityTypes().First().FindProperty("Id")["AnnotationName"])
         );
@@ -3878,7 +3897,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });"),
             o => Assert.Null(o.GetEntityTypes().First().FindProperty("Id")[CoreAnnotationNames.ValueGeneratorFactory])
         );
@@ -3904,7 +3923,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });"),
             o => Assert.False(o.GetEntityTypes().First().FindProperty("Name").IsNullable));
 
@@ -3934,7 +3953,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });", usingSystem: true),
             o => Assert.Equal(ValueGenerated.OnAdd, o.GetEntityTypes().First().FindProperty("AlternateId").ValueGenerated));
 
@@ -3965,7 +3984,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"", ""DefaultSchema"");
                 });"),
             model =>
             {
@@ -3998,9 +4017,36 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(100, o.GetEntityTypes().First().FindProperty("Name").GetMaxLength()));
+
+
+    [ConditionalFact]
+    public virtual void Property_maximum_maxLength_is_stored_in_snapshot()
+        => Test(
+            builder => builder.Entity<EntityWithStringProperty>().Property<string>("Name").HasMaxLength(-1),
+            AddBoilerPlate(
+                GetHeading() +
+"""
+            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(-1)
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("EntityWithStringProperty", "DefaultSchema");
+                });
+"""),
+            o => Assert.Equal(-1, o.GetEntityTypes().First().FindProperty("Name").GetMaxLength()));
 
     [ConditionalFact]
     public virtual void Property_unicodeness_is_stored_in_snapshot()
@@ -4023,7 +4069,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });"),
             o => Assert.False(o.GetEntityTypes().First().FindProperty("Name").IsUnicode()));
 
@@ -4049,7 +4095,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });"),
             o => Assert.True(o.GetEntityTypes().First().FindProperty("Name").IsFixedLength()));
 
@@ -4077,7 +4123,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithDecimalProperty"");
+                    b.ToTable(""EntityWithDecimalProperty"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4110,7 +4156,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithDecimalProperty"");
+                    b.ToTable(""EntityWithDecimalProperty"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4149,7 +4195,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4184,7 +4230,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.True(o.GetEntityTypes().First().FindProperty("AlternateId").IsConcurrencyToken));
 
@@ -4213,7 +4259,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal("CName", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ColumnName"]));
 
@@ -4242,7 +4288,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""BaseEntity"");
+                    b.ToTable(""BaseEntity"", ""DefaultSchema"");
 
                     b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseEntity"");
 
@@ -4266,7 +4312,7 @@ namespace RootNamespace
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(max)"");
 
-                    b.ToTable(""BaseEntity"", t =>
+                    b.ToTable(""BaseEntity"", "DefaultSchema", t =>
                         {
                             t.Property(""Name"")
                                 .HasColumnName(""DuplicateDerivedEntity_Name"");
@@ -4288,7 +4334,7 @@ namespace RootNamespace
                         Assert.Equal(
                             "DuplicateDerivedEntity_Name",
                             t.FindProperty(nameof(DuplicateDerivedEntity.Name))
-                                .GetColumnName(StoreObjectIdentifier.Table(nameof(BaseEntity))));
+                                .GetColumnName(StoreObjectIdentifier.Table(nameof(BaseEntity), "DefaultSchema")));
                     }
                 );
             });
@@ -4317,7 +4363,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal("CType", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ColumnType"]));
 
@@ -4347,7 +4393,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(1, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValue"]));
 
@@ -4377,7 +4423,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });",
                 usingSystem: true),
             o => Assert.Equal(DBNull.Value, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValue"]));
@@ -4408,7 +4454,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(string.Empty, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValueSql"]));
 
@@ -4438,7 +4484,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValueSql"]));
 
@@ -4468,7 +4514,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedColumnSql"]));
 
@@ -4498,7 +4544,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4532,7 +4578,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(string.Empty, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedColumnSql"]));
 
@@ -4558,7 +4604,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(3L, o.GetEntityTypes().First().FindProperty("Day")["Relational:DefaultValue"]));
 
@@ -4592,7 +4638,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"", ""DefaultSchema"");
 
                     b.HasData(
                         new
@@ -4629,7 +4675,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithNullableEnumType"");
+                    b.ToTable(""EntityWithNullableEnumType"", ""DefaultSchema"");
                 });"),
             o => Assert.True(o.GetEntityTypes().First().FindProperty("Day").IsNullable));
 
@@ -4654,7 +4700,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"", ""DefaultSchema"");
                 });", usingSystem: true),
             o => Assert.False(o.GetEntityTypes().First().FindProperty("Day").IsNullable));
 
@@ -4678,7 +4724,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithNullableEnumType"");
+                    b.ToTable(""EntityWithNullableEnumType"", ""DefaultSchema"");
                 });"),
             o => Assert.True(o.GetEntityTypes().First().FindProperty("Day").IsNullable));
 
@@ -4709,7 +4755,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4738,7 +4784,7 @@ namespace RootNamespace
 
                         b.HasKey("Id");
 
-                        b.ToTable("Buildings");
+                        b.ToTable("Buildings", "DefaultSchema");
                     });
             },
             AddBoilerPlate(
@@ -4754,7 +4800,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", (string)null);
+                    b.ToTable(""Buildings"", "DefaultSchema");
                 });"),
             o =>
             {
@@ -4774,7 +4820,7 @@ namespace RootNamespace
 
                         b.HasKey("Id");
 
-                        b.ToTable("Buildings");
+                        b.ToTable("Buildings", "DefaultSchema");
                     });
             },
             AddBoilerPlate(
@@ -4790,7 +4836,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", (string)null);
+                    b.ToTable(""Buildings"", "DefaultSchema");
                 });"),
             o =>
             {
@@ -4812,7 +4858,7 @@ namespace RootNamespace
 
                         b.HasKey("Id");
 
-                        b.ToTable("Buildings");
+                        b.ToTable("Buildings", "DefaultSchema");
                     });
             },
             AddBoilerPlate(
@@ -4828,7 +4874,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", (string)null);
+                    b.ToTable(""Buildings"", "DefaultSchema");
                 });"),
             o =>
             {
@@ -4850,7 +4896,7 @@ namespace RootNamespace
 
                         b.HasKey("Id");
 
-                        b.ToTable("Buildings");
+                        b.ToTable("Buildings", "DefaultSchema");
                     });
             },
             AddBoilerPlate(
@@ -4866,7 +4912,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", (string)null);
+                    b.ToTable(""Buildings"", "DefaultSchema");
                 });"),
             o =>
             {
@@ -4888,7 +4934,7 @@ namespace RootNamespace
 
                         b.HasKey("Id");
 
-                        b.ToTable("Buildings");
+                        b.ToTable("Buildings", "DefaultSchema");
                     });
             },
             AddBoilerPlate(
@@ -4904,7 +4950,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", (string)null);
+                    b.ToTable(""Buildings"", "DefaultSchema");
                 });"),
             o =>
             {
@@ -4939,7 +4985,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(1, o.GetEntityTypes().First().FindProperty("AlternateId").GetColumnOrder()));
 
@@ -4949,7 +4995,9 @@ namespace RootNamespace
             builder => builder.HasAnnotation(SqlServerAnnotationNames.IdentitySeed, 8),
             AddBoilerPlate(
                 @"
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 8L);"),
             o => Assert.Equal(8L, o.GetIdentitySeed()));
@@ -4979,7 +5027,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(8L, o.GetEntityTypes().First().FindProperty("Id").GetIdentitySeed()));
 
@@ -5015,7 +5063,7 @@ namespace RootNamespace
                     b.HasAlternateKey(""AlternateId"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(
                 "AnnotationValue", o.GetEntityTypes().First().GetKeys().Where(k => !k.IsPrimaryKey()).First()["AnnotationName"]));
@@ -5043,7 +5091,7 @@ namespace RootNamespace
 
                     SqlServerKeyBuilderExtensions.IsClustered(b.HasKey(""Id""));
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });"),
             o => Assert.True(o.GetEntityTypes().First().GetKeys().Single(k => k.IsPrimaryKey()).IsClustered()));
 
@@ -5074,7 +5122,7 @@ namespace RootNamespace
                     b.HasAlternateKey(""AlternateId"")
                         .HasName(""KeyName"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(
                 "KeyName", o.GetEntityTypes().First().GetKeys().Where(k => !k.IsPrimaryKey()).First()["Relational:Name"]));
@@ -5108,7 +5156,7 @@ namespace RootNamespace
                         .HasName(""IndexName"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -5150,7 +5198,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal("AnnotationValue", o.GetEntityTypes().First().GetIndexes().First()["AnnotationName"]));
 
@@ -5182,7 +5230,7 @@ namespace RootNamespace
 
                     SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex(""AlternateId""));
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.True(o.GetEntityTypes().Single().GetIndexes().Single().IsClustered()));
 
@@ -5213,7 +5261,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .IsUnique();
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.True(o.GetEntityTypes().First().GetIndexes().First().IsUnique));
 
@@ -5301,7 +5349,7 @@ namespace RootNamespace
 
                     b.HasIndex(new[] { ""X"", ""Y"", ""Z"" }, ""IX_unspecified"");
 
-                    b.ToTable(""EntityWithThreeProperties"");
+                    b.ToTable(""EntityWithThreeProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -5353,7 +5401,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .HasDatabaseName(""IndexName"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -5390,7 +5438,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .HasFilter(""AlternateId <> 0"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal(
                 "AlternateId <> 0",
@@ -5424,7 +5472,7 @@ namespace RootNamespace
                     b.HasIndex(new[] { ""AlternateId"" }, ""IndexName"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -5467,7 +5515,7 @@ namespace RootNamespace
 
                     b.HasIndex(""SomePropertyWithAnExceedinglyLongIdentifierThatCausesTheDefaultIndexNameToExceedTheMaximumIdentifierLimit"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });"),
             model => Assert.Equal(128, model.GetEntityTypes().First().GetIndexes().First().GetDatabaseName().Length));
 
@@ -5496,7 +5544,7 @@ namespace RootNamespace
 
                     b.HasIndex(""FirstName"", ""LastName"");
 
-                    b.ToTable(""EntityWithIndexAttribute"");
+                    b.ToTable(""EntityWithIndexAttribute"", ""DefaultSchema"");
                 });"),
             model =>
                 Assert.Collection(
@@ -5538,7 +5586,7 @@ namespace RootNamespace
 
                     b.HasIndex(new[] { ""FirstName"", ""LastName"" }, ""NamedIndex"");
 
-                    b.ToTable(""EntityWithNamedIndexAttribute"");
+                    b.ToTable(""EntityWithNamedIndexAttribute"", ""DefaultSchema"");
                 });"),
             model =>
             {
@@ -5586,7 +5634,7 @@ namespace RootNamespace
                         .IsUnique()
                         .HasFilter(""[FirstName] IS NOT NULL AND [LastName] IS NOT NULL"");
 
-                    b.ToTable(""EntityWithUniqueIndexAttribute"");
+                    b.ToTable(""EntityWithUniqueIndexAttribute"", ""DefaultSchema"");
                 });"),
             model =>
             {
@@ -5635,7 +5683,7 @@ namespace RootNamespace
 
                     SqlServerIndexBuilderExtensions.IncludeProperties(b.HasIndex(""Id""), new[] { ""Name"" });
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });"),
             model =>
             {
@@ -5671,7 +5719,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -5690,7 +5738,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .IsUnique();
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -5734,7 +5782,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringKey"");
+                    b.ToTable(""EntityWithStringKey"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
@@ -5754,7 +5802,7 @@ namespace RootNamespace
                     b.HasIndex(""Name"")
                         .IsUnique();
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
@@ -5787,7 +5835,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringKey"");
+                    b.ToTable(""EntityWithStringKey"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
@@ -5805,7 +5853,7 @@ namespace RootNamespace
 
                     b.HasIndex(""Name"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
@@ -5849,7 +5897,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringAlternateKey"");
+                    b.ToTable(""EntityWithStringAlternateKey"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
@@ -5867,7 +5915,7 @@ namespace RootNamespace
 
                     b.HasIndex(""Name"");
 
-                    b.ToTable(""EntityWithStringProperty"");
+                    b.ToTable(""EntityWithStringProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
@@ -5905,7 +5953,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -5921,7 +5969,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -5957,7 +6005,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -5973,7 +6021,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -6018,7 +6066,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithGenericKey<Guid>"");
+                    b.ToTable(""EntityWithGenericKey<Guid>"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
@@ -6036,7 +6084,7 @@ namespace RootNamespace
 
                     b.HasIndex(""Property"");
 
-                    b.ToTable(""EntityWithGenericProperty<Guid>"");
+                    b.ToTable(""EntityWithGenericProperty<Guid>"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
@@ -6099,7 +6147,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6118,7 +6166,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .IsUnique();
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6165,7 +6213,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6184,7 +6232,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .IsUnique();
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6243,7 +6291,7 @@ namespace RootNamespace
 
                     b.HasIndex(""NavigationId"");
 
-                    b.ToTable(""BaseType"");
+                    b.ToTable(""BaseType"", ""DefaultSchema"");
 
                     b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseType"");
 
@@ -6260,7 +6308,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedType"", b =>
@@ -6301,7 +6349,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6317,7 +6365,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -6365,7 +6413,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6384,7 +6432,7 @@ namespace RootNamespace
                     b.HasAlternateKey(""AlternateId"")
                         .HasAnnotation(""Name"", ""Value"");
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -6441,7 +6489,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6460,7 +6508,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .IsUnique();
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6508,7 +6556,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6527,7 +6575,7 @@ namespace RootNamespace
                     b.HasIndex(""AlternateId"")
                         .IsUnique();
 
-                    b.ToTable(""EntityWithTwoProperties"");
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -6710,7 +6758,9 @@ namespace RootNamespace
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
@@ -6848,7 +6898,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithManyProperties"");
+                    b.ToTable(""EntityWithManyProperties"", ""DefaultSchema"");
 
                     b.HasData(
                         new
@@ -7057,7 +7107,9 @@ namespace RootNamespace
 
     protected virtual string GetHeading(bool empty = false)
         => @"
-            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+            modelBuilder
+                .HasDefaultSchema("DefaultSchema")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);"
             + (empty
@@ -7107,6 +7159,7 @@ namespace RootNamespace
     protected void Test(Action<ModelBuilder> buildModel, string expectedCode, Action<IModel, IModel> assert)
     {
         var modelBuilder = CreateConventionalModelBuilder();
+        modelBuilder.HasDefaultSchema("DefaultSchema");
         modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
         modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersion);
         buildModel(modelBuilder);

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -331,7 +331,7 @@ public class ModelSnapshotSqlServerTest
             AddBoilerPlate(
                 @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
@@ -357,7 +357,7 @@ public class ModelSnapshotSqlServerTest
             AddBoilerPlate(
                 @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseHiLo(modelBuilder, ""EntityFrameworkHiLoSequence"");
@@ -397,7 +397,7 @@ public class ModelSnapshotSqlServerTest
             AddBoilerPlate(
                 @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseKeySequences(modelBuilder, ""Sequence"");
@@ -486,8 +486,7 @@ public class ModelSnapshotSqlServerTest
                     b.HasKey(""Id"");
 
                     b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"");
-                });
-"""),
+                });"),
             o =>
             {
                 Assert.Equal(2, o.GetEntityTypes().Count());
@@ -522,7 +521,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable("AbstractBase", ""DefaultSchema"");
+                    b.ToTable(""AbstractBase"", ""DefaultSchema"");
 
                     b.UseTptMappingStrategy();
                 });
@@ -531,7 +530,7 @@ public class ModelSnapshotSqlServerTest
                 {
                     b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AbstractBase"");
 
-                    b.ToTable("BaseEntity", ""DefaultSchema"");
+                    b.ToTable(""BaseEntity"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity"", b =>
@@ -647,7 +646,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.ToTable((string)null);
 
-                    b.ToView(""EntityWithOneProperty"", "DefaultSchema");
+                    b.ToView(""EntityWithOneProperty"", ""DefaultSchema"");
                 });"),
             o => Assert.Equal("EntityWithOneProperty", o.GetEntityTypes().Single().GetViewName()));
 
@@ -825,7 +824,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Order"", "DefaultSchema", t =>
+                    b.ToTable(""Order"", ""DefaultSchema"", t =>
                         {
                             t.Property(""Id"")
                                 .HasAnnotation(""fii"", ""arr"")
@@ -836,7 +835,7 @@ public class ModelSnapshotSqlServerTest
                             t.Property(""Shadow"");
                         });
 
-                    b.SplitToTable(""SplitOrder"", "DefaultSchema", t =>
+                    b.SplitToTable(""SplitOrder"", ""DefaultSchema"", t =>
                         {
                             t.HasTrigger(""splitTrigger"")
                                 .HasAnnotation(""oof"", ""rab"");
@@ -865,13 +864,13 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasKey(""OrderId"");
 
-                            b1.ToTable(""SplitOrder"", "DefaultSchema", t =>
+                            b1.ToTable(""SplitOrder"", ""DefaultSchema"", t =>
                                 {
                                     t.Property(""BillingShadow"")
                                         .HasColumnName(""Shadow"");
                                 });
 
-                            b1.SplitToTable(""BillingDetails"", "DefaultSchema", t =>
+                            b1.SplitToTable(""BillingDetails"", ""DefaultSchema"", t =>
                                 {
                                     t.Property(""BillingShadow"")
                                         .HasColumnName(""Shadow"");
@@ -915,13 +914,13 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasKey(""OrderId"");
 
-                            b1.ToTable(""Order"", "DefaultSchema", t =>
+                            b1.ToTable(""Order"", ""DefaultSchema"", t =>
                                 {
                                     t.Property(""ShippingShadow"")
                                         .HasColumnName(""Shadow"");
                                 });
 
-                            b1.SplitToTable(""ShippingDetails"", "DefaultSchema", t =>
+                            b1.SplitToTable(""ShippingDetails"", ""DefaultSchema"", t =>
                                 {
                                     t.Property(""ShippingShadow"");
                                 });
@@ -945,7 +944,7 @@ public class ModelSnapshotSqlServerTest
 
                                     b2.HasKey(""OrderDetailsOrderId"");
 
-                                    b2.ToTable(""ShippingDetails"", "DefaultSchema");
+                                    b2.ToTable(""ShippingDetails"", ""DefaultSchema"");
 
                                     b2.WithOwner()
                                         .HasForeignKey(""OrderDetailsOrderId"");
@@ -1088,12 +1087,12 @@ public class ModelSnapshotSqlServerTest
 
                     b.ToTable((string)null);
 
-                    b.ToView(""EntityWithOneProperty"", "DefaultSchema", v =>
+                    b.ToView(""EntityWithOneProperty"", ""DefaultSchema"", v =>
                         {
                             v.Property(""Shadow"");
                         });
 
-                    b.SplitToView(""SplitView"", "DefaultSchema", v =>
+                    b.SplitToView(""SplitView"", ""DefaultSchema"", v =>
                         {
                             v.Property(""Shadow"");
                         });
@@ -1113,13 +1112,13 @@ public class ModelSnapshotSqlServerTest
 
                             b1.ToTable((string)null);
 
-                            b1.ToView(""EntityWithOneProperty"", "DefaultSchema", v =>
+                            b1.ToView(""EntityWithOneProperty"", ""DefaultSchema"", v =>
                                 {
                                     v.Property(""AlternateId"")
                                         .HasColumnName(""SomeId"");
                                 });
 
-                            b1.SplitToView(""SplitView"", "DefaultSchema", v =>
+                            b1.SplitToView(""SplitView"", ""DefaultSchema"", v =>
                                 {
                                     v.Property(""AlternateId"")
                                         .HasColumnName(""SomeOtherId"");
@@ -1371,7 +1370,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithTwoProperties"", "DefaultSchema", t =>
+                    b.ToTable(""EntityWithTwoProperties"", ""DefaultSchema"", t =>
                         {
                             t.HasCheckConstraint(""AlternateId"", ""AlternateId > Id"")
                                 .HasName(""CK_Customer_AlternateId"")
@@ -1460,7 +1459,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"", "DefaultSchema", t =>
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"", t =>
                         {
                             t.HasTrigger(""SomeTrigger"")
                                 .HasDatabaseName(""SomeTrg"")
@@ -1502,7 +1501,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithOneProperty"", "DefaultSchema", t =>
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"", t =>
                         {
                             t.ExcludeFromMigrations();
 
@@ -1542,7 +1541,7 @@ public class ModelSnapshotSqlServerTest
             AddBoilerPlate(
                 @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);"),
@@ -1561,7 +1560,7 @@ public class ModelSnapshotSqlServerTest
             AddBoilerPlate(
                 @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 5L);"),
@@ -1580,7 +1579,7 @@ public class ModelSnapshotSqlServerTest
             AddBoilerPlate(
                 @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 5);"),
@@ -1611,7 +1610,7 @@ public class ModelSnapshotSqlServerTest
             AddBoilerPlate(
                 @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 9223372036854775807L, 5);
@@ -1626,7 +1625,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", "DefaultSchema");
+                    b.ToTable(""Buildings"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -2364,7 +2363,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasIndex(""RightsId"");
 
-                    b.ToTable(""MyJoinTable"", "DefaultSchema");
+                    b.ToTable(""MyJoinTable"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyLeft"", b =>
@@ -2555,7 +2554,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithProperties"", "DefaultSchema");
+                    b.ToTable(""EntityWithProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -2570,7 +2569,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithProperties"", "DefaultSchema");
+                    b.ToTable(""EntityWithProperties"", ""DefaultSchema"");
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -3152,7 +3151,7 @@ public class ModelSnapshotSqlServerTest
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
 
-                    b.ToTable(""EntityWithOneProperty"", "DefaultSchema", t =>
+                    b.ToTable(""EntityWithOneProperty"", ""DefaultSchema"", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -3171,7 +3170,7 @@ public class ModelSnapshotSqlServerTest
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringKey"", "DefaultSchema", t =>
+                    b.ToTable(""EntityWithStringKey"", ""DefaultSchema"", t =>
                         {
                             t.ExcludeFromMigrations();
                         });
@@ -3252,7 +3251,7 @@ public class ModelSnapshotSqlServerTest
 
                             b1.HasIndex(""EntityWithStringKeyId"");
 
-                            b1.ToTable(""EntityWithStringProperty"", "DefaultSchema", t =>
+                            b1.ToTable(""EntityWithStringProperty"", ""DefaultSchema"", t =>
                                 {
                                     t.ExcludeFromMigrations();
                                 });
@@ -3507,7 +3506,7 @@ namespace RootNamespace
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -3542,7 +3541,7 @@ namespace RootNamespace
 
                             b1.ToTable((string)null);
 
-                            b1.ToView(""OwnedView"", "DefaultSchema");
+                            b1.ToView(""OwnedView"", ""DefaultSchema"");
 
                             b1.WithOwner()
                                 .HasForeignKey(""TestOwnerId"");
@@ -3593,7 +3592,7 @@ namespace RootNamespace
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -3629,7 +3628,7 @@ namespace RootNamespace
 
                             b1.HasKey(""TestOwnerId"", ""Id"");
 
-                            b1.ToTable(""TestOwnee"", "DefaultSchema", t =>
+                            b1.ToTable(""TestOwnee"", ""DefaultSchema"", t =>
                                 {
                                     t.HasCheckConstraint(""CK_TestOwnee_TestEnum_Enum_Constraint"", ""[TestEnum] IN (0, 1, 2)"");
                                 });
@@ -4021,33 +4020,6 @@ namespace RootNamespace
                 });"),
             o => Assert.Equal(100, o.GetEntityTypes().First().FindProperty("Name").GetMaxLength()));
 
-
-    [ConditionalFact]
-    public virtual void Property_maximum_maxLength_is_stored_in_snapshot()
-        => Test(
-            builder => builder.Entity<EntityWithStringProperty>().Property<string>("Name").HasMaxLength(-1),
-            AddBoilerPlate(
-                GetHeading() +
-"""
-            modelBuilder.Entity("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(-1)
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("EntityWithStringProperty", "DefaultSchema");
-                });
-"""),
-            o => Assert.Equal(-1, o.GetEntityTypes().First().FindProperty("Name").GetMaxLength()));
-
     [ConditionalFact]
     public virtual void Property_unicodeness_is_stored_in_snapshot()
         => Test(
@@ -4312,7 +4284,7 @@ namespace RootNamespace
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(max)"");
 
-                    b.ToTable(""BaseEntity"", "DefaultSchema", t =>
+                    b.ToTable(""BaseEntity"", ""DefaultSchema"", t =>
                         {
                             t.Property(""Name"")
                                 .HasColumnName(""DuplicateDerivedEntity_Name"");
@@ -4800,7 +4772,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", "DefaultSchema");
+                    b.ToTable(""Buildings"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4836,7 +4808,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", "DefaultSchema");
+                    b.ToTable(""Buildings"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4874,7 +4846,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", "DefaultSchema");
+                    b.ToTable(""Buildings"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4912,7 +4884,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", "DefaultSchema");
+                    b.ToTable(""Buildings"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4950,7 +4922,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"", "DefaultSchema");
+                    b.ToTable(""Buildings"", ""DefaultSchema"");
                 });"),
             o =>
             {
@@ -4996,7 +4968,7 @@ namespace RootNamespace
             AddBoilerPlate(
                 @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 8L);"),
@@ -6759,7 +6731,7 @@ namespace RootNamespace
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -7108,7 +7080,7 @@ namespace RootNamespace
     protected virtual string GetHeading(bool empty = false)
         => @"
             modelBuilder
-                .HasDefaultSchema("DefaultSchema")
+                .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);"


### PR DESCRIPTION
Port of #30214
Fixes #29899

**Description**

With TPC mapping, it is common for to have derived types that are mapped to tables while the base type is not mapped to a table. In these cases, the default schema was not being picked up for the derived types.

**Customer impact**

Customer reported in relatively common scenario. There is a workaround to manually specify the schema on all tables, but this can get tricky, especially when the schema is obtained from the tenant in multi-tenant scenarios.

**How found**

Customer reported on 7.0.

**Regression**

No; new feature in 7.0.

**Testing**

Default schema set for more existing tests to give better coverage.

**Risk**

Low; trivial code change to get the default schema in cases like this, and quirked.
