### PR TITLE
Allow changing an open connection if it's not owned

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -181,7 +181,7 @@ public abstract class RelationalConnection : IRelationalConnection, ITransaction
     {
         if (!ReferenceEquals(_connection, value))
         {
-            if (_openedCount > 0)
+            if (_connectionOwned && _openedCount > 0)
             {
                 throw new InvalidOperationException(RelationalStrings.CannotChangeWhenOpen);
             }

--- a/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
@@ -1012,6 +1012,48 @@ public class RelationalConnectionTest
                 () => connection.RollbackTransaction()).Message);
     }
 
+    [ConditionalFact]
+    public void Throws_when_changing_DbConnection_if_current_is_open_and_owned()
+    {
+        using var connection = new FakeRelationalConnection(
+            CreateOptions(new FakeRelationalOptionsExtension().WithConnectionString("Database=FrodoLives")));
+        Assert.Equal(0, connection.DbConnections.Count);
+
+        connection.Open();
+
+        Assert.Throws<InvalidOperationException>(() => connection.DbConnection = new FakeDbConnection("Fake"));
+    }
+
+    [ConditionalFact]
+    public void Disposes_when_changing_DbConnection_if_current_is_owned_and_not_open()
+    {
+        using var connection = new FakeRelationalConnection(
+            CreateOptions(new FakeRelationalOptionsExtension().WithConnectionString("Database=FrodoLives")));
+        Assert.Equal(0, connection.DbConnections.Count);
+
+        var dbConnection = connection.DbConnection;
+
+        Assert.Raises<EventArgs>(
+            h => dbConnection.Disposed += h.Invoke,
+            h => dbConnection.Disposed -= h.Invoke,
+            () => connection.DbConnection = new FakeDbConnection("Fake"));
+    }
+
+    [ConditionalFact]
+    public void Does_not_dispose_when_changing_DbConnection_if_current_is_open_and_not_owned()
+    {
+        using var connection = new FakeRelationalConnection();
+        Assert.Equal(0, connection.DbConnections.Count);
+
+        var dbConnection = new FakeDbConnection("Database=FrodoLives");
+        connection.DbConnection = dbConnection;
+        connection.Open();
+
+        connection.DbConnection = new FakeDbConnection("Database=FrodoLives");
+
+        Assert.Equal(ConnectionState.Open, dbConnection.State);
+    }
+
     private static IDbContextOptions CreateOptions(params RelationalOptionsExtension[] optionsExtensions)
     {
         var optionsBuilder = new DbContextOptionsBuilder();

--- a/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
@@ -1021,7 +1021,9 @@ public class RelationalConnectionTest
 
         connection.Open();
 
-        Assert.Throws<InvalidOperationException>(() => connection.DbConnection = new FakeDbConnection("Fake"));
+        Assert.Equal(
+            RelationalStrings.CannotChangeWhenOpen,
+            Assert.Throws<InvalidOperationException>(() => connection.DbConnection = new FakeDbConnection("Fake")).Message);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Fixes #30704

I went ahead and tried something, it's fine if it's not the direction you want to take though.

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue ~with a detailed description of how I am planning to contribute and got approval from a member of the team~ [It's a very small change, I thought I'd try my luck]
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

