### PR TITLE
API review changes

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -1020,11 +1020,13 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
         mainBuilder
             .Append("var ").Append(variableName).Append(" = ").Append(parameters.TargetName).AppendLine(".AddServiceProperty(")
             .IncrementIndent()
-            .Append(_code.Literal(property.Name))
-            .AppendLine(",")
-            .Append("typeof(" + property.ClrType.DisplayName(fullName: true, compilable: true) + ")");
+            .Append(_code.Literal(property.Name));
 
         PropertyBaseParameters(property, parameters, skipType: true);
+
+        mainBuilder
+            .AppendLine(",")
+            .Append("serviceType: typeof(" + property.ClrType.DisplayName(fullName: true, compilable: true) + ")");
 
         mainBuilder
             .AppendLine(");")

--- a/src/EFCore.Proxies/LazyLoadingProxiesOptionsBuilder.cs
+++ b/src/EFCore.Proxies/LazyLoadingProxiesOptionsBuilder.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Proxies.Internal;
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Allows SQL Server specific configuration to be performed on <see cref="DbContextOptions" />.
+/// </summary>
+/// <remarks>
+///     Instances of this class are returned from a call to <see cref="O:SqlServerDbContextOptionsExtensions.UseSqlServer" />
+///     and it is not designed to be directly constructed in your application code.
+/// </remarks>
+public class LazyLoadingProxiesOptionsBuilder
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="LazyLoadingProxiesOptionsBuilder" /> class.
+    /// </summary>
+    /// <param name="optionsBuilder">The core options builder.</param>
+    public LazyLoadingProxiesOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
+    {
+        OptionsBuilder = optionsBuilder;
+    }
+
+    /// <summary>
+    ///     Gets the core options builder.
+    /// </summary>
+    protected virtual DbContextOptionsBuilder OptionsBuilder { get; }
+
+    /// <summary>
+    ///     Configures the proxies to ignore navigations that are not virtual. By default, an exception will be thrown if a non-virtual
+    ///     navigation is found.
+    /// </summary>
+    /// <param name="ignoreNonVirtualNavigations">
+    ///     <see langword="true" /> to ignore navigations that are not virtual. The default value is
+    ///     <see langword="false" />, meaning an exception will be thrown if a non-virtual navigation is found.
+    /// </param>
+    public virtual LazyLoadingProxiesOptionsBuilder IgnoreNonVirtualNavigations(bool ignoreNonVirtualNavigations = true)
+        => WithOption(e => e.WithIgnoreNonVirtualNavigations(ignoreNonVirtualNavigations));
+
+    /// <summary>
+    ///     Sets an option by cloning the extension used to store the settings. This ensures the builder
+    ///     does not modify options that are already in use elsewhere.
+    /// </summary>
+    /// <param name="setAction">An action to set the option.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    protected virtual LazyLoadingProxiesOptionsBuilder WithOption(Func<ProxiesOptionsExtension, ProxiesOptionsExtension> setAction)
+    {
+        ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(
+            setAction(OptionsBuilder.Options.FindExtension<ProxiesOptionsExtension>() ?? new ProxiesOptionsExtension()));
+
+        return this;
+    }
+}

--- a/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
@@ -113,11 +113,25 @@ public class ProxiesOptionsExtension : IDbContextOptionsExtension
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual ProxiesOptionsExtension WithLazyLoading(bool useLazyLoadingProxies, bool ignoreNonVirtualNavigations)
+    public virtual ProxiesOptionsExtension WithLazyLoading(bool useLazyLoadingProxies)
     {
         var clone = Clone();
 
         clone._useLazyLoadingProxies = useLazyLoadingProxies;
+
+        return clone;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual ProxiesOptionsExtension WithIgnoreNonVirtualNavigations(bool ignoreNonVirtualNavigations)
+    {
+        var clone = Clone();
+
         clone._ignoreNonVirtualNavigations = ignoreNonVirtualNavigations;
 
         return clone;

--- a/src/EFCore.Proxies/ProxiesExtensions.cs
+++ b/src/EFCore.Proxies/ProxiesExtensions.cs
@@ -105,22 +105,51 @@ public static class ProxiesExtensions
     ///     or exposed AddDbContext.
     /// </param>
     /// <param name="useLazyLoadingProxies"><see langword="true" /> to use lazy loading proxies; <see langword="false" /> to prevent their use.</param>
-    /// <param name="ignoreNonVirtualNavigations">
-    ///     <see langword="true" /> to ignore navigations that are not virtual. The default value is
-    ///     <see langword="false" />, meaning an exception will be thrown if a non-virtual navigation is found.
-    /// </param>
     /// <returns>The same builder to allow method calls to be chained.</returns>
     public static DbContextOptionsBuilder UseLazyLoadingProxies(
         this DbContextOptionsBuilder optionsBuilder,
-        bool useLazyLoadingProxies = true,
-        bool ignoreNonVirtualNavigations = false)
+        bool useLazyLoadingProxies = true)
     {
         var extension = optionsBuilder.Options.FindExtension<ProxiesOptionsExtension>()
             ?? new ProxiesOptionsExtension();
 
-        extension = extension.WithLazyLoading(useLazyLoadingProxies, ignoreNonVirtualNavigations);
+        extension = extension.WithLazyLoading(useLazyLoadingProxies);
 
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+        return optionsBuilder;
+    }
+
+    /// <summary>
+    ///     Turns on the creation of lazy loading proxies.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Note that this requires appropriate services to be available in the EF internal service provider. Normally this
+    ///         will happen automatically, but if the application is controlling the service provider, then a call to
+    ///         <see cref="ProxiesServiceCollectionExtensions.AddEntityFrameworkProxies" /> may be needed.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-lazy-loading">Lazy loading</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <param name="optionsBuilder">
+    ///     The options builder, as passed to <see cref="DbContext.OnConfiguring" />
+    ///     or exposed AddDbContext.
+    /// </param>
+    /// <param name="lazyLoadingProxiesOptionsAction">An optional action to allow additional proxy-specific configuration.</param>
+    /// <returns>The same builder to allow method calls to be chained.</returns>
+    public static DbContextOptionsBuilder UseLazyLoadingProxies(
+        this DbContextOptionsBuilder optionsBuilder,
+        Action<LazyLoadingProxiesOptionsBuilder>? lazyLoadingProxiesOptionsAction)
+    {
+        var extension = optionsBuilder.Options.FindExtension<ProxiesOptionsExtension>()
+            ?? new ProxiesOptionsExtension();
+
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(
+            extension.WithLazyLoading(useLazyLoadingProxies: true));
+
+        lazyLoadingProxiesOptionsAction?.Invoke(new LazyLoadingProxiesOptionsBuilder(optionsBuilder));
 
         return optionsBuilder;
     }
@@ -144,17 +173,38 @@ public static class ProxiesExtensions
     ///     or exposed AddDbContext.
     /// </param>
     /// <param name="useLazyLoadingProxies"><see langword="true" /> to use lazy loading proxies; <see langword="false" /> to prevent their use.</param>
-    /// <param name="ignoreNonVirtualNavigations">
-    ///     <see langword="true" /> to ignore navigations that are not virtual. The default value is
-    ///     <see langword="false" />, meaning an exception will be thrown if a non-virtual navigation is found.
-    /// </param>
     /// <returns>The same builder to allow method calls to be chained.</returns>
     public static DbContextOptionsBuilder<TContext> UseLazyLoadingProxies<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
-        bool useLazyLoadingProxies = true,
-        bool ignoreNonVirtualNavigations = false)
+        bool useLazyLoadingProxies = true)
         where TContext : DbContext
         => (DbContextOptionsBuilder<TContext>)UseLazyLoadingProxies((DbContextOptionsBuilder)optionsBuilder, useLazyLoadingProxies);
+
+    /// <summary>
+    ///     Turns on the creation of lazy loading proxies.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Note that this requires appropriate services to be available in the EF internal service provider. Normally this
+    ///         will happen automatically, but if the application is controlling the service provider, then a call to
+    ///         <see cref="ProxiesServiceCollectionExtensions.AddEntityFrameworkProxies" /> may be needed.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-lazy-loading">Lazy loading</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TContext">The <see cref="DbContext" /> type.</typeparam>
+    /// <param name="optionsBuilder">
+    ///     The options builder, as passed to <see cref="DbContext.OnConfiguring" />
+    ///     or exposed AddDbContext.
+    /// </param>
+    /// <param name="lazyLoadingProxiesOptionsAction">An optional action to allow additional proxy-specific configuration.</param>
+    /// <returns>The same builder to allow method calls to be chained.</returns>
+    public static DbContextOptionsBuilder<TContext> UseLazyLoadingProxies<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        Action<LazyLoadingProxiesOptionsBuilder>? lazyLoadingProxiesOptionsAction)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseLazyLoadingProxies((DbContextOptionsBuilder)optionsBuilder, lazyLoadingProxiesOptionsAction);
 
     /// <summary>
     ///     Creates a proxy instance for an entity type if proxy creation has been turned on.

--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -106,7 +106,7 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
     /// <summary>
     ///     <see langword="true"/> if the <see cref="Connection"/> is owned by the context and should be disposed appropriately.
     /// </summary>
-    public virtual bool ConnectionOwned
+    public virtual bool IsConnectionOwned
         => _connectionOwned;
 
     /// <summary>

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -67,7 +67,7 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
         if (relationalOptions.Connection != null)
         {
             _connection = relationalOptions.Connection;
-            _connectionOwned = relationalOptions.ConnectionOwned;
+            _connectionOwned = relationalOptions.IsConnectionOwned;
 
             if (_connectionString != null)
             {

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -252,15 +252,6 @@ public readonly record struct RelationalTypeMappingInfo
     }
 
     /// <summary>
-    ///     Indicates whether or not the mapping should be compared, etc. as if it is a key.
-    /// </summary>
-    public bool HasKeySemantics
-    {
-        get => _coreTypeMappingInfo.HasKeySemantics;
-        init => _coreTypeMappingInfo = _coreTypeMappingInfo with { HasKeySemantics = value };
-    }
-
-    /// <summary>
     ///     Indicates whether or not the mapping supports Unicode, or <see langword="null" /> if not defined.
     /// </summary>
     public bool? IsUnicode

--- a/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
@@ -1107,8 +1107,8 @@ public static class SqlServerDbFunctionsExtensions
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMillisecond)));
 
     /// <summary>
-    ///     Counts the number of millisecond boundaries crossed between the <paramref name="startTime" /> and
-    ///     <paramref name="endTime" />. Corresponds to SQL Server's <c>DATEDIFF(millisecond, @startTimeSpan, @endTimeSpan)</c>.
+    ///     Counts the number of millisecond boundaries crossed between the <paramref name="startTimeSpan" /> and
+    ///     <paramref name="endTimeSpan" />. Corresponds to SQL Server's <c>DATEDIFF(millisecond, @startTimeSpan, @endTimeSpan)</c>.
     /// </summary>
     /// <remarks>
     ///     See <see href="https://aka.ms/efcore-docs-database-functions">Database functions</see>, and
@@ -1116,13 +1116,13 @@ public static class SqlServerDbFunctionsExtensions
     ///     for more information and examples.
     /// </remarks>
     /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
-    /// <param name="startTime">Starting timespan for the calculation.</param>
-    /// <param name="endTime">Ending timespan for the calculation.</param>
+    /// <param name="startTimeSpan">Starting timespan for the calculation.</param>
+    /// <param name="endTimeSpan">Ending timespan for the calculation.</param>
     /// <returns>Number of millisecond boundaries crossed between the timespans.</returns>
     public static int DateDiffMillisecond(
         this DbFunctions _,
-        TimeSpan startTime,
-        TimeSpan endTime)
+        TimeSpan startTimeSpan,
+        TimeSpan endTimeSpan)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateDiffMillisecond)));
 
     /// <summary>

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -369,7 +369,7 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
 
                 if (size == null
                     && storeTypeName == null
-                    && !mappingInfo.HasKeySemantics)
+                    && !mappingInfo.IsKeyOrIndex)
                 {
                     return isAnsi
                         ? isFixedLength
@@ -385,7 +385,7 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
                     size: size,
                     fixedLength: isFixedLength,
                     storeTypePostfix: storeTypeName == null ? StoreTypePostfix.Size : StoreTypePostfix.None,
-                    useKeyComparison: mappingInfo.HasKeySemantics);
+                    useKeyComparison: mappingInfo.IsKeyOrIndex);
             }
 
             if (clrType == typeof(byte[]))

--- a/src/EFCore/ChangeTracking/CollectionEntry.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry.cs
@@ -211,57 +211,18 @@ public class CollectionEntry : NavigationEntry
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
-    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
-    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
-    ///         instances in the collection or inverse collection for any entities with the same key value.
-    ///         Use <see cref="LoadWithIdentityResolution" /> to avoid getting these duplicates.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadWithIdentityResolution" />. For entities that are not tracked, this method can be faster than
-    ///         <see cref="LoadWithIdentityResolution" />.
-    ///     </para>
-    ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
     ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
     ///     </para>
     /// </remarks>
-    public override void Load()
+    /// <param name="options">Options to control the way related entities are loaded.</param>
+    public override void Load(LoadOptions options = LoadOptions.Default)
     {
         EnsureInitialized();
 
         if (!IsLoaded)
         {
-            TargetLoader.Load(InternalEntry, forceIdentityResolution: false);
-        }
-    }
-
-    /// <summary>
-    ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to <see langword="true"/>.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
-    ///         This navigation and its inverse will not contain duplicate entities.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="Load" />. For entities that are not tracked, this method can be slower than <see cref="Load" />.
-    ///     </para>
-    ///     <para>
-    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
-    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
-    ///     </para>
-    /// </remarks>
-    public override void LoadWithIdentityResolution()
-    {
-        EnsureInitialized();
-
-        if (!IsLoaded)
-        {
-            TargetLoader.Load(InternalEntry, forceIdentityResolution: true);
+            TargetLoader.Load(InternalEntry, options);
         }
     }
 
@@ -271,18 +232,6 @@ public class CollectionEntry : NavigationEntry
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
-    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
-    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
-    ///         instances in the collection or inverse collection for any entities with the same key value.
-    ///         Use <see cref="LoadWithIdentityResolutionAsync" /> to avoid getting these duplicates.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadWithIdentityResolutionAsync" />. For entities that are not tracked, this method can be faster than
-    ///         <see cref="LoadWithIdentityResolutionAsync" />.
-    ///     </para>
-    ///     <para>
     ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
     ///         that any asynchronous operations have completed before calling another method on this context.
     ///     </para>
@@ -291,50 +240,17 @@ public class CollectionEntry : NavigationEntry
     ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
     ///     </para>
     /// </remarks>
+    /// <param name="options">Options to control the way related entities are loaded.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous save operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public override Task LoadAsync(CancellationToken cancellationToken = default)
+    public override Task LoadAsync(LoadOptions options = LoadOptions.Default, CancellationToken cancellationToken = default)
     {
         EnsureInitialized();
 
         return IsLoaded
             ? Task.CompletedTask
-            : TargetLoader.LoadAsync(InternalEntry, forceIdentityResolution: false, cancellationToken);
-    }
-
-    /// <summary>
-    ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to <see langword="true"/>.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
-    ///         This navigation and its inverse will not contain duplicate entities.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadAsync" />. For entities that are not tracked, this method can be slower than <see cref="LoadAsync" />.
-    ///     </para>
-    ///     <para>
-    ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
-    ///         that any asynchronous operations have completed before calling another method on this context.
-    ///     </para>
-    ///     <para>
-    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
-    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
-    ///     </para>
-    /// </remarks>
-    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-    /// <returns>A task that represents the asynchronous save operation.</returns>
-    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public override Task LoadWithIdentityResolutionAsync(CancellationToken cancellationToken = default)
-    {
-        EnsureInitialized();
-
-        return IsLoaded
-            ? Task.CompletedTask
-            : TargetLoader.LoadAsync(InternalEntry, forceIdentityResolution: true, cancellationToken);
+            : TargetLoader.LoadAsync(InternalEntry, options, cancellationToken);
     }
 
     /// <summary>

--- a/src/EFCore/ChangeTracking/LoadOptions.cs
+++ b/src/EFCore/ChangeTracking/LoadOptions.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking;
+
+/// <summary>
+///     Options to control the behavior of loading related entities with <see cref="NavigationEntry.Load" />.
+/// </summary>
+[Flags]
+public enum LoadOptions
+{
+    /// <summary>
+    ///     <para>
+    ///         Applies no special options to loading of related entities.
+    ///     </para>
+    ///     <para>
+    ///         If the the entity is tracked, then entities with the same primary key value are not replaced
+    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
+    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
+    ///         instances in the collection or inverse collection for any entities with the same key value.
+    ///         Use <see cref="ForceIdentityResolution" /> to avoid getting these duplicates.
+    ///     </para>
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    ///     <para>
+    ///         Ensures that entities with the same primary key value are not replaced by new entities or overwritten with new data from
+    ///         the database. The loaded navigation and its inverse will not contain duplicate entities.
+    ///     </para>
+    ///     <para>
+    ///         For tracked entities, this option behaves in the same way and has the same performance as
+    ///         the default. For entities that are not tracked, this option can be significantly slower.
+    ///     </para>
+    /// </summary>
+    ForceIdentityResolution = 1
+}

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -90,61 +90,18 @@ public abstract class NavigationEntry : MemberEntry
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
-    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
-    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
-    ///         instances in the collection or inverse collection for any entities with the same key value.
-    ///         Use <see cref="LoadWithIdentityResolution" /> to avoid getting these duplicates.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadWithIdentityResolution" />. For entities that are not tracked, this method can be faster than
-    ///         <see cref="LoadWithIdentityResolution" />.
-    ///     </para>
-    ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
     ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
     ///     </para>
     /// </remarks>
-    public abstract void Load();
-
-    /// <summary>
-    ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to <see langword="true"/>.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
-    ///         This navigation and its inverse will not contain duplicate entities.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="Load" />. For entities that are not tracked, this method can be slower than <see cref="Load" />.
-    ///     </para>
-    ///     <para>
-    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
-    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
-    ///     </para>
-    /// </remarks>
-    public abstract void LoadWithIdentityResolution();
+    /// <param name="options">Options to control the way related entities are loaded.</param>
+    public abstract void Load(LoadOptions options = LoadOptions.Default);
 
     /// <summary>
     ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
     ///     is already set to <see langword="true"/>.
     /// </summary>
     /// <remarks>
-    ///     <para>
-    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
-    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
-    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
-    ///         instances in the collection or inverse collection for any entities with the same key value.
-    ///         Use <see cref="LoadWithIdentityResolutionAsync" /> to avoid getting these duplicates.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadWithIdentityResolutionAsync" />. For entities that are not tracked, this method can be faster than
-    ///         <see cref="LoadWithIdentityResolutionAsync" />.
-    ///     </para>
     ///     <para>
     ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
     ///         that any asynchronous operations have completed before calling another method on this context.
@@ -154,37 +111,11 @@ public abstract class NavigationEntry : MemberEntry
     ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
     ///     </para>
     /// </remarks>
+    /// <param name="options">Options to control the way related entities are loaded.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous save operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public abstract Task LoadAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
-    ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to <see langword="true"/>.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
-    ///         This navigation and its inverse will not contain duplicate entities.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadAsync" />. For entities that are not tracked, this method can be slower than <see cref="LoadAsync" />.
-    ///     </para>
-    ///     <para>
-    ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
-    ///         that any asynchronous operations have completed before calling another method on this context.
-    ///     </para>
-    ///     <para>
-    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
-    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
-    ///     </para>
-    /// </remarks>
-    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-    /// <returns>A task that represents the asynchronous save operation.</returns>
-    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public abstract Task LoadWithIdentityResolutionAsync(CancellationToken cancellationToken = default);
+    public abstract Task LoadAsync(LoadOptions options = LoadOptions.Default, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Returns the query that would be used by <see cref="Load" /> to load entities referenced by

--- a/src/EFCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry.cs
@@ -81,53 +81,16 @@ public class ReferenceEntry : NavigationEntry
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
-    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
-    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
-    ///         instances in the collection or inverse collection for any entities with the same key value.
-    ///         Use <see cref="LoadWithIdentityResolution" /> to avoid getting these duplicates.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadWithIdentityResolution" />. For entities that are not tracked, this method can be faster than
-    ///         <see cref="LoadWithIdentityResolution" />.
-    ///     </para>
-    ///     <para>
     ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
     ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
     ///     </para>
     /// </remarks>
-    public override void Load()
+    /// <param name="options">Options to control the way related entities are loaded.</param>
+    public override void Load(LoadOptions options = LoadOptions.Default)
     {
         if (!IsLoaded)
         {
-            TargetFinder.Load((INavigation)Metadata, InternalEntry, forceIdentityResolution: false);
-        }
-    }
-
-    /// <summary>
-    ///     Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to <see langword="true"/>.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
-    ///         This navigation and its inverse will not contain duplicate entities.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="Load" />. For entities that are not tracked, this method can be slower than <see cref="Load" />.
-    ///     </para>
-    ///     <para>
-    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
-    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
-    ///     </para>
-    /// </remarks>
-    public override void LoadWithIdentityResolution()
-    {
-        if (!IsLoaded)
-        {
-            TargetFinder.Load((INavigation)Metadata, InternalEntry, forceIdentityResolution: true);
+            TargetFinder.Load((INavigation)Metadata, InternalEntry, options);
         }
     }
 
@@ -137,18 +100,6 @@ public class ReferenceEntry : NavigationEntry
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         If the the entity represented by this entry is tracked, then entities with the same primary key value are not replaced
-    ///         by new entities or overwritten with new data from the database. If the entity entity represented by this entry is not
-    ///         tracked and the collection already contains entities, then calling this method will result in duplicate
-    ///         instances in the collection or inverse collection for any entities with the same key value.
-    ///         Use <see cref="LoadWithIdentityResolutionAsync" /> to avoid getting these duplicates.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadWithIdentityResolutionAsync" />. For entities that are not tracked, this method can be faster than
-    ///         <see cref="LoadWithIdentityResolutionAsync" />.
-    ///     </para>
-    ///     <para>
     ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
     ///         that any asynchronous operations have completed before calling another method on this context.
     ///     </para>
@@ -157,43 +108,14 @@ public class ReferenceEntry : NavigationEntry
     ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
     ///     </para>
     /// </remarks>
+    /// <param name="options">Options to control the way related entities are loaded.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous save operation.</returns>
     /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public override Task LoadAsync(CancellationToken cancellationToken = default)
+    public override Task LoadAsync(LoadOptions options = LoadOptions.Default, CancellationToken cancellationToken = default)
         => IsLoaded
             ? Task.CompletedTask
-            : TargetFinder.LoadAsync((INavigation)Metadata, InternalEntry, forceIdentityResolution: false, cancellationToken);
-
-    /// <summary>
-    ///     Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
-    ///     is already set to <see langword="true"/>.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Entities with the same primary key value are not replaced by new entities or overwritten with new data from the database.
-    ///         This navigation and its inverse will not contain duplicate entities.
-    ///     </para>
-    ///     <para>
-    ///         For tracked entities, this method behaves in the same way and has the same performance as
-    ///         <see cref="LoadAsync" />. For entities that are not tracked, this method can be slower than <see cref="LoadAsync" />.
-    ///     </para>
-    ///     <para>
-    ///         Multiple active operations on the same context instance are not supported. Use <see langword="await" /> to ensure
-    ///         that any asynchronous operations have completed before calling another method on this context.
-    ///     </para>
-    ///     <para>
-    ///         See <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>
-    ///         and <see href="https://aka.ms/efcore-docs-load-related-data">Loading related entities</see> for more information and examples.
-    ///     </para>
-    /// </remarks>
-    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-    /// <returns>A task that represents the asynchronous save operation.</returns>
-    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
-    public override Task LoadWithIdentityResolutionAsync(CancellationToken cancellationToken = default)
-        => IsLoaded
-            ? Task.CompletedTask
-            : TargetFinder.LoadAsync((INavigation)Metadata, InternalEntry, forceIdentityResolution: true, cancellationToken);
+            : TargetFinder.LoadAsync((INavigation)Metadata, InternalEntry, options, cancellationToken);
 
     /// <summary>
     ///     Returns the query that would be used by <see cref="Load" /> to load entities referenced by

--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -478,8 +478,8 @@ public class DbContextOptionsBuilder : IDbContextOptionsBuilderInfrastructure
     ///     </para>
     /// </remarks>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public virtual DbContextOptionsBuilder ResolveRootApplicationServiceProvider()
-        => WithOption(e => e.WithAutoResolveRootApplicationServiceProvider(true));
+    public virtual DbContextOptionsBuilder UseRootApplicationServiceProvider()
+        => WithOption(e => e.WithRootApplicationServiceProvider(true));
 
     /// <summary>
     ///     Enables application data to be included in exception messages, logging, etc. This can include the

--- a/src/EFCore/DbContextOptionsBuilder`.cs
+++ b/src/EFCore/DbContextOptionsBuilder`.cs
@@ -397,8 +397,8 @@ public class DbContextOptionsBuilder<TContext> : DbContextOptionsBuilder
     ///     </para>
     /// </remarks>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public new virtual DbContextOptionsBuilder<TContext> ResolveRootApplicationServiceProvider()
-        => (DbContextOptionsBuilder<TContext>)base.ResolveRootApplicationServiceProvider();
+    public new virtual DbContextOptionsBuilder<TContext> UseRootApplicationServiceProvider()
+        => (DbContextOptionsBuilder<TContext>)base.UseRootApplicationServiceProvider();
 
     /// <summary>
     ///     Enables application data to be included in exception messages, logging, etc. This can include the

--- a/src/EFCore/Diagnostics/IdentityResolutionInterceptionData.cs
+++ b/src/EFCore/Diagnostics/IdentityResolutionInterceptionData.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using JetBrains.Annotations;
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics;
 
 /// <summary>
@@ -15,6 +17,8 @@ public readonly struct IdentityResolutionInterceptionData
     ///     Constructs the parameter object.
     /// </summary>
     /// <param name="context">The <see cref="DbContext" /> in use.</param>
+    [EntityFrameworkInternal]
+    [UsedImplicitly]
     public IdentityResolutionInterceptionData(DbContext context)
     {
         Context = context;

--- a/src/EFCore/Diagnostics/InstantiationBindingInterceptionData.cs
+++ b/src/EFCore/Diagnostics/InstantiationBindingInterceptionData.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using JetBrains.Annotations;
+
 namespace Microsoft.EntityFrameworkCore.Diagnostics;
 
 /// <summary>
@@ -15,6 +17,8 @@ public readonly struct InstantiationBindingInterceptionData
     ///     Constructs the parameter object.
     /// </summary>
     /// <param name="entityType">The entity type for which the binding is being used.</param>
+    [EntityFrameworkInternal]
+    [UsedImplicitly]
     public InstantiationBindingInterceptionData(IEntityType entityType)
     {
         EntityType = entityType;

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -158,7 +158,7 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
     /// </summary>
     /// <param name="autoResolve">The option to change.</param>
     /// <returns>A new instance with the option changed.</returns>
-    public virtual CoreOptionsExtension WithAutoResolveRootApplicationServiceProvider(bool autoResolve = true)
+    public virtual CoreOptionsExtension WithRootApplicationServiceProvider(bool autoResolve = true)
     {
         var clone = Clone();
 
@@ -461,13 +461,13 @@ public class CoreOptionsExtension : IDbContextOptionsExtension
         => _applicationServiceProvider;
 
     /// <summary>
-    ///     The option set from the <see cref="DbContextOptionsBuilder.UseRootApplicationServiceProvider" /> method.
+    ///     The option set from the <see cref="DbContextOptionsBuilder.UseRootApplicationServiceProvider(IServiceProvider?)" /> method.
     /// </summary>
     public virtual IServiceProvider? RootApplicationServiceProvider
         => _rootApplicationServiceProvider;
 
     /// <summary>
-    ///     The option set from the <see cref="DbContextOptionsBuilder.UseRootApplicationServiceProvider" /> method.
+    ///     The option set from the <see cref="DbContextOptionsBuilder.UseRootApplicationServiceProvider(IServiceProvider?)" /> method.
     /// </summary>
     public virtual bool AutoResolveRootProvider
         => _autoResolveResolveRootProvider;

--- a/src/EFCore/Infrastructure/Internal/LazyLoader.cs
+++ b/src/EFCore/Infrastructure/Internal/LazyLoader.cs
@@ -114,14 +114,10 @@ public class LazyLoader : ILazyLoader, IInjectableService
                 {
                     try
                     {
-                        if (_queryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution)
-                        {
-                            entry.LoadWithIdentityResolution();
-                        }
-                        else
-                        {
-                            entry.Load();
-                        }
+                        entry.Load(
+                            _queryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution
+                                ? LoadOptions.ForceIdentityResolution
+                                : LoadOptions.Default);
                     }
                     catch
                     {
@@ -162,14 +158,11 @@ public class LazyLoader : ILazyLoader, IInjectableService
                 {
                     try
                     {
-                        if (_queryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution)
-                        {
-                            await entry.LoadWithIdentityResolutionAsync(cancellationToken).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            await entry.LoadAsync(cancellationToken).ConfigureAwait(false);
-                        }
+                        await entry.LoadAsync(
+                            _queryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution
+                                ? LoadOptions.ForceIdentityResolution
+                                : LoadOptions.Default,
+                            cancellationToken).ConfigureAwait(false);
                     }
                     catch
                     {

--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -418,29 +418,29 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void Load(INavigation navigation, InternalEntityEntry entry, bool forceIdentityResolution)
+    public virtual void Load(INavigation navigation, InternalEntityEntry entry, LoadOptions options)
     {
         var keyValues = GetLoadValues(navigation, entry);
         // Short-circuit for any null key values for perf and because of #6129
         if (keyValues != null)
         {
-            var queryable = Query(navigation, keyValues, entry, forceIdentityResolution);
+            var queryable = Query(navigation, keyValues, entry, options);
             if (entry.EntityState == EntityState.Detached)
             {
                 var inverse = navigation.Inverse;
-                var stateManager = GetOrCreateStateManagerAndStartTrackingIfNeeded(navigation, entry, forceIdentityResolution);
+                var stateManager = GetOrCreateStateManagerAndStartTrackingIfNeeded(navigation, entry, options);
                 try
                 {
                     if (navigation.IsCollection)
                     {
                         foreach (var loaded in queryable)
                         {
-                            Fixup(stateManager, entry.Entity, navigation, inverse, forceIdentityResolution, loaded);
+                            Fixup(stateManager, entry.Entity, navigation, inverse, options, loaded);
                         }
                     }
                     else
                     {
-                        Fixup(stateManager, entry.Entity, navigation, inverse, forceIdentityResolution, queryable.FirstOrDefault());
+                        Fixup(stateManager, entry.Entity, navigation, inverse, options, queryable.FirstOrDefault());
                     }
                 }
                 finally
@@ -476,18 +476,18 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
     public virtual async Task LoadAsync(
         INavigation navigation,
         InternalEntityEntry entry,
-        bool forceIdentityResolution,
+        LoadOptions options,
         CancellationToken cancellationToken = default)
     {
         var keyValues = GetLoadValues(navigation, entry);
         // Short-circuit for any null key values for perf and because of #6129
         if (keyValues != null)
         {
-            var queryable = Query(navigation, keyValues, entry, forceIdentityResolution);
+            var queryable = Query(navigation, keyValues, entry, options);
             if (entry.EntityState == EntityState.Detached)
             {
                 var inverse = navigation.Inverse;
-                var stateManager = GetOrCreateStateManagerAndStartTrackingIfNeeded(navigation, entry, forceIdentityResolution);
+                var stateManager = GetOrCreateStateManagerAndStartTrackingIfNeeded(navigation, entry, options);
                 try
                 {
                     if (navigation.IsCollection)
@@ -495,13 +495,13 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
                         await foreach (var loaded in queryable.AsAsyncEnumerable().WithCancellation(cancellationToken)
                                            .ConfigureAwait(false))
                         {
-                            Fixup(stateManager, entry.Entity, navigation, inverse, forceIdentityResolution, loaded);
+                            Fixup(stateManager, entry.Entity, navigation, inverse, options, loaded);
                         }
                     }
                     else
                     {
                         Fixup(
-                            stateManager, entry.Entity, navigation, inverse, forceIdentityResolution,
+                            stateManager, entry.Entity, navigation, inverse, options,
                             await queryable.FirstOrDefaultAsync(cancellationToken: cancellationToken).ConfigureAwait(false));
                     }
                 }
@@ -534,23 +534,23 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
         object entity,
         INavigation beingLoaded,
         INavigation? inverse,
-        bool forceIdentityResolution,
+        LoadOptions options,
         object? loaded)
     {
-        SetValue(stateManager.GetOrCreateEntry(entity), beingLoaded, loaded, forceIdentityResolution);
+        SetValue(stateManager.GetOrCreateEntry(entity), beingLoaded, loaded, options);
 
         if (inverse != null && loaded != null)
         {
-            SetValue(stateManager.GetOrCreateEntry(loaded), inverse, entity, forceIdentityResolution);
+            SetValue(stateManager.GetOrCreateEntry(loaded), inverse, entity, options);
         }
 
-        static void SetValue(InternalEntityEntry entry, INavigation navigation, object? value, bool forceIdentityResolution)
+        static void SetValue(InternalEntityEntry entry, INavigation navigation, object? value, LoadOptions options)
         {
             var stateManager = entry.StateManager;
             if (navigation.IsCollection)
             {
                 if (value != null
-                    && (!forceIdentityResolution || !TryGetTracked(stateManager, value, out _)))
+                    && ((options & LoadOptions.ForceIdentityResolution) == 0 || !TryGetTracked(stateManager, value, out _)))
                 {
                     entry.AddToCollection(navigation, value, forMaterialization: true);
                 }
@@ -558,7 +558,7 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
             else
             {
                 if (value != null
-                    && forceIdentityResolution
+                    && (options & LoadOptions.ForceIdentityResolution) != 0
                     && TryGetTracked(stateManager, value, out var existing))
                 {
                     value = existing;
@@ -586,9 +586,9 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
     private IStateManager GetOrCreateStateManagerAndStartTrackingIfNeeded(
         INavigation loading,
         InternalEntityEntry entry,
-        bool forceIdentityResolution)
+        LoadOptions options)
     {
-        if (!forceIdentityResolution)
+        if ((options & LoadOptions.ForceIdentityResolution) == 0)
         {
             return _stateManager;
         }
@@ -639,7 +639,7 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
             return _queryRoot.Where(e => false);
         }
 
-        return Query(navigation, keyValues, entry, forceIdentityResolution: false);
+        return Query(navigation, keyValues, entry, LoadOptions.Default);
     }
 
     /// <summary>
@@ -684,11 +684,11 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
             .Select(BuildProjection(entityType));
     }
 
-    private IQueryable<TEntity> Query(INavigation navigation, object[] keyValues, InternalEntityEntry entry, bool forceIdentityResolution)
+    private IQueryable<TEntity> Query(INavigation navigation, object[] keyValues, InternalEntityEntry entry, LoadOptions options)
     {
         var queryable = _queryRoot.Where(BuildLambda(GetLoadProperties(navigation), new ValueBuffer(keyValues)));
         return entry.EntityState == EntityState.Detached
-            ? forceIdentityResolution
+            ? (options & LoadOptions.ForceIdentityResolution) != 0
                 ? queryable.AsNoTrackingWithIdentityResolution()
                 : queryable.AsNoTracking()
             : queryable.AsTracking();

--- a/src/EFCore/Internal/EntityFinderCollectionLoaderAdapter.cs
+++ b/src/EFCore/Internal/EntityFinderCollectionLoaderAdapter.cs
@@ -34,8 +34,8 @@ public class EntityFinderCollectionLoaderAdapter : ICollectionLoader
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void Load(InternalEntityEntry entry, bool forceIdentityResolution)
-        => _entityFinder.Load(_navigation, entry, forceIdentityResolution);
+    public virtual void Load(InternalEntityEntry entry, LoadOptions options)
+        => _entityFinder.Load(_navigation, entry, options);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -43,8 +43,8 @@ public class EntityFinderCollectionLoaderAdapter : ICollectionLoader
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Task LoadAsync(InternalEntityEntry entry, bool forceIdentityResolution, CancellationToken cancellationToken = default)
-        => _entityFinder.LoadAsync(_navigation, entry, forceIdentityResolution, cancellationToken);
+    public virtual Task LoadAsync(InternalEntityEntry entry, LoadOptions options, CancellationToken cancellationToken = default)
+        => _entityFinder.LoadAsync(_navigation, entry, options, cancellationToken);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/ICollectionLoader.cs
+++ b/src/EFCore/Internal/ICollectionLoader.cs
@@ -19,7 +19,7 @@ public interface ICollectionLoader
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void Load(InternalEntityEntry entry, bool forceIdentityResolution);
+    void Load(InternalEntityEntry entry, LoadOptions options);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -27,7 +27,7 @@ public interface ICollectionLoader
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    Task LoadAsync(InternalEntityEntry entry, bool forceIdentityResolution, CancellationToken cancellationToken = default);
+    Task LoadAsync(InternalEntityEntry entry, LoadOptions options, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/IEntityFinder.cs
+++ b/src/EFCore/Internal/IEntityFinder.cs
@@ -83,7 +83,7 @@ public interface IEntityFinder
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    void Load(INavigation navigation, InternalEntityEntry entry, bool forceIdentityResolution);
+    void Load(INavigation navigation, InternalEntityEntry entry, LoadOptions options);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -94,7 +94,7 @@ public interface IEntityFinder
     Task LoadAsync(
         INavigation navigation,
         InternalEntityEntry entry,
-        bool forceIdentityResolution,
+        LoadOptions options,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -385,9 +385,9 @@ public class RuntimeModelConvention : IModelFinalizedConvention
     private static RuntimeServiceProperty Create(IServiceProperty property, RuntimeEntityType runtimeEntityType)
         => runtimeEntityType.AddServiceProperty(
             property.Name,
-            property.ClrType,
             property.PropertyInfo,
             property.FieldInfo,
+            property.ClrType,
             property.GetPropertyAccessMode());
 
     /// <summary>

--- a/src/EFCore/Metadata/IConventionEntityType.cs
+++ b/src/EFCore/Metadata/IConventionEntityType.cs
@@ -967,18 +967,10 @@ public interface IConventionEntityType : IReadOnlyEntityType, IConventionTypeBas
     ///     Adds a service property to this entity type.
     /// </summary>
     /// <param name="memberInfo">The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property to add.</param>
+    /// <param name="serviceType">The type of the service, or <see langword="null"/> to use the type of the member.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The newly created service property.</returns>
-    IConventionServiceProperty AddServiceProperty(MemberInfo memberInfo, bool fromDataAnnotation = false);
-
-    /// <summary>
-    ///     Adds a service property to this entity type.
-    /// </summary>
-    /// <param name="serviceType">The type of the service.</param>
-    /// <param name="memberInfo">The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property to add.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>The newly created service property.</returns>
-    IConventionServiceProperty AddServiceProperty(Type serviceType, MemberInfo memberInfo, bool fromDataAnnotation = false);
+    IConventionServiceProperty AddServiceProperty(MemberInfo memberInfo, Type? serviceType = null, bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Gets the service property with a given name.

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -836,16 +836,9 @@ public interface IMutableEntityType : IReadOnlyEntityType, IMutableTypeBase
     ///     Adds a service property to this entity type.
     /// </summary>
     /// <param name="memberInfo">The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property to add.</param>
+    /// <param name="serviceType">The type of the service, or <see langword="null"/> to use the type of the member.</param>
     /// <returns>The newly created service property.</returns>
-    IMutableServiceProperty AddServiceProperty(MemberInfo memberInfo);
-
-    /// <summary>
-    ///     Adds a service property to this entity type.
-    /// </summary>
-    /// <param name="serviceType">The type of the service.</param>
-    /// <param name="memberInfo">The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property to add.</param>
-    /// <returns>The newly created service property.</returns>
-    IMutableServiceProperty AddServiceProperty(Type serviceType, MemberInfo memberInfo);
+    IMutableServiceProperty AddServiceProperty(MemberInfo memberInfo, Type? serviceType = null);
 
     /// <summary>
     ///     Gets the service property with a given name.

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2793,8 +2793,8 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual ServiceProperty AddServiceProperty(
-        Type serviceType,
         MemberInfo memberInfo,
+        Type serviceType,
         // ReSharper disable once MethodOverloadWithOptionalParameter
         ConfigurationSource configurationSource)
     {
@@ -5155,8 +5155,8 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IMutableServiceProperty IMutableEntityType.AddServiceProperty(MemberInfo memberInfo)
-        => AddServiceProperty(memberInfo.GetMemberType(), memberInfo, ConfigurationSource.Explicit);
+    IMutableServiceProperty IMutableEntityType.AddServiceProperty(MemberInfo memberInfo, Type? serviceType)
+        => AddServiceProperty(memberInfo, serviceType ?? memberInfo.GetMemberType(), ConfigurationSource.Explicit);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -5165,31 +5165,11 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IMutableServiceProperty IMutableEntityType.AddServiceProperty(Type serviceType, MemberInfo memberInfo)
-        => AddServiceProperty(serviceType, memberInfo, ConfigurationSource.Explicit);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [DebuggerStepThrough]
-    IConventionServiceProperty IConventionEntityType.AddServiceProperty(MemberInfo memberInfo, bool fromDataAnnotation)
+    IConventionServiceProperty IConventionEntityType.AddServiceProperty(MemberInfo memberInfo, Type? serviceType, bool fromDataAnnotation)
         => AddServiceProperty(
-            memberInfo.GetMemberType(), memberInfo,
+            memberInfo,
+            serviceType ?? memberInfo.GetMemberType(),
             fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [DebuggerStepThrough]
-    IConventionServiceProperty IConventionEntityType.AddServiceProperty(Type serviceType, MemberInfo memberInfo, bool fromDataAnnotation)
-        => AddServiceProperty(
-            serviceType, memberInfo, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1011,7 +1011,7 @@ public class InternalEntityTypeBuilder : AnnotatableBuilder<EntityType, Internal
                 }
             }
 
-            builder = Metadata.AddServiceProperty(serviceType, memberInfo, configurationSource.Value).Builder;
+            builder = Metadata.AddServiceProperty(memberInfo, serviceType, configurationSource.Value).Builder;
 
             if (detachedProperties != null)
             {

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -724,36 +724,21 @@ public class RuntimeEntityType : AnnotatableBase, IRuntimeEntityType
     /// <param name="name">The name of the property to add.</param>
     /// <param name="propertyInfo">The corresponding CLR property or <see langword="null" /> for a shadow property.</param>
     /// <param name="fieldInfo">The corresponding CLR field or <see langword="null" /> for a shadow property.</param>
+    /// <param name="serviceType">The type of the service, or <see langword="null"/> to use the type of the member.</param>
     /// <param name="propertyAccessMode">The <see cref="PropertyAccessMode" /> used for this property.</param>
     /// <returns>The newly created service property.</returns>
     public virtual RuntimeServiceProperty AddServiceProperty(
         string name,
         PropertyInfo? propertyInfo = null,
         FieldInfo? fieldInfo = null,
-        PropertyAccessMode propertyAccessMode = Internal.Model.DefaultPropertyAccessMode)
-        => AddServiceProperty(name, (propertyInfo?.PropertyType ?? fieldInfo?.FieldType)!, propertyInfo, fieldInfo, propertyAccessMode);
-
-    /// <summary>
-    ///     Adds a service property to this entity type.
-    /// </summary>
-    /// <param name="name">The name of the property to add.</param>
-    /// <param name="serviceType">The type of the service.</param>
-    /// <param name="propertyInfo">The corresponding CLR property or <see langword="null" /> for a shadow property.</param>
-    /// <param name="fieldInfo">The corresponding CLR field or <see langword="null" /> for a shadow property.</param>
-    /// <param name="propertyAccessMode">The <see cref="PropertyAccessMode" /> used for this property.</param>
-    /// <returns>The newly created service property.</returns>
-    public virtual RuntimeServiceProperty AddServiceProperty(
-        string name,
-        Type serviceType,
-        PropertyInfo? propertyInfo = null,
-        FieldInfo? fieldInfo = null,
+        Type? serviceType = null,
         PropertyAccessMode propertyAccessMode = Internal.Model.DefaultPropertyAccessMode)
     {
         var serviceProperty = new RuntimeServiceProperty(
             name,
             propertyInfo,
             fieldInfo,
-            serviceType,
+            serviceType ?? (propertyInfo?.PropertyType ?? fieldInfo?.FieldType)!,
             this,
             propertyAccessMode);
 

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -97,8 +97,7 @@ public readonly record struct TypeMappingInfo
         var mappingHints = customConverter?.MappingHints;
         var property = principals[0];
 
-        HasKeySemantics = property.IsKey() || property.IsForeignKey();
-        IsKeyOrIndex = HasKeySemantics || property.IsIndex();
+        IsKeyOrIndex = property.IsKey() || property.IsForeignKey() || property.IsIndex();
         Size = fallbackSize ?? mappingHints?.Size;
         IsUnicode = fallbackUnicode ?? mappingHints?.IsUnicode;
         IsRowVersion = property.IsConcurrencyToken && property.ValueGenerated == ValueGenerated.OnAddOrUpdate;
@@ -139,7 +138,6 @@ public readonly record struct TypeMappingInfo
     /// <param name="rowVersion">Specifies a row-version, or <see langword="null" /> for default.</param>
     /// <param name="precision">Specifies a precision for the mapping, or <see langword="null" /> for default.</param>
     /// <param name="scale">Specifies a scale for the mapping, or <see langword="null" /> for default.</param>
-    /// <param name="keySemantics">If <see langword="true" />, then a special mapping for a key or foreign key may be returned.</param>
     public TypeMappingInfo(
         Type? type = null,
         bool keyOrIndex = false,
@@ -147,13 +145,11 @@ public readonly record struct TypeMappingInfo
         int? size = null,
         bool? rowVersion = null,
         int? precision = null,
-        int? scale = null,
-        bool keySemantics = false)
+        int? scale = null)
     {
         ClrType = type?.UnwrapNullableType();
 
         IsKeyOrIndex = keyOrIndex;
-        HasKeySemantics = keySemantics;
         Size = size;
         IsUnicode = unicode;
         IsRowVersion = rowVersion;
@@ -180,7 +176,6 @@ public readonly record struct TypeMappingInfo
     {
         IsRowVersion = source.IsRowVersion;
         IsKeyOrIndex = source.IsKeyOrIndex;
-        HasKeySemantics = source.HasKeySemantics;
 
         var mappingHints = converter.MappingHints;
 
@@ -204,11 +199,6 @@ public readonly record struct TypeMappingInfo
     ///     Indicates whether or not the mapping is part of a key or index.
     /// </summary>
     public bool IsKeyOrIndex { get; init; }
-
-    /// <summary>
-    ///     Indicates whether or not the mapping should be compared, etc. as if it is a key.
-    /// </summary>
-    public bool HasKeySemantics { get; init; }
 
     /// <summary>
     ///     Indicates the store-size to use for the mapping, or null if none.

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -203,8 +203,8 @@ namespace TestNamespace
                     b =>
                     {
                         var serviceProperty = (ServiceProperty)b.Metadata.AddServiceProperty(
-                            typeof(ILazyLoader),
-                            typeof(LazyPropertyDelegateEntity).GetAnyProperty("LoaderState")!);
+                            typeof(LazyPropertyDelegateEntity).GetAnyProperty("LoaderState")!,
+                            typeof(ILazyLoader));
 
                         serviceProperty.SetParameterBinding(
                             new DependencyInjectionParameterBinding(typeof(object), typeof(ILazyLoader), serviceProperty),
@@ -1347,8 +1347,8 @@ namespace TestNamespace
 
             var context = runtimeEntityType.AddServiceProperty(
                 "Context",
-                typeof(Microsoft.EntityFrameworkCore.DbContext),
-                propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Context", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+                propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Context", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                serviceType: typeof(Microsoft.EntityFrameworkCore.DbContext));
 
             var key = runtimeEntityType.AddKey(
                 new[] { principalBaseId, principalBaseAlternateId });
@@ -1478,8 +1478,8 @@ namespace TestNamespace
 
             var context = runtimeEntityType.AddServiceProperty(
                 "Context",
-                typeof(Microsoft.EntityFrameworkCore.DbContext),
-                propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Context", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+                propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Context", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                serviceType: typeof(Microsoft.EntityFrameworkCore.DbContext));
 
             var key = runtimeEntityType.AddKey(
                 new[] { principalDerivedId, principalDerivedAlternateId, id });
@@ -2632,8 +2632,8 @@ namespace TestNamespace
 
             var context = runtimeEntityType.AddServiceProperty(
                 "Context",
-                typeof(Microsoft.EntityFrameworkCore.DbContext),
-                propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Context", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+                propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Context", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                serviceType: typeof(Microsoft.EntityFrameworkCore.DbContext));
 
             var key = runtimeEntityType.AddKey(
                 new[] { principalBaseId, principalBaseAlternateId });
@@ -2744,8 +2744,8 @@ namespace TestNamespace
 
             var context = runtimeEntityType.AddServiceProperty(
                 "Context",
-                typeof(Microsoft.EntityFrameworkCore.DbContext),
-                propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Context", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+                propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Context", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                serviceType: typeof(Microsoft.EntityFrameworkCore.DbContext));
 
             var key = runtimeEntityType.AddKey(
                 new[] { principalDerivedId, principalDerivedAlternateId, id });

--- a/test/EFCore.Proxies.Tests/TestUtilities/TestContext.cs
+++ b/test/EFCore.Proxies.Tests/TestUtilities/TestContext.cs
@@ -42,7 +42,14 @@ internal abstract class TestContext<TEntity> : DbContext
     {
         if (_useLazyLoadingProxies)
         {
-            optionsBuilder.UseLazyLoadingProxies(ignoreNonVirtualNavigations: _ignoreNonVirtualNavigations);
+            optionsBuilder.UseLazyLoadingProxies(
+                b =>
+                {
+                    if (_ignoreNonVirtualNavigations)
+                    {
+                        b.IgnoreNonVirtualNavigations();
+                    }
+                });
         }
 
         if (_useChangeDetectionProxies)

--- a/test/EFCore.Relational.Tests/RelationalOptionsExtensionTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalOptionsExtensionTest.cs
@@ -21,7 +21,7 @@ public class RelationalOptionsExtensionTest
         optionsExtension = (FakeRelationalOptionsExtension)optionsExtension.WithConnection(connection);
 
         Assert.Same(connection, optionsExtension.Connection);
-        Assert.False(optionsExtension.ConnectionOwned);
+        Assert.False(optionsExtension.IsConnectionOwned);
     }
 
     [ConditionalFact]
@@ -35,7 +35,7 @@ public class RelationalOptionsExtensionTest
         optionsExtension = (FakeRelationalOptionsExtension)optionsExtension.WithConnection(connection, owned: true);
 
         Assert.Same(connection, optionsExtension.Connection);
-        Assert.True(optionsExtension.ConnectionOwned);
+        Assert.True(optionsExtension.IsConnectionOwned);
     }
 
     [ConditionalFact]

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -3530,7 +3530,7 @@ public abstract class LazyLoadProxyTestBase<TFixture> : IClassFixture<TFixture>
             => "LazyLoadProxyTest";
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder.UseLazyLoadingProxies(ignoreNonVirtualNavigations: true));
+            => base.AddOptions(builder.UseLazyLoadingProxies(b => b.IgnoreNonVirtualNavigations()));
 
         protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
             => base.AddServices(

--- a/test/EFCore.Specification.Tests/LoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoadTestBase.cs
@@ -6013,8 +6013,8 @@ public abstract partial class LoadTestBase<TFixture> : IClassFixture<TFixture>
                 b =>
                 {
                     var serviceProperty = (ServiceProperty)b.Metadata.AddServiceProperty(
-                        typeof(ILazyLoader),
-                        typeof(ChildDelegateLoaderWithStateByProperty).GetAnyProperty("LazyLoaderState")!);
+                        typeof(ChildDelegateLoaderWithStateByProperty).GetAnyProperty("LazyLoaderState")!,
+                        typeof(ILazyLoader));
 
                     serviceProperty.SetParameterBinding(
                         new DependencyInjectionParameterBinding(typeof(object), typeof(ILazyLoader), serviceProperty),
@@ -6025,8 +6025,8 @@ public abstract partial class LoadTestBase<TFixture> : IClassFixture<TFixture>
                 b =>
                 {
                     var serviceProperty = (ServiceProperty)b.Metadata.AddServiceProperty(
-                        typeof(ILazyLoader),
-                        typeof(SingleDelegateLoaderWithStateByProperty).GetAnyProperty("LazyLoaderState")!);
+                        typeof(SingleDelegateLoaderWithStateByProperty).GetAnyProperty("LazyLoaderState")!,
+                        typeof(ILazyLoader));
 
                     serviceProperty.SetParameterBinding(
                         new DependencyInjectionParameterBinding(typeof(object), typeof(ILazyLoader), serviceProperty),
@@ -6037,8 +6037,8 @@ public abstract partial class LoadTestBase<TFixture> : IClassFixture<TFixture>
                 b =>
                 {
                     var serviceProperty = (ServiceProperty)b.Metadata.AddServiceProperty(
-                        typeof(ILazyLoader),
-                        typeof(ParentDelegateLoaderWithStateByProperty).GetAnyProperty("LazyLoaderState")!);
+                        typeof(ParentDelegateLoaderWithStateByProperty).GetAnyProperty("LazyLoaderState")!,
+                        typeof(ILazyLoader));
 
                     serviceProperty.SetParameterBinding(
                         new DependencyInjectionParameterBinding(typeof(object), typeof(ILazyLoader), serviceProperty),

--- a/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
@@ -422,18 +422,11 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         {
             if (async)
             {
-                await (forceIdentityResolution ? collectionEntry.LoadWithIdentityResolutionAsync() : collectionEntry.LoadAsync());
+                await collectionEntry.LoadAsync(forceIdentityResolution ? LoadOptions.ForceIdentityResolution : LoadOptions.Default);
             }
             else
             {
-                if (forceIdentityResolution)
-                {
-                    collectionEntry.LoadWithIdentityResolution();
-                }
-                else
-                {
-                    collectionEntry.Load();
-                }
+                collectionEntry.Load(forceIdentityResolution ? LoadOptions.ForceIdentityResolution : LoadOptions.Default);
             }
 
             Assert.True(collectionEntry.IsLoaded);
@@ -526,18 +519,11 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         {
             if (async)
             {
-                await (forceIdentityResolution ? collectionEntry.LoadWithIdentityResolutionAsync() : collectionEntry.LoadAsync());
+                await collectionEntry.LoadAsync(forceIdentityResolution ? LoadOptions.ForceIdentityResolution : LoadOptions.Default);
             }
             else
             {
-                if (forceIdentityResolution)
-                {
-                    collectionEntry.LoadWithIdentityResolution();
-                }
-                else
-                {
-                    collectionEntry.Load();
-                }
+                collectionEntry.Load(forceIdentityResolution ? LoadOptions.ForceIdentityResolution : LoadOptions.Default);
             }
 
             Assert.True(collectionEntry.IsLoaded);
@@ -586,14 +572,10 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
         else
         {
             Assert.Single(left.ThreeSkipPayloadFull);
-            if (queryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution)
-            {
-                collectionEntry.LoadWithIdentityResolution();
-            }
-            else
-            {
-                collectionEntry.Load();
-            }
+            collectionEntry.Load(
+                queryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution
+                    ? LoadOptions.ForceIdentityResolution
+                    : LoadOptions.Default);
         }
 
         context.ChangeTracker.LazyLoadingEnabled = false;

--- a/test/EFCore.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
@@ -68,7 +68,7 @@ public class SqlServerDbContextOptionsExtensionsTest
         var extension = optionsBuilder.Options.Extensions.OfType<SqlServerOptionsExtension>().Single();
 
         Assert.Same(connection, extension.Connection);
-        Assert.False(extension.ConnectionOwned);
+        Assert.False(extension.IsConnectionOwned);
         Assert.Null(extension.ConnectionString);
     }
 
@@ -83,7 +83,7 @@ public class SqlServerDbContextOptionsExtensionsTest
         var extension = optionsBuilder.Options.Extensions.OfType<SqlServerOptionsExtension>().Single();
 
         Assert.Same(connection, extension.Connection);
-        Assert.True(extension.ConnectionOwned);
+        Assert.True(extension.IsConnectionOwned);
         Assert.Null(extension.ConnectionString);
     }
 
@@ -98,7 +98,7 @@ public class SqlServerDbContextOptionsExtensionsTest
         var extension = optionsBuilder.Options.Extensions.OfType<SqlServerOptionsExtension>().Single();
 
         Assert.Same(connection, extension.Connection);
-        Assert.False(extension.ConnectionOwned);
+        Assert.False(extension.IsConnectionOwned);
         Assert.Null(extension.ConnectionString);
     }
 
@@ -113,7 +113,7 @@ public class SqlServerDbContextOptionsExtensionsTest
         var extension = optionsBuilder.Options.Extensions.OfType<SqlServerOptionsExtension>().Single();
 
         Assert.Same(connection, extension.Connection);
-        Assert.True(extension.ConnectionOwned);
+        Assert.True(extension.IsConnectionOwned);
         Assert.Null(extension.ConnectionString);
     }
 

--- a/test/EFCore.Sqlite.Tests/SqliteDbContextOptionsBuilderExtensionsTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteDbContextOptionsBuilderExtensionsTest.cs
@@ -67,7 +67,7 @@ public class SqliteDbContextOptionsBuilderExtensionsTest
         var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
 
         Assert.Same(connection, extension.Connection);
-        Assert.False(extension.ConnectionOwned);
+        Assert.False(extension.IsConnectionOwned);
         Assert.Null(extension.ConnectionString);
     }
 
@@ -82,7 +82,7 @@ public class SqliteDbContextOptionsBuilderExtensionsTest
         var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
 
         Assert.Same(connection, extension.Connection);
-        Assert.True(extension.ConnectionOwned);
+        Assert.True(extension.IsConnectionOwned);
         Assert.Null(extension.ConnectionString);
     }
 
@@ -110,7 +110,7 @@ public class SqliteDbContextOptionsBuilderExtensionsTest
         var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
 
         Assert.Same(connection, extension.Connection);
-        Assert.False(extension.ConnectionOwned);
+        Assert.False(extension.IsConnectionOwned);
         Assert.Null(extension.ConnectionString);
     }
 
@@ -125,7 +125,7 @@ public class SqliteDbContextOptionsBuilderExtensionsTest
         var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
 
         Assert.Same(connection, extension.Connection);
-        Assert.True(extension.ConnectionOwned);
+        Assert.True(extension.IsConnectionOwned);
         Assert.Null(extension.ConnectionString);
     }
 

--- a/test/EFCore.Tests/DbContextServicesTest.cs
+++ b/test/EFCore.Tests/DbContextServicesTest.cs
@@ -407,7 +407,7 @@ namespace Microsoft.EntityFrameworkCore
 
                         if (autoResolve)
                         {
-                            b.ResolveRootApplicationServiceProvider();
+                            b.UseRootApplicationServiceProvider();
                         }
                         else
                         {


### PR DESCRIPTION
Part of #30306

- Make DbContextOptionsBuilder.ResolveRootApplicationServiceProvider a parameterless overload of UseRootApplicationServiceProvider
- Make NavigationEntry.LoadWithIdentityResolution an overload of Load with a flags enum with a ForceIdentityResolution value
- Ensure all interceptor data classes (including MaterializationInterceptionData) have pubternal ctors
- Move the serviceType parameter to the second position in IConventionEntityType.AddServiceProperty
- Collapse the overloads of RuntimeEntityType.AddServiceProperty. A serviceType of null means the type is inferred.
- Add *Is* prefix to RelationalOptionsExtension.ConnectionOwned
- Make the parameter names of SqlServerDbFunctionsExtensions.DateDiffMillisecond consistent with other functions (e.g. Rename startTime to startTimeSpan)
- Instead of adding ignoreNonVirtualNavigations to ProxiesExtensions.UseLazyLoadingProxies, add a nested closure overload with a builder. The builder overload shouldn't include the useproxies parameter.

