### PR TITLE
Fix trimming warnings in Microsoft.Data.Sqlite

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -311,6 +312,9 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The data type of the column.</returns>
+#if NET6_0_OR_GREATER
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+#endif
         public override Type GetFieldType(int ordinal)
             => _closed
                 ? throw new InvalidOperationException(Resources.DataReaderClosed(nameof(GetFieldType)))

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -191,6 +192,9 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
+#if NET6_0_OR_GREATER
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+#endif
         public virtual Type GetFieldType(int ordinal)
         {
             var sqliteType = GetSqliteType(ordinal);
@@ -207,6 +211,9 @@ namespace Microsoft.Data.Sqlite
             return GetFieldTypeFromSqliteType(sqliteType);
         }
 
+#if NET6_0_OR_GREATER
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+#endif
         internal static Type GetFieldTypeFromSqliteType(int sqliteType)
         {
             switch (sqliteType)
@@ -228,6 +235,9 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
+#if NET6_0_OR_GREATER
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+#endif
         public static Type GetFieldType(string type)
         {
             switch (type)


### PR DESCRIPTION
Fixes #29725

There were two types of issue:

- In SqliteConnection, the linker was unable to determine the type returned by the `GetType` call. Fixed by explicitly specifying the type.
- In SqliteDataReader, `GetFieldType` on the base has been annotated with `DynamicallyAccessedMembers`, which needed to be flowed through to called methods.

Tested with code from [Nanorm](https://github.com/DamianEdwards/Nanorm/tree/main/samples/Nanorm.Samples.Console.Todos.Sqlite)

After fixes:

```
PS C:\local\code\TrimTest\TrimTest> dotnet publish -f net8.0 -r win10-x64 --self-contained -v m --nologo -o pub
  Determining projects to restore...
  Restored C:\local\code\TrimTest\TrimTest\TrimTest.csproj (in 283 ms).
  Restored C:\local\code\TrimTest\Nanorm.Sqlite\Nanorm.Sqlite.csproj (in 283 ms).
  Restored C:\local\code\TrimTest\Nanorm\Nanorm.csproj (in 283 ms).
C:\Program Files\dotnet\sdk\8.0.100-preview.3.23178.7\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(287,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [C:\local\code\TrimTest\TrimTest\TrimTest.csproj]
  Nanorm -> C:\local\code\TrimTest\Nanorm\bin\Release\net8.0\Nanorm.dll
  Nanorm.Sqlite -> C:\local\code\TrimTest\Nanorm.Sqlite\bin\Release\net8.0\Nanorm.Sqlite.dll
  TrimTest -> C:\local\code\TrimTest\TrimTest\bin\Release\net8.0\win10-x64\TrimTest.dll
  Generating native code
  TrimTest -> C:\local\code\TrimTest\TrimTest\pub\
```
