### PR TITLE
Update SqliteMigrationsSqlGenerator.cs

### DIFF
--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -312,7 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     createTableOperation.PrimaryKey = AddPrimaryKeyOperation.CreateFrom(primaryKey);
                 }
 
-                foreach (var column in table.Columns.Where(c => c.Order.HasValue).OrderBy(c => c.Order.Value)
+                foreach (var column in table.Columns.Where(c => c.Order.HasValue).OrderBy(c => c.Order!.Value)
                     .Concat(table.Columns.Where(c => !c.Order.HasValue)))
                 {
                     if (!column.TryGetDefaultValue(out var defaultValue))


### PR DESCRIPTION
This happens on the `release/6.0` branch only.
VS Analyzer complains with an possibly null error while `c.Order` cannot be null.

Building with both VS and the `build` batch failed with the following error:
```
H:\Samples\_forks\efcore\src\EFCore.Sqlite.Core\Migrations\SqliteMigrationsSqlGenerator.cs(315,96): error CS8629: Nulla
ble value type may be null. [H:\Samples\_forks\efcore\src\EFCore.Sqlite.Core\EFCore.Sqlite.Core.csproj]
    0 Warning(s)
    1 Error(s)

Time Elapsed 00:01:35.00
Build failed with exit code 1. Check errors above.
```


- [ X] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [X ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ X] Code follows the same patterns and style as existing code in this repo

HTH
