### PR TITLE
Avoid check on CLR conversion when IsMappedToJson

### DIFF
--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -155,6 +155,11 @@ public class ModelValidator : IModelValidator
                 continue;
             }
 
+            if (entityType.FindAnnotation("Relational:ContainerColumnName") != null)
+            {
+                continue;
+            }
+
             var runtimeProperties = entityType.GetRuntimeProperties();
             var clrProperties = new HashSet<string>(StringComparer.Ordinal);
             clrProperties.UnionWith(


### PR DESCRIPTION
@ajcvickers I need your insight on how you would tackle this problem. When mapping an owned entity type to JSON, the properties of that entity type cannot be of type `string[]` or `int[]` or `object`. However, since it is JSON it shouldn't matter and all these types should be allowed.

Now, currently when using the `RelationalOwnedNavigationBuilderExtensions.ToJson` method it sets a `Relational:ContainerColumnName` annotation on the owned entity type. There is even an extension method `RelationalEntityTypeExtensions.IsMappedToJson` available in EFCore.Relational. However, this extension method isn't available in EFCore itself.

I want to add a check like in this PR to avoid the `ModelValidator` checking CLR type conversion existing for columns which are mapped to JSON. But I would have preferred to use the extension method. How should I proceed?