### PR TITLE
[release/7.0] Handle entity paths with no tables in model differ

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -939,11 +939,13 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
 
     private static bool EntityTypePathEquals(IEntityType source, IEntityType target, DiffContext diffContext)
     {
-        var sourceTable = diffContext.GetTable(source);
-        var targetTable = diffContext.GetTable(target);
+        var sourceTable = diffContext.FindTable(source);
+        var targetTable = diffContext.FindTable(target);
 
-        if (sourceTable.EntityTypeMappings.Count() == 1
-            && targetTable.EntityTypeMappings.Count() == 1)
+        if ((sourceTable == null
+                && targetTable == null)
+            || (sourceTable?.EntityTypeMappings.Count() == 1
+                && targetTable?.EntityTypeMappings.Count() == 1))
         {
             return true;
         }
@@ -953,8 +955,8 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
             return false;
         }
 
-        var nextSource = sourceTable.GetRowInternalForeignKeys(source).FirstOrDefault()?.PrincipalEntityType;
-        var nextTarget = targetTable.GetRowInternalForeignKeys(target).FirstOrDefault()?.PrincipalEntityType;
+        var nextSource = sourceTable?.GetRowInternalForeignKeys(source).FirstOrDefault()?.PrincipalEntityType;
+        var nextTarget = targetTable?.GetRowInternalForeignKeys(target).FirstOrDefault()?.PrincipalEntityType;
         return (nextSource == null && nextTarget == null)
             || (nextSource != null
                 && nextTarget != null
@@ -1516,7 +1518,7 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
             Diff,
             Add,
             Remove,
-            (s, t, c) => c.GetTable(s.EntityType) == c.FindSource(c.GetTable(t.EntityType))
+            (s, t, c) => c.FindTable(s.EntityType) == c.FindSource(c.FindTable(t.EntityType))
                 && string.Equals(s.Name, t.Name, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(s.Sql, t.Sql, StringComparison.OrdinalIgnoreCase));
 
@@ -2563,8 +2565,8 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ITable GetTable(IEntityType entityType)
-            => entityType.GetTableMappings().First().Table;
+        public virtual ITable? FindTable(IEntityType entityType)
+            => entityType.GetTableMappings().FirstOrDefault()?.Table;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -19,6 +19,9 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
     private static readonly bool QuirkEnabled27504
         = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue27504", out var enabled) && enabled;
 
+    private static readonly bool UseOldBehavior30321
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30321", out var enabled) && enabled;
+
     private static readonly Type[] DropOperationTypes =
     {
         typeof(DropIndexOperation),
@@ -942,7 +945,8 @@ public class MigrationsModelDiffer : IMigrationsModelDiffer
         var sourceTable = diffContext.FindTable(source);
         var targetTable = diffContext.FindTable(target);
 
-        if ((sourceTable == null
+        if ((!UseOldBehavior30321
+                && sourceTable == null
                 && targetTable == null)
             || (sourceTable?.EntityTypeMappings.Count() == 1
                 && targetTable?.EntityTypeMappings.Count() == 1))


### PR DESCRIPTION
Port of #30347
Fixes #30321

## Description

With TPC mapping (new feature in EF7), abstract types are not mapped to any table. This case was not being handled correctly in the model differ.

## Customer impact

"Sequence contains no elements" exception when attempting to generate a migration for simple changes in abstract types. No workaround.

## How found

Customer reported on 7.0.

## Regression

No; bug in new feature.

## Testing

Tests updated.

## Risk

Low and quirked.