### PR TITLE
Use NormalizeDelimitersInRawString in Ad_hoc_query_for_shared_type_entity_type_works

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/SharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SharedTypeQueryRelationalTestBase.cs
@@ -38,7 +38,8 @@ public abstract class SharedTypeQueryRelationalTestBase : SharedTypeQueryTestBas
 
         using var context = contextFactory.CreateContext();
 
-        var result = context.Database.SqlQueryRaw<ViewQuery24601>(@"SELECT * FROM ViewQuery24601");
+        var result = context.Database.SqlQueryRaw<ViewQuery24601>(
+            ((RelationalTestStore)TestStore).NormalizeDelimitersInRawString((@"SELECT * FROM [ViewQuery24601]")));
 
         Assert.Empty(result);
     }

--- a/test/EFCore.Relational.Specification.Tests/Query/SharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SharedTypeQueryRelationalTestBase.cs
@@ -39,7 +39,7 @@ public abstract class SharedTypeQueryRelationalTestBase : SharedTypeQueryTestBas
         using var context = contextFactory.CreateContext();
 
         var result = context.Database.SqlQueryRaw<ViewQuery24601>(
-            ((RelationalTestStore)TestStore).NormalizeDelimitersInRawString((@"SELECT * FROM [ViewQuery24601]")));
+            ((RelationalTestStore)TestStore).NormalizeDelimitersInRawString(@"SELECT * FROM [ViewQuery24601]"));
 
         Assert.Empty(result);
     }


### PR DESCRIPTION
Fixes #30367
