### PR TITLE
Optimize SqliteDataReader.GetFieldValue

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -307,6 +307,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Namer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=navigations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=niladic/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NOCASE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pluralizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Poolable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pushdown/@EntryIndexedValue">True</s:Boolean>

--- a/src/Microsoft.Data.Sqlite.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Extensions/TypeExtensions.cs
@@ -6,10 +6,6 @@ namespace System
 {
     internal static class TypeExtensions
     {
-        public static bool IsNullable(this Type type)
-            => !type.IsValueType
-                || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
-
         public static Type UnwrapEnumType(this Type type)
             => type.IsEnum ? Enum.GetUnderlyingType(type) : type;
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -48,14 +48,12 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void ConnectionString_setter_throws_when_open()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
 
-                var ex = Assert.Throws<InvalidOperationException>(() => connection.ConnectionString = "Data Source=test.db");
+            var ex = Assert.Throws<InvalidOperationException>(() => connection.ConnectionString = "Data Source=test.db");
 
-                Assert.Equal(Resources.ConnectionStringRequiresClosedConnection, ex.Message);
-            }
+            Assert.Equal(Resources.ConnectionStringRequiresClosedConnection, ex.Message);
         }
 
         [Fact]
@@ -88,15 +86,13 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void DataSource_returns_actual_filename_when_open()
         {
-            using (var connection = new SqliteConnection("Data Source=test.db"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=test.db");
+            connection.Open();
 
-                var result = connection.DataSource;
+            var result = connection.DataSource;
 
-                Assert.True(Path.IsPathRooted(result));
-                Assert.Equal("test.db", Path.GetFileName(result));
-            }
+            Assert.True(Path.IsPathRooted(result));
+            Assert.Equal("test.db", Path.GetFileName(result));
         }
 
         [Fact]
@@ -155,7 +151,7 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void Open_adjusts_data_directory_path()
         {
-            string dataSubDirectory = Path.Combine(AppContext.BaseDirectory, "DataFolder");
+            var dataSubDirectory = Path.Combine(AppContext.BaseDirectory, "DataFolder");
 
             if (!Directory.Exists(dataSubDirectory))
                 Directory.CreateDirectory(dataSubDirectory);
@@ -164,12 +160,10 @@ namespace Microsoft.Data.Sqlite
 
             try
             {
-                using (var connection = new SqliteConnection("Data Source=|DataDirectory|local.db"))
-                {
-                    connection.Open();
+                using var connection = new SqliteConnection("Data Source=|DataDirectory|local.db");
+                connection.Open();
 
-                    Assert.Equal(Path.Combine(dataSubDirectory, "local.db"), connection.DataSource);
-                }
+                Assert.Equal(Path.Combine(dataSubDirectory, "local.db"), connection.DataSource);
             }
             finally
             {
@@ -180,52 +174,47 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void Open_adjusts_relative_path()
         {
-            using (var connection = new SqliteConnection("Data Source=local.db"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=local.db");
+            connection.Open();
 
-                Assert.Equal(Path.Combine(AppContext.BaseDirectory, "local.db"), connection.DataSource);
-            }
+            Assert.Equal(Path.Combine(AppContext.BaseDirectory, "local.db"), connection.DataSource);
         }
 
         [Fact]
         public void Open_throws_when_error()
         {
-            using (var connection = new SqliteConnection("Data Source=file:data.db?mode=invalidmode"))
-            {
-                var ex = Assert.Throws<SqliteException>(() => connection.Open());
+            using var connection = new SqliteConnection("Data Source=file:data.db?mode=invalidmode");
+            var ex = Assert.Throws<SqliteException>(() => connection.Open());
 
-                Assert.Equal(SQLITE_ERROR, ex.SqliteErrorCode);
-            }
+            Assert.Equal(SQLITE_ERROR, ex.SqliteErrorCode);
         }
 
         [Fact]
         public void Open_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            using var connection = new SqliteConnection("Data Source=:memory:");
+
+            var raised = false;
+            StateChangeEventHandler handler = (sender, e) =>
             {
-                var raised = false;
-                StateChangeEventHandler handler = (sender, e) =>
-                {
-                    raised = true;
+                raised = true;
 
-                    Assert.Equal(connection, sender);
-                    Assert.Equal(ConnectionState.Closed, e.OriginalState);
-                    Assert.Equal(ConnectionState.Open, e.CurrentState);
-                };
+                Assert.Equal(connection, sender);
+                Assert.Equal(ConnectionState.Closed, e.OriginalState);
+                Assert.Equal(ConnectionState.Open, e.CurrentState);
+            };
 
-                connection.StateChange += handler;
-                try
-                {
-                    connection.Open();
+            connection.StateChange += handler;
+            try
+            {
+                connection.Open();
 
-                    Assert.True(raised);
-                    Assert.Equal(ConnectionState.Open, connection.State);
-                }
-                finally
-                {
-                    connection.StateChange -= handler;
-                }
+                Assert.True(raised);
+                Assert.Equal(ConnectionState.Open, connection.State);
+            }
+            finally
+            {
+                connection.StateChange -= handler;
             }
         }
 
@@ -253,12 +242,10 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void Open_works_when_readwrite()
         {
-            using (var connection = new SqliteConnection("Data Source=readwrite.db;Mode=ReadWrite"))
-            {
-                var ex = Assert.Throws<SqliteException>(() => connection.Open());
+            using var connection = new SqliteConnection("Data Source=readwrite.db;Mode=ReadWrite");
+            var ex = Assert.Throws<SqliteException>(() => connection.Open());
 
-                Assert.Equal(SQLITE_CANTOPEN, ex.SqliteErrorCode);
-            }
+            Assert.Equal(SQLITE_CANTOPEN, ex.SqliteErrorCode);
         }
 
         [Fact]
@@ -266,21 +253,17 @@ namespace Microsoft.Data.Sqlite
         {
             var connectionString = "Data Source=people;Mode=Memory;Cache=Shared";
 
-            using (var connection1 = new SqliteConnection(connectionString))
-            {
-                connection1.Open();
+            using var connection1 = new SqliteConnection(connectionString);
+            connection1.Open();
 
-                connection1.ExecuteNonQuery(
-                    "CREATE TABLE Person (Name TEXT);" + "INSERT INTO Person VALUES ('Waldo');");
+            connection1.ExecuteNonQuery(
+                "CREATE TABLE Person (Name TEXT);" + "INSERT INTO Person VALUES ('Waldo');");
 
-                using (var connection2 = new SqliteConnection(connectionString))
-                {
-                    connection2.Open();
+            using var connection2 = new SqliteConnection(connectionString);
+            connection2.Open();
 
-                    var name = connection2.ExecuteScalar<string>("SELECT Name FROM Person;");
-                    Assert.Equal("Waldo", name);
-                }
-            }
+            var name = connection2.ExecuteScalar<string>("SELECT Name FROM Person;");
+            Assert.Equal("Waldo", name);
         }
 
         [Fact]
@@ -299,40 +282,34 @@ namespace Microsoft.Data.Sqlite
 
         private void Open_works_when_password_unsupported()
         {
-            using (var connection = new SqliteConnection("Data Source=encrypted.db;Password=password"))
-            {
-                var stateChangeRaised = false;
-                connection.StateChange += (sender, e) => stateChangeRaised = true;
+            using var connection = new SqliteConnection("Data Source=encrypted.db;Password=password");
+            var stateChangeRaised = false;
+            connection.StateChange += (sender, e) => stateChangeRaised = true;
 
-                var ex = Assert.Throws<InvalidOperationException>(() => connection.Open());
+            var ex = Assert.Throws<InvalidOperationException>(() => connection.Open());
 
-                Assert.Equal(Resources.EncryptionNotSupported(GetNativeLibraryName()), ex.Message);
-                Assert.False(stateChangeRaised);
-                Assert.Equal(ConnectionState.Closed, connection.State);
-            }
+            Assert.Equal(Resources.EncryptionNotSupported(GetNativeLibraryName()), ex.Message);
+            Assert.False(stateChangeRaised);
+            Assert.Equal(ConnectionState.Closed, connection.State);
         }
 
         private void Open_works_when_password_supported()
         {
-            using (var connection1 = new SqliteConnection("Data Source=encrypted.db;Password=password"))
-            {
-                connection1.Open();
+            using var connection1 = new SqliteConnection("Data Source=encrypted.db;Password=password");
+            connection1.Open();
 
-                // NB: The file is only encrypted after writing
-                connection1.ExecuteNonQuery("CREATE TABLE IF NOT EXISTS dual (dummy)");
+            // NB: The file is only encrypted after writing
+            connection1.ExecuteNonQuery("CREATE TABLE IF NOT EXISTS dual (dummy)");
 
-                using (var connection2 = new SqliteConnection("Data Source=encrypted.db;Password=wrong"))
-                {
-                    var stateChangeRaised = false;
-                    connection2.StateChange += (sender, e) => stateChangeRaised = true;
+            using var connection2 = new SqliteConnection("Data Source=encrypted.db;Password=wrong");
+            var stateChangeRaised = false;
+            connection2.StateChange += (sender, e) => stateChangeRaised = true;
 
-                    var ex = Assert.Throws<SqliteException>(() => connection2.Open());
+            var ex = Assert.Throws<SqliteException>(() => connection2.Open());
 
-                    Assert.Equal(SQLITE_NOTADB, ex.SqliteErrorCode);
-                    Assert.False(stateChangeRaised);
-                    Assert.Equal(ConnectionState.Closed, connection2.State);
-                }
-            }
+            Assert.Equal(SQLITE_NOTADB, ex.SqliteErrorCode);
+            Assert.False(stateChangeRaised);
+            Assert.Equal(ConnectionState.Closed, connection2.State);
         }
 
         private void Open_works_when_password_might_be_supported()
@@ -376,57 +353,47 @@ namespace Microsoft.Data.Sqlite
         [InlineData("False", 0L)]
         public void Open_works_when_foreign_keys(string foreignKeys, long expected)
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=" + foreignKeys))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=" + foreignKeys);
+            connection.Open();
 
-                Assert.Equal(expected, connection.ExecuteScalar<long>("PRAGMA foreign_keys;"));
-            }
+            Assert.Equal(expected, connection.ExecuteScalar<long>("PRAGMA foreign_keys;"));
         }
 
         [Fact]
         public void Open_works_when_recursive_triggers()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:;Recursive Triggers=True"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:;Recursive Triggers=True");
+            connection.Open();
 
-                Assert.Equal(1L, connection.ExecuteScalar<long>("PRAGMA recursive_triggers;"));
-            }
+            Assert.Equal(1L, connection.ExecuteScalar<long>("PRAGMA recursive_triggers;"));
         }
 
         [Fact]
         public void BackupDatabase_works()
         {
-            using (var connection1 = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection1.Open();
+            using var connection1 = new SqliteConnection("Data Source=:memory:");
+            connection1.Open();
 
-                connection1.ExecuteNonQuery(
-                    "CREATE TABLE Person (Name TEXT);" + "INSERT INTO Person VALUES ('Waldo');");
+            connection1.ExecuteNonQuery(
+                "CREATE TABLE Person (Name TEXT);" + "INSERT INTO Person VALUES ('Waldo');");
 
-                using (var connection2 = new SqliteConnection("Data Source=:memory:"))
-                {
-                    connection2.Open();
-                    connection1.BackupDatabase(connection2);
+            using var connection2 = new SqliteConnection("Data Source=:memory:");
+            connection2.Open();
+            connection1.BackupDatabase(connection2);
 
-                    var name = connection2.ExecuteScalar<string>("SELECT Name FROM Person;");
-                    Assert.Equal("Waldo", name);
-                }
-            }
+            var name = connection2.ExecuteScalar<string>("SELECT Name FROM Person;");
+            Assert.Equal("Waldo", name);
         }
 
         [Fact]
         public void BackupDatabase_works_when_destination_closed()
         {
-            using (var source = new SqliteConnection("Data Source=:memory:"))
-            using (var destination = new SqliteConnection("Data Source=:memory:"))
-            {
-                source.Open();
-                source.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
+            using var source = new SqliteConnection("Data Source=:memory:");
+            using var destination = new SqliteConnection("Data Source=:memory:");
+            source.Open();
+            source.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
 
-                source.BackupDatabase(destination);
-            }
+            source.BackupDatabase(destination);
         }
 
         [Fact]
@@ -443,75 +410,67 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void BackupDatabase_throws_when_destination_null()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
 
-                var ex = Assert.Throws<ArgumentNullException>(() => connection.BackupDatabase(null!));
+            var ex = Assert.Throws<ArgumentNullException>(() => connection.BackupDatabase(null!));
 
-                Assert.Equal("destination", ex.ParamName);
-            }
+            Assert.Equal("destination", ex.ParamName);
         }
 
         [Fact]
         public void BackupDatabase_throws_with_correct_message()
         {
-            using (var source = new SqliteConnection("Data Source=:memory:"))
-            using (var destination = new SqliteConnection("Data Source=:memory:"))
+            using var source = new SqliteConnection("Data Source=:memory:");
+            using var destination = new SqliteConnection("Data Source=:memory:");
+            source.Open();
+            source.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
+
+            using (source.BeginTransaction())
             {
-                source.Open();
-                source.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
+                source.ExecuteNonQuery("UPDATE Data SET Value = 1;");
 
-                using (source.BeginTransaction())
-                {
-                    source.ExecuteNonQuery("UPDATE Data SET Value = 1;");
-
-                    var ex = Assert.Throws<SqliteException>(() => source.BackupDatabase(destination));
-                    Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
-                }
+                var ex = Assert.Throws<SqliteException>(() => source.BackupDatabase(destination));
+                Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
             }
         }
 
         [Fact]
         public void Open_works_when_uri()
         {
-            using (var connection = new SqliteConnection("Data Source=file:readwrite.db?mode=rw"))
-            {
-                var ex = Assert.Throws<SqliteException>(() => connection.Open());
+            using var connection = new SqliteConnection("Data Source=file:readwrite.db?mode=rw");
+            var ex = Assert.Throws<SqliteException>(() => connection.Open());
 
-                Assert.Equal(SQLITE_CANTOPEN, ex.SqliteErrorCode);
-            }
+            Assert.Equal(SQLITE_CANTOPEN, ex.SqliteErrorCode);
         }
 
         [Fact]
         public void Close_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+
+            var raised = false;
+            StateChangeEventHandler handler = (sender, e) =>
             {
-                connection.Open();
+                raised = true;
 
-                var raised = false;
-                StateChangeEventHandler handler = (sender, e) =>
-                {
-                    raised = true;
+                Assert.Equal(connection, sender);
+                Assert.Equal(ConnectionState.Open, e.OriginalState);
+                Assert.Equal(ConnectionState.Closed, e.CurrentState);
+            };
 
-                    Assert.Equal(connection, sender);
-                    Assert.Equal(ConnectionState.Open, e.OriginalState);
-                    Assert.Equal(ConnectionState.Closed, e.CurrentState);
-                };
+            connection.StateChange += handler;
+            try
+            {
+                connection.Close();
 
-                connection.StateChange += handler;
-                try
-                {
-                    connection.Close();
-
-                    Assert.True(raised);
-                    Assert.Equal(ConnectionState.Closed, connection.State);
-                }
-                finally
-                {
-                    connection.StateChange -= handler;
-                }
+                Assert.True(raised);
+                Assert.Equal(ConnectionState.Closed, connection.State);
+            }
+            finally
+            {
+                connection.StateChange -= handler;
             }
         }
 
@@ -526,13 +485,11 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void Close_can_be_called_more_than_once()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
 
-                connection.Close();
-                connection.Close();
-            }
+            connection.Close();
+            connection.Close();
         }
 
         [Fact]
@@ -559,472 +516,408 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void CreateCommand_returns_command()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
 
-                using (var transaction = connection.BeginTransaction())
-                {
-                    var command = connection.CreateCommand();
+            using var transaction = connection.BeginTransaction();
+            var command = connection.CreateCommand();
 
-                    Assert.NotNull(command);
-                    Assert.Same(connection, command.Connection);
-                    Assert.Same(transaction, command.Transaction);
-                }
-            }
+            Assert.NotNull(command);
+            Assert.Same(connection, command.Connection);
+            Assert.Same(transaction, command.Transaction);
         }
 
         [Fact]
         public void CreateCollation_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateCollation("MY_NOCASE", (s1, s2) => string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateCollation("MY_NOCASE", (s1, s2) => string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase));
 
-                Assert.Equal(1L, connection.ExecuteScalar<long>("SELECT 'Νικοσ' = 'ΝΙΚΟΣ' COLLATE MY_NOCASE;"));
-            }
+            Assert.Equal(1L, connection.ExecuteScalar<long>("SELECT 'Νικοσ' = 'ΝΙΚΟΣ' COLLATE MY_NOCASE;"));
         }
 
         [Fact]
         public void CreateCollation_with_null_comparer_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateCollation("MY_NOCASE", (s1, s2) => string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase));
-                connection.CreateCollation("MY_NOCASE", null);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateCollation("MY_NOCASE", (s1, s2) => string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase));
+            connection.CreateCollation("MY_NOCASE", null);
 
-                var ex = Assert.Throws<SqliteException>(
-                    () => connection.ExecuteScalar<long>("SELECT 'Νικοσ' = 'ΝΙΚΟΣ' COLLATE MY_NOCASE;"));
+            var ex = Assert.Throws<SqliteException>(
+                () => connection.ExecuteScalar<long>("SELECT 'Νικοσ' = 'ΝΙΚΟΣ' COLLATE MY_NOCASE;"));
 
-                Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "no such collation sequence: MY_NOCASE"), ex.Message);
-            }
+            Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "no such collation sequence: MY_NOCASE"), ex.Message);
         }
 
         [Fact]
         public void CreateCollation_works_when_closed()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.CreateCollation("MY_NOCASE", (s1, s2) => string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase));
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.CreateCollation("MY_NOCASE", (s1, s2) => string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase));
+            connection.Open();
 
-                Assert.Equal(1L, connection.ExecuteScalar<long>("SELECT 'Νικοσ' = 'ΝΙΚΟΣ' COLLATE MY_NOCASE;"));
-            }
+            Assert.Equal(1L, connection.ExecuteScalar<long>("SELECT 'Νικοσ' = 'ΝΙΚΟΣ' COLLATE MY_NOCASE;"));
         }
 
         [Fact]
         public void CreateCollation_throws_with_empty_name()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateCollation(null!, null));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateCollation(null!, null));
 
-                Assert.Equal("name", ex.ParamName);
-            }
+            Assert.Equal("name", ex.ParamName);
         }
 
         [Fact]
         public void CreateCollation_works_with_state()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                var list = new List<string>();
-                connection.CreateCollation(
-                    "MY_NOCASE",
-                    list,
-                    (l, s1, s2) =>
-                    {
-                        l.Add("Invoked");
-                        return string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase);
-                    });
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            var list = new List<string>();
+            connection.CreateCollation(
+                "MY_NOCASE",
+                list,
+                (l, s1, s2) =>
+                {
+                    l.Add("Invoked");
+                    return string.Compare(s1, s2, StringComparison.OrdinalIgnoreCase);
+                });
 
-                Assert.Equal(1L, connection.ExecuteScalar<long>("SELECT 'Νικοσ' = 'ΝΙΚΟΣ' COLLATE MY_NOCASE;"));
-                var item = Assert.Single(list);
-                Assert.Equal("Invoked", item);
-            }
+            Assert.Equal(1L, connection.ExecuteScalar<long>("SELECT 'Νικοσ' = 'ΝΙΚΟΣ' COLLATE MY_NOCASE;"));
+            var item = Assert.Single(list);
+            Assert.Equal("Invoked", item);
         }
 
         [Fact]
         public void CreateFunction_works_when_closed()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.CreateFunction("test", 1L, (long state, long x, int y) => $"{state} {x} {y}");
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.CreateFunction("test", 1L, (long state, long x, int y) => $"{state} {x} {y}");
+            connection.Open();
 
-                var result = connection.ExecuteScalar<string>("SELECT test(2, 3);");
+            var result = connection.ExecuteScalar<string>("SELECT test(2, 3);");
 
-                Assert.Equal("1 2 3", result);
-            }
+            Assert.Equal("1 2 3", result);
         }
 
         [Fact]
         public void CreateFunction_throws_when_no_name()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateFunction(null!, () => 1L));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateFunction(null!, () => 1L));
 
-                Assert.Equal("name", ex.ParamName);
-            }
+            Assert.Equal("name", ex.ParamName);
         }
 
         [Fact]
         public void CreateFunction_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction("test", 1L, (long state, long x, int y) => $"{state} {x} {y}");
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction("test", 1L, (long state, long x, int y) => $"{state} {x} {y}");
 
-                var result = connection.ExecuteScalar<string>("SELECT test(2, 3);");
+            var result = connection.ExecuteScalar<string>("SELECT test(2, 3);");
 
-                Assert.Equal("1 2 3", result);
-            }
+            Assert.Equal("1 2 3", result);
         }
 
         [Fact]
         public void CreateFunction_works_when_params()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction(
-                    "test",
-                    args => string.Join(", ", args.Select(a => a?.GetType().FullName ?? "(null)")));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction(
+                "test",
+                args => string.Join(", ", args.Select(a => a?.GetType().FullName ?? "(null)")));
 
-                var result = connection.ExecuteScalar<string>("SELECT test(1, 3.1, 'A', X'7E57', NULL);");
+            var result = connection.ExecuteScalar<string>("SELECT test(1, 3.1, 'A', X'7E57', NULL);");
 
-                Assert.Equal("System.Int64, System.Double, System.String, System.Byte[], (null)", result);
-            }
+            Assert.Equal("System.Int64, System.Double, System.String, System.Byte[], (null)", result);
         }
 
         [Fact]
         public void CreateFunction_works_when_exception()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction<long>("test", () => throw new Exception("Test"));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction<long>("test", () => throw new Exception("Test"));
 
-                var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<long>("SELECT test();"));
+            var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<long>("SELECT test();"));
 
-                Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "Test"), ex.Message);
-            }
+            Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "Test"), ex.Message);
         }
 
         [Fact]
         public void CreateFunction_works_when_sqlite_exception()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction<long>("test", () => throw new SqliteException("Test", 200));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction<long>("test", () => throw new SqliteException("Test", 200));
 
-                var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<long>("SELECT test();"));
+            var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<long>("SELECT test();"));
 
-                Assert.Equal(Resources.SqliteNativeError(200, "Test"), ex.Message);
-            }
+            Assert.Equal(Resources.SqliteNativeError(200, "Test"), ex.Message);
         }
 
         [Fact]
         public void CreateFunction_works_when_null()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction("test", () => 1L);
-                connection.CreateFunction("test", default(Func<long>));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction("test", () => 1L);
+            connection.CreateFunction("test", default(Func<long>));
 
-                var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<long>("SELECT test();"));
+            var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<long>("SELECT test();"));
 
-                Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "no such function: test"), ex.Message);
-            }
+            Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "no such function: test"), ex.Message);
         }
 
         [Fact]
         public void CreateFunction_works_when_result_null()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction<object?>("test", () => null);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction<object?>("test", () => null);
 
-                var result = connection.ExecuteScalar<object>("SELECT test();");
+            var result = connection.ExecuteScalar<object>("SELECT test();");
 
-                Assert.Equal(DBNull.Value, result);
-            }
+            Assert.Equal(DBNull.Value, result);
         }
 
         [Fact]
         public void CreateFunction_works_when_result_DBNull()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction<object>("test", () => DBNull.Value);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction<object>("test", () => DBNull.Value);
 
-                var result = connection.ExecuteScalar<object>("SELECT test();");
+            var result = connection.ExecuteScalar<object>("SELECT test();");
 
-                Assert.Equal(DBNull.Value, result);
-            }
+            Assert.Equal(DBNull.Value, result);
         }
 
         [Fact]
         public void CreateFunction_works_when_parameter_null_and_type_nullable()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction("test", (long? x) => x == null);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction("test", (long? x) => x == null);
 
-                var result = connection.ExecuteScalar<long>("SELECT test(NULL);");
+            var result = connection.ExecuteScalar<long>("SELECT test(NULL);");
 
-                Assert.Equal(1L, result);
-            }
+            Assert.Equal(1L, result);
         }
 
         [Fact]
         public void CreateFunction_works_when_parameter_null_but_type_long()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction("test", (long x) => x);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction("test", (long x) => x);
 
-                var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<long>("SELECT test(NULL);"));
+            var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<long>("SELECT test(NULL);"));
 
-                Assert.Equal(
-                    Resources.SqliteNativeError(SQLITE_ERROR, Resources.UDFCalledWithNull("test", 0)),
-                    ex.Message);
-            }
+            Assert.Equal(
+                Resources.SqliteNativeError(SQLITE_ERROR, Resources.UDFCalledWithNull("test", 0)),
+                ex.Message);
         }
 
         [Fact]
         public void CreateFunction_works_when_parameter_null_but_type_double()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction("test", (double x) => x);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction("test", (double x) => x);
 
-                var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<double>("SELECT test(NULL);"));
+            var ex = Assert.Throws<SqliteException>(() => connection.ExecuteScalar<double>("SELECT test(NULL);"));
 
-                Assert.Equal(
-                    Resources.SqliteNativeError(SQLITE_ERROR, Resources.UDFCalledWithNull("test", 0)),
-                    ex.Message);
-                Assert.Equal(SQLITE_ERROR, ex.SqliteErrorCode);
-            }
+            Assert.Equal(
+                Resources.SqliteNativeError(SQLITE_ERROR, Resources.UDFCalledWithNull("test", 0)),
+                ex.Message);
+            Assert.Equal(SQLITE_ERROR, ex.SqliteErrorCode);
         }
 
         [Fact]
         public void CreateFunction_works_when_parameter_null_and_type_string()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction("test", (string? x) => x == null);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction("test", (string? x) => x == null);
 
-                var result = connection.ExecuteScalar<long>("SELECT test(NULL);");
+            var result = connection.ExecuteScalar<long>("SELECT test(NULL);");
 
-                Assert.Equal(1L, result);
-            }
+            Assert.Equal(1L, result);
         }
 
         [Fact]
         public void CreateFunction_works_when_parameter_null_and_type_byteArray()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction("test", (byte[] x) => x == null);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction("test", (byte[] x) => x == null);
 
-                var result = connection.ExecuteScalar<long>("SELECT test(NULL);");
+            var result = connection.ExecuteScalar<long>("SELECT test(NULL);");
 
-                Assert.Equal(1L, result);
-            }
+            Assert.Equal(1L, result);
         }
 
         [Fact]
         public void CreateFunction_works_when_parameter_empty_blob()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.CreateFunction("test", (byte[] x) => x?.Length == 0);
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.CreateFunction("test", (byte[] x) => x?.Length == 0);
 
-                var result = connection.ExecuteScalar<long>("SELECT test(X'');");
+            var result = connection.ExecuteScalar<long>("SELECT test(X'');");
 
-                Assert.Equal(1L, result);
-            }
+            Assert.Equal(1L, result);
         }
 
         [Fact]
         public void CreateFunction_is_non_deterministic()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
 
-                connection.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
-                connection.CreateFunction("test", (double x) => x);
+            connection.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
+            connection.CreateFunction("test", (double x) => x);
 
-                var ex = Assert.Throws<SqliteException>(
-                    () => connection.ExecuteNonQuery("CREATE INDEX InvalidIndex ON Data (Value) WHERE test(Value) = 0;"));
+            var ex = Assert.Throws<SqliteException>(
+                () => connection.ExecuteNonQuery("CREATE INDEX InvalidIndex ON Data (Value) WHERE test(Value) = 0;"));
 
-                Assert.Equal(
-                    Resources.SqliteNativeError(SQLITE_ERROR, "non-deterministic functions prohibited in partial index WHERE clauses"),
-                    ex.Message);
-            }
+            Assert.Equal(
+                Resources.SqliteNativeError(SQLITE_ERROR, "non-deterministic functions prohibited in partial index WHERE clauses"),
+                ex.Message);
         }
 
         [Fact]
         public void CreateFunction_deterministic_param_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
 
-                connection.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
-                connection.CreateFunction("test", (double x) => x, true);
+            connection.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
+            connection.CreateFunction("test", (double x) => x, true);
 
-                Assert.Equal(1, connection.ExecuteNonQuery("CREATE INDEX InvalidIndex ON Data (Value) WHERE test(Value) = 0;"));
-            }
+            Assert.Equal(1, connection.ExecuteNonQuery("CREATE INDEX InvalidIndex ON Data (Value) WHERE test(Value) = 0;"));
         }
 
         [Fact]
         public void CreateAggregate_works_when_closed()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.CreateAggregate(
-                    "test",
-                    "A",
-                    (string a, string x, int y) => a + x + y,
-                    a => a + "Z");
-                connection.Open();
-                connection.ExecuteNonQuery("CREATE TABLE dual2 (dummy1, dummy2); INSERT INTO dual2 (dummy1, dummy2) VALUES ('X', 1);");
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.CreateAggregate(
+                "test",
+                "A",
+                (string a, string x, int y) => a + x + y,
+                a => a + "Z");
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE dual2 (dummy1, dummy2); INSERT INTO dual2 (dummy1, dummy2) VALUES ('X', 1);");
 
-                var result = connection.ExecuteScalar<string>("SELECT test(dummy1, dummy2) FROM dual2;");
+            var result = connection.ExecuteScalar<string>("SELECT test(dummy1, dummy2) FROM dual2;");
 
-                Assert.Equal("AX1Z", result);
-            }
+            Assert.Equal("AX1Z", result);
         }
 
         [Fact]
         public void CreateAggregate_throws_when_no_name()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateAggregate(null!, (string? a) => "A"));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateAggregate(null!, (string? _) => "A"));
 
-                Assert.Equal("name", ex.ParamName);
-            }
+            Assert.Equal("name", ex.ParamName);
         }
 
         [Fact]
         public void CreateAggregate_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.ExecuteNonQuery("CREATE TABLE dual2 (dummy1, dummy2); INSERT INTO dual2 (dummy1, dummy2) VALUES ('X', 1);");
-                connection.CreateAggregate(
-                    "test",
-                    "A",
-                    (string a, string x, int y) => a + x + y,
-                    a => a + "Z");
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE dual2 (dummy1, dummy2); INSERT INTO dual2 (dummy1, dummy2) VALUES ('X', 1);");
+            connection.CreateAggregate(
+                "test",
+                "A",
+                (string a, string x, int y) => a + x + y,
+                a => a + "Z");
 
-                var result = connection.ExecuteScalar<string>("SELECT test(dummy1, dummy2) FROM dual2;");
+            var result = connection.ExecuteScalar<string>("SELECT test(dummy1, dummy2) FROM dual2;");
 
-                Assert.Equal("AX1Z", result);
-            }
+            Assert.Equal("AX1Z", result);
         }
 
         [Fact]
         public void CreateAggregate_works_when_params()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate("test", (string? a, object?[] args) => a + string.Join(", ", args) + "; ");
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
+            connection.CreateAggregate("test", (string? a, object?[] args) => a + string.Join(", ", args) + "; ");
 
-                var result = connection.ExecuteScalar<string>("SELECT test(dummy) FROM dual;");
+            var result = connection.ExecuteScalar<string>("SELECT test(dummy) FROM dual;");
 
-                Assert.Equal("X; ", result);
-            }
+            Assert.Equal("X; ", result);
         }
 
         [Fact]
         public void CreateAggregate_works_when_exception_during_step()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate("test", (string? a) => throw new Exception("Test"));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
+            connection.CreateAggregate("test", (string? _) => throw new Exception("Test"));
 
-                var ex = Assert.Throws<SqliteException>(
-                    () => connection.ExecuteScalar<string>("SELECT test() FROM dual;"));
+            var ex = Assert.Throws<SqliteException>(
+                () => connection.ExecuteScalar<string>("SELECT test() FROM dual;"));
 
-                Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "Test"), ex.Message);
-            }
+            Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "Test"), ex.Message);
         }
 
         [Fact]
         public void CreateAggregate_works_when_exception_during_final()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate<string, string>("test", "A", a => "B", a => throw new Exception("Test"));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
+            connection.CreateAggregate<string, string>("test", "A", _ => "B", a => throw new Exception("Test"));
 
-                var ex = Assert.Throws<SqliteException>(
-                    () => connection.ExecuteScalar<string>("SELECT test() FROM dual;"));
+            var ex = Assert.Throws<SqliteException>(
+                () => connection.ExecuteScalar<string>("SELECT test() FROM dual;"));
 
-                Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "Test"), ex.Message);
-            }
+            Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "Test"), ex.Message);
         }
 
         [Fact]
         public void CreateAggregate_works_when_sqlite_exception()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate("test", (string? a) => throw new SqliteException("Test", 200));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
+            connection.CreateAggregate("test", (string? _) => throw new SqliteException("Test", 200));
 
-                var ex = Assert.Throws<SqliteException>(
-                    () => connection.ExecuteScalar<string>("SELECT test() FROM dual;"));
+            var ex = Assert.Throws<SqliteException>(
+                () => connection.ExecuteScalar<string>("SELECT test() FROM dual;"));
 
-                Assert.Equal(Resources.SqliteNativeError(200, "Test"), ex.Message);
-            }
+            Assert.Equal(Resources.SqliteNativeError(200, "Test"), ex.Message);
         }
 
         [Fact]
         public void CreateAggregate_works_when_null()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate("test", (string? a) => "A");
-                connection.CreateAggregate("test", default(Func<string?, string>));
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
+            connection.CreateAggregate("test", (string? _) => "A");
+            connection.CreateAggregate("test", default(Func<string?, string>));
 
-                var ex = Assert.Throws<SqliteException>(
-                    () => connection.ExecuteScalar<long>("SELECT test() FROM dual;"));
+            var ex = Assert.Throws<SqliteException>(
+                () => connection.ExecuteScalar<long>("SELECT test() FROM dual;"));
 
-                Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "no such function: test"), ex.Message);
-            }
+            Assert.Equal(Resources.SqliteNativeError(SQLITE_ERROR, "no such function: test"), ex.Message);
         }
 
         [Fact]
@@ -1040,199 +933,177 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void BeginTransaction_throws_when_parallel_transaction()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+
+            using (connection.BeginTransaction())
             {
-                connection.Open();
+                var ex = Assert.Throws<InvalidOperationException>(() => connection.BeginTransaction());
 
-                using (connection.BeginTransaction())
-                {
-                    var ex = Assert.Throws<InvalidOperationException>(() => connection.BeginTransaction());
-
-                    Assert.Equal(Resources.ParallelTransactionsNotSupported, ex.Message);
-                }
+                Assert.Equal(Resources.ParallelTransactionsNotSupported, ex.Message);
             }
         }
 
         [Fact]
         public void BeginTransaction_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
 
-                using (var transaction = connection.BeginTransaction(IsolationLevel.Serializable))
-                {
-                    Assert.NotNull(transaction);
-                    Assert.Equal(connection, transaction.Connection);
-                    Assert.Equal(IsolationLevel.Serializable, transaction.IsolationLevel);
-                }
-            }
+            using var transaction = connection.BeginTransaction(IsolationLevel.Serializable);
+            Assert.NotNull(transaction);
+            Assert.Equal(connection, transaction.Connection);
+            Assert.Equal(IsolationLevel.Serializable, transaction.IsolationLevel);
         }
 
         [Fact]
         public void ChangeDatabase_not_supported()
         {
-            using (var connection = new SqliteConnection())
-            {
-                Assert.Throws<NotSupportedException>(() => connection.ChangeDatabase("new"));
-            }
+            using var connection = new SqliteConnection();
+            Assert.Throws<NotSupportedException>(() => connection.ChangeDatabase("new"));
         }
 
         [Fact]
         public void Mars_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
 
-                var command1 = connection.CreateCommand();
-                command1.CommandText = "SELECT '1A' UNION SELECT '1B';";
+            var command1 = connection.CreateCommand();
+            command1.CommandText = "SELECT '1A' UNION SELECT '1B';";
 
-                using (var reader1 = command1.ExecuteReader())
-                {
-                    reader1.Read();
-                    Assert.Equal("1A", reader1.GetString(0));
+            using var reader1 = command1.ExecuteReader();
+            reader1.Read();
+            Assert.Equal("1A", reader1.GetString(0));
 
-                    var command2 = connection.CreateCommand();
-                    command2.CommandText = "SELECT '2A' UNION SELECT '2B';";
+            var command2 = connection.CreateCommand();
+            command2.CommandText = "SELECT '2A' UNION SELECT '2B';";
 
-                    using (var reader2 = command2.ExecuteReader())
-                    {
-                        reader2.Read();
-                        Assert.Equal("2A", reader2.GetString(0));
+            using var reader2 = command2.ExecuteReader();
+            reader2.Read();
+            Assert.Equal("2A", reader2.GetString(0));
 
-                        reader1.Read();
-                        Assert.Equal("1B", reader1.GetString(0));
+            reader1.Read();
+            Assert.Equal("1B", reader1.GetString(0));
 
-                        reader2.Read();
-                        Assert.Equal("2B", reader2.GetString(0));
-                    }
-                }
-            }
+            reader2.Read();
+            Assert.Equal("2B", reader2.GetString(0));
         }
 
         [Fact]
         public void EnableExtensions_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+
+            var loadExtensionOmitted = connection.ExecuteScalar<long>(
+                "SELECT COUNT(*) FROM pragma_compile_options WHERE compile_options = 'OMIT_LOAD_EXTENSION';");
+            if (loadExtensionOmitted != 0L)
             {
-                connection.Open();
-
-                var loadExtensionOmitted = connection.ExecuteScalar<long>(
-                    "SELECT COUNT(*) FROM pragma_compile_options WHERE compile_options = 'OMIT_LOAD_EXTENSION';");
-                if (loadExtensionOmitted != 0L)
-                {
-                    return;
-                }
-
-                var sql = "SELECT load_extension('unknown');";
-
-                var ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
-                var originalError = ex.Message;
-
-                connection.EnableExtensions();
-
-                ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
-                var enabledError = ex.Message;
-
-                connection.EnableExtensions(enable: false);
-
-                ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
-                var disabledError = ex.Message;
-
-                Assert.NotEqual(originalError, enabledError);
-                Assert.Equal(originalError, disabledError);
+                return;
             }
+
+            var sql = "SELECT load_extension('unknown');";
+
+            var ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
+            var originalError = ex.Message;
+
+            connection.EnableExtensions();
+
+            ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
+            var enabledError = ex.Message;
+
+            connection.EnableExtensions(enable: false);
+
+            ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
+            var disabledError = ex.Message;
+
+            Assert.NotEqual(originalError, enabledError);
+            Assert.Equal(originalError, disabledError);
         }
 
         [Fact]
         public void EnableExtensions_works_when_closed()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+
+            var loadExtensionOmitted = connection.ExecuteScalar<long>(
+                "SELECT COUNT(*) FROM pragma_compile_options WHERE compile_options = 'OMIT_LOAD_EXTENSION';");
+            if (loadExtensionOmitted != 0L)
             {
-                connection.Open();
-
-                var loadExtensionOmitted = connection.ExecuteScalar<long>(
-                    "SELECT COUNT(*) FROM pragma_compile_options WHERE compile_options = 'OMIT_LOAD_EXTENSION';");
-                if (loadExtensionOmitted != 0L)
-                {
-                    return;
-                }
-
-                var sql = "SELECT load_extension('unknown');";
-
-                var ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
-                var originalError = ex.Message;
-
-                connection.Close();
-                connection.EnableExtensions();
-                connection.Open();
-
-                ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
-                var enabledError = ex.Message;
-
-                Assert.NotEqual(originalError, enabledError);
+                return;
             }
+
+            var sql = "SELECT load_extension('unknown');";
+
+            var ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
+            var originalError = ex.Message;
+
+            connection.Close();
+            connection.EnableExtensions();
+            connection.Open();
+
+            ex = Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery(sql));
+            var enabledError = ex.Message;
+
+            Assert.NotEqual(originalError, enabledError);
         }
 
         [Fact]
         public void LoadExtension_works()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+
+            var loadExtensionOmitted = connection.ExecuteScalar<long>(
+                "SELECT COUNT(*) FROM pragma_compile_options WHERE compile_options = 'OMIT_LOAD_EXTENSION';");
+            if (loadExtensionOmitted != 0L)
             {
-                connection.Open();
-
-                var loadExtensionOmitted = connection.ExecuteScalar<long>(
-                    "SELECT COUNT(*) FROM pragma_compile_options WHERE compile_options = 'OMIT_LOAD_EXTENSION';");
-                if (loadExtensionOmitted != 0L)
-                {
-                    return;
-                }
-
-                connection.Close();
-                connection.EnableExtensions(false);
-                connection.Open();
-
-                var ex = Assert.Throws<SqliteException>(
-                    () => connection.ExecuteNonQuery("SELECT load_extension('unknown');"));
-                var extensionsDisabledError = ex.Message;
-
-                ex = Assert.Throws<SqliteException>(() => connection.LoadExtension("unknown"));
-
-                Assert.NotEqual(extensionsDisabledError, ex.Message);
+                return;
             }
+
+            connection.Close();
+            connection.EnableExtensions(false);
+            connection.Open();
+
+            var ex = Assert.Throws<SqliteException>(
+                () => connection.ExecuteNonQuery("SELECT load_extension('unknown');"));
+            var extensionsDisabledError = ex.Message;
+
+            ex = Assert.Throws<SqliteException>(() => connection.LoadExtension("unknown"));
+
+            Assert.NotEqual(extensionsDisabledError, ex.Message);
         }
 
         [Fact]
         public void LoadExtension_works_when_closed()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+
+            var loadExtensionOmitted = connection.ExecuteScalar<long>(
+                "SELECT COUNT(*) FROM pragma_compile_options WHERE compile_options = 'OMIT_LOAD_EXTENSION';");
+            if (loadExtensionOmitted != 0L)
             {
-                connection.Open();
-
-                var loadExtensionOmitted = connection.ExecuteScalar<long>(
-                    "SELECT COUNT(*) FROM pragma_compile_options WHERE compile_options = 'OMIT_LOAD_EXTENSION';");
-                if (loadExtensionOmitted != 0L)
-                {
-                    return;
-                }
-
-                connection.Close();
-                connection.EnableExtensions(false);
-                connection.Open();
-
-                var ex = Assert.Throws<SqliteException>(
-                    () => connection.ExecuteNonQuery("SELECT load_extension('unknown');"));
-                var extensionsDisabledError = ex.Message;
-
-                connection.Close();
-
-                connection.LoadExtension("unknown");
-
-                ex = Assert.Throws<SqliteException>(() => connection.Open());
-
-                Assert.NotEqual(extensionsDisabledError, ex.Message);
+                return;
             }
+
+            connection.Close();
+            connection.EnableExtensions(false);
+            connection.Open();
+
+            var ex = Assert.Throws<SqliteException>(
+                () => connection.ExecuteNonQuery("SELECT load_extension('unknown');"));
+            var extensionsDisabledError = ex.Message;
+
+            connection.Close();
+
+            connection.LoadExtension("unknown");
+
+            ex = Assert.Throws<SqliteException>(() => connection.Open());
+
+            Assert.NotEqual(extensionsDisabledError, ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Following a discussion on generic methods, this optimizes SqliteDataReader.GetFieldValue to take advantage of JIT elision when doing value-type checks. The mechanism (with produced assembly code) can be seen [here](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACAZQAtsoAHAGW2ADoASgFcAdhgCW+GAG4aNYgGYGZBgGEGAbxoMdypcRQMAsgAoAlNt1bqu2wwDiMDADFxMADYATAGrZ3QmAAecTEAPhM6M1kbXQBfSx0EhgBtAClxDEcRGChxMBMMAE8OGAgAMxMQjDMzNAZ0zJhs3PyikvKTMvcIbGra+oysnLyC4tKKqoB+GrqGoZbR9orickizAF0kxQYqhydXDx8/AMCAFXDd6E8QvwsYnWs7XXEyhkXxk1OzBgBeH4Y2h8qjUkrZHk87MQAOwMcjRCEMeL3Oyg56vd4dL6/f6AjpdHp9VEPImQmGkeEQpEIkkvN64ipYv4AsYdKYg5Fgkm2aEMOBwklUiE09H0z7fJmilZrEnghE6HmrClPJEknkATg1SsRNFiQA).

Note that we can optimize nullable value types in the same way (`int?`) if we want. While looking at this I noticed that GetFieldValue returns null if an unknown nullable type is requested and the database returns null; in other words, `GetFieldValue<Blog>()` doesn't throw, but rather returns null, which is a bit odd.

/cc @AndriySvyryd 