### PR TITLE
Temporarily switch to Ubuntu 20.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,7 +216,7 @@ stages:
                   vmImage: ubuntu-22.04
                 ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
                   name: $(DncEngInternalBuildPool)
-                  demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
+                  demands: ImageOverride -equals Build.Ubuntu.20304.Amd64
               variables:
                 - _runCounter: $[counter(variables['Build.Reason'], 0)]
                 # Rely on task Arcade injects, not auto-injected build step.
@@ -273,12 +273,12 @@ stages:
                   value: $(_BuildConfig)
                 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
                   - name: HelixTargetQueues
-                    value: OSX.1100.Amd64.Open;(Ubuntu.2204.Amd64.SqlServer)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64
+                    value: OSX.1100.Amd64.Open;(Ubuntu.2004.Amd64.SqlServer)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64
                   - name: _HelixAccessToken
                     value: '' # Needed for public queues
                 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
                   - name: HelixTargetQueues
-                    value: OSX.1100.Amd64;(Ubuntu.2204.Amd64.SqlServer)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64
+                    value: OSX.1100.Amd64;(Ubuntu.2004.Amd64.SqlServer)Ubuntu.2004.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-sqlserver-amd64
                   - name: _HelixAccessToken
                     value: $(HelixApiAccessToken) # Needed for internal queues
               steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,7 +216,7 @@ stages:
                   vmImage: ubuntu-22.04
                 ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule')) }}:
                   name: $(DncEngInternalBuildPool)
-                  demands: ImageOverride -equals Build.Ubuntu.20304.Amd64
+                  demands: ImageOverride -equals Build.Ubuntu.2004.Amd64
               variables:
                 - _runCounter: $[counter(variables['Build.Reason'], 0)]
                 # Rely on task Arcade injects, not auto-injected build step.


### PR DESCRIPTION
We're seeing issues with the 22.04 images/queues - this should be reverted once those issues are resolved: https://github.com/dotnet/arcade/issues/13169.