### PR TITLE
Fix to #30326 - Query: converter from bool used in predicate without comparison fails on sqlite (and other non-sql server backends?)

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalValueConverterCompensatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalValueConverterCompensatingExpressionVisitor.cs
@@ -142,9 +142,9 @@ public class RelationalValueConverterCompensatingExpressionVisitor : ExpressionV
     [return: NotNullIfNotNull("sqlExpression")]
     private SqlExpression? TryCompensateForBoolWithValueConverter(SqlExpression? sqlExpression)
     {
-        if (sqlExpression is ColumnExpression columnExpression
-            && columnExpression.TypeMapping!.ClrType == typeof(bool)
-            && columnExpression.TypeMapping.Converter != null)
+        if ((sqlExpression is ColumnExpression or JsonScalarExpression)
+            && sqlExpression.TypeMapping!.ClrType == typeof(bool)
+            && sqlExpression.TypeMapping.Converter != null)
         {
             return _sqlExpressionFactory.Equal(
                 sqlExpression,

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -67,28 +67,40 @@ FROM (
 """);
     }
 
-    [ConditionalTheory(Skip = "issue #30326")]
     public override async Task Json_predicate_on_bool_converted_to_int_zero_one(bool async)
     {
         await base.Json_predicate_on_bool_converted_to_int_zero_one(async);
 
-        AssertSql();
+        AssertSql(
+"""
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE json_extract("j"."Reference", '$.BoolConvertedToIntZeroOne') = 1
+""");
     }
 
-    [ConditionalTheory(Skip = "issue #30326")]
     public override async Task Json_predicate_on_bool_converted_to_string_True_False(bool async)
     {
         await base.Json_predicate_on_bool_converted_to_string_True_False(async);
 
-        AssertSql();
+        AssertSql(
+"""
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE json_extract("j"."Reference", '$.BoolConvertedToStringTrueFalse') = 'True'
+""");
     }
 
-    [ConditionalTheory(Skip = "issue #30326")]
     public override async Task Json_predicate_on_bool_converted_to_string_Y_N(bool async)
     {
         await base.Json_predicate_on_bool_converted_to_string_Y_N(async);
 
-        AssertSql();
+        AssertSql(
+"""
+SELECT "j"."Id", "j"."Reference"
+FROM "JsonEntitiesConverters" AS "j"
+WHERE json_extract("j"."Reference", '$.BoolConvertedToStringYN') = 'Y'
+""");
     }
 
     private void AssertSql(params string[] expected)


### PR DESCRIPTION
SqlServer doesn't have the problem because search condition replacing visitor already converts all bool values in the predicate into conditions. Fix is to re-purpose this visitor to be used by other providers also and convert bool values to conditions when they have a converter.

Fixes #30326