### PR TITLE
Allow DI for pooled DbContexts

### DIFF
--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2018,7 +2018,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, principalEntityType, dependentEntityType);
 
         /// <summary>
-        ///     The DbContext of type '{contextType}' cannot be pooled because it does not have a public constructor accepting a single parameter of type DbContextOptions or has more than one constructor.
+        ///     The DbContext of type '{contextType}' cannot be pooled because it does not have a public constructor accepting a parameter of type DbContextOptions or has more than one constructor.
         /// </summary>
         public static string PoolingContextCtorError(object? contextType)
             => string.Format(


### PR DESCRIPTION
Fixes #27752

This allows resolving additional constructor parameters from the root service provider when creating a new DbContext in DbContextPool. The main intention here is to allow singleton services, which should generally be safe, but there are some risks with this approach:
- You can create scoped services from the root provider if scope validation is disabled. I think it's generally good practice to have scope validation enabled at least during development (this is [default in hosted environments](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovideroptions.validatescopes?view=dotnet-plat-ext-8.0#property-value)) so these issues can be caught, so I think this might be alright.
- You can create transient services from the root provider, even with scope validation. Although it's already the case today that any singleton today can inject a transient service, let's think about it in the context of developer who is used to the typical setup-- without pooling and with a scoped DbContext. A transient service injected into a _scoped_ service is safe to do things like store information specific to a request, and maybe that is how they've designed some transient services. The developer moves to pooling and creates a scoped factory so he can go on treating the DbContext as scoped. But now the transient service it has injected (facilitated by this PR) actually has the lifetime of the container and its behaviour is dangerous.

I'm not sure if these risks are unique to this situation, or are always there in some form when using DI. The documentation for pooling is already quite good at highlighting some of this. On the other hand, the current pattern - where you're forced to manually set scoped dependencies in a scoped factory after you get the DbContext from the pool - isn't really that arduous and perhaps makes the developer more conscious of all this. Therefore I really wouldn't mind if this PR is rejected, but it was fun & a learning experience!

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

