### PR TITLE
[release/7.0] Fix to #30115 - IndexOutOfRangeException in CreateNavigationExpansionExpression

### DIFF
--- a/src/EFCore/Metadata/IReadOnlyTypeBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyTypeBase.cs
@@ -14,6 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// </remarks>
 public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
 {
+    private static readonly bool UseOldBehavior30115
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30115", out var enabled30115) && enabled30115;
+
     /// <summary>
     ///     Gets the model that this type belongs to.
     /// </summary>
@@ -118,6 +121,12 @@ public interface IReadOnlyTypeBase : IReadOnlyAnnotatable
         if (!HasSharedClrType)
         {
             var name = ClrType.ShortDisplayName();
+
+            if (!UseOldBehavior30115 && name.StartsWith("<>", StringComparison.Ordinal))
+            {
+                name = name[2..];
+            }
+
             var lessIndex = name.IndexOf("<", StringComparison.Ordinal);
             if (lessIndex == -1)
             {

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Globalization;
+using System.Reflection.Emit;
 
 // ReSharper disable CollectionNeverUpdated.Local
 // ReSharper disable UnusedAutoPropertyAccessor.Local
@@ -2957,6 +2958,56 @@ public partial class EntityTypeTest
         Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
 
         Assert.Equal(3, entityType.RelationshipPropertyCount());
+    }
+
+    [ConditionalFact]
+    public void ShortName_on_compiler_generated_type1()
+    {
+        var model = CreateModel();
+
+        var typeName = "<>f__AnonymousType01Child";
+        model.AddEntityType(typeName);
+        var entityType = model.FinalizeModel().FindEntityType(typeName);
+
+        Assert.Equal(typeName, entityType.ShortName());
+    }
+
+    [ConditionalFact]
+    public void ShortName_on_compiler_generated_type2()
+    {
+        var model = CreateModel();
+
+        var typeName = "<>f__AnonymousType01Child";
+        var assemblyName = new AssemblyName("DynamicEntityClrTypeAssembly");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("MyModule");
+        var typeBuilder = moduleBuilder.DefineType(typeName);
+        var type = typeBuilder.CreateType();
+
+        model.AddEntityType(type);
+
+        var entityType = model.FinalizeModel().FindEntityType(typeName);
+
+        Assert.Equal(typeName[2..], entityType.ShortName());
+    }
+
+    [ConditionalFact]
+    public void ShortName_on_compiler_generated_type3()
+    {
+        var model = CreateModel();
+
+        var typeName = "<>__AnonymousType01Child<int>";
+        var assemblyName = new AssemblyName("DynamicEntityClrTypeAssembly");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("MyModule");
+        var typeBuilder = moduleBuilder.DefineType(typeName);
+        var type = typeBuilder.CreateType();
+
+        model.AddEntityType(type);
+
+        var entityType = model.FinalizeModel().FindEntityType(typeName);
+
+        Assert.Equal("__AnonymousType01Child", entityType.ShortName());
     }
 
     private readonly IMutableModel _model = BuildModel();


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/30537
Fixes https://github.com/dotnet/efcore/issues/30115 

**Description**

Entity based on clr types generated by the compiler (i.e. having non-standard names) throw during compilation.

**Customer impact**

Queries with affected entities throw during translation.

**How found**

Customer report on 7.0

**Regression**

Yes. This scenario worked correctly in previous version of EF Core.

**Testing**

Added regression tests for affected scenario.

**Risk**

Low/minimal: Scenario is quite an edge case since the names for types that would trigger the issue can't be generated with regular user code. Also fix is very straightforward and the code path affected (apart from this one case) is only used for error reporting. So at worst the fix is incomplete for the same class of issues, but it shouldn't regress into other scenarios. Added quirk to revert to old behavior if necessary.
