### PR TITLE
[release/7.0] Add back setter for scaffolded collection navigations

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             this.Write(this.ToStringHelper.ToStringWithCulture(targetType));
             this.Write("> ");
             this.Write(this.ToStringHelper.ToStringWithCulture(navigation.Name));
-            this.Write(" { get; } = new List<");
+            this.Write(" { get; set; } = new List<");
             this.Write(this.ToStringHelper.ToStringWithCulture(targetType));
             this.Write(">();\r\n");
 
@@ -200,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             this.Write(this.ToStringHelper.ToStringWithCulture(skipNavigation.TargetEntityType.Name));
             this.Write("> ");
             this.Write(this.ToStringHelper.ToStringWithCulture(skipNavigation.Name));
-            this.Write(" { get; } = new List<");
+            this.Write(" { get; set; } = new List<");
             this.Write(this.ToStringHelper.ToStringWithCulture(skipNavigation.TargetEntityType.Name));
             this.Write(">();\r\n");
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.tt
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.tt
@@ -124,7 +124,7 @@ public partial class <#= EntityType.Name #>
         if (navigation.IsCollection)
         {
 #>
-    public virtual ICollection<<#= targetType #>> <#= navigation.Name #> { get; } = new List<<#= targetType #>>();
+    public virtual ICollection<<#= targetType #>> <#= navigation.Name #> { get; set; } = new List<<#= targetType #>>();
 <#
         }
         else
@@ -151,7 +151,7 @@ public partial class <#= EntityType.Name #>
             }
         }
 #>
-    public virtual ICollection<<#= skipNavigation.TargetEntityType.Name #>> <#= skipNavigation.Name #> { get; } = new List<<#= skipNavigation.TargetEntityType.Name #>>();
+    public virtual ICollection<<#= skipNavigation.TargetEntityType.Name #>> <#= skipNavigation.Name #> { get; set; } = new List<<#= skipNavigation.TargetEntityType.Name #>>();
 <#
     }
 #>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -935,7 +935,7 @@ public partial class Entity
                 for (var i = 1; i <= 4; i++)
                 {
                     Assert.Contains(
-                        "public virtual ICollection<Entity> Entity { get; }",
+                        "public virtual ICollection<Entity> Entity { get; set; }",
                         code.AdditionalFiles.Single(f => f.Path == $"Dependent{i}.cs").Code);
                 }
             },
@@ -1414,7 +1414,7 @@ public partial class Post
     public virtual Person Author { get; set; }
 
     [InverseProperty(""Post"")]
-    public virtual ICollection<Contribution> Contributions { get; } = new List<Contribution>();
+    public virtual ICollection<Contribution> Contributions { get; set; } = new List<Contribution>();
 }
 ",
                     code.AdditionalFiles.Single(f => f.Path == "Post.cs"));
@@ -1434,7 +1434,7 @@ public partial class Person
     public int Id { get; set; }
 
     [InverseProperty(""Author"")]
-    public virtual ICollection<Post> Posts { get; } = new List<Post>();
+    public virtual ICollection<Post> Posts { get; set; } = new List<Post>();
 }
 ",
                     code.AdditionalFiles.Single(f => f.Path == "Person.cs"));
@@ -1703,7 +1703,7 @@ public partial class Color
 
     public string ColorCode { get; set; } = null!;
 
-    public virtual ICollection<Car> Cars { get; } = new List<Car>();
+    public virtual ICollection<Car> Cars { get; set; } = new List<Car>();
 }
 ",
                     code.AdditionalFiles.Single(f => f.Path == "Color.cs"));
@@ -2350,7 +2350,7 @@ public partial class Blog
 {
     public int Id { get; set; }
 
-    public virtual ICollection<Post> Posts { get; } = new List<Post>();
+    public virtual ICollection<Post> Posts { get; set; } = new List<Post>();
 }
 ",
                     code.AdditionalFiles.Single(e => e.Path == "Blog.cs"));
@@ -2365,7 +2365,7 @@ public partial class Post
 {
     public int Id { get; set; }
 
-    public virtual ICollection<Blog> Blogs { get; } = new List<Blog>();
+    public virtual ICollection<Blog> Blogs { get; set; } = new List<Blog>();
 }
 ",
                     code.AdditionalFiles.Single(e => e.Path == "Post.cs"));
@@ -2476,7 +2476,7 @@ public partial class Blog
 {
     public int Id { get; set; }
 
-    public virtual ICollection<Post> Posts { get; } = new List<Post>();
+    public virtual ICollection<Post> Posts { get; set; } = new List<Post>();
 }
 ",
                     code.AdditionalFiles.Single(e => e.Path == "Blog.cs"));
@@ -2491,7 +2491,7 @@ public partial class Post
 {
     public string Id { get; set; }
 
-    public virtual ICollection<Blog> Blogs { get; } = new List<Blog>();
+    public virtual ICollection<Blog> Blogs { get; set; } = new List<Blog>();
 }
 ",
                     code.AdditionalFiles.Single(e => e.Path == "Post.cs"));
@@ -2613,7 +2613,7 @@ public partial class Blog
 
     [ForeignKey(""BlogsId"")]
     [InverseProperty(""Blogs"")]
-    public virtual ICollection<Post> Posts { get; } = new List<Post>();
+    public virtual ICollection<Post> Posts { get; set; } = new List<Post>();
 }
 ",
                     code.AdditionalFiles.Single(e => e.Path == "Blog.cs"));
@@ -2634,7 +2634,7 @@ public partial class Post
 
     [ForeignKey(""PostsId"")]
     [InverseProperty(""Posts"")]
-    public virtual ICollection<Blog> Blogs { get; } = new List<Blog>();
+    public virtual ICollection<Blog> Blogs { get; set; } = new List<Blog>();
 }
 ",
                     code.AdditionalFiles.Single(e => e.Path == "Post.cs"));
@@ -2762,7 +2762,7 @@ public partial class Blog
 
     public int Key { get; set; }
 
-    public virtual ICollection<Post> Posts { get; } = new List<Post>();
+    public virtual ICollection<Post> Posts { get; set; } = new List<Post>();
 }
 ",
                     code.AdditionalFiles.Single(e => e.Path == "Blog.cs"));
@@ -2783,7 +2783,7 @@ public partial class Post
 
     [ForeignKey(""PostsId"")]
     [InverseProperty(""Posts"")]
-    public virtual ICollection<Blog> Blogs { get; } = new List<Blog>();
+    public virtual ICollection<Blog> Blogs { get; set; } = new List<Blog>();
 }
 ",
                     code.AdditionalFiles.Single(e => e.Path == "Post.cs"));


### PR DESCRIPTION
Port of #30311
Fixes https://github.com/dotnet/efcore/issues/30286

**Description**

The generated code when reverse engineering (scaffolding) from an existing database was changed to drop the setter from collection navigation properties. The setter is not needed for EF use cases, so this made the generated code cleaner. However, it turns out that:

- Like to use the setter to set an entirely new collection, even though it isn't really designed to be used that way
- Some serializers, notably System.Text.Json, ignore properties without setters, even though the property is pre-initialized and so is never null or needs setting.

**Customer impact**

Multiple customers prefer the previously generated code, and, more importantly, System.Text.Json no longer serializes entities correctly. There is a workaround--customize the T4 template to add the setter.

**How found**

Multiple customer reports on 7.0.

**Regression**

Maybe, if you squint. This isn't a runtime code change; it requires the user to generate new code. However, the code generated is different than it used to be.

**Testing**

Tests updated.

**Risk**

Low. No quirk, because this is tooling code. However, the T4 template can be customized to generate whatever the user wants.