### PR TITLE
Avoid considering unchanged properties as modified

### DIFF
--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -17,6 +17,9 @@ public class CommandBatchPreparer : ICommandBatchPreparer
     private static readonly bool QuirkEnabled29647
         = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29647", out var enabled) && enabled;
 
+    private static readonly bool QuirkEnabled30601
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30601", out var enabled) && enabled;
+
     private readonly int _minBatchSize;
     private readonly bool _sensitiveLoggingEnabled;
     private readonly bool _detailedErrorsEnabled;
@@ -983,6 +986,10 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                             }
 
                             originalValue ??= entry.GetOriginalProviderValue(property);
+                            if (!QuirkEnabled30601)
+                            {
+                                currentValue ??= entry.GetCurrentProviderValue(property);
+                            }
                             break;
                     }
 


### PR DESCRIPTION
Fixes #30601

**Description**

Starting with 7.0 EF compares the original store value with the current one when persisting a modified property, but due to a bug the comparison almost always returned `false` even if the values should be treated as equal.

**Customer impact**

In the reported case it results in an exception, because the properties appear to create a dependency cycle when treated as if they are modified.

**How found**

Customer report on 7.0

**Regression**

Yes

**Testing**

Added a test for the impacted scenario.

**Risk**

Low. Added quirk to revert to old behavior if necessary.