### PR TITLE
[SMALL] Fix to #30358 - Duplicate table alias in generated select query (An item with the same key has already been added)

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
@@ -180,4 +180,21 @@ SELECT [r].[Rot_ApartmentNo]
 FROM [RotRutCases] AS [r]
 """);
     }
+
+    public override async Task Join_selects_with_duplicating_aliases_and_owned_expansion_uniquifies_correctly(bool async)
+    {
+        await base.Join_selects_with_duplicating_aliases_and_owned_expansion_uniquifies_correctly(async);
+
+        AssertSql(
+"""
+SELECT [m].[Id], [m].[Name], [m].[RulerOf], [t].[Id], [t].[Affiliation], [t].[Name], [t].[Magus30358Id], [t].[Name0]
+FROM [Monarchs] AS [m]
+INNER JOIN (
+    SELECT [m0].[Id], [m0].[Affiliation], [m0].[Name], [m1].[Magus30358Id], [m1].[Name] AS [Name0]
+    FROM [Magi] AS [m0]
+    LEFT JOIN [MagicTools] AS [m1] ON [m0].[Id] = [m1].[Magus30358Id]
+    WHERE [m0].[Name] LIKE N'%Bayaz%'
+) AS [t] ON [m].[RulerOf] = [t].[Affiliation]
+""");
+    }
 }


### PR DESCRIPTION
We were not updating usedAliases list as we uniquify tabke aliases after combining two sources because of JOIN. If the resulting query also needs owned type expanded (when owned type is mapped to a separate table - this expansion happens in translation rather than nav expansion), additional table generated could have incorrect alias. Fix is to update the usedAliases list as we make changes to aliases, so that when new tables are added we generate new aliases correctly.

Fixes #30358