### PR TITLE
[SMALL] Fix to #30273 - EF7 generating incorrect SQL for the Concat/Union All, The same code was working fine for EF6.4.4

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -3997,6 +3997,12 @@ public sealed partial class SelectExpression : TableExpressionBase
             }
             else if (table is SetOperationBase { IsDistinct: false } setOperation)
             {
+                if (setOperation.Source1.IsDistinct
+                    || setOperation.Source2.IsDistinct)
+                {
+                    continue;
+                }
+
 #if DEBUG
                 setOperation.Source1.Prune(columnsMap[tableAlias], removedAliases);
                 setOperation.Source2.Prune(columnsMap[tableAlias], removedAliases);

--- a/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
@@ -877,4 +877,51 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture> : QueryTestB
                 AssertCollection(e.Orders, a.Orders);
             },
             entryCount: 11);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Concat_with_pruning(bool async)
+           => AssertQuery(
+               async,
+               ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))
+                   .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("B")))
+                   .Select(x => x.City));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Concat_with_distinct_on_one_source_and_pruning(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))
+                .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("B")).Distinct())
+                .Select(x => x.City));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Concat_with_distinct_on_both_source_and_pruning(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A")).Distinct()
+                .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("B")).Distinct())
+                .Select(x => x.City));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Nested_concat_with_pruning(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))
+                .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("B")))
+                .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A")))
+                .Select(x => x.City));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Nested_concat_with_distinct_in_the_middle_and_pruning(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))
+                .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("B")).Distinct())
+                .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A")))
+                .Select(x => x.City));
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -1317,6 +1317,103 @@ WHERE [c0].[ContactTitle] = N'Owner'
         AssertSql();
     }
 
+    public override async Task Concat_with_pruning(bool async)
+    {
+        await base.Concat_with_pruning(async);
+
+        AssertSql(
+"""
+SELECT [c].[City]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'
+UNION ALL
+SELECT [c0].[City]
+FROM [Customers] AS [c0]
+WHERE [c0].[CustomerID] LIKE N'B%'
+""");
+    }
+
+    public override async Task Concat_with_distinct_on_one_source_and_pruning(bool async)
+    {
+        await base.Concat_with_distinct_on_one_source_and_pruning(async);
+
+        AssertSql(
+"""
+SELECT [t].[City]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    UNION ALL
+    SELECT DISTINCT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'B%'
+) AS [t]
+""");
+    }
+
+    public override async Task Concat_with_distinct_on_both_source_and_pruning(bool async)
+    {
+        await base.Concat_with_distinct_on_both_source_and_pruning(async);
+
+        AssertSql(
+"""
+SELECT [t].[City]
+FROM (
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    UNION ALL
+    SELECT DISTINCT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'B%'
+) AS [t]
+""");
+    }
+
+    public override async Task Nested_concat_with_pruning(bool async)
+    {
+        await base.Nested_concat_with_pruning(async);
+
+        AssertSql(
+"""
+SELECT [c].[City]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'
+UNION ALL
+SELECT [c0].[City]
+FROM [Customers] AS [c0]
+WHERE [c0].[CustomerID] LIKE N'B%'
+UNION ALL
+SELECT [c1].[City]
+FROM [Customers] AS [c1]
+WHERE [c1].[CustomerID] LIKE N'A%'
+""");
+    }
+
+    public override async Task Nested_concat_with_distinct_in_the_middle_and_pruning(bool async)
+    {
+        await base.Nested_concat_with_distinct_in_the_middle_and_pruning(async);
+
+        AssertSql(
+"""
+SELECT [t].[City]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'A%'
+    UNION ALL
+    SELECT DISTINCT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'B%'
+) AS [t]
+UNION ALL
+SELECT [c1].[City]
+FROM [Customers] AS [c1]
+WHERE [c1].[CustomerID] LIKE N'A%'
+""");
+    }
+
     public override async Task Client_eval_Union_FirstOrDefault(bool async)
     {
         // Client evaluation in projection. Issue #16243.


### PR DESCRIPTION
Problem was that during SelectExpression pruning for set operations we would try to prune both sources independently. However, if a source is Distinct we can't prune (that could affect the result). So the problematic case is where we prune one source but can't prune the second due to Distinct, and we end up with both sources having not matching projections. Fix is to check if either source has Distinct before attempting to prune them.

Fixed #30273