### PR TITLE
Fix to #30266 - Linq select cannot project an entity containing both Json columns and ICollections

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -1415,6 +1415,53 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_with_projection_of_json_reference_leaf_and_entity_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => new { x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf, x.EntityCollection }).AsNoTracking(),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.OwnedReferenceLeaf, a.OwnedReferenceLeaf);
+                AssertCollection(e.EntityCollection, a.EntityCollection);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_with_projection_of_json_reference_and_entity_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => new { x.OwnedReferenceRoot, x.EntityCollection }).AsNoTracking(),
+            elementAsserter: (e, a) =>
+            {
+                AssertEqual(e.OwnedReferenceRoot, a.OwnedReferenceRoot);
+                AssertCollection(e.EntityCollection, a.EntityCollection);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_with_projection_of_multiple_json_references_and_entity_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>().Select(x => new
+            {
+                Reference1 = x.OwnedReferenceRoot,
+                Reference2 = x.OwnedCollectionRoot[0].OwnedReferenceBranch,
+                x.EntityCollection,
+                Reference3 = x.OwnedCollectionRoot[1].OwnedReferenceBranch.OwnedReferenceLeaf,
+                Reference4 = x.OwnedCollectionRoot[0].OwnedCollectionBranch[0].OwnedReferenceLeaf,
+
+            }).AsNoTracking(),
+            elementAsserter: (e, a) =>
+            {
+                AssertCollection(e.EntityCollection, a.EntityCollection);
+                AssertEqual(e.Reference1, a.Reference1);
+                AssertEqual(e.Reference2, a.Reference2);
+                AssertEqual(e.Reference3, a.Reference3);
+                AssertEqual(e.Reference4, a.Reference4);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Json_all_types_entity_projection(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -1312,6 +1312,45 @@ ORDER BY [j].[Id], [j0].[Id]
 """);
     }
 
+    public override async Task Json_with_projection_of_json_reference_leaf_and_entity_collection(bool async)
+    {
+        await base.Json_with_projection_of_json_reference_leaf_and_entity_collection(async);
+
+        AssertSql(
+"""
+SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id], [j0].[Id], [j0].[Name], [j0].[ParentId]
+FROM [JsonEntitiesBasic] AS [j]
+LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
+ORDER BY [j].[Id]
+""");
+    }
+
+    public override async Task Json_with_projection_of_json_reference_and_entity_collection(bool async)
+    {
+        await base.Json_with_projection_of_json_reference_and_entity_collection(async);
+
+        AssertSql(
+"""
+SELECT [j].[OwnedReferenceRoot], [j].[Id], [j0].[Id], [j0].[Name], [j0].[ParentId]
+FROM [JsonEntitiesBasic] AS [j]
+LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
+ORDER BY [j].[Id]
+""");
+    }
+
+    public override async Task Json_with_projection_of_multiple_json_references_and_entity_collection(bool async)
+    {
+        await base.Json_with_projection_of_multiple_json_references_and_entity_collection(async);
+
+        AssertSql(
+"""
+SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedReferenceBranch'), [j0].[Id], [j0].[Name], [j0].[ParentId], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[0].OwnedReferenceLeaf')
+FROM [JsonEntitiesBasic] AS [j]
+LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
+ORDER BY [j].[Id]
+""");
+    }
+
     public override async Task Json_all_types_entity_projection(bool async)
     {
         await base.Json_all_types_entity_projection(async);


### PR DESCRIPTION
Problem was that when we projection collection of entities we use result coordinator and generate different pattern in shaper code. Json entity shaper code is generated inside `resultContext.Values == null` block and all the products should be referred to via `resultContext.Values` array access. We were not doing that for json, so in the final projection code we would refer to parameters (storing the actual json entities) that were out of scope.

Fix is to use the correct result coordinator pattern, just like we do for non-json entities.

Fixes #30266