### PR TITLE
Don't warn in model validation when bool property with default value has nullable backing field

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -675,15 +675,12 @@ public class RelationalModelValidator : ModelValidator
         {
             foreach (var property in entityType.GetDeclaredProperties())
             {
-                if (property.ClrType != typeof(bool)
-                    || property.ValueGenerated == ValueGenerated.Never)
-                {
-                    continue;
-                }
-
-                if (StoreObjectIdentifier.Create(property.DeclaringEntityType, StoreObjectType.Table) is { } table
-                    && (IsNotNullAndFalse(property.GetDefaultValue(table))
-                        || property.GetDefaultValueSql(table) != null))
+                if (property.ClrType == typeof(bool)
+                    && property.ValueGenerated != ValueGenerated.Never
+                    && property.FieldInfo?.FieldType != typeof(bool?)
+                    && (StoreObjectIdentifier.Create(property.DeclaringEntityType, StoreObjectType.Table) is { } table
+                        && (IsNotNullAndFalse(property.GetDefaultValue(table))
+                            || property.GetDefaultValueSql(table) != null)))
                 {
                     logger.BoolWithDefaultWarning(property);
                 }

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -149,6 +149,24 @@ public partial class RelationalModelValidatorTest : ModelValidatorTest
                 .GenerateMessage("ImBool", "E"), modelBuilder);
     }
 
+    [ConditionalFact] // Issue #28509
+    public virtual void Bool_with_default_value_and_nullable_backing_field_is_fine()
+    {
+        var modelBuilder = CreateConventionlessModelBuilder();
+        var model = modelBuilder.Model;
+
+        var entityType = model.AddEntityType(typeof(E2));
+        SetPrimaryKey(entityType);
+        var property = entityType.AddProperty(typeof(E2).GetAnyProperty("ImBool")!);
+        property.SetField("_imBool");
+        property.SetDefaultValue(true);
+        property.ValueGenerated = ValueGenerated.OnAdd;
+
+        VerifyLogDoesNotContain(
+            RelationalResources.LogBoolWithDefaultWarning(new TestLogger<TestRelationalLoggingDefinitions>())
+                .GenerateMessage("ImBool", "E2"), modelBuilder);
+    }
+
     [ConditionalFact]
     public virtual void Detects_bool_with_default_expression()
     {

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -167,6 +167,19 @@ public abstract class ModelValidatorTestBase
         public bool? ImNot { get; set; }
     }
 
+    protected class E2
+    {
+        private bool? _imBool;
+
+        public int Id { get; set; }
+
+        public bool ImBool
+        {
+            get => _imBool ?? true;
+            set => _imBool = value;
+        }
+    }
+
     protected class EntityWithInvalidProperties
     {
         public int Id { get; set; }


### PR DESCRIPTION
Fixes #28509
