### PR TITLE
[release/7.x] Fixes around IncludeExpression for ExecuteUpdate/Delete (#30571)

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
@@ -111,6 +111,58 @@ public abstract class NonSharedModelBulkUpdatesTestBase : NonSharedModelTestBase
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Update_non_owned_property_on_entity_with_owned2(bool async)
+    {
+        var contextFactory = await InitializeAsync<Context28671>(
+            onModelCreating: mb =>
+            {
+                mb.Entity<Owner>().OwnsOne(o => o.OwnedReference);
+            });
+
+        await AssertUpdate(
+            async,
+            contextFactory.CreateContext,
+            ss => ss.Set<Owner>(),
+            s => s.SetProperty(o => o.Title, o => o.Title + "_Suffix"),
+            rowsAffectedCount: 0);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Delete_entity_with_auto_include(bool async)
+    {
+        var contextFactory = await InitializeAsync<Context30572>();
+        await AssertDelete(async, contextFactory.CreateContext, ss => ss.Set<Context30572_Principal>(), rowsAffectedCount: 0);
+    }
+
+    protected class Context30572 : DbContext
+    {
+        public Context30572(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Context30572_Principal>().Navigation(o => o.Dependent).AutoInclude();
+    }
+
+    public class Context30572_Principal
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+
+        public Context30572_Dependent? Dependent { get; set; }
+    }
+
+    public class Context30572_Dependent
+    {
+        public int Id { get; set; }
+
+        public int Number { get; set; }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual async Task Delete_predicate_based_on_optional_navigation(bool async)
     {
         var contextFactory = await InitializeAsync<Context28745>();

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -53,6 +53,30 @@ FROM [Owner] AS [o]
 """);
     }
 
+    public override async Task Update_non_owned_property_on_entity_with_owned2(bool async)
+    {
+        await base.Update_non_owned_property_on_entity_with_owned2(async);
+
+        AssertSql(
+"""
+UPDATE [o]
+SET [o].[Title] = COALESCE([o].[Title], N'') + N'_Suffix'
+FROM [Owner] AS [o]
+""");
+    }
+
+    public override async Task Delete_entity_with_auto_include(bool async)
+    {
+        await base.Delete_entity_with_auto_include(async);
+
+        AssertSql(
+"""
+DELETE FROM [c]
+FROM [Context30572_Principal] AS [c]
+LEFT JOIN [Context30572_Dependent] AS [c0] ON [c].[DependentId] = [c0].[Id]
+""");
+    }
+
     public override async Task Delete_predicate_based_on_optional_navigation(bool async)
     {
         await base.Delete_predicate_based_on_optional_navigation(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -50,6 +50,20 @@ SET "Title" = 'SomeValue'
 """);
     }
 
+    public override async Task Update_non_owned_property_on_entity_with_owned2(bool async)
+    {
+        await base.Update_non_owned_property_on_entity_with_owned2(async);
+
+        AssertSql(
+"""
+UPDATE "Owner" AS "o"
+SET "Title" = COALESCE("o"."Title", '') || '_Suffix'
+""");
+    }
+
+    public override Task Delete_entity_with_auto_include(bool async)
+        => Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => base.Delete_entity_with_auto_include(async));
+
     public override async Task Delete_predicate_based_on_optional_navigation(bool async)
     {
         await base.Delete_predicate_based_on_optional_navigation(async);


### PR DESCRIPTION
Fixes #30572
Fixes #30528
Backport of #30571

**Description**

When an owned entity or auto-include was defined on an entity type, this causes IncludeExpressions to be added to the query tree which interfere with ExecuteUpdate/Delete.

**Customer impact**

Using ExecuteUpdate/Delete against entities which have owned entities or auto-includes would fail in some major scenarios.

**How found**

Customer report on 7.0

**Regression**

No, ExecuteUpdate/Delete are new in 7.0.

**Testing**

Added regression tests.

**Risk**

Low: The fix is local to ExecuteUpdate/Delete and is simple. Quirks have been added.
