### PR TITLE
Regression test for #30181 - Missing parentheses when using Expression.Or over bool (instead of OrElse)

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OperatorsQueryTestBase.cs
@@ -118,6 +118,41 @@ public abstract class OperatorsQueryTestBase : NonSharedModelTestBase
     }
 
     [ConditionalFact]
+    public virtual async Task Or_on_two_nested_binaries_and_another_simple_comparison()
+    {
+        var contextFactory = await InitializeAsync<OperatorsContext>(seed: Seed);
+        using var context = contextFactory.CreateContext();
+
+        var expected = (from e1 in ExpectedData.OperatorEntitiesString
+                        from e2 in ExpectedData.OperatorEntitiesString
+                        from e3 in ExpectedData.OperatorEntitiesString
+                        from e4 in ExpectedData.OperatorEntitiesString
+                        from e5 in ExpectedData.OperatorEntitiesInt
+                        where ((e1.Value == "A" && e2.Value == "A") | (e3.Value == "B" && e4.Value == "B")) && e5.Value == 2
+                        orderby e1.Id, e2.Id, e3.Id, e4.Id, e5.Id
+                        select new { Id1 = e1.Id, Id2 = e2.Id, Id3 = e3.Id, Id4 = e4.Id, Id5 = e5.Id }).ToList();
+
+        var actual = (from e1 in context.Set<OperatorEntityString>()
+                      from e2 in context.Set<OperatorEntityString>()
+                      from e3 in context.Set<OperatorEntityString>()
+                      from e4 in context.Set<OperatorEntityString>()
+                      from e5 in context.Set<OperatorEntityInt>()
+                      where ((e1.Value == "A" && e2.Value == "A") | (e3.Value == "B" && e4.Value == "B")) && e5.Value == 2
+                      orderby e1.Id, e2.Id, e3.Id, e4.Id, e5.Id
+                      select new { Id1 = e1.Id, Id2 = e2.Id, Id3 = e3.Id, Id4 = e4.Id, Id5 = e5.Id }).ToList();
+
+        Assert.Equal(expected.Count, actual.Count);
+        for (var i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i].Id1, actual[i].Id1);
+            Assert.Equal(expected[i].Id2, actual[i].Id2);
+            Assert.Equal(expected[i].Id3, actual[i].Id3);
+            Assert.Equal(expected[i].Id4, actual[i].Id4);
+            Assert.Equal(expected[i].Id5, actual[i].Id5);
+        }
+    }
+
+    [ConditionalFact]
     public virtual async Task Projection_with_not_and_negation_on_integer()
     {
         var contextFactory = await InitializeAsync<OperatorsContext>(seed: Seed);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -42,6 +42,29 @@ public class OperatorsQuerySqlServerTest : OperatorsQueryTestBase
         AssertSql("");
     }
 
+    public override async Task Or_on_two_nested_binaries_and_another_simple_comparison()
+    {
+        await base.Or_on_two_nested_binaries_and_another_simple_comparison();
+
+        AssertSql(
+"""
+SELECT [o].[Id] AS [Id1], [o0].[Id] AS [Id2], [o1].[Id] AS [Id3], [o2].[Id] AS [Id4], [o3].[Id] AS [Id5]
+FROM [OperatorEntityString] AS [o]
+CROSS JOIN [OperatorEntityString] AS [o0]
+CROSS JOIN [OperatorEntityString] AS [o1]
+CROSS JOIN [OperatorEntityString] AS [o2]
+CROSS JOIN [OperatorEntityInt] AS [o3]
+WHERE CASE
+    WHEN [o].[Value] = N'A' AND [o].[Value] IS NOT NULL AND [o0].[Value] = N'A' AND [o0].[Value] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END | CASE
+    WHEN [o1].[Value] = N'B' AND [o1].[Value] IS NOT NULL AND [o2].[Value] = N'B' AND [o2].[Value] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END = CAST(1 AS bit) AND [o3].[Value] = 2
+ORDER BY [o].[Id], [o0].[Id], [o1].[Id], [o2].[Id], [o3].[Id]
+""");
+    }
+
     public override async Task Projection_with_not_and_negation_on_integer()
     {
         await base.Projection_with_not_and_negation_on_integer();

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
@@ -40,6 +40,23 @@ public class OperatorsQuerySqliteTest : OperatorsQueryTestBase
         AssertSql("");
     }
 
+    public override async Task Or_on_two_nested_binaries_and_another_simple_comparison()
+    {
+        await base.Or_on_two_nested_binaries_and_another_simple_comparison();
+
+        AssertSql(
+"""
+SELECT "o"."Id" AS "Id1", "o0"."Id" AS "Id2", "o1"."Id" AS "Id3", "o2"."Id" AS "Id4", "o3"."Id" AS "Id5"
+FROM "OperatorEntityString" AS "o"
+CROSS JOIN "OperatorEntityString" AS "o0"
+CROSS JOIN "OperatorEntityString" AS "o1"
+CROSS JOIN "OperatorEntityString" AS "o2"
+CROSS JOIN "OperatorEntityInt" AS "o3"
+WHERE ("o"."Value" = 'A' AND "o"."Value" IS NOT NULL AND "o0"."Value" = 'A' AND "o0"."Value" IS NOT NULL) | ("o1"."Value" = 'B' AND "o1"."Value" IS NOT NULL AND "o2"."Value" = 'B' AND "o2"."Value" IS NOT NULL) AND "o3"."Value" = 2
+ORDER BY "o"."Id", "o0"."Id", "o1"."Id", "o2"."Id", "o3"."Id"
+""");
+    }
+
     public override async Task Projection_with_not_and_negation_on_integer()
     {
         await base.Projection_with_not_and_negation_on_integer();


### PR DESCRIPTION
Just adding regression test, bug already fixed by roji in the parentheses work.

Resolves #30181