### PR TITLE
Make `SequentialGuidValueGenerator` non-allocating

### DIFF
--- a/src/EFCore/ValueGeneration/SequentialGuidValueGenerator.cs
+++ b/src/EFCore/ValueGeneration/SequentialGuidValueGenerator.cs
@@ -36,7 +36,8 @@ public class SequentialGuidValueGenerator : ValueGenerator<Guid>
     public override Guid Next(EntityEntry entry)
     {
         Span<byte> guidBytes = stackalloc byte[16];
-        Guid.NewGuid().TryWriteBytes(guidBytes);
+        var succeeded = Guid.NewGuid().TryWriteBytes(guidBytes);
+        Check.DebugAssert(succeeded, "Could not write Guid to Span");
         var incrementedCounter = Interlocked.Increment(ref _counter);
         Span<byte> counterBytes = stackalloc byte[sizeof(long)];
         MemoryMarshal.Write(counterBytes, ref incrementedCounter);


### PR DESCRIPTION
The current implementation of `SequentialGuidValueGenerator.Next()` allocates some heap memory due to `byte[]` usages. Rewrite this to a `Span` based version to avoid any allocations. Fixes #30610

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

