### PR TITLE
[release/7.0] Fix to #30358 - Duplicate table alias in generated select query (An item with the same key has already been added)

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -385,6 +385,9 @@ public sealed partial class SelectExpression
 
     private sealed class AliasUniquifier : ExpressionVisitor
     {
+        private static readonly bool UseOldBehavior30358
+            = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30358", out var enabled30358) && enabled30358;
+
         private readonly HashSet<string> _usedAliases;
         private readonly List<SelectExpression> _visitedSelectExpressions = new();
 
@@ -401,7 +404,30 @@ public sealed partial class SelectExpression
             {
                 for (var i = 0; i < innerSelectExpression._tableReferences.Count; i++)
                 {
-                    var newAlias = GenerateUniqueAlias(_usedAliases, innerSelectExpression._tableReferences[i].Alias);
+                    string newAlias;
+                    if (UseOldBehavior30358)
+                    {
+                        newAlias = GenerateUniqueAlias(_usedAliases, innerSelectExpression._tableReferences[i].Alias);
+                    }
+                    else
+                    {
+                        var currentAlias = innerSelectExpression._tableReferences[i].Alias;
+                        newAlias = GenerateUniqueAlias(_usedAliases, currentAlias);
+
+                        if (newAlias != currentAlias)
+                        {
+                            // we keep the old alias in the list (even though it's not actually being used anymore)
+                            // to disambiguate the APPLY case, e.g. something like this:
+                            // SELECT * FROM EntityOne as e
+                            // OUTER APPLY (
+                            //    SELECT * FROM EntityTwo as e1
+                            //    LEFT JOIN EntityThree as e ON (...) -- reuse alias e, since we use e1 after uniqification
+                            //    WHERE e.Foo == e1.Bar -- ambiguity! e could refer to EntityOne or EntityThree
+                            // ) as t
+                            innerSelectExpression._usedAliases.Add(newAlias);
+                        }
+                    }
+
                     innerSelectExpression._tableReferences[i].Alias = newAlias;
                     UnwrapJoinExpression(innerSelectExpression._tables[i]).Alias = newAlias;
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
@@ -180,4 +180,21 @@ SELECT [r].[Rot_ApartmentNo]
 FROM [RotRutCases] AS [r]
 """);
     }
+
+    public override async Task Join_selects_with_duplicating_aliases_and_owned_expansion_uniquifies_correctly(bool async)
+    {
+        await base.Join_selects_with_duplicating_aliases_and_owned_expansion_uniquifies_correctly(async);
+
+        AssertSql(
+"""
+SELECT [m].[Id], [m].[Name], [m].[RulerOf], [t].[Id], [t].[Affiliation], [t].[Name], [t].[Magus30358Id], [t].[Name0]
+FROM [Monarchs] AS [m]
+INNER JOIN (
+    SELECT [m0].[Id], [m0].[Affiliation], [m0].[Name], [m1].[Magus30358Id], [m1].[Name] AS [Name0]
+    FROM [Magi] AS [m0]
+    LEFT JOIN [MagicTools] AS [m1] ON [m0].[Id] = [m1].[Magus30358Id]
+    WHERE [m0].[Name] LIKE N'%Bayaz%'
+) AS [t] ON [m].[RulerOf] = [t].[Affiliation]
+""");
+    }
 }


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/30484
Fixes #30358

**Description**

Queries that join tables starting with the same letter that also have owned navigations mapped to a different table, also starting with the same letter generate incorrect aliases resulting in exception when trying to execute those queries. Problem was that the metadata describing our sql expressions and the actual expression were out of sync, so there might be other cases fixed by this as well.

**Customer impact**

Affected queries throw during translation.

**How found**

Customer report on 7.0

**Regression**

Yes. This scenario worked correctly in previous version of EF Core.

**Testing**

Added regression tests for affected scenario.

**Risk**

Low: Fix is on a relatively common path but is very simple and safe. Worst case we will generate query with different aliases (e.g. e1 rather than e) but it shouldn't have a negative functional impact. Added quirk to revert to old behavior if necessary.