### PR TITLE
[release/7.0] Fix to #30028 - Added nullable property to Json mapped model resulting in errors instead of mapping non existing json property to null

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
@@ -83,4 +83,129 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
         public int NonNullableScalar { get; set; }
         public int? NullableScalar { get; set; }
     }
+
+    protected abstract void Seed30028(MyContext30028 ctx);
+
+    protected class MyContext30028 : DbContext
+    {
+        public MyContext30028(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<MyEntity30028> Entities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<MyEntity30028>(b =>
+            {
+                b.Property(x => x.Id).ValueGeneratedNever();
+                b.OwnsOne(x => x.Json, nb =>
+                {
+                    nb.ToJson();
+                    nb.OwnsMany(x => x.Collection, nnb => nnb.OwnsOne(x => x.Nested));
+                    nb.OwnsOne(x => x.OptionalReference, nnb => nnb.OwnsOne(x => x.Nested));
+                    nb.OwnsOne(x => x.RequiredReference, nnb => nnb.OwnsOne(x => x.Nested));
+                    nb.Navigation(x => x.RequiredReference).IsRequired();
+                });
+            });
+        }
+    }
+
+    public class MyEntity30028
+    {
+        public int Id { get; set; }
+        public MyJsonRootEntity30028 Json { get; set; }
+    }
+
+    public class MyJsonRootEntity30028
+    {
+        public string RootName { get; set; }
+        public MyJsonBranchEntity30028 RequiredReference { get; set; }
+        public MyJsonBranchEntity30028 OptionalReference { get; set; }
+        public List<MyJsonBranchEntity30028> Collection { get; set; }
+    }
+
+    public class MyJsonBranchEntity30028
+    {
+        public string BranchName { get; set; }
+        public MyJsonLeafEntity30028 Nested { get; set; }
+    }
+
+    public class MyJsonLeafEntity30028
+    {
+        public string LeafName { get; set; }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Accessing_missing_navigation_works(bool async)
+    {
+        var contextFactory = await InitializeAsync<MyContext30028>(seed: Seed30028);
+        using (var context = contextFactory.CreateContext())
+        {
+            var result = context.Entities.OrderBy(x => x.Id).ToList();
+            Assert.Equal(4, result.Count);
+            Assert.NotNull(result[0].Json.Collection);
+            Assert.NotNull(result[0].Json.OptionalReference);
+            Assert.NotNull(result[0].Json.RequiredReference);
+
+            Assert.Null(result[1].Json.Collection);
+            Assert.NotNull(result[1].Json.OptionalReference);
+            Assert.NotNull(result[1].Json.RequiredReference);
+
+            Assert.NotNull(result[2].Json.Collection);
+            Assert.Null(result[2].Json.OptionalReference);
+            Assert.NotNull(result[2].Json.RequiredReference);
+
+            Assert.NotNull(result[3].Json.Collection);
+            Assert.NotNull(result[3].Json.OptionalReference);
+            Assert.Null(result[3].Json.RequiredReference);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Missing_navigation_works_with_deduplication(bool async)
+    {
+        var contextFactory = await InitializeAsync<MyContext30028>(seed: Seed30028);
+        using (var context = contextFactory.CreateContext())
+        {
+            var result = context.Entities.OrderBy(x => x.Id).Select(x => new
+            {
+                x,
+                x.Json,
+                x.Json.OptionalReference,
+                x.Json.RequiredReference,
+                NestedOptional = x.Json.OptionalReference.Nested,
+                NestedRequired = x.Json.RequiredReference.Nested,
+                x.Json.Collection,
+            }).ToList();
+
+            Assert.Equal(4, result.Count);
+            Assert.NotNull(result[0].OptionalReference);
+            Assert.NotNull(result[0].RequiredReference);
+            Assert.NotNull(result[0].NestedOptional);
+            Assert.NotNull(result[0].NestedRequired);
+            Assert.NotNull(result[0].Collection);
+
+            Assert.NotNull(result[1].OptionalReference);
+            Assert.NotNull(result[1].RequiredReference);
+            Assert.NotNull(result[1].NestedOptional);
+            Assert.NotNull(result[1].NestedRequired);
+            Assert.Null(result[1].Collection);
+
+            Assert.Null(result[2].OptionalReference);
+            Assert.NotNull(result[2].RequiredReference);
+            Assert.Null(result[2].NestedOptional);
+            Assert.NotNull(result[2].NestedRequired);
+            Assert.NotNull(result[2].Collection);
+
+            Assert.NotNull(result[3].OptionalReference);
+            Assert.Null(result[3].RequiredReference);
+            Assert.NotNull(result[3].NestedOptional);
+            Assert.Null(result[3].NestedRequired);
+            Assert.NotNull(result[3].Collection);
+        }
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryAdHocSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryAdHocSqlServerTest.cs
@@ -43,4 +43,31 @@ public class JsonQueryAdHocSqlServerTest : JsonQueryAdHocTestBase
         ctx.Database.ExecuteSqlRaw(@"INSERT INTO [Entities] ([Id], [Reference], [Collection])
 VALUES(3, N'{{ ""NonNullableScalar"" : 30 }}', N'[{{ ""NonNullableScalar"" : 10001 }}]')");
     }
+
+    protected override void Seed30028(MyContext30028 ctx)
+    {
+        // complete
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO [Entities] ([Id], [Json])
+VALUES(
+1,
+N'{{""RootName"":""e1"",""Collection"":[{{""BranchName"":""e1 c1"",""Nested"":{{""LeafName"":""e1 c1 l""}}}},{{""BranchName"":""e1 c2"",""Nested"":{{""LeafName"":""e1 c2 l""}}}}],""OptionalReference"":{{""BranchName"":""e1 or"",""Nested"":{{""LeafName"":""e1 or l""}}}},""RequiredReference"":{{""BranchName"":""e1 rr"",""Nested"":{{""LeafName"":""e1 rr l""}}}}}}')");
+
+        // missing collection
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO [Entities] ([Id], [Json])
+VALUES(
+2,
+N'{{""RootName"":""e2"",""OptionalReference"":{{""BranchName"":""e2 or"",""Nested"":{{""LeafName"":""e2 or l""}}}},""RequiredReference"":{{""BranchName"":""e2 rr"",""Nested"":{{""LeafName"":""e2 rr l""}}}}}}')");
+
+        // missing optional reference
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO [Entities] ([Id], [Json])
+VALUES(
+3,
+N'{{""RootName"":""e3"",""Collection"":[{{""BranchName"":""e3 c1"",""Nested"":{{""LeafName"":""e3 c1 l""}}}},{{""BranchName"":""e3 c2"",""Nested"":{{""LeafName"":""e3 c2 l""}}}}],""RequiredReference"":{{""BranchName"":""e3 rr"",""Nested"":{{""LeafName"":""e3 rr l""}}}}}}')");
+
+        // missing required reference
+        ctx.Database.ExecuteSqlRaw(@"INSERT INTO [Entities] ([Id], [Json])
+VALUES(
+4,
+N'{{""RootName"":""e4"",""Collection"":[{{""BranchName"":""e4 c1"",""Nested"":{{""LeafName"":""e4 c1 l""}}}},{{""BranchName"":""e4 c2"",""Nested"":{{""LeafName"":""e4 c2 l""}}}}],""OptionalReference"":{{""BranchName"":""e4 or"",""Nested"":{{""LeafName"":""e4 or l""}}}}}}')");
+    }
 }


### PR DESCRIPTION
Ported from #30101
Fixes #30028

**Description**

Projecting or accessing into JSON object that has an optional subdocument that is missing (rather than being null) throws during query.

**Customer impact**

Customers are unable to query JSON objects when they are missing part of the document (which should be allowed when mapped using optional navigation). There is no good workaround, customers need to edit JSON and add the missing element(s). Also, we already patched similar issue, when the "leaf" property was missing rather than navigation - see https://github.com/dotnet/efcore/issues/29219

**How found**

Multiple customer reports on 7.0.

**Regression**

No. JSON support has been introduced in 7.0.

**Testing**

Added regression tests.

**Risk**

Low-Mid; Fix is relatively small and involves hand-crafting expression call to TryGetValue() rather than GetValue() that we used before. Additional risk comes from the fact that the change is in common code path. It gets used every time JSON is mapped to entities that are nested (e.g. Customer entity having Details entity mapped to JSON, and Details entity itself has a sub-entity Address mapped to the same JSON). Added quirk to revert to old behavior if necessary.