### PR TITLE
Fix to #30516 - Query: JSON collection issues incorrect warning CompositeKeyWithValueGeneration

### DIFF
--- a/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteModelValidator.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteModelValidator.cs
@@ -139,7 +139,8 @@ public class SqliteModelValidator : RelationalModelValidator
         base.ValidateValueGeneration(entityType, key, logger);
 
         var keyProperties = key.Properties;
-        if (key.IsPrimaryKey()
+        if (!entityType.IsMappedToJson()
+            && key.IsPrimaryKey()
             && keyProperties.Count(p => p.ClrType.UnwrapNullableType().IsInteger()) > 1
             && keyProperties.Any(
                 p => p.ValueGenerated == ValueGenerated.OnAdd

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryAdHocTestBase.cs
@@ -20,7 +20,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     public virtual async Task Optional_json_properties_materialized_as_null_when_the_element_in_json_is_not_present(bool async)
     {
         var contextFactory = await InitializeAsync<MyContext29219>(
-            onConfiguring: OnConfiguring29219,
             seed: Seed29219);
 
         using (var context = contextFactory.CreateContext())
@@ -42,7 +41,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     public virtual async Task Can_project_nullable_json_property_when_the_element_in_json_is_not_present(bool async)
     {
         var contextFactory = await InitializeAsync<MyContext29219>(
-            onConfiguring: OnConfiguring29219,
             seed: Seed29219);
 
         using (var context = contextFactory.CreateContext())
@@ -58,10 +56,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
             Assert.Equal(null, result[1]);
             Assert.Equal(null, result[2]);
         }
-    }
-
-    protected virtual void OnConfiguring29219(DbContextOptionsBuilder builder)
-    {
     }
 
     protected abstract void Seed29219(MyContext29219 ctx);
@@ -99,10 +93,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     #endregion
 
     #region 30028
-
-    protected virtual void OnConfiguring30028(DbContextOptionsBuilder builder)
-    {
-    }
 
     protected abstract void Seed30028(MyContext30028 ctx);
 
@@ -238,7 +228,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     public virtual async Task Project_json_array_of_primitives_on_reference(bool async)
     {
         var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
-            onConfiguring: OnConfiguringArrayOfPrimitives,
             seed: SeedArrayOfPrimitives);
 
         using (var context = contextFactory.CreateContext())
@@ -262,7 +251,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     public virtual async Task Project_json_array_of_primitives_on_collection(bool async)
     {
         var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
-            onConfiguring: OnConfiguringArrayOfPrimitives,
             seed: SeedArrayOfPrimitives);
 
         using (var context = contextFactory.CreateContext())
@@ -286,7 +274,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     public virtual async Task Project_element_of_json_array_of_primitives(bool async)
     {
         var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
-            onConfiguring: OnConfiguringArrayOfPrimitives,
             seed: SeedArrayOfPrimitives);
 
         using (var context = contextFactory.CreateContext())
@@ -308,7 +295,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     public virtual async Task Predicate_based_on_element_of_json_array_of_primitives1(bool async)
     {
         var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
-            onConfiguring: OnConfiguringArrayOfPrimitives,
             seed: SeedArrayOfPrimitives);
 
         using (var context = contextFactory.CreateContext())
@@ -331,7 +317,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     public virtual async Task Predicate_based_on_element_of_json_array_of_primitives2(bool async)
     {
         var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
-            onConfiguring: OnConfiguringArrayOfPrimitives,
             seed: SeedArrayOfPrimitives);
 
         using (var context = contextFactory.CreateContext())
@@ -354,7 +339,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
     public virtual async Task Predicate_based_on_element_of_json_array_of_primitives3(bool async)
     {
         var contextFactory = await InitializeAsync<MyContextArrayOfPrimitives>(
-            onConfiguring: OnConfiguringArrayOfPrimitives,
             seed: SeedArrayOfPrimitives);
 
         using (var context = contextFactory.CreateContext())
@@ -375,10 +359,6 @@ public abstract class JsonQueryAdHocTestBase : NonSharedModelTestBase
 
 
     protected abstract void SeedArrayOfPrimitives(MyContextArrayOfPrimitives ctx);
-
-    protected virtual void OnConfiguringArrayOfPrimitives(DbContextOptionsBuilder builder)
-    {
-    }
 
     protected class MyContextArrayOfPrimitives : DbContext
     {

--- a/test/EFCore.Sqlite.FunctionalTests/MaterializationInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MaterializationInterceptionSqliteTest.cs
@@ -43,8 +43,5 @@ public class MaterializationInterceptionSqliteTest : MaterializationInterception
             IServiceCollection serviceCollection,
             IEnumerable<ISingletonInterceptor> injectedInterceptors)
             => base.InjectInterceptors(serviceCollection.AddEntityFrameworkSqlite(), injectedInterceptors);
-
-        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder.ConfigureWarnings(e => e.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQueryAdHocSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQueryAdHocSqliteTest.cs
@@ -13,10 +13,6 @@ public class JsonQueryAdHocSqliteTest : JsonQueryAdHocTestBase
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;
 
-    // issue #26708
-    protected override void OnConfiguring29219(DbContextOptionsBuilder builder)
-        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
-
     protected override void Seed29219(MyContext29219 ctx)
     {
         var entity1 = new MyEntity29219
@@ -48,10 +44,6 @@ public class JsonQueryAdHocSqliteTest : JsonQueryAdHocTestBase
 VALUES(3, '{{ ""NonNullableScalar"" : 30 }}', '[{{ ""NonNullableScalar"" : 10001 }}]')");
     }
 
-    // issue #26708
-    protected override void OnConfiguring30028(DbContextOptionsBuilder builder)
-        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
-
     protected override void Seed30028(MyContext30028 ctx)
     {
         // complete
@@ -78,10 +70,6 @@ VALUES(
 4,
 '{{""RootName"":""e4"",""Collection"":[{{""BranchName"":""e4 c1"",""Nested"":{{""LeafName"":""e4 c1 l""}}}},{{""BranchName"":""e4 c2"",""Nested"":{{""LeafName"":""e4 c2 l""}}}}],""OptionalReference"":{{""BranchName"":""e4 or"",""Nested"":{{""LeafName"":""e4 or l""}}}}}}')");
     }
-
-    // issue #26708
-    protected override void OnConfiguringArrayOfPrimitives(DbContextOptionsBuilder builder)
-        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
 
     protected override void SeedArrayOfPrimitives(MyContextArrayOfPrimitives ctx)
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteFixture.cs
@@ -7,9 +7,4 @@ public class JsonQuerySqliteFixture : JsonQueryFixtureBase
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;
-
-
-    // issue #26708
-    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteFixture.cs
@@ -7,8 +7,4 @@ public class JsonUpdateSqliteFixture : JsonUpdateFixtureBase
 {
     protected override ITestStoreFactory TestStoreFactory
         => SqliteTestStoreFactory.Instance;
-
-    // issue #26708
-    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-        => base.AddOptions(builder.ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration)));
 }


### PR DESCRIPTION
Don't issue the warning for entities mapped to JSON.

Fixes #30516