### PR TITLE
Fix to #30326 - Query: converter from bool used in predicate without comparison fails on sqlite (and other non-sql server backends?)

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedSqlProcessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedSqlProcessor.cs
@@ -42,7 +42,10 @@ public class SqlServerParameterBasedSqlProcessor : RelationalParameterBasedSqlPr
 
         canCache &= canCache2;
 
-        return new SearchConditionConvertingExpressionVisitor(Dependencies.SqlExpressionFactory).Visit(optimizedQueryExpression);
+        return new SearchConditionConvertingExpressionVisitor(
+            Dependencies.SqlExpressionFactory,
+            shouldConvertToSearchCondition: _ => true,
+            shouldConvertToValue: _ => true).Visit(optimizedQueryExpression);
     }
 
     /// <inheritdoc />

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteParameterBasedSqlProcessor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteParameterBasedSqlProcessor.cs
@@ -30,6 +30,29 @@ public class SqliteParameterBasedSqlProcessor : RelationalParameterBasedSqlProce
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public override Expression Optimize(
+        Expression queryExpression,
+        IReadOnlyDictionary<string, object?> parametersValues,
+        out bool canCache)
+    {
+        var optimizedQueryExpression = base.Optimize(queryExpression, parametersValues, out canCache);
+
+        return new SearchConditionConvertingExpressionVisitor(
+            Dependencies.SqlExpressionFactory,
+            shouldConvertToSearchCondition:
+                e => e.Type == typeof(bool)
+                && e.TypeMapping != null
+                && e.TypeMapping.Converter != null,
+            shouldConvertToValue: _ => false).Visit(optimizedQueryExpression);
+    }
+
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     ///
     protected override Expression ProcessSqlNullability(
         Expression queryExpression,

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -67,28 +67,40 @@ FROM (
 """);
     }
 
-    [ConditionalTheory(Skip = "issue #30326")]
     public override async Task Json_predicate_on_bool_converted_to_int_zero_one(bool async)
     {
         await base.Json_predicate_on_bool_converted_to_int_zero_one(async);
 
-        AssertSql();
+        AssertSql(
+"""
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE json_extract("j"."Reference", '$.BoolConvertedToIntZeroOne') = 1
+""");
     }
 
-    [ConditionalTheory(Skip = "issue #30326")]
     public override async Task Json_predicate_on_bool_converted_to_string_True_False(bool async)
     {
         await base.Json_predicate_on_bool_converted_to_string_True_False(async);
 
-        AssertSql();
+        AssertSql(
+"""
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE json_extract("j"."Reference", '$.BoolConvertedToStringTrueFalse') = 'True'
+""");
     }
 
-    [ConditionalTheory(Skip = "issue #30326")]
     public override async Task Json_predicate_on_bool_converted_to_string_Y_N(bool async)
     {
         await base.Json_predicate_on_bool_converted_to_string_Y_N(async);
 
-        AssertSql();
+        AssertSql(
+"""
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE json_extract("j"."Reference", '$.BoolConvertedToStringYN') = 'Y'
+""");
     }
 
     private void AssertSql(params string[] expected)


### PR DESCRIPTION
SqlServer doesn't have the problem because search condition replacing visitor already converts all bool values in the predicate into conditions. Fix is to re-purpose this visitor to be used by other providers also and convert bool values to conditions when they have a converter.

Fixes #30326