### PR TITLE
Fix to #28816 - Json: add support for Sqlite provider

### DIFF
--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -330,7 +330,7 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
 
                 if (updateInfo.Property != null)
                 {
-                    json = new JsonArray(JsonValue.Create(updateInfo.PropertyValue));
+                    json = new JsonArray(GenerateJsonForSinglePropertyUpdate(updateInfo.Property, updateInfo.PropertyValue));
                     jsonPathString = jsonPathString + "." + updateInfo.Property.GetJsonPropertyName();
                 }
                 else
@@ -698,6 +698,16 @@ public class ModificationCommand : IModificationCommand, INonTrackedModification
             return result;
         }
     }
+
+    /// <summary>
+    ///     Generates <see cref="JsonNode" /> representing the value to use for update in case a single property is being updated.
+    /// </summary>
+    /// <param name="property">Property to be updated.</param>
+    /// <param name="propertyValue">Value object that the property will be updated to.</param>
+    /// <returns><see cref="JsonNode" /> representing the value that the property will be updated to.</returns>
+    [EntityFrameworkInternal]
+    protected virtual JsonNode? GenerateJsonForSinglePropertyUpdate(IProperty property, object? propertyValue)
+        => JsonValue.Create(propertyValue);
 
     private JsonNode? CreateJson(object? navigationValue, IUpdateEntry parentEntry, IEntityType entityType, int? ordinal, bool isCollection)
     {

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
@@ -335,7 +335,7 @@ public class SqlServerQuerySqlGenerator : QuerySqlGenerator
 
         Visit(jsonScalarExpression.JsonColumn);
 
-        Sql.Append(",'");
+        Sql.Append(", '");
         foreach (var pathSegment in jsonScalarExpression.Path)
         {
             if (pathSegment.PropertyName != null)

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -142,8 +142,7 @@ public class SqlServerUpdateSqlGenerator : UpdateAndSelectSqlGenerator, ISqlServ
         string name,
         string? schema)
     {
-        if (columnModification.JsonPath != null
-            && columnModification.JsonPath != "$")
+        if (columnModification.JsonPath is not (null or "$"))
         {
             stringBuilder.Append("JSON_MODIFY(");
             updateSqlGeneratorHelper.DelimitIdentifier(stringBuilder, columnModification.ColumnName);

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -100,6 +100,7 @@ public static class SqliteServiceCollectionExtensions
             .TryAdd<IModelValidator, SqliteModelValidator>()
             .TryAdd<IProviderConventionSetBuilder, SqliteConventionSetBuilder>()
             .TryAdd<IModificationCommandBatchFactory, SqliteModificationCommandBatchFactory>()
+            .TryAdd<IModificationCommandFactory, SqliteModificationCommandFactory>()
             .TryAdd<IRelationalConnection>(p => p.GetRequiredService<ISqliteRelationalConnection>())
             .TryAdd<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator>()
             .TryAdd<IRelationalDatabaseCreator, SqliteDatabaseCreator>()

--- a/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
@@ -47,6 +48,12 @@ public class SqliteAnnotationProvider : RelationalAnnotationProvider
     /// </summary>
     public override IEnumerable<IAnnotation> For(IColumn column, bool designTime)
     {
+        // JSON columns have no property mappings so all annotations that rely on property mappings should be skipped for them
+        if (column is JsonColumn)
+        {
+            yield break;
+        }
+
         // Model validation ensures that these facets are the same on all mapped properties
         var property = column.PropertyMappings.First().Property;
         // Only return auto increment for integer single column primary key

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
@@ -117,4 +117,66 @@ public class SqliteQuerySqlGenerator : QuerySqlGenerator
 
         return regexpExpression;
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitJsonScalar(JsonScalarExpression jsonScalarExpression)
+    {
+        if (jsonScalarExpression.Path.Count == 1
+            && jsonScalarExpression.Path[0].ToString() == "$")
+        {
+            Visit(jsonScalarExpression.JsonColumn);
+
+            return jsonScalarExpression;
+        }
+
+        Sql.Append("json_extract(");
+
+        Visit(jsonScalarExpression.JsonColumn);
+
+        Sql.Append(", '");
+        foreach (var pathSegment in jsonScalarExpression.Path)
+        {
+            if (pathSegment.PropertyName != null)
+            {
+                Sql.Append((pathSegment.PropertyName == "$" ? "" : ".") + pathSegment.PropertyName);
+            }
+
+            if (pathSegment.ArrayIndex != null)
+            {
+                Sql.Append("[");
+
+                if (pathSegment.ArrayIndex is SqlConstantExpression)
+                {
+                    Visit(pathSegment.ArrayIndex);
+                }
+                else
+                {
+                    Sql.Append("' || ");
+                    if (pathSegment.ArrayIndex is SqlParameterExpression)
+                    {
+                        Visit(pathSegment.ArrayIndex);
+                    }
+                    else
+                    {
+                        Sql.Append("(");
+                        Visit(pathSegment.ArrayIndex);
+                        Sql.Append(")");
+                    }
+
+                    Sql.Append(" || '");
+                }
+
+                Sql.Append("]");
+            }
+        }
+
+        Sql.Append("')");
+
+        return jsonScalarExpression;
+    }
 }

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteJsonTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteJsonTypeMapping.cs
@@ -1,9 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data;
 using System.Text.Json;
 
-namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 
 /// <summary>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -11,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public class SqlServerJsonTypeMapping : JsonTypeMapping
+public class SqliteJsonTypeMapping : JsonTypeMapping
 {
     private static readonly MethodInfo GetStringMethod
         = typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetString), new[] { typeof(int) })!;
@@ -23,13 +24,22 @@ public class SqlServerJsonTypeMapping : JsonTypeMapping
         = typeof(JsonDocument).GetRuntimeProperty(nameof(JsonDocument.RootElement))!;
 
     /// <summary>
+    ///     Initializes a new instance of the <see cref="SqliteJsonTypeMapping" /> class.
+    /// </summary>
+    /// <param name="storeType">The name of the database type.</param>
+    public SqliteJsonTypeMapping(string storeType)
+        : base(storeType, typeof(JsonElement), System.Data.DbType.String)
+    {
+    }
+
+    /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public SqlServerJsonTypeMapping(string storeType)
-        : base(storeType, typeof(JsonElement), System.Data.DbType.String)
+    protected SqliteJsonTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
     {
     }
 
@@ -62,10 +72,8 @@ public class SqlServerJsonTypeMapping : JsonTypeMapping
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected SqlServerJsonTypeMapping(RelationalTypeMappingParameters parameters)
-        : base(parameters)
-    {
-    }
+    protected override string GenerateNonNullSqlLiteral(object value)
+        => $"'{EscapeSqlLiteral(JsonSerializer.Serialize(value))}'";
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -82,15 +90,6 @@ public class SqlServerJsonTypeMapping : JsonTypeMapping
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override string GenerateNonNullSqlLiteral(object value)
-        => $"'{EscapeSqlLiteral(JsonSerializer.Serialize(value))}'";
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-        => new SqlServerJsonTypeMapping(parameters);
+        => new SqliteJsonTypeMapping(parameters);
 }

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+
 namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 
 /// <summary>
@@ -80,7 +82,8 @@ public class SqliteTypeMappingSource : RelationalTypeMappingSource
         { typeof(decimal), new SqliteDecimalTypeMapping(TextTypeName) },
         { typeof(double), Real },
         { typeof(float), new FloatTypeMapping(RealTypeName) },
-        { typeof(Guid), new SqliteGuidTypeMapping(TextTypeName) }
+        { typeof(Guid), new SqliteGuidTypeMapping(TextTypeName) },
+        { typeof(JsonElement), new SqliteJsonTypeMapping(TextTypeName) }
     };
 
     private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings = new(StringComparer.OrdinalIgnoreCase)

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommand.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommand.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Update.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteModificationCommand : ModificationCommand
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqliteModificationCommand(in ModificationCommandParameters modificationCommandParameters)
+        : base(modificationCommandParameters)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqliteModificationCommand(in NonTrackedModificationCommandParameters modificationCommandParameters)
+        : base(modificationCommandParameters)
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override JsonNode? GenerateJsonForSinglePropertyUpdate(IProperty property, object? propertyValue)
+    {
+        if (propertyValue is bool boolPropertyValue
+            && (property.GetTypeMapping().Converter?.ProviderClrType ?? property.ClrType).UnwrapNullableType() == typeof(bool))
+        {
+            // Sqlite converts true/false into native 0/1 when using json_extract
+            // so we convert those values to strings so that they stay as true/false
+            // which is what we want to store in json object in the end
+            var modifiedPropertyValue = boolPropertyValue
+                ? "true"
+                : "false";
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            return base.GenerateJsonForSinglePropertyUpdate(property, modifiedPropertyValue);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+        }
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        return base.GenerateJsonForSinglePropertyUpdate(property, propertyValue);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+    }
+}

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommandFactory.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommandFactory.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Update.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class SqliteModificationCommandFactory : IModificationCommandFactory
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual IModificationCommand CreateModificationCommand(
+        in ModificationCommandParameters modificationCommandParameters)
+        => new SqliteModificationCommand(modificationCommandParameters);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual INonTrackedModificationCommand CreateNonTrackedModificationCommand(
+        in NonTrackedModificationCommandParameters modificationCommandParameters)
+        => new SqliteModificationCommand(modificationCommandParameters);
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
@@ -19,7 +19,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Optional_json_properties_materialized_as_null_when_the_element_in_json_is_not_present(bool async)
     {
-        var contextFactory = await InitializeAsync<MyContext29219>(seed: Seed29219);
+        var contextFactory = await InitializeAsync<MyContext29219>(
+            onConfiguring: OnConfiguring29219,
+            seed: Seed29219);
+
         using (var context = contextFactory.CreateContext())
         {
             var query = context.Entities.Where(x => x.Id == 3);
@@ -38,7 +41,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Can_project_nullable_json_property_when_the_element_in_json_is_not_present(bool async)
     {
-        var contextFactory = await InitializeAsync<MyContext29219>(seed: Seed29219);
+        var contextFactory = await InitializeAsync<MyContext29219>(
+            onConfiguring: OnConfiguring29219,
+            seed: Seed29219);
+
         using (var context = contextFactory.CreateContext())
         {
             var query = context.Entities.OrderBy(x => x.Id).Select(x => x.Reference.NullableScalar);
@@ -52,6 +58,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
             Assert.Equal(null, result[1]);
             Assert.Equal(null, result[2]);
         }
+    }
+
+    protected virtual void OnConfiguring29219(DbContextOptionsBuilder builder)
+    {
     }
 
     protected abstract void Seed29219(MyContext29219 ctx);
@@ -89,6 +99,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     #endregion
 
     #region 30028
+
+    protected virtual void OnConfiguring30028(DbContextOptionsBuilder builder)
+    {
+    }
 
     protected abstract void Seed30028(MyContext30028 ctx);
 
@@ -223,7 +237,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Project_json_array_of_primitives_on_reference(bool async)
     {
-        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
+            onConfiguring: OnConfiguringArrayOfPrimitives,
+            seed: SeedArrayOfPrimitives);
+
         using (var context = contextFactory.CreateContext())
         {
             var query = context.Entities.OrderBy(x => x.Id).Select(x => new { x.Reference.IntArray, x.Reference.ListOfString });
@@ -244,7 +261,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Project_json_array_of_primitives_on_collection(bool async)
     {
-        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
+            onConfiguring: OnConfiguringArrayOfPrimitives,
+            seed: SeedArrayOfPrimitives);
+
         using (var context = contextFactory.CreateContext())
         {
             var query = context.Entities.OrderBy(x => x.Id).Select(x => new { x.Collection[0].IntArray, x.Collection[1].ListOfString });
@@ -265,7 +285,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Project_element_of_json_array_of_primitives(bool async)
     {
-        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
+            onConfiguring: OnConfiguringArrayOfPrimitives,
+            seed: SeedArrayOfPrimitives);
+
         using (var context = contextFactory.CreateContext())
         {
             var query = context.Entities.OrderBy(x => x.Id).Select(x => new
@@ -284,7 +307,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Predicate_based_on_element_of_json_array_of_primitives1(bool async)
     {
-        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
+            onConfiguring: OnConfiguringArrayOfPrimitives,
+            seed: SeedArrayOfPrimitives);
+
         using (var context = contextFactory.CreateContext())
         {
             var query = context.Entities.Where(x => x.Reference.IntArray[0] == 1);
@@ -304,7 +330,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Predicate_based_on_element_of_json_array_of_primitives2(bool async)
     {
-        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
+            onConfiguring: OnConfiguringArrayOfPrimitives,
+            seed: SeedArrayOfPrimitives);
+
         using (var context = contextFactory.CreateContext())
         {
             var query = context.Entities.Where(x => x.Reference.ListOfString[1] == "Bar");
@@ -324,7 +353,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task Predicate_based_on_element_of_json_array_of_primitives3(bool async)
     {
-        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(seed: SeedArrayOfPrimitives);
+        var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
+            onConfiguring: OnConfiguringArrayOfPrimitives,
+            seed: SeedArrayOfPrimitives);
+
         using (var context = contextFactory.CreateContext())
         {
             var query = context.Entities.Where(x => x.Reference.IntArray.AsQueryable().ElementAt(0) == 1
@@ -343,6 +375,10 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
 
 
     protected abstract void SeedArrayOfPrimitives(MyContextArrayOfPrimitives ctx);
+
+    protected virtual void OnConfiguringArrayOfPrimitives(DbContextOptionsBuilder builder)
+    {
+    }
 
     protected class MyContextArrayOfPrimitives : DbContext
     {

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -1719,6 +1719,78 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_bool_converted_to_int_zero_one(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.BoolConvertedToIntZeroOne),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_bool_converted_to_int_zero_one_with_explicit_comparison(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.BoolConvertedToIntZeroOne == false),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_bool_converted_to_string_True_False(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.BoolConvertedToStringTrueFalse),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_bool_converted_to_string_True_False_with_explicit_comparison(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.BoolConvertedToStringTrueFalse == true),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_bool_converted_to_string_Y_N(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.BoolConvertedToStringYN),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_bool_converted_to_string_Y_N_with_explicit_comparison(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.BoolConvertedToStringYN == false),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_int_zero_one_converted_to_bool(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.IntZeroOneConvertedToBool == 1),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_string_True_False_converted_to_bool(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.StringTrueFalseConvertedToBool == "False"),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_predicate_on_string_Y_N_converted_to_bool(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityConverters>().Where(x => x.Reference.StringYNConvertedToBool == "N"),
+            entryCount: 2);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task FromSql_on_entity_with_json_basic(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonEntityConverters.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonEntityConverters.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
+
+public class JsonEntityConverters
+{
+    public int Id { get; set; }
+    public JsonOwnedConverters Reference { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedConverters.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedConverters.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
+
+public class JsonOwnedConverters
+{
+    public bool BoolConvertedToIntZeroOne { get; set; }
+    public bool BoolConvertedToStringTrueFalse { get; set; }
+    public bool BoolConvertedToStringYN { get; set; }
+    public int IntZeroOneConvertedToBool { get; set; }
+    public string StringTrueFalseConvertedToBool { get; set; }
+    public string StringYNConvertedToBool { get; set; }
+}

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
@@ -18,6 +18,7 @@ public class JsonQueryContext : DbContext
     public DbSet<JsonEntitySingleOwned> JsonEntitiesSingleOwned { get; set; }
     public DbSet<JsonEntityInheritanceBase> JsonEntitiesInheritance { get; set; }
     public DbSet<JsonEntityAllTypes> JsonEntitiesAllTypes { get; set; }
+    public DbSet<JsonEntityConverters> JsonEntitiesConverters { get; set; }
 
     public static void Seed(JsonQueryContext context)
     {
@@ -31,6 +32,7 @@ public class JsonQueryContext : DbContext
         var jsonEntitiesSingleOwned = JsonQueryData.CreateJsonEntitiesSingleOwned();
         var jsonEntitiesInheritance = JsonQueryData.CreateJsonEntitiesInheritance();
         var jsonEntitiesAllTypes = JsonQueryData.CreateJsonEntitiesAllTypes();
+        var jsonEntitiesConverters = JsonQueryData.CreateJsonEntitiesConverters();
 
         context.JsonEntitiesBasic.AddRange(jsonEntitiesBasic);
         context.EntitiesBasic.AddRange(entitiesBasic);
@@ -40,6 +42,7 @@ public class JsonQueryContext : DbContext
         context.JsonEntitiesSingleOwned.AddRange(jsonEntitiesSingleOwned);
         context.JsonEntitiesInheritance.AddRange(jsonEntitiesInheritance);
         context.JsonEntitiesAllTypes.AddRange(jsonEntitiesAllTypes);
+        context.JsonEntitiesConverters.AddRange(jsonEntitiesConverters);
         context.SaveChanges();
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
@@ -17,6 +17,7 @@ public class JsonQueryData : ISetSource
         JsonEntitiesSingleOwned = CreateJsonEntitiesSingleOwned();
         JsonEntitiesInheritance = CreateJsonEntitiesInheritance();
         JsonEntitiesAllTypes = CreateJsonEntitiesAllTypes();
+        JsonEntitiesConverters = CreateJsonEntitiesConverters();
     }
 
     public IReadOnlyList<EntityBasic> EntitiesBasic { get; }
@@ -27,6 +28,7 @@ public class JsonQueryData : ISetSource
     public IReadOnlyList<JsonEntitySingleOwned> JsonEntitiesSingleOwned { get; set; }
     public IReadOnlyList<JsonEntityInheritanceBase> JsonEntitiesInheritance { get; set; }
     public IReadOnlyList<JsonEntityAllTypes> JsonEntitiesAllTypes { get; set; }
+    public IReadOnlyList<JsonEntityConverters> JsonEntitiesConverters { get; set; }
 
     public static IReadOnlyList<JsonEntityBasic> CreateJsonEntitiesBasic()
     {
@@ -773,6 +775,43 @@ public class JsonQueryData : ISetSource
         };
     }
 
+    public static IReadOnlyList<JsonEntityConverters> CreateJsonEntitiesConverters()
+    {
+        var r1 = new JsonOwnedConverters
+        {
+            BoolConvertedToIntZeroOne = true,
+            BoolConvertedToStringTrueFalse = false,
+            BoolConvertedToStringYN = true,
+            IntZeroOneConvertedToBool = 0,
+            StringTrueFalseConvertedToBool = "True",
+            StringYNConvertedToBool = "N",
+        };
+
+        var r2 = new JsonOwnedConverters
+        {
+            BoolConvertedToIntZeroOne = false,
+            BoolConvertedToStringTrueFalse = true,
+            BoolConvertedToStringYN = false,
+            IntZeroOneConvertedToBool = 1,
+            StringTrueFalseConvertedToBool = "False",
+            StringYNConvertedToBool = "Y",
+        };
+
+        return new List<JsonEntityConverters>
+        {
+            new()
+            {
+                Id = 1,
+                Reference = r1,
+            },
+            new()
+            {
+                Id = 2,
+                Reference = r2,
+            }
+        };
+    }
+
     public IQueryable<TEntity> Set<TEntity>()
         where TEntity : class
     {
@@ -809,6 +848,11 @@ public class JsonQueryData : ISetSource
         if (typeof(TEntity) == typeof(JsonEntityAllTypes))
         {
             return (IQueryable<TEntity>)JsonEntitiesAllTypes.OfType<JsonEntityAllTypes>().AsQueryable();
+        }
+
+        if (typeof(TEntity) == typeof(JsonEntityConverters))
+        {
+            return (IQueryable<TEntity>)JsonEntitiesConverters.OfType<JsonEntityConverters>().AsQueryable();
         }
 
         if (typeof(TEntity) == typeof(JsonEntityBasicForReference))

--- a/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateFixtureBase.cs
@@ -124,6 +124,30 @@ public abstract class JsonUpdateFixtureBase : SharedStoreFixtureBase<JsonQueryCo
                 b.Property(x => x.TestDecimal).HasPrecision(18, 3);
             });
 
+        modelBuilder.Entity<JsonEntityConverters>().Property(x => x.Id).ValueGeneratedNever();
+        modelBuilder.Entity<JsonEntityConverters>().OwnsOne(
+            x => x.Reference, b =>
+            {
+                b.ToJson();
+                b.Property(x => x.BoolConvertedToIntZeroOne).HasConversion<BoolToZeroOneConverter<int>>();
+                b.Property(x => x.BoolConvertedToStringTrueFalse).HasConversion(new BoolToStringConverter("False", "True"));
+                b.Property(x => x.BoolConvertedToStringYN).HasConversion(new BoolToStringConverter("N", "Y"));
+                b.Property(x => x.IntZeroOneConvertedToBool).HasConversion(
+                    new ValueConverter<int, bool>(
+                        x => x == 0 ? false : true,
+                        x => x == false ? 0 : 1));
+
+                b.Property(x => x.StringTrueFalseConvertedToBool).HasConversion(
+                    new ValueConverter<string, bool>(
+                        x => x == "True" ? true : false,
+                        x => x == true ? "True" : "False"));
+
+                b.Property(x => x.StringYNConvertedToBool).HasConversion(
+                    new ValueConverter<string, bool>(
+                        x => x == "Y" ? true : false,
+                        x => x == true ? "Y" : "N"));
+            });
+
         base.OnModelCreating(modelBuilder, context);
     }
 
@@ -132,10 +156,12 @@ public abstract class JsonUpdateFixtureBase : SharedStoreFixtureBase<JsonQueryCo
         var jsonEntitiesBasic = JsonQueryData.CreateJsonEntitiesBasic();
         var jsonEntitiesInheritance = JsonQueryData.CreateJsonEntitiesInheritance();
         var jsonEntitiesAllTypes = JsonQueryData.CreateJsonEntitiesAllTypes();
+        var jsonEntitiesConverters = JsonQueryData.CreateJsonEntitiesConverters();
 
         context.JsonEntitiesBasic.AddRange(jsonEntitiesBasic);
         context.JsonEntitiesInheritance.AddRange(jsonEntitiesInheritance);
         context.JsonEntitiesAllTypes.AddRange(jsonEntitiesAllTypes);
+        context.JsonEntitiesConverters.AddRange(jsonEntitiesConverters);
         context.SaveChanges();
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Update/JsonUpdateTestBase.cs
@@ -1361,6 +1361,126 @@ public abstract class JsonUpdateTestBase<TFixture> : IClassFixture<TFixture>
                 Assert.Equal("edit", result.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething);
             });
 
+    [ConditionalFact]
+    public virtual Task Edit_single_property_with_converter_bool_to_int_zero_one()
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            CreateContext,
+            UseTransaction,
+            async context =>
+            {
+                var query = await context.JsonEntitiesConverters.ToListAsync();
+                var entity = query.Single(x => x.Id == 1);
+                entity.Reference.BoolConvertedToIntZeroOne = false;
+
+                ClearLog();
+                await context.SaveChangesAsync();
+            },
+            async context =>
+            {
+                var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
+                Assert.Equal(false, result.Reference.BoolConvertedToIntZeroOne);
+            });
+
+    [ConditionalFact]
+    public virtual Task Edit_single_property_with_converter_bool_to_string_True_False()
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            CreateContext,
+            UseTransaction,
+            async context =>
+            {
+                var query = await context.JsonEntitiesConverters.ToListAsync();
+                var entity = query.Single(x => x.Id == 1);
+                entity.Reference.BoolConvertedToStringTrueFalse = true;
+
+                ClearLog();
+                await context.SaveChangesAsync();
+            },
+            async context =>
+            {
+                var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
+                Assert.Equal(true, result.Reference.BoolConvertedToStringTrueFalse);
+            });
+
+    [ConditionalFact]
+    public virtual Task Edit_single_property_with_converter_bool_to_string_Y_N()
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            CreateContext,
+            UseTransaction,
+            async context =>
+            {
+                var query = await context.JsonEntitiesConverters.ToListAsync();
+                var entity = query.Single(x => x.Id == 1);
+                entity.Reference.BoolConvertedToStringYN = false;
+
+                ClearLog();
+                await context.SaveChangesAsync();
+            },
+            async context =>
+            {
+                var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
+                Assert.Equal(false, result.Reference.BoolConvertedToStringYN);
+            });
+
+    [ConditionalFact]
+    public virtual Task Edit_single_property_with_converter_int_zero_one_to_bool()
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            CreateContext,
+            UseTransaction,
+            async context =>
+            {
+                var query = await context.JsonEntitiesConverters.ToListAsync();
+                var entity = query.Single(x => x.Id == 1);
+                entity.Reference.IntZeroOneConvertedToBool = 1;
+
+                ClearLog();
+                await context.SaveChangesAsync();
+            },
+            async context =>
+            {
+                var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
+                Assert.Equal(1, result.Reference.IntZeroOneConvertedToBool);
+            });
+
+    [ConditionalFact]
+    public virtual Task Edit_single_property_with_converter_string_True_False_to_bool()
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            CreateContext,
+            UseTransaction,
+            async context =>
+            {
+                var query = await context.JsonEntitiesConverters.ToListAsync();
+                var entity = query.Single(x => x.Id == 1);
+                entity.Reference.StringTrueFalseConvertedToBool = "False";
+
+                ClearLog();
+                await context.SaveChangesAsync();
+            },
+            async context =>
+            {
+                var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
+                Assert.Equal("False", result.Reference.StringTrueFalseConvertedToBool);
+            });
+
+    [ConditionalFact]
+    public virtual Task Edit_single_property_with_converter_string_Y_N_to_bool()
+        => TestHelpers.ExecuteWithStrategyInTransactionAsync(
+            CreateContext,
+            UseTransaction,
+            async context =>
+            {
+                var query = await context.JsonEntitiesConverters.ToListAsync();
+                var entity = query.Single(x => x.Id == 1);
+                entity.Reference.StringYNConvertedToBool = "Y";
+
+                ClearLog();
+                await context.SaveChangesAsync();
+            },
+            async context =>
+            {
+                var result = await context.Set<JsonEntityConverters>().SingleAsync(x => x.Id == 1);
+                Assert.Equal("Y", result.Reference.StringYNConvertedToBool);
+            });
+
     public void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
         => facade.UseTransaction(transaction.GetDbTransaction());
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -66,7 +66,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -77,7 +77,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedCollectionBranch'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -88,7 +88,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -99,7 +99,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.OwnedCollectionLeaf'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -110,7 +110,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_VALUE([j].[OwnedReferenceRoot],'$.Name')
+SELECT JSON_VALUE([j].[OwnedReferenceRoot], '$.Name')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -123,7 +123,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 SELECT [j].[Name]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE CAST(LEN(JSON_VALUE([j].[OwnedReferenceRoot],'$.Name')) AS int) > 2
+WHERE CAST(LEN(JSON_VALUE([j].[OwnedReferenceRoot], '$.Name')) AS int) > 2
 """);
     }
 
@@ -133,7 +133,7 @@ WHERE CAST(LEN(JSON_VALUE([j].[OwnedReferenceRoot],'$.Name')) AS int) > 2
 
         AssertSql(
 """
-SELECT [j].[Id], JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.Enum') AS [Enum]
+SELECT [j].[Id], JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS [Enum]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -144,7 +144,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT [j].[Id], CAST(JSON_VALUE([j].[json_reference_custom_naming],'$.CustomEnum') AS int) AS [Enum]
+SELECT [j].[Id], CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomEnum') AS int) AS [Enum]
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }
@@ -155,7 +155,7 @@ FROM [JsonEntitiesCustomNaming] AS [j]
 
         AssertSql(
 """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething')
+SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -179,7 +179,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.Fraction') AS decimal(18,2)) < 20.5
+WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Fraction') AS decimal(18,2)) < 20.5
 """);
     }
 
@@ -195,7 +195,7 @@ SELECT CAST(LEN([t0].[c]) AS int)
 FROM (
     SELECT DISTINCT [t].[c]
     FROM (
-        SELECT TOP(@__p_0) JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') AS [c]
+        SELECT TOP(@__p_0) JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') AS [c]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [t]
@@ -211,7 +211,7 @@ FROM (
 """
 @__p_0='10'
 
-SELECT JSON_QUERY([t0].[c],'$.OwnedReferenceBranch'), [t0].[Id]
+SELECT JSON_QUERY([t0].[c], '$.OwnedReferenceBranch'), [t0].[Id]
 FROM (
     SELECT DISTINCT [t].[c] AS [c], [t].[Id]
     FROM (
@@ -231,11 +231,11 @@ FROM (
 """
 @__p_0='10'
 
-SELECT JSON_QUERY([t0].[c],'$.OwnedReferenceSharedBranch'), [t0].[Id], CAST(LEN([t0].[c0]) AS int)
+SELECT JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch'), [t0].[Id], CAST(LEN([t0].[c0]) AS int)
 FROM (
     SELECT DISTINCT JSON_QUERY([t].[c],'$') AS [c], [t].[Id], [t].[c0]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j].[json_reference_shared],'$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared],'$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [c0]
+        SELECT TOP(@__p_0) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [c0]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [t]
@@ -251,15 +251,15 @@ FROM (
 """
 @__p_0='10'
 
-SELECT JSON_QUERY([t2].[c],'$.OwnedReferenceSharedLeaf'), [t2].[Id], JSON_QUERY([t2].[c],'$.OwnedCollectionSharedLeaf'), [t2].[Length]
+SELECT JSON_QUERY([t2].[c],'$.OwnedReferenceSharedLeaf'), [t2].[Id], JSON_QUERY([t2].[c], '$.OwnedCollectionSharedLeaf'), [t2].[Length]
 FROM (
     SELECT DISTINCT JSON_QUERY([t1].[c],'$') AS [c], [t1].[Id], [t1].[Length]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([t0].[c],'$.OwnedReferenceSharedBranch') AS [c], [t0].[Id], CAST(LEN([t0].[Scalar]) AS int) AS [Length]
+        SELECT TOP(@__p_0) JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch') AS [c], [t0].[Id], CAST(LEN([t0].[Scalar]) AS int) AS [Length]
         FROM (
             SELECT DISTINCT JSON_QUERY([t].[c],'$') AS [c], [t].[Id], [t].[Scalar]
             FROM (
-                SELECT TOP(@__p_0) JSON_QUERY([j].[json_reference_shared],'$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared],'$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [Scalar]
+                SELECT TOP(@__p_0) JSON_QUERY([j].[json_reference_shared], '$') AS [c], [j].[Id], CAST(JSON_VALUE([j].[json_reference_shared], '$.OwnedReferenceSharedBranch.OwnedReferenceSharedLeaf.SomethingSomething') AS nvarchar(max)) AS [Scalar]
                 FROM [JsonEntitiesBasic] AS [j]
                 ORDER BY [j].[Id]
             ) AS [t]
@@ -278,11 +278,11 @@ FROM (
 """
 @__p_0='10'
 
-SELECT JSON_QUERY([t2].[c],'$.OwnedReferenceLeaf'), [t2].[Id]
+SELECT JSON_QUERY([t2].[c], '$.OwnedReferenceLeaf'), [t2].[Id]
 FROM (
     SELECT DISTINCT [t1].[c] AS [c], [t1].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([t0].[c],'$.OwnedReferenceBranch') AS [c], [t0].[Id]
+        SELECT TOP(@__p_0) JSON_QUERY([t0].[c], '$.OwnedReferenceBranch') AS [c], [t0].[Id]
         FROM (
             SELECT DISTINCT [t].[c] AS [c], [t].[Id], [t].[c] AS [c0]
             FROM (
@@ -291,7 +291,7 @@ FROM (
                 ORDER BY [j].[Id]
             ) AS [t]
         ) AS [t0]
-        ORDER BY JSON_VALUE([t0].[c0],'$.Name')
+        ORDER BY JSON_VALUE([t0].[c0], '$.Name')
     ) AS [t1]
 ) AS [t2]
 """);
@@ -305,11 +305,11 @@ FROM (
 """
 @__p_0='10'
 
-SELECT JSON_QUERY([t2].[c],'$.OwnedCollectionLeaf'), [t2].[Id]
+SELECT JSON_QUERY([t2].[c], '$.OwnedCollectionLeaf'), [t2].[Id]
 FROM (
     SELECT DISTINCT [t1].[c] AS [c], [t1].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([t0].[c],'$.OwnedReferenceBranch') AS [c], [t0].[Id]
+        SELECT TOP(@__p_0) JSON_QUERY([t0].[c], '$.OwnedReferenceBranch') AS [c], [t0].[Id]
         FROM (
             SELECT DISTINCT [t].[c] AS [c], [t].[Id], [t].[c] AS [c0]
             FROM (
@@ -318,7 +318,7 @@ FROM (
                 ORDER BY [j].[Id]
             ) AS [t]
         ) AS [t0]
-        ORDER BY JSON_VALUE([t0].[c0],'$.Name')
+        ORDER BY JSON_VALUE([t0].[c0], '$.Name')
     ) AS [t1]
 ) AS [t2]
 """);
@@ -332,11 +332,11 @@ FROM (
 """
 @__p_0='10'
 
-SELECT JSON_VALUE([t0].[c],'$.SomethingSomething')
+SELECT JSON_VALUE([t0].[c], '$.SomethingSomething')
 FROM (
     SELECT DISTINCT [t].[c] AS [c], [t].[Id]
     FROM (
-        SELECT TOP(@__p_0) JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.OwnedReferenceLeaf') AS [c], [j].[Id]
+        SELECT TOP(@__p_0) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf') AS [c], [j].[Id]
         FROM [JsonEntitiesBasic] AS [j]
         ORDER BY [j].[Id]
     ) AS [t]
@@ -361,7 +361,7 @@ FROM [JsonEntitiesCustomNaming] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[json_reference_custom_naming],'$.CustomOwnedReferenceBranch'), [j].[Id]
+SELECT JSON_QUERY([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch'), [j].[Id]
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }
@@ -384,7 +384,7 @@ ORDER BY [j].[Id]
 
         AssertSql(
 """
-SELECT CAST(JSON_VALUE([j].[json_reference_custom_naming],'$.CustomOwnedReferenceBranch.CustomFraction') AS float)
+SELECT CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch.CustomFraction') AS float)
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }
@@ -395,7 +395,7 @@ FROM [JsonEntitiesCustomNaming] AS [j]
 
         AssertSql(
 """
-SELECT [j].[Id], [j].[Title], [j].[json_collection_custom_naming], [j].[json_reference_custom_naming], JSON_VALUE([j].[json_reference_custom_naming],'$.CustomName'), CAST(JSON_VALUE([j].[json_reference_custom_naming],'$.CustomOwnedReferenceBranch.CustomFraction') AS float)
+SELECT [j].[Id], [j].[Title], [j].[json_collection_custom_naming], [j].[json_reference_custom_naming], JSON_VALUE([j].[json_reference_custom_naming], '$.CustomName'), CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch.CustomFraction') AS float)
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
     }
@@ -468,7 +468,7 @@ LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
 SELECT [t].[c], [t].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j0].[OwnedReferenceRoot],'$.OwnedReferenceBranch') AS [c], [j0].[Id]
+    SELECT TOP(1) JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c], [j0].[Id]
     FROM [JsonEntitiesBasic] AS [j0]
     ORDER BY [j0].[Id]
 ) AS [t]
@@ -483,7 +483,7 @@ ORDER BY [j].[Id]
         AssertSql(
 """
 SELECT (
-    SELECT TOP(1) CAST(JSON_VALUE([j0].[OwnedReferenceRoot],'$.OwnedReferenceBranch.Date') AS datetime2)
+    SELECT TOP(1) CAST(JSON_VALUE([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Date') AS datetime2)
     FROM [JsonEntitiesBasic] AS [j0]
     ORDER BY [j0].[Id])
 FROM [JsonEntitiesBasic] AS [j]
@@ -508,7 +508,7 @@ ORDER BY [j].[Id]
 SELECT [t].[c], [t].[Id], [t].[c0], [t].[Id0], [t].[c1], [t].[c2], [t].[c3], [t].[c4]
 FROM [JsonEntitiesBasic] AS [j]
 OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot],'$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS [c2], JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.Enum') AS [c3], 1 AS [c4]
+    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS [c3], 1 AS [c4]
     FROM [JsonEntitiesBasic] AS [j0]
     ORDER BY [j0].[Id]
 ) AS [t]
@@ -525,7 +525,7 @@ ORDER BY [j].[Id]
 SELECT [t].[c], [t].[Id], [t].[c0], [t].[Id0], [t].[c1], [t].[c2], [t].[c3], [t].[c4]
 FROM [JsonEntitiesBasic] AS [j]
 OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot],'$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS [c2], JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.Enum') AS [c3], 1 AS [c4]
+    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], [j0].[OwnedReferenceRoot] AS [c0], [j0].[Id] AS [Id0], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch') AS [c1], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [c2], JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS [c3], 1 AS [c4]
     FROM [JsonEntitiesBasic] AS [j0]
     ORDER BY [j0].[Id]
 ) AS [t]
@@ -542,7 +542,7 @@ ORDER BY [j].[Id]
 SELECT [t].[c], [t].[Id], [t].[c0]
 FROM [JsonEntitiesBasic] AS [j]
 OUTER APPLY (
-    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedCollectionBranch') AS [c], [j].[Id], 1 AS [c0]
+    SELECT TOP(1) JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch') AS [c], [j].[Id], 1 AS [c0]
     FROM [JsonEntitiesBasic] AS [j0]
     ORDER BY [j0].[Id]
 ) AS [t]
@@ -610,7 +610,7 @@ WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1]'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -621,7 +621,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1]'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -632,7 +632,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1]'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -643,7 +643,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -654,7 +654,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -665,7 +665,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -679,7 +679,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 @__prm_0='0'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -691,7 +691,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[' + CAST([j].[Id] AS nvarchar(max)) + ']'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + ']'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -716,7 +716,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[25]'), [j].[Id]
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[25]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -727,7 +727,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot],'$[25].Number') AS int)
+SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[25].Number') AS int)
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
 """);
@@ -742,7 +742,7 @@ ORDER BY [j].[Id]
 """
 @__prm_0='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -756,7 +756,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 @__prm_0='1'
 
-SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].Date') AS datetime2)
+SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].Date') AS datetime2)
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -770,7 +770,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 @__prm_0='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceLeaf'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceLeaf'), [j].[Id], @__prm_0
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -784,7 +784,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 @__prm_0='1'
 
-SELECT JSON_QUERY([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), [j].[Id], @__prm_0
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
 """);
@@ -799,7 +799,7 @@ ORDER BY [j].[Id]
 """
 @__prm_0='1'
 
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot],'$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), @__prm_0
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), @__prm_0
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -812,7 +812,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Name') IS NULL)
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') IS NULL)
 """);
     }
 
@@ -827,7 +827,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Name') <> N'Foo' OR (JSON_VALUE
 
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') IS NULL)
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].Name') IS NULL)
 """);
     }
 
@@ -840,7 +840,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST(@__prm_0 AS nvarchar(max)
 """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST([j].[Id] AS nvarchar(max)) + '].Name') = N'e1_c2'
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].Name') = N'e1_c2'
 """);
     }
 
@@ -853,7 +853,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST([j].[Id] AS nvarchar(max)
 """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST(CASE
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(CASE
     WHEN [j].[Id] = 1 THEN 0
     ELSE 1
 END AS nvarchar(max)) + '].Name') = N'e1_c1'
@@ -869,7 +869,7 @@ END AS nvarchar(max)) + '].Name') = N'e1_c1'
 """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST((
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST((
     SELECT MAX([j].[Id])
     FROM [JsonEntitiesBasic] AS [j]) AS nvarchar(max)) + '].Name') = N'e1_c2'
 """);
@@ -883,7 +883,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[' + CAST((
 """
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[1].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot],'$[1].Name') IS NULL)
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].Name') <> N'Foo' OR (JSON_VALUE([j].[OwnedCollectionRoot], '$[1].Name') IS NULL)
 """);
     }
 
@@ -898,7 +898,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[1].Name') <> N'Foo' OR (JSON_VALUE
 
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST([j].[Id] - 1 AS nvarchar(max)) + '].SomethingSomething') = N'e1_c2_c1_c1'
+WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf[' + CAST([j].[Id] - 1 AS nvarchar(max)) + '].SomethingSomething') = N'e1_c2_c1_c1'
 """);
     }
 
@@ -908,7 +908,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot],'$[1].OwnedCollectionBranch[' + CAST(
 
         AssertSql(
 """
-SELECT [j].[Id], CAST(JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Number') AS int) AS [CollectionElement]
+SELECT [j].[Id], CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Number') AS int) AS [CollectionElement]
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -961,7 +961,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot],'$[0]')
+SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0]')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -988,7 +988,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 @__prm_0='1'
 
-SELECT JSON_QUERY([j].[OwnedReferenceRoot],'$.OwnedCollectionBranch'), [j].[Id], @__prm_0
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [j].[Id], @__prm_0
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
@@ -1086,7 +1086,7 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 SELECT [j].[Name]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.Number') AS int) <> CAST(LEN(JSON_VALUE([j].[OwnedReferenceRoot],'$.Name')) AS int) OR (JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') IS NULL)
+WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.Number') AS int) <> CAST(LEN(JSON_VALUE([j].[OwnedReferenceRoot], '$.Name')) AS int) OR (JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') IS NULL)
 """);
     }
 
@@ -1098,7 +1098,7 @@ WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot],'$.Number') AS int) <> CAST(LEN(J
 """
 SELECT [j].[Name]
 FROM [JsonEntitiesBasic] AS [j]
-WHERE JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') = JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') OR ((JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') IS NULL) AND (JSON_VALUE([j].[OwnedReferenceRoot],'$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') IS NULL))
+WHERE JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') = JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') OR ((JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') IS NULL) AND (JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') IS NULL))
 """);
     }
 
@@ -1110,7 +1110,7 @@ WHERE JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') = JSON_VALUE([j].[OwnedRefer
 """
 SELECT [t].[Key], COUNT(*) AS [Count]
 FROM (
-    SELECT JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS [Key]
+    SELECT JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') AS [Key]
     FROM [JsonEntitiesBasic] AS [j]
 ) AS [t]
 GROUP BY [t].[Key]
@@ -1125,7 +1125,7 @@ GROUP BY [t].[Key]
 """
 SELECT [t].[Key], COUNT(*) AS [Count]
 FROM (
-    SELECT JSON_VALUE([j].[OwnedCollectionRoot],'$[0].Name') AS [Key]
+    SELECT JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') AS [Key]
     FROM [JsonEntitiesBasic] AS [j]
 ) AS [t]
 GROUP BY [t].[Key]
@@ -1142,7 +1142,7 @@ SELECT [t1].[Id], [t1].[EntityBasicId], [t1].[Name], [t1].[c], [t1].[c0]
 FROM (
     SELECT [t].[Key]
     FROM (
-        SELECT JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS [Key]
+        SELECT JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') AS [Key]
         FROM [JsonEntitiesBasic] AS [j]
     ) AS [t]
     GROUP BY [t].[Key]
@@ -1152,7 +1152,7 @@ LEFT JOIN (
     FROM (
         SELECT [t3].[Id], [t3].[EntityBasicId], [t3].[Name], [t3].[c] AS [c], [t3].[c0] AS [c0], [t3].[Key], ROW_NUMBER() OVER(PARTITION BY [t3].[Key] ORDER BY [t3].[Id]) AS [row]
         FROM (
-            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot] AS [c], [j0].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS [Key]
+            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot] AS [c], [j0].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [Key]
             FROM [JsonEntitiesBasic] AS [j0]
         ) AS [t3]
     ) AS [t2]
@@ -1171,7 +1171,7 @@ SELECT [t1].[Id], [t1].[EntityBasicId], [t1].[Name], [t1].[c], [t1].[c0]
 FROM (
     SELECT [t].[Key]
     FROM (
-        SELECT JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS [Key]
+        SELECT JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') AS [Key]
         FROM [JsonEntitiesBasic] AS [j]
     ) AS [t]
     GROUP BY [t].[Key]
@@ -1181,7 +1181,7 @@ LEFT JOIN (
     FROM (
         SELECT [t3].[Id], [t3].[EntityBasicId], [t3].[Name], [t3].[c] AS [c], [t3].[c0] AS [c0], [t3].[Key], ROW_NUMBER() OVER(PARTITION BY [t3].[Key] ORDER BY [t3].[Id]) AS [row]
         FROM (
-            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot] AS [c], [j0].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS [Key]
+            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot] AS [c], [j0].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [Key]
             FROM [JsonEntitiesBasic] AS [j0]
         ) AS [t3]
     ) AS [t2]
@@ -1200,7 +1200,7 @@ SELECT [t0].[Key], [t1].[Id], [t1].[EntityBasicId], [t1].[Name], [t1].[c], [t1].
 FROM (
     SELECT [t].[Key]
     FROM (
-        SELECT JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS [Key]
+        SELECT JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') AS [Key]
         FROM [JsonEntitiesBasic] AS [j]
     ) AS [t]
     GROUP BY [t].[Key]
@@ -1210,7 +1210,7 @@ LEFT JOIN (
     FROM (
         SELECT [t3].[Id], [t3].[EntityBasicId], [t3].[Name], [t3].[c] AS [c], [t3].[c0] AS [c0], [t3].[Key], ROW_NUMBER() OVER(PARTITION BY [t3].[Key] ORDER BY [t3].[Id]) AS [row]
         FROM (
-            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot] AS [c], [j0].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS [Key]
+            SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot] AS [c], [j0].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [Key]
             FROM [JsonEntitiesBasic] AS [j0]
         ) AS [t3]
     ) AS [t2]
@@ -1235,14 +1235,14 @@ ORDER BY [t0].[Key], [t1].[Key], [t1].[Id]
         AssertSql(
 """
 SELECT (
-    SELECT TOP(1) JSON_VALUE([t0].[c0],'$.OwnedReferenceBranch.Enum')
+    SELECT TOP(1) JSON_VALUE([t0].[c0], '$.OwnedReferenceBranch.Enum')
     FROM (
-        SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot] AS [c], [j0].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j0].[OwnedReferenceRoot],'$.Name') AS [Key]
+        SELECT [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot] AS [c], [j0].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j0].[OwnedReferenceRoot], '$.Name') AS [Key]
         FROM [JsonEntitiesBasic] AS [j0]
     ) AS [t0]
     WHERE [t].[Key] = [t0].[Key] OR (([t].[Key] IS NULL) AND ([t0].[Key] IS NULL)))
 FROM (
-    SELECT JSON_VALUE([j].[OwnedReferenceRoot],'$.Name') AS [Key]
+    SELECT JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') AS [Key]
     FROM [JsonEntitiesBasic] AS [j]
 ) AS [t]
 GROUP BY [t].[Key]
@@ -1329,7 +1329,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
 
         AssertSql(
 """
-SELECT JSON_VALUE([j].[Reference],'$.TestDefaultString') AS [TestDefaultString], JSON_VALUE([j].[Reference],'$.TestMaxLengthString') AS [TestMaxLengthString], CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) AS [TestBoolean], CAST(JSON_VALUE([j].[Reference],'$.TestByte') AS tinyint) AS [TestByte], JSON_VALUE([j].[Reference],'$.TestCharacter') AS [TestCharacter], CAST(JSON_VALUE([j].[Reference],'$.TestDateTime') AS datetime2) AS [TestDateTime], CAST(JSON_VALUE([j].[Reference],'$.TestDateTimeOffset') AS datetimeoffset) AS [TestDateTimeOffset], CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18,3)) AS [TestDecimal], CAST(JSON_VALUE([j].[Reference],'$.TestDouble') AS float) AS [TestDouble], CAST(JSON_VALUE([j].[Reference],'$.TestGuid') AS uniqueidentifier) AS [TestGuid], CAST(JSON_VALUE([j].[Reference],'$.TestInt16') AS smallint) AS [TestInt16], CAST(JSON_VALUE([j].[Reference],'$.TestInt32') AS int) AS [TestInt32], CAST(JSON_VALUE([j].[Reference],'$.TestInt64') AS bigint) AS [TestInt64], CAST(JSON_VALUE([j].[Reference],'$.TestSignedByte') AS smallint) AS [TestSignedByte], CAST(JSON_VALUE([j].[Reference],'$.TestSingle') AS real) AS [TestSingle], CAST(JSON_VALUE([j].[Reference],'$.TestTimeSpan') AS time) AS [TestTimeSpan], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt16') AS int) AS [TestUnsignedInt16], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt32') AS bigint) AS [TestUnsignedInt32], CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20,0)) AS [TestUnsignedInt64], JSON_VALUE([j].[Reference],'$.TestEnum') AS [TestEnum], CAST(JSON_VALUE([j].[Reference],'$.TestEnumWithIntConverter') AS int) AS [TestEnumWithIntConverter], JSON_VALUE([j].[Reference],'$.TestNullableEnum') AS [TestNullableEnum], CAST(JSON_VALUE([j].[Reference],'$.TestNullableEnumWithIntConverter') AS int) AS [TestNullableEnumWithIntConverter], JSON_VALUE([j].[Reference],'$.TestNullableEnumWithConverterThatHandlesNulls') AS [TestNullableEnumWithConverterThatHandlesNulls]
+SELECT JSON_VALUE([j].[Reference], '$.TestDefaultString') AS [TestDefaultString], JSON_VALUE([j].[Reference], '$.TestMaxLengthString') AS [TestMaxLengthString], CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) AS [TestBoolean], CAST(JSON_VALUE([j].[Reference], '$.TestByte') AS tinyint) AS [TestByte], JSON_VALUE([j].[Reference], '$.TestCharacter') AS [TestCharacter], CAST(JSON_VALUE([j].[Reference], '$.TestDateTime') AS datetime2) AS [TestDateTime], CAST(JSON_VALUE([j].[Reference], '$.TestDateTimeOffset') AS datetimeoffset) AS [TestDateTimeOffset], CAST(JSON_VALUE([j].[Reference], '$.TestDecimal') AS decimal(18,3)) AS [TestDecimal], CAST(JSON_VALUE([j].[Reference], '$.TestDouble') AS float) AS [TestDouble], CAST(JSON_VALUE([j].[Reference], '$.TestGuid') AS uniqueidentifier) AS [TestGuid], CAST(JSON_VALUE([j].[Reference], '$.TestInt16') AS smallint) AS [TestInt16], CAST(JSON_VALUE([j].[Reference], '$.TestInt32') AS int) AS [TestInt32], CAST(JSON_VALUE([j].[Reference], '$.TestInt64') AS bigint) AS [TestInt64], CAST(JSON_VALUE([j].[Reference], '$.TestSignedByte') AS smallint) AS [TestSignedByte], CAST(JSON_VALUE([j].[Reference], '$.TestSingle') AS real) AS [TestSingle], CAST(JSON_VALUE([j].[Reference], '$.TestTimeSpan') AS time) AS [TestTimeSpan], CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt16') AS int) AS [TestUnsignedInt16], CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt32') AS bigint) AS [TestUnsignedInt32], CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt64') AS decimal(20,0)) AS [TestUnsignedInt64], JSON_VALUE([j].[Reference], '$.TestEnum') AS [TestEnum], CAST(JSON_VALUE([j].[Reference], '$.TestEnumWithIntConverter') AS int) AS [TestEnumWithIntConverter], JSON_VALUE([j].[Reference], '$.TestNullableEnum') AS [TestNullableEnum], CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS int) AS [TestNullableEnumWithIntConverter], JSON_VALUE([j].[Reference], '$.TestNullableEnumWithConverterThatHandlesNulls') AS [TestNullableEnumWithConverterThatHandlesNulls]
 FROM [JsonEntitiesAllTypes] AS [j]
 """);
     }
@@ -1342,7 +1342,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(1 AS bit)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(1 AS bit)
 """);
     }
 
@@ -1354,7 +1354,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(1 AS bit)
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(0 AS bit)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(0 AS bit)
 """);
     }
 
@@ -1364,7 +1364,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(0 AS bit)
 
         AssertSql(
 """
-SELECT CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit)
+SELECT CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit)
 FROM [JsonEntitiesAllTypes] AS [j]
 """);
     }
@@ -1376,7 +1376,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
         AssertSql(
 """
 SELECT CASE
-    WHEN CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(0 AS bit) THEN CAST(1 AS bit)
+    WHEN CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(0 AS bit) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [JsonEntitiesAllTypes] AS [j]
@@ -1391,7 +1391,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE JSON_VALUE([j].[Reference],'$.TestDefaultString') <> N'MyDefaultStringInReference1' OR (JSON_VALUE([j].[Reference],'$.TestDefaultString') IS NULL)
+WHERE JSON_VALUE([j].[Reference], '$.TestDefaultString') <> N'MyDefaultStringInReference1' OR (JSON_VALUE([j].[Reference], '$.TestDefaultString') IS NULL)
 """);
     }
 
@@ -1403,7 +1403,7 @@ WHERE JSON_VALUE([j].[Reference],'$.TestDefaultString') <> N'MyDefaultStringInRe
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE JSON_VALUE([j].[Reference],'$.TestMaxLengthString') <> N'Foo' OR (JSON_VALUE([j].[Reference],'$.TestMaxLengthString') IS NULL)
+WHERE JSON_VALUE([j].[Reference], '$.TestMaxLengthString') <> N'Foo' OR (JSON_VALUE([j].[Reference], '$.TestMaxLengthString') IS NULL)
 """);
     }
 
@@ -1416,8 +1416,8 @@ WHERE JSON_VALUE([j].[Reference],'$.TestMaxLengthString') <> N'Foo' OR (JSON_VAL
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CASE
-    WHEN CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(0 AS bit) THEN JSON_VALUE([j].[Reference],'$.TestMaxLengthString')
-    ELSE JSON_VALUE([j].[Reference],'$.TestDefaultString')
+    WHEN CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(0 AS bit) THEN JSON_VALUE([j].[Reference], '$.TestMaxLengthString')
+    ELSE JSON_VALUE([j].[Reference], '$.TestDefaultString')
 END = N'MyDefaultStringInReference1'
 """);
     }
@@ -1430,7 +1430,7 @@ END = N'MyDefaultStringInReference1'
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestByte') AS tinyint) <> CAST(3 AS tinyint) OR (CAST(JSON_VALUE([j].[Reference],'$.TestByte') AS tinyint) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestByte') AS tinyint) <> CAST(3 AS tinyint) OR (CAST(JSON_VALUE([j].[Reference], '$.TestByte') AS tinyint) IS NULL)
 """);
     }
 
@@ -1442,7 +1442,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestByte') AS tinyint) <> CAST(3 AS tin
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE JSON_VALUE([j].[Reference],'$.TestCharacter') <> N'z' OR (JSON_VALUE([j].[Reference],'$.TestCharacter') IS NULL)
+WHERE JSON_VALUE([j].[Reference], '$.TestCharacter') <> N'z' OR (JSON_VALUE([j].[Reference], '$.TestCharacter') IS NULL)
 """);
     }
 
@@ -1454,7 +1454,7 @@ WHERE JSON_VALUE([j].[Reference],'$.TestCharacter') <> N'z' OR (JSON_VALUE([j].[
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDateTime') AS datetime2) <> '2000-01-03T00:00:00.0000000' OR (CAST(JSON_VALUE([j].[Reference],'$.TestDateTime') AS datetime2) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDateTime') AS datetime2) <> '2000-01-03T00:00:00.0000000' OR (CAST(JSON_VALUE([j].[Reference], '$.TestDateTime') AS datetime2) IS NULL)
 """);
     }
 
@@ -1466,7 +1466,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDateTime') AS datetime2) <> '2000-0
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDateTimeOffset') AS datetimeoffset) <> '2000-01-04T00:00:00.0000000+03:02' OR (CAST(JSON_VALUE([j].[Reference],'$.TestDateTimeOffset') AS datetimeoffset) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDateTimeOffset') AS datetimeoffset) <> '2000-01-04T00:00:00.0000000+03:02' OR (CAST(JSON_VALUE([j].[Reference], '$.TestDateTimeOffset') AS datetimeoffset) IS NULL)
 """);
     }
 
@@ -1478,7 +1478,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDateTimeOffset') AS datetimeoffset)
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18,3)) <> 1.35 OR (CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18,3)) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDecimal') AS decimal(18,3)) <> 1.35 OR (CAST(JSON_VALUE([j].[Reference], '$.TestDecimal') AS decimal(18,3)) IS NULL)
 """);
     }
 
@@ -1490,7 +1490,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDecimal') AS decimal(18,3)) <> 1.35
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDouble') AS float) <> 33.25E0 OR (CAST(JSON_VALUE([j].[Reference],'$.TestDouble') AS float) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDouble') AS float) <> 33.25E0 OR (CAST(JSON_VALUE([j].[Reference], '$.TestDouble') AS float) IS NULL)
 """);
     }
 
@@ -1502,7 +1502,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestDouble') AS float) <> 33.25E0 OR (C
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE JSON_VALUE([j].[Reference],'$.TestEnum') <> N'Two' OR (JSON_VALUE([j].[Reference],'$.TestEnum') IS NULL)
+WHERE JSON_VALUE([j].[Reference], '$.TestEnum') <> N'Two' OR (JSON_VALUE([j].[Reference], '$.TestEnum') IS NULL)
 """);
     }
 
@@ -1514,7 +1514,7 @@ WHERE JSON_VALUE([j].[Reference],'$.TestEnum') <> N'Two' OR (JSON_VALUE([j].[Ref
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestEnumWithIntConverter') AS int) <> 2 OR (CAST(JSON_VALUE([j].[Reference],'$.TestEnumWithIntConverter') AS int) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestEnumWithIntConverter') AS int) <> 2 OR (CAST(JSON_VALUE([j].[Reference], '$.TestEnumWithIntConverter') AS int) IS NULL)
 """);
     }
 
@@ -1526,7 +1526,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestEnumWithIntConverter') AS int) <> 2
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestGuid') AS uniqueidentifier) <> '00000000-0000-0000-0000-000000000000' OR (CAST(JSON_VALUE([j].[Reference],'$.TestGuid') AS uniqueidentifier) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestGuid') AS uniqueidentifier) <> '00000000-0000-0000-0000-000000000000' OR (CAST(JSON_VALUE([j].[Reference], '$.TestGuid') AS uniqueidentifier) IS NULL)
 """);
     }
 
@@ -1538,7 +1538,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestGuid') AS uniqueidentifier) <> '000
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestInt16') AS smallint) <> CAST(3 AS smallint) OR (CAST(JSON_VALUE([j].[Reference],'$.TestInt16') AS smallint) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt16') AS smallint) <> CAST(3 AS smallint) OR (CAST(JSON_VALUE([j].[Reference], '$.TestInt16') AS smallint) IS NULL)
 """);
     }
 
@@ -1550,7 +1550,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestInt16') AS smallint) <> CAST(3 AS s
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestInt32') AS int) <> 33 OR (CAST(JSON_VALUE([j].[Reference],'$.TestInt32') AS int) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt32') AS int) <> 33 OR (CAST(JSON_VALUE([j].[Reference], '$.TestInt32') AS int) IS NULL)
 """);
     }
 
@@ -1562,7 +1562,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestInt32') AS int) <> 33 OR (CAST(JSON
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestInt64') AS bigint) <> CAST(333 AS bigint) OR (CAST(JSON_VALUE([j].[Reference],'$.TestInt64') AS bigint) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt64') AS bigint) <> CAST(333 AS bigint) OR (CAST(JSON_VALUE([j].[Reference], '$.TestInt64') AS bigint) IS NULL)
 """);
     }
 
@@ -1574,7 +1574,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestInt64') AS bigint) <> CAST(333 AS b
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE JSON_VALUE([j].[Reference],'$.TestNullableEnum') <> N'One' OR (JSON_VALUE([j].[Reference],'$.TestNullableEnum') IS NULL)
+WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnum') <> N'One' OR (JSON_VALUE([j].[Reference], '$.TestNullableEnum') IS NULL)
 """);
     }
 
@@ -1586,7 +1586,7 @@ WHERE JSON_VALUE([j].[Reference],'$.TestNullableEnum') <> N'One' OR (JSON_VALUE(
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE JSON_VALUE([j].[Reference],'$.TestNullableEnum') IS NOT NULL
+WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnum') IS NOT NULL
 """);
     }
 
@@ -1598,7 +1598,7 @@ WHERE JSON_VALUE([j].[Reference],'$.TestNullableEnum') IS NOT NULL
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestNullableEnumWithIntConverter') AS int) <> 1 OR (CAST(JSON_VALUE([j].[Reference],'$.TestNullableEnumWithIntConverter') AS int) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS int) <> 1 OR (CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS int) IS NULL)
 """);
     }
 
@@ -1610,7 +1610,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestNullableEnumWithIntConverter') AS i
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestNullableEnumWithIntConverter') AS int) IS NOT NULL
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS int) IS NOT NULL
 """);
     }
 
@@ -1622,7 +1622,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestNullableEnumWithIntConverter') AS i
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE JSON_VALUE([j].[Reference],'$.TestNullableEnumWithConverterThatHandlesNulls') <> N'One' OR (JSON_VALUE([j].[Reference],'$.TestNullableEnumWithConverterThatHandlesNulls') IS NULL)
+WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnumWithConverterThatHandlesNulls') <> N'One' OR (JSON_VALUE([j].[Reference], '$.TestNullableEnumWithConverterThatHandlesNulls') IS NULL)
 """);
     }
 
@@ -1644,7 +1644,7 @@ x
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestNullableInt32') AS int) <> 100 OR (CAST(JSON_VALUE([j].[Reference],'$.TestNullableInt32') AS int) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableInt32') AS int) <> 100 OR (CAST(JSON_VALUE([j].[Reference], '$.TestNullableInt32') AS int) IS NULL)
 """);
     }
 
@@ -1656,7 +1656,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestNullableInt32') AS int) <> 100 OR (
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestNullableInt32') AS int) IS NOT NULL
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableInt32') AS int) IS NOT NULL
 """);
     }
 
@@ -1668,7 +1668,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestNullableInt32') AS int) IS NOT NULL
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestSignedByte') AS smallint) <> CAST(100 AS smallint) OR (CAST(JSON_VALUE([j].[Reference],'$.TestSignedByte') AS smallint) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestSignedByte') AS smallint) <> CAST(100 AS smallint) OR (CAST(JSON_VALUE([j].[Reference], '$.TestSignedByte') AS smallint) IS NULL)
 """);
     }
 
@@ -1680,7 +1680,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestSignedByte') AS smallint) <> CAST(1
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestSingle') AS real) <> CAST(10.4 AS real) OR (CAST(JSON_VALUE([j].[Reference],'$.TestSingle') AS real) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestSingle') AS real) <> CAST(10.4 AS real) OR (CAST(JSON_VALUE([j].[Reference], '$.TestSingle') AS real) IS NULL)
 """);
     }
 
@@ -1692,7 +1692,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestSingle') AS real) <> CAST(10.4 AS r
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestTimeSpan') AS time) <> '03:02:00' OR (CAST(JSON_VALUE([j].[Reference],'$.TestTimeSpan') AS time) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestTimeSpan') AS time) <> '03:02:00' OR (CAST(JSON_VALUE([j].[Reference], '$.TestTimeSpan') AS time) IS NULL)
 """);
     }
 
@@ -1704,7 +1704,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestTimeSpan') AS time) <> '03:02:00' O
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt16') AS int) <> 100 OR (CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt16') AS int) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt16') AS int) <> 100 OR (CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt16') AS int) IS NULL)
 """);
     }
 
@@ -1716,7 +1716,7 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt16') AS int) <> 100 OR (
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt32') AS bigint) <> CAST(1000 AS bigint) OR (CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt32') AS bigint) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt32') AS bigint) <> CAST(1000 AS bigint) OR (CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt32') AS bigint) IS NULL)
 """);
     }
 
@@ -1728,7 +1728,79 @@ WHERE CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt32') AS bigint) <> CAST(
 """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
-WHERE CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20,0)) <> 10000.0 OR (CAST(JSON_VALUE([j].[Reference],'$.TestUnsignedInt64') AS decimal(20,0)) IS NULL)
+WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt64') AS decimal(20,0)) <> 10000.0 OR (CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt64') AS decimal(20,0)) IS NULL)
+""");
+    }
+
+    public override async Task Json_predicate_on_bool_converted_to_int_zero_one(bool async)
+    {
+        await base.Json_predicate_on_bool_converted_to_int_zero_one(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Reference]
+FROM [JsonEntitiesConverters] AS [j]
+WHERE CAST(JSON_VALUE([j].[Reference], '$.BoolConvertedToIntZeroOne') AS int) = 1
+""");
+    }
+
+    public override async Task Json_predicate_on_bool_converted_to_string_True_False(bool async)
+    {
+        await base.Json_predicate_on_bool_converted_to_string_True_False(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Reference]
+FROM [JsonEntitiesConverters] AS [j]
+WHERE JSON_VALUE([j].[Reference], '$.BoolConvertedToStringTrueFalse') = N'True'
+""");
+    }
+
+    public override async Task Json_predicate_on_bool_converted_to_string_Y_N(bool async)
+    {
+        await base.Json_predicate_on_bool_converted_to_string_Y_N(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Reference]
+FROM [JsonEntitiesConverters] AS [j]
+WHERE JSON_VALUE([j].[Reference], '$.BoolConvertedToStringYN') = N'Y'
+""");
+    }
+
+    public override async Task Json_predicate_on_int_zero_one_converted_to_bool(bool async)
+    {
+        await base.Json_predicate_on_int_zero_one_converted_to_bool(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Reference]
+FROM [JsonEntitiesConverters] AS [j]
+WHERE CAST(JSON_VALUE([j].[Reference], '$.IntZeroOneConvertedToBool') AS bit) = CAST(1 AS bit)
+""");
+    }
+
+    public override async Task Json_predicate_on_string_True_False_converted_to_bool(bool async)
+    {
+        await base.Json_predicate_on_string_True_False_converted_to_bool(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Reference]
+FROM [JsonEntitiesConverters] AS [j]
+WHERE CAST(JSON_VALUE([j].[Reference], '$.StringTrueFalseConvertedToBool') AS bit) = CAST(0 AS bit)
+""");
+    }
+
+    public override async Task Json_predicate_on_string_Y_N_converted_to_bool(bool async)
+    {
+        await base.Json_predicate_on_string_Y_N_converted_to_bool(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], [j].[Reference]
+FROM [JsonEntitiesConverters] AS [j]
+WHERE CAST(JSON_VALUE([j].[Reference], '$.StringYNConvertedToBool') AS bit) = CAST(0 AS bit)
 """);
     }
 
@@ -1778,7 +1850,7 @@ FROM (
 
         AssertSql(
 """
-SELECT JSON_QUERY([m].[OwnedReferenceRoot],'$.OwnedReferenceBranch'), [m].[Id]
+SELECT JSON_QUERY([m].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [m].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j
 ) AS [m]
@@ -1793,7 +1865,7 @@ FROM (
 
         AssertSql(
 """
-SELECT JSON_QUERY([m].[OwnedReferenceRoot],'$.OwnedCollectionBranch'), [m].[Id]
+SELECT JSON_QUERY([m].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [m].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j
 ) AS [m]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQueryAdHocSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQueryAdHocSqliteTest.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class JsonQueryAdHocSqliteTest : JsonQueryAdHocTestBase
+{
+    public JsonQueryAdHocSqliteTest(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+
+    // issue #26708
+    protected override void OnConfiguring29219(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
+
+    protected override void Seed29219(MyContext29219 ctx)
+    {
+        var entity1 = new MyEntity29219
+        {
+            Id = 1,
+            Reference = new MyJsonEntity29219 { NonNullableScalar = 10, NullableScalar = 11 },
+            Collection = new List<MyJsonEntity29219>
+            {
+                new MyJsonEntity29219 { NonNullableScalar = 100, NullableScalar = 101 },
+                new MyJsonEntity29219 { NonNullableScalar = 200, NullableScalar = 201 },
+                new MyJsonEntity29219 { NonNullableScalar = 300, NullableScalar = null },
+            }
+        };
+
+        var entity2 = new MyEntity29219
+        {
+            Id = 2,
+            Reference = new MyJsonEntity29219 { NonNullableScalar = 20, NullableScalar = null },
+            Collection = new List<MyJsonEntity29219>
+            {
+                new MyJsonEntity29219 { NonNullableScalar = 1001, NullableScalar = null },
+            }
+        };
+
+        ctx.Entities.AddRange(entity1, entity2);
+        ctx.SaveChanges();
+
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO ""Entities"" (""Id"", ""Reference"", ""Collection"")
+VALUES(3, '{{ ""NonNullableScalar"" : 30 }}', '[{{ ""NonNullableScalar"" : 10001 }}]')");
+    }
+
+    // issue #26708
+    protected override void OnConfiguring30028(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
+
+    protected override void Seed30028(MyContext30028 ctx)
+    {
+        // complete
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO ""Entities"" (""Id"", ""Json"")
+VALUES(
+1,
+'{{""RootName"":""e1"",""Collection"":[{{""BranchName"":""e1 c1"",""Nested"":{{""LeafName"":""e1 c1 l""}}}},{{""BranchName"":""e1 c2"",""Nested"":{{""LeafName"":""e1 c2 l""}}}}],""OptionalReference"":{{""BranchName"":""e1 or"",""Nested"":{{""LeafName"":""e1 or l""}}}},""RequiredReference"":{{""BranchName"":""e1 rr"",""Nested"":{{""LeafName"":""e1 rr l""}}}}}}')");
+
+        // missing collection
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO ""Entities"" (""Id"", ""Json"")
+VALUES(
+2,
+'{{""RootName"":""e2"",""OptionalReference"":{{""BranchName"":""e2 or"",""Nested"":{{""LeafName"":""e2 or l""}}}},""RequiredReference"":{{""BranchName"":""e2 rr"",""Nested"":{{""LeafName"":""e2 rr l""}}}}}}')");
+
+        // missing optional reference
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO ""Entities"" (""Id"", ""Json"")
+VALUES(
+3,
+'{{""RootName"":""e3"",""Collection"":[{{""BranchName"":""e3 c1"",""Nested"":{{""LeafName"":""e3 c1 l""}}}},{{""BranchName"":""e3 c2"",""Nested"":{{""LeafName"":""e3 c2 l""}}}}],""RequiredReference"":{{""BranchName"":""e3 rr"",""Nested"":{{""LeafName"":""e3 rr l""}}}}}}')");
+
+        // missing required reference
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO ""Entities"" (""Id"", ""Json"")
+VALUES(
+4,
+'{{""RootName"":""e4"",""Collection"":[{{""BranchName"":""e4 c1"",""Nested"":{{""LeafName"":""e4 c1 l""}}}},{{""BranchName"":""e4 c2"",""Nested"":{{""LeafName"":""e4 c2 l""}}}}],""OptionalReference"":{{""BranchName"":""e4 or"",""Nested"":{{""LeafName"":""e4 or l""}}}}}}')");
+    }
+
+    // issue #26708
+    protected override void OnConfiguringArrayOfPrimitives(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
+
+    protected override void SeedArrayOfPrimitives(MyContextArrayOfPrimitives ctx)
+    {
+        var entity1 = new MyEntityArrayOfPrimitives
+        {
+            Id = 1,
+            Reference = new MyJsonEntityArrayOfPrimitives
+            {
+                IntArray = new int[] { 1, 2, 3 },
+                ListOfString = new List<string> { "Foo", "Bar", "Baz" }
+            },
+            Collection = new List<MyJsonEntityArrayOfPrimitives>
+            {
+                new MyJsonEntityArrayOfPrimitives
+                {
+                    IntArray = new int[] { 111, 112, 113 },
+                    ListOfString = new List<string> { "Foo11", "Bar11" }
+                },
+                new MyJsonEntityArrayOfPrimitives
+                {
+                    IntArray = new int[] { 211, 212, 213 },
+                    ListOfString = new List<string> { "Foo12", "Bar12" }
+                },
+            }
+        };
+
+        var entity2 = new MyEntityArrayOfPrimitives
+        {
+            Id = 2,
+            Reference = new MyJsonEntityArrayOfPrimitives
+            {
+                IntArray = new int[] { 10, 20, 30 },
+                ListOfString = new List<string> { "A", "B", "C" }
+            },
+            Collection = new List<MyJsonEntityArrayOfPrimitives>
+            {
+                new MyJsonEntityArrayOfPrimitives
+                {
+                    IntArray = new int[] { 110, 120, 130 },
+                    ListOfString = new List<string> { "A1", "Z1" }
+                },
+                new MyJsonEntityArrayOfPrimitives
+                {
+                    IntArray = new int[] { 210, 220, 230 },
+                    ListOfString = new List<string> { "A2", "Z2" }
+                },
+            }
+        };
+
+        ctx.Entities.AddRange(entity1, entity2);
+        ctx.SaveChanges();
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteFixture.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class JsonQuerySqliteFixture : JsonQueryFixtureBase
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+
+
+    // issue #26708
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class JsonQuerySqliteTest : JsonQueryTestBase<JsonQuerySqliteFixture>
+{
+    public JsonQuerySqliteTest(JsonQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Project_json_entity_FirstOrDefault_subquery(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_json_entity_FirstOrDefault_subquery(async)))
+            .Message);
+
+    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_json_entity_FirstOrDefault_subquery_deduplication(async)))
+            .Message);
+
+    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async)))
+            .Message);
+
+    public override async Task Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async)))
+            .Message);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task FromSqlInterpolated_on_entity_with_json_with_predicate(bool async)
+    {
+        var parameter = new SqliteParameter { ParameterName = "prm", Value = 1 };
+        await AssertQuery(
+            async,
+            ss => ((DbSet<JsonEntityBasic>)ss.Set<JsonEntityBasic>()).FromSql(
+                Fixture.TestStore.NormalizeDelimitersInInterpolatedString($"SELECT * FROM [JsonEntitiesBasic] AS j WHERE [j].[Id] = {parameter}")),
+            ss => ss.Set<JsonEntityBasic>(),
+            entryCount: 40);
+
+        AssertSql(
+"""
+prm='1' (DbType = String)
+
+SELECT "m"."Id", "m"."EntityBasicId", "m"."Name", "m"."OwnedCollectionRoot", "m"."OwnedReferenceRoot"
+FROM (
+    SELECT * FROM "JsonEntitiesBasic" AS j WHERE "j"."Id" = @prm
+) AS "m"
+""");
+    }
+
+    [ConditionalTheory(Skip = "issue #30326")]
+    public override async Task Json_predicate_on_bool_converted_to_int_zero_one(bool async)
+    {
+        await base.Json_predicate_on_bool_converted_to_int_zero_one(async);
+
+        AssertSql();
+    }
+
+    [ConditionalTheory(Skip = "issue #30326")]
+    public override async Task Json_predicate_on_bool_converted_to_string_True_False(bool async)
+    {
+        await base.Json_predicate_on_bool_converted_to_string_True_False(async);
+
+        AssertSql();
+    }
+
+    [ConditionalTheory(Skip = "issue #30326")]
+    public override async Task Json_predicate_on_bool_converted_to_string_Y_N(bool async)
+    {
+        await base.Json_predicate_on_bool_converted_to_string_Y_N(async);
+
+        AssertSql();
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteComplianceTest.cs
@@ -8,9 +8,6 @@ public class SqliteComplianceTest : RelationalComplianceTestBase
     protected override ICollection<Type> IgnoredTestBases { get; } = new HashSet<Type>
     {
         typeof(FromSqlSprocQueryTestBase<>),
-        typeof(JsonQueryTestBase<>),
-        typeof(JsonUpdateTestBase<>),
-        typeof(JsonQueryAdHocTestBase),
         typeof(SqlExecutorTestBase<>),
         typeof(UdfDbFunctionTestBase<>),
         typeof(TPCRelationshipsQueryTestBase<>), // internal class is added

--- a/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteFixture.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Update;
+
+public class JsonUpdateSqliteFixture : JsonUpdateFixtureBase
+{
+    protected override ITestStoreFactory TestStoreFactory
+        => SqliteTestStoreFactory.Instance;
+
+    // issue #26708
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteTest.cs
@@ -3,9 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.Update;
 
-public class JsonUpdateSqlServerTest : JsonUpdateTestBase<JsonUpdateSqlServerFixture>
+public class JsonUpdateSqliteTest : JsonUpdateTestBase<JsonUpdateSqliteFixture>
 {
-    public JsonUpdateSqlServerTest(JsonUpdateSqlServerFixture fixture)
+    public JsonUpdateSqliteTest(JsonUpdateSqliteFixture fixture)
         : base(fixture)
     {
         ClearLog();
@@ -20,16 +20,15 @@ public class JsonUpdateSqlServerTest : JsonUpdateTestBase<JsonUpdateSqlServerFix
 @p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":10.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 684)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedCollectionBranch', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -42,16 +41,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"},{"SomethingSomething":"ss1"}]' (Nullable = false) (Size = 100)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedReferenceBranch.OwnedCollectionLeaf', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch.OwnedCollectionLeaf', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -64,17 +62,16 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='[{"Date":"2221-01-01T00:00:00","Enum":"Two","Fraction":221.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2222-01-01T00:00:00","Enum":"Three","Fraction":222.1,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 668)
 @p1='2'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesInheritance] SET [CollectionOnDerived] = @p0
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesInheritance" SET "CollectionOnDerived" = @p0
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Discriminator], [j].[Name], [j].[Fraction], [j].[CollectionOnBase], [j].[ReferenceOnBase], [j].[CollectionOnDerived], [j].[ReferenceOnDerived]
-FROM [JsonEntitiesInheritance] AS [j]
-WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
+SELECT "j"."Id", "j"."Discriminator", "j"."Name", "j"."Fraction", "j"."CollectionOnBase", "j"."ReferenceOnBase", "j"."CollectionOnDerived", "j"."ReferenceOnDerived"
+FROM "JsonEntitiesInheritance" AS "j"
+WHERE "j"."Discriminator" = 'JsonEntityInheritanceDerived'
+LIMIT 2
 """);
     }
 
@@ -87,16 +84,15 @@ WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
 @p0='[{"Name":"e1_c1","Number":11,"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Fraction":11.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Number":12,"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Fraction":12.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Fraction":12.2,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Fraction":12.0,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Number":142,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}]' (Nullable = false) (Size = 1867)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = @p0
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = @p0
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -109,17 +105,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='{"Name":"RootName","Number":42,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 296)
 @p1='2'
 @p2=NULL (DbType = Int32)
-@p3='NewEntity' (Size = 4000)
+@p3='NewEntity' (Size = 9)
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-INSERT INTO [JsonEntitiesBasic] ([OwnedReferenceRoot], [Id], [EntityBasicId], [Name])
+INSERT INTO "JsonEntitiesBasic" ("OwnedReferenceRoot", "Id", "EntityBasicId", "Name")
 VALUES (@p0, @p1, @p2, @p3);
 """,
                 //
                 """
-SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
 """);
     }
 
@@ -132,16 +126,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='{"SomethingSomething":"ss3"}' (Nullable = false) (Size = 28)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedCollectionBranch[0].OwnedReferenceLeaf', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch[0].OwnedReferenceLeaf', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -154,16 +147,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='{"Name":"RootName","Number":42,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 296)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = @p0
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = @p0
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -175,16 +167,14 @@ FROM [JsonEntitiesBasic] AS [j]
 """
 @p0='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-DELETE FROM [JsonEntitiesBasic]
-OUTPUT 1
-WHERE [Id] = @p0;
+DELETE FROM "JsonEntitiesBasic"
+WHERE "Id" = @p0
+RETURNING 1;
 """,
-            //
-"""
+                //
+                """
 SELECT COUNT(*)
-FROM [JsonEntitiesBasic] AS [j]
+FROM "JsonEntitiesBasic" AS "j"
 """);
     }
 
@@ -197,16 +187,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='[]' (Nullable = false) (Size = 2)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedCollectionBranch', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -219,16 +208,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='[]' (Nullable = false) (Size = 2)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = @p0
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = @p0
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -241,16 +229,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0=NULL (Nullable = false)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedReferenceBranch.OwnedReferenceLeaf', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch.OwnedReferenceLeaf', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -263,16 +250,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0=NULL (Nullable = false)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = @p0
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = @p0
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -285,16 +271,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='["2111-11-11T00:00:00"]' (Nullable = false) (Size = 23)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[0].OwnedCollectionBranch[0].Date', JSON_VALUE(@p0, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[0].OwnedCollectionBranch[0].Date', json_extract(@p0, '$[0]'))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -307,16 +292,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='["Modified"]' (Nullable = false) (Size = 12)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[0].Name', JSON_VALUE(@p0, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[0].Name', json_extract(@p0, '$[0]'))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -329,16 +313,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='["Modified"]' (Nullable = false) (Size = 12)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[1].Name', JSON_VALUE(@p0, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[1].Name', json_extract(@p0, '$[0]'))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -352,16 +335,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p1='{"Name":"edit","Number":10,"OwnedCollectionBranch":[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":10.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}}],"OwnedReferenceBranch":{"Date":"2111-11-11T00:00:00","Enum":"One","Fraction":10.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}}' (Nullable = false) (Size = 773)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[0].OwnedCollectionBranch', JSON_QUERY(@p0)), [OwnedReferenceRoot] = @p1
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[0].OwnedCollectionBranch', json(@p0)), "OwnedReferenceRoot" = @p1
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -374,16 +356,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":4321.3,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2222-11-11T00:00:00","Enum":"Three","Fraction":45.32,"NullableEnum":null,"OwnedCollectionLeaf":[],"OwnedReferenceLeaf":{"SomethingSomething":"cc"}}]' (Nullable = false) (Size = 628)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedCollectionBranch', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -396,16 +377,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='[{"SomethingSomething":"edit1"},{"SomethingSomething":"edit2"}]' (Nullable = false) (Size = 63)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedCollectionBranch[0].OwnedCollectionLeaf', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch[0].OwnedCollectionLeaf', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -418,16 +398,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='[{"Name":"edit1","Number":11,"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Fraction":11.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"edit2","Number":12,"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Fraction":12.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Fraction":12.2,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Fraction":12.0,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}}]' (Nullable = false) (Size = 1569)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = @p0
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = @p0
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -440,16 +419,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"edit1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit2"}}' (Nullable = false) (Size = 225)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedCollectionBranch[1]', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch[1]', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -463,16 +441,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p1='["Two"]' (Nullable = false) (Size = 7)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[1].OwnedCollectionBranch[1].Enum', JSON_VALUE(@p0, '$[0]')), [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedReferenceBranch.Enum', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[1].OwnedCollectionBranch[1].Enum', json_extract(@p0, '$[0]')), "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch.Enum', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -486,16 +463,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p1='[999]' (Nullable = false) (Size = 5)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[1].Number', CAST(JSON_VALUE(@p0, '$[0]') AS int)), [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.Number', CAST(JSON_VALUE(@p1, '$[0]') AS int))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[1].Number', json_extract(@p0, '$[0]')), "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.Number', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -505,21 +481,20 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-@p0='[true]' (Nullable = false) (Size = 6)
-@p1='[false]' (Nullable = false) (Size = 7)
+@p0='["true"]' (Nullable = false) (Size = 8)
+@p1='["false"]' (Nullable = false) (Size = 9)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestBoolean', CAST(JSON_VALUE(@p0, '$[0]') AS bit)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestBoolean', CAST(JSON_VALUE(@p1, '$[0]') AS bit))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestBoolean', json(json_extract(@p0, '$[0]'))), "Reference" = json_set("Reference", '$.TestBoolean', json(json_extract(@p1, '$[0]')))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -533,17 +508,16 @@ WHERE [j].[Id] = 1
 @p1='[25]' (Nullable = false) (Size = 4)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestByte', CAST(JSON_VALUE(@p0, '$[0]') AS tinyint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestByte', CAST(JSON_VALUE(@p1, '$[0]') AS tinyint))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestByte', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestByte', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -556,17 +530,16 @@ WHERE [j].[Id] = 1
 @p0='["t"]' (Nullable = false) (Size = 5)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Reference] = JSON_MODIFY([Reference], 'strict $.TestCharacter', CAST(JSON_VALUE(@p0, '$[0]') AS nvarchar(1)))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesAllTypes" SET "Reference" = json_set("Reference", '$.TestCharacter', json_extract(@p0, '$[0]'))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -580,17 +553,16 @@ WHERE [j].[Id] = 1
 @p1='["3000-01-01T12:34:56"]' (Nullable = false) (Size = 23)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDateTime', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDateTime', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDateTime', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestDateTime', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -604,17 +576,16 @@ WHERE [j].[Id] = 1
 @p1='["3000-01-01T12:34:56-04:00"]' (Nullable = false) (Size = 29)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDateTimeOffset', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDateTimeOffset', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDateTimeOffset', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestDateTimeOffset', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -628,17 +599,16 @@ WHERE [j].[Id] = 1
 @p1='[-13579.01]' (Nullable = false) (Size = 11)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDecimal', CAST(JSON_VALUE(@p0, '$[0]') AS decimal(18,3))), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDecimal', CAST(JSON_VALUE(@p1, '$[0]') AS decimal(18,3)))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDecimal', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestDecimal', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -652,17 +622,16 @@ WHERE [j].[Id] = 1
 @p1='[-1.23579]' (Nullable = false) (Size = 10)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDouble', CAST(JSON_VALUE(@p0, '$[0]') AS float)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDouble', CAST(JSON_VALUE(@p1, '$[0]') AS float))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDouble', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestDouble', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -676,17 +645,16 @@ WHERE [j].[Id] = 1
 @p1='["12345678-1234-4321-5555-987654321000"]' (Nullable = false) (Size = 40)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestGuid', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestGuid', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestGuid', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestGuid', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -700,17 +668,16 @@ WHERE [j].[Id] = 1
 @p1='[-3234]' (Nullable = false) (Size = 7)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt16', CAST(JSON_VALUE(@p0, '$[0]') AS smallint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt16', CAST(JSON_VALUE(@p1, '$[0]') AS smallint))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt16', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestInt16', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -724,17 +691,16 @@ WHERE [j].[Id] = 1
 @p1='[-3234]' (Nullable = false) (Size = 7)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt32', CAST(JSON_VALUE(@p0, '$[0]') AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt32', CAST(JSON_VALUE(@p1, '$[0]') AS int))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt32', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestInt32', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -748,17 +714,16 @@ WHERE [j].[Id] = 1
 @p1='[-3234]' (Nullable = false) (Size = 7)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt64', CAST(JSON_VALUE(@p0, '$[0]') AS bigint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt64', CAST(JSON_VALUE(@p1, '$[0]') AS bigint))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt64', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestInt64', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -772,17 +737,16 @@ WHERE [j].[Id] = 1
 @p1='[-108]' (Nullable = false) (Size = 6)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestSignedByte', CAST(JSON_VALUE(@p0, '$[0]') AS smallint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestSignedByte', CAST(JSON_VALUE(@p1, '$[0]') AS smallint))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestSignedByte', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestSignedByte', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -796,17 +760,16 @@ WHERE [j].[Id] = 1
 @p1='[-7.234]' (Nullable = false) (Size = 8)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestSingle', CAST(JSON_VALUE(@p0, '$[0]') AS real)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestSingle', CAST(JSON_VALUE(@p1, '$[0]') AS real))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestSingle', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestSingle', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -820,17 +783,16 @@ WHERE [j].[Id] = 1
 @p1='["10:01:01.0070000"]' (Nullable = false) (Size = 20)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestTimeSpan', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestTimeSpan', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestTimeSpan', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestTimeSpan', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -844,17 +806,16 @@ WHERE [j].[Id] = 1
 @p1='[1534]' (Nullable = false) (Size = 6)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt16', CAST(JSON_VALUE(@p0, '$[0]') AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt16', CAST(JSON_VALUE(@p1, '$[0]') AS int))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt16', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestUnsignedInt16', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -868,17 +829,16 @@ WHERE [j].[Id] = 1
 @p1='[1237775789]' (Nullable = false) (Size = 12)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt32', CAST(JSON_VALUE(@p0, '$[0]') AS bigint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt32', CAST(JSON_VALUE(@p1, '$[0]') AS bigint))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt32', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestUnsignedInt32', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -892,17 +852,16 @@ WHERE [j].[Id] = 1
 @p1='[1234555555123456789]' (Nullable = false) (Size = 21)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt64', CAST(JSON_VALUE(@p0, '$[0]') AS decimal(20,0))), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt64', CAST(JSON_VALUE(@p1, '$[0]') AS decimal(20,0)))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt64', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestUnsignedInt64', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -916,17 +875,16 @@ WHERE [j].[Id] = 1
 @p1='[64528]' (Nullable = false) (Size = 7)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableInt32', CAST(JSON_VALUE(@p0, '$[0]') AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableInt32', CAST(JSON_VALUE(@p1, '$[0]') AS int))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableInt32', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestNullableInt32', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -940,17 +898,16 @@ WHERE [j].[Id] = 1
 @p1='[null]' (Nullable = false) (Size = 6)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableInt32', CAST(JSON_VALUE(@p0, '$[0]') AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableInt32', CAST(JSON_VALUE(@p1, '$[0]') AS int))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableInt32', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestNullableInt32', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -964,17 +921,16 @@ WHERE [j].[Id] = 1
 @p1='["Three"]' (Nullable = false) (Size = 9)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestEnum', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestEnum', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestEnum', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestEnum', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -988,17 +944,16 @@ WHERE [j].[Id] = 1
 @p1='["Three"]' (Nullable = false) (Size = 9)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestEnumWithIntConverter', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestEnumWithIntConverter', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestEnumWithIntConverter', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestEnumWithIntConverter', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1012,17 +967,16 @@ WHERE [j].[Id] = 1
 @p1='["Three"]' (Nullable = false) (Size = 9)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestEnum', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestEnum', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestEnum', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestEnum', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1036,17 +990,16 @@ WHERE [j].[Id] = 1
 @p1='[null]' (Nullable = false) (Size = 6)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnum', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnum', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnum', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestNullableEnum', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1060,17 +1013,16 @@ WHERE [j].[Id] = 1
 @p1='["Three"]' (Nullable = false) (Size = 9)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithIntConverter', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithIntConverter', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithIntConverter', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestNullableEnumWithIntConverter', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1084,17 +1036,16 @@ WHERE [j].[Id] = 1
 @p1='[null]' (Nullable = false) (Size = 6)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithIntConverter', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithIntConverter', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithIntConverter', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestNullableEnumWithIntConverter', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1108,17 +1059,16 @@ WHERE [j].[Id] = 1
 @p1='["One"]' (Nullable = false) (Size = 7)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithConverterThatHandlesNulls', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithConverterThatHandlesNulls', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithConverterThatHandlesNulls', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestNullableEnumWithConverterThatHandlesNulls', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1132,17 +1082,16 @@ WHERE [j].[Id] = 1
 @p1='[null]' (Nullable = false) (Size = 6)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithConverterThatHandlesNulls', JSON_VALUE(@p0, '$[0]')), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithConverterThatHandlesNulls', JSON_VALUE(@p1, '$[0]'))
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithConverterThatHandlesNulls', json_extract(@p0, '$[0]')), "Reference" = json_set("Reference", '$.TestNullableEnumWithConverterThatHandlesNulls', json_extract(@p1, '$[0]'))
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1156,17 +1105,16 @@ WHERE [j].[Id] = 1
 @p1='{"TestBoolean":true,"TestByte":255,"TestCharacter":"a","TestDateTime":"2000-01-01T12:34:56","TestDateTimeOffset":"2000-01-01T12:34:56-08:00","TestDecimal":-1234567890.01,"TestDefaultString":"MyDefaultStringInReference1","TestDouble":-1.23456789,"TestEnum":"One","TestEnumWithIntConverter":"Two","TestGuid":"12345678-1234-4321-7777-987654321000","TestInt16":-1234,"TestInt32":32,"TestInt64":64,"TestMaxLengthString":"Foo","TestNullableEnum":"One","TestNullableEnumWithConverterThatHandlesNulls":"Three","TestNullableEnumWithIntConverter":"Two","TestNullableInt32":78,"TestSignedByte":-128,"TestSingle":-1.234,"TestTimeSpan":"10:09:08.0070000","TestUnsignedInt16":1234,"TestUnsignedInt32":1234565789,"TestUnsignedInt64":1234567890123456789}' (Nullable = false) (Size = 738)
 @p2='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0]', JSON_QUERY(@p0)), [Reference] = @p1
-OUTPUT 1
-WHERE [Id] = @p2;
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0]', json(@p0)), "Reference" = @p1
+WHERE "Id" = @p2
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
-FROM [JsonEntitiesAllTypes] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1179,16 +1127,15 @@ WHERE [j].[Id] = 1
 @p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 227)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedReferenceBranch', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -1201,16 +1148,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"edit"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}' (Nullable = false) (Size = 191)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedReferenceBranch', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -1223,16 +1169,15 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 227)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.OwnedReferenceBranch', JSON_QUERY(@p0))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch', json(@p0))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
-FROM [JsonEntitiesBasic] AS [j]
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
 """);
     }
 
@@ -1245,17 +1190,16 @@ FROM [JsonEntitiesBasic] AS [j]
 @p0='[0]' (Nullable = false) (Size = 3)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.BoolConvertedToIntZeroOne', CAST(JSON_VALUE(@p0, '$[0]') AS int))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesConverters" SET "Reference" = json_set("Reference", '$.BoolConvertedToIntZeroOne', json_extract(@p0, '$[0]'))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Reference]
-FROM [JsonEntitiesConverters] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1268,17 +1212,16 @@ WHERE [j].[Id] = 1
 @p0='["True"]' (Nullable = false) (Size = 8)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.BoolConvertedToStringTrueFalse', CAST(JSON_VALUE(@p0, '$[0]') AS nvarchar(5)))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesConverters" SET "Reference" = json_set("Reference", '$.BoolConvertedToStringTrueFalse', json_extract(@p0, '$[0]'))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Reference]
-FROM [JsonEntitiesConverters] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1291,17 +1234,16 @@ WHERE [j].[Id] = 1
 @p0='["N"]' (Nullable = false) (Size = 5)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.BoolConvertedToStringYN', CAST(JSON_VALUE(@p0, '$[0]') AS nvarchar(1)))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesConverters" SET "Reference" = json_set("Reference", '$.BoolConvertedToStringYN', json_extract(@p0, '$[0]'))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Reference]
-FROM [JsonEntitiesConverters] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
@@ -1311,37 +1253,64 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='[true]' (Nullable = false) (Size = 6)
+@p0='["true"]' (Nullable = false) (Size = 8)
 @p1='1'
 
-SET IMPLICIT_TRANSACTIONS OFF;
-SET NOCOUNT ON;
-UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.IntZeroOneConvertedToBool', CAST(JSON_VALUE(@p0, '$[0]') AS bit))
-OUTPUT 1
-WHERE [Id] = @p1;
+UPDATE "JsonEntitiesConverters" SET "Reference" = json_set("Reference", '$.IntZeroOneConvertedToBool', json(json_extract(@p0, '$[0]')))
+WHERE "Id" = @p1
+RETURNING 1;
 """,
                 //
                 """
-SELECT TOP(2) [j].[Id], [j].[Reference]
-FROM [JsonEntitiesConverters] AS [j]
-WHERE [j].[Id] = 1
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
 """);
     }
 
-    [ConditionalFact(Skip = "issue #30330")]
     public override async Task Edit_single_property_with_converter_string_True_False_to_bool()
     {
         await base.Edit_single_property_with_converter_string_True_False_to_bool();
 
-        AssertSql();
+        AssertSql(
+"""
+@p0='["false"]' (Nullable = false) (Size = 9)
+@p1='1'
+
+UPDATE "JsonEntitiesConverters" SET "Reference" = json_set("Reference", '$.StringTrueFalseConvertedToBool', json(json_extract(@p0, '$[0]')))
+WHERE "Id" = @p1
+RETURNING 1;
+""",
+                //
+                """
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
     }
 
-    [ConditionalFact(Skip = "issue #30330")]
     public override async Task Edit_single_property_with_converter_string_Y_N_to_bool()
     {
         await base.Edit_single_property_with_converter_string_Y_N_to_bool();
 
-        AssertSql();
+        AssertSql(
+"""
+@p0='["true"]' (Nullable = false) (Size = 8)
+@p1='1'
+
+UPDATE "JsonEntitiesConverters" SET "Reference" = json_set("Reference", '$.StringYNConvertedToBool', json(json_extract(@p0, '$[0]')))
+WHERE "Id" = @p1
+RETURNING 1;
+""",
+                //
+                """
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
     }
 
     protected override void ClearLog()


### PR DESCRIPTION
Adding support for Sqlite.

Limitation:
When accessing element of a JSON array we can only use constant values. Unlike Sql Server which supports parameters, columns or even arbitrary expressions.

Also since JSON aggregates are mapped to own types, in case of collections users need to ignore SqliteEventId.CompositeKeyWithValueGeneration

Fixes #28816
