### PR TITLE
Fix #30072 : Add Generic version of EntityTypeConfiguration Attribute 

### DIFF
--- a/src/EFCore.Abstractions/EntityTypeConfigurationAttribute.cs
+++ b/src/EFCore.Abstractions/EntityTypeConfigurationAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore;
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class)]
-public sealed class EntityTypeConfigurationAttribute : Attribute
+public class EntityTypeConfigurationAttribute : Attribute
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="EntityTypeConfigurationAttribute" /> class.
@@ -32,3 +32,24 @@ public sealed class EntityTypeConfigurationAttribute : Attribute
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
     public Type EntityTypeConfigurationType { get; }
 }
+
+/// <summary>
+///     Specifies the configuration type for the entity type.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+/// </remarks>
+/// <typeparam name="TEntity">The IEntityTypeConfiguration&lt;&gt; type to use.</typeparam>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class EntityTypeConfigurationAttribute<TEntity> : EntityTypeConfigurationAttribute
+//where TEntity : IEntityTypeConfiguration
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="EntityTypeConfigurationAttribute" /> class.
+    /// </summary>
+    public EntityTypeConfigurationAttribute(): base(typeof(TEntity)) { }
+
+}
+
+
+

--- a/src/EFCore.Abstractions/EntityTypeConfigurationAttribute.cs
+++ b/src/EFCore.Abstractions/EntityTypeConfigurationAttribute.cs
@@ -33,23 +33,5 @@ public class EntityTypeConfigurationAttribute : Attribute
     public Type EntityTypeConfigurationType { get; }
 }
 
-/// <summary>
-///     Specifies the configuration type for the entity type.
-/// </summary>
-/// <remarks>
-///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
-/// </remarks>
-/// <typeparam name="TEntity">The IEntityTypeConfiguration&lt;&gt; type to use.</typeparam>
-[AttributeUsage(AttributeTargets.Class)]
-public sealed class EntityTypeConfigurationAttribute<TEntity> : EntityTypeConfigurationAttribute
-//where TEntity : IEntityTypeConfiguration
-{
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="EntityTypeConfigurationAttribute" /> class.
-    /// </summary>
-    public EntityTypeConfigurationAttribute(): base(typeof(TEntity)) { }
-
-}
-
 
 

--- a/src/EFCore/EntityTypeConfigurationAttribute.cs
+++ b/src/EFCore/EntityTypeConfigurationAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Specifies the configuration type for the entity type.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
+/// </remarks>
+/// <typeparam name="TConfiguration">The IEntityTypeConfiguration&lt;&gt; type to use.</typeparam>
+/// <typeparam name="TEntity">The entity type to be configured.</typeparam>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class EntityTypeConfigurationAttribute<TConfiguration, TEntity> : EntityTypeConfigurationAttribute
+where TConfiguration : class , IEntityTypeConfiguration<TEntity>
+where TEntity : class
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="EntityTypeConfigurationAttribute" /> class.
+    /// </summary>
+    public EntityTypeConfigurationAttribute() : base(typeof(TConfiguration)) { }
+
+}

--- a/test/EFCore.Tests/Metadata/Conventions/EntityTypeConfigurationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/EntityTypeConfigurationAttributeConventionTest.cs
@@ -19,6 +19,17 @@ public class EntityTypeConfigurationAttributeConventionTest
     }
 
     [ConditionalFact]
+    public void EntityTypeConfigurationAttribute_should_apply_configuration_to_EntityType_Generic()
+    {
+        var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+        builder.Entity<CustomerGeneric>();
+
+        var entityType = builder.Model.FindEntityType(typeof(CustomerGeneric));
+        Assert.Equal(1000, entityType.FindProperty(nameof(CustomerGeneric.Name)).GetMaxLength());
+    }
+
+    [ConditionalFact]
     public void EntityTypeConfigurationAttribute_should_throw_when_configuration_is_wrong_type()
     {
         var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
@@ -59,8 +70,23 @@ public class EntityTypeConfigurationAttributeConventionTest
             => builder.Property(c => c.Name).HasMaxLength(1000);
     }
 
+    private class CustomerGenericConfiguration : IEntityTypeConfiguration<CustomerGeneric>
+    {
+        public void Configure(EntityTypeBuilder<CustomerGeneric> builder)
+            => builder.Property(c => c.Name).HasMaxLength(1000);
+    }
+
     [EntityTypeConfiguration(typeof(CustomerConfiguration))]
     private class Customer
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+
+    [EntityTypeConfiguration<CustomerGenericConfiguration>()]
+    private class CustomerGeneric
     {
         public int Id { get; set; }
 

--- a/test/EFCore.Tests/Metadata/Conventions/EntityTypeConfigurationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/EntityTypeConfigurationAttributeConventionTest.cs
@@ -85,7 +85,7 @@ public class EntityTypeConfigurationAttributeConventionTest
     }
 
 
-    [EntityTypeConfiguration<CustomerGenericConfiguration>()]
+    [EntityTypeConfigurationAttribute<CustomerGenericConfiguration, CustomerGeneric>]
     private class CustomerGeneric
     {
         public int Id { get; set; }


### PR DESCRIPTION
<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - I add generic version of `EntityTypeConfigurationAttribute<TConfiguration, TEntity>` in the EFCore poject
        - I add Test method in `EntityTypeConfigurationAttribute_should_apply_configuration_to_EntityType_Generic`

        Fixes #30072
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

