### PR TITLE
Don't log both `SaveChangesFailed` and `OptimisticConcurrencyException` for same event

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -639,8 +639,6 @@ public class DbContext :
         {
             EntityFrameworkEventSource.Log.OptimisticConcurrencyFailure();
 
-            DbContextDependencies.UpdateLogger.SaveChangesFailed(this, exception);
-
             SaveChangesFailed?.Invoke(this, new SaveChangesFailedEventArgs(acceptAllChangesOnSuccess, exception));
 
             throw;
@@ -785,8 +783,6 @@ public class DbContext :
         catch (DbUpdateConcurrencyException exception)
         {
             EntityFrameworkEventSource.Log.OptimisticConcurrencyFailure();
-
-            await DbContextDependencies.UpdateLogger.SaveChangesFailedAsync(this, exception, cancellationToken).ConfigureAwait(false);
 
             SaveChangesFailed?.Invoke(this, new SaveChangesFailedEventArgs(acceptAllChangesOnSuccess, exception));
 

--- a/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
@@ -337,7 +337,7 @@ public abstract class SaveChangesInterceptionTestBase : InterceptionTestBase
         Assert.Equal(async, interceptor.AsyncCalled);
         Assert.NotEqual(async, interceptor.SyncCalled);
         Assert.NotEqual(interceptor.AsyncCalled, interceptor.SyncCalled);
-        Assert.True(interceptor.FailedCalled);
+        Assert.Equal(concurrencyError, !interceptor.FailedCalled);
         Assert.Same(context, interceptor.Context);
         Assert.Same(thrown, interceptor.Exception);
 

--- a/test/EFCore.SqlServer.FunctionalTests/SaveChangesInterceptionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SaveChangesInterceptionSqlServerTest.cs
@@ -57,7 +57,7 @@ public abstract class SaveChangesInterceptionSqlServerTestBase : SaveChangesInte
         Assert.Equal(async, saveChangesInterceptor.AsyncCalled);
         Assert.NotEqual(async, saveChangesInterceptor.SyncCalled);
         Assert.NotEqual(saveChangesInterceptor.AsyncCalled, saveChangesInterceptor.SyncCalled);
-        Assert.True(saveChangesInterceptor.FailedCalled);
+        Assert.False(saveChangesInterceptor.FailedCalled);
         Assert.Same(context, saveChangesInterceptor.Context);
         Assert.Same(thrown, saveChangesInterceptor.Exception);
 


### PR DESCRIPTION
Fixes #30429
