### PR TITLE
Refactor internal usage analyzer

### DIFF
--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -16,7 +16,8 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
     private static readonly int EFLen = "EntityFrameworkCore".Length;
 
     private static readonly DiagnosticDescriptor Descriptor
-        = new(
+        // HACK: Work around dotnet/roslyn-analyzers#5890 by not using target-typed new
+        = new DiagnosticDescriptor(
             Id,
             title: AnalyzerStrings.InternalUsageTitle,
             messageFormat: AnalyzerStrings.InternalUsageMessageFormat,

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -301,11 +301,11 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
         };
 
     private static bool IsInternal(SymbolAnalysisContext context, ITypeSymbol symbol)
-        => !(symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) == true)
+        => symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) != true
             && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
     private static bool IsInternal(OperationAnalysisContext context, ITypeSymbol symbol)
-        => !(symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) == true)
+        => symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) != true
             && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
     private static bool HasInternalAttribute(ISymbol symbol)

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -59,27 +59,35 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
             case IFieldReferenceOperation fieldReference:
                 AnalyzeMember(context, fieldReference.Field);
                 break;
+
             case IPropertyReferenceOperation propertyReference:
                 AnalyzeMember(context, propertyReference.Property);
                 break;
+
             case IEventReferenceOperation eventReference:
                 AnalyzeMember(context, eventReference.Event);
                 break;
+
             case IMethodReferenceOperation methodReference:
                 AnalyzeMember(context, methodReference.Method);
                 break;
+
             case IObjectCreationOperation { Constructor: { } constructor }:
                 AnalyzeMember(context, constructor);
                 break;
+
             case IInvocationOperation invocation:
                 AnalyzeInvocation(context, invocation);
                 break;
+
             case IVariableDeclarationOperation variableDeclaration:
                 AnalyzeVariableDeclaration(context, variableDeclaration);
                 break;
+
             case ITypeOfOperation typeOf:
                 AnalyzeTypeof(context, typeOf);
                 break;
+
             default:
                 throw new ArgumentException($"Unexpected operation: {context.Operation.Kind}");
         }

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -96,7 +96,7 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeMember(OperationAnalysisContext context, ISymbol symbol)
     {
-        if (symbol.ContainingAssembly.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default))
+        if (symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) == true)
         {
             // Skip all methods inside the same assembly - internal access is fine
             return;
@@ -301,11 +301,11 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
         };
 
     private static bool IsInternal(SymbolAnalysisContext context, ITypeSymbol symbol)
-        => !symbol.ContainingAssembly.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default)
+        => !(symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) == true)
             && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
     private static bool IsInternal(OperationAnalysisContext context, ITypeSymbol symbol)
-        => !symbol.ContainingAssembly.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default)
+        => !(symbol.ContainingAssembly?.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default) == true)
             && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
     private static bool HasInternalAttribute(ISymbol symbol)

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -96,7 +96,7 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeMember(OperationAnalysisContext context, ISymbol symbol)
     {
-        if (ReferenceEquals(symbol.ContainingAssembly, context.Compilation.Assembly))
+        if (symbol.ContainingAssembly.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default))
         {
             // Skip all methods inside the same assembly - internal access is fine
             return;
@@ -301,11 +301,11 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
         };
 
     private static bool IsInternal(SymbolAnalysisContext context, ITypeSymbol symbol)
-        => !ReferenceEquals(symbol.ContainingAssembly, context.Compilation.Assembly)
+        => !symbol.ContainingAssembly.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default)
             && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
     private static bool IsInternal(OperationAnalysisContext context, ITypeSymbol symbol)
-        => !ReferenceEquals(symbol.ContainingAssembly, context.Compilation.Assembly)
+        => !symbol.ContainingAssembly.Equals(context.Compilation.Assembly, SymbolEqualityComparer.Default)
             && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
     private static bool HasInternalAttribute(ISymbol symbol)

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -219,8 +219,7 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeMethodTypeSymbol(SymbolAnalysisContext context, IMethodSymbol symbol)
     {
-        if (symbol.MethodKind == MethodKind.PropertyGet
-            || symbol.MethodKind == MethodKind.PropertySet)
+        if (symbol.MethodKind is MethodKind.PropertyGet or MethodKind.PropertySet)
         {
             // Property getters/setters are handled via IPropertySymbol
             return;

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -16,8 +16,7 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
     private static readonly int EFLen = "EntityFrameworkCore".Length;
 
     private static readonly DiagnosticDescriptor Descriptor
-        // HACK: Work around dotnet/roslyn-analyzers#5828 by not using target-typed new
-        = new DiagnosticDescriptor(
+        = new(
             Id,
             title: AnalyzerStrings.InternalUsageTitle,
             messageFormat: AnalyzerStrings.InternalUsageMessageFormat,
@@ -55,41 +54,40 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeNode(OperationAnalysisContext context)
     {
-        switch (context.Operation.Kind)
+        switch (context.Operation)
         {
-            case OperationKind.FieldReference:
-                AnalyzeMember(context, ((IFieldReferenceOperation)context.Operation).Field);
+            case IFieldReferenceOperation fieldReference:
+                AnalyzeMember(context, fieldReference.Field);
                 break;
-            case OperationKind.PropertyReference:
-                AnalyzeMember(context, ((IPropertyReferenceOperation)context.Operation).Property);
+            case IPropertyReferenceOperation propertyReference:
+                AnalyzeMember(context, propertyReference.Property);
                 break;
-            case OperationKind.EventReference:
-                AnalyzeMember(context, ((IEventReferenceOperation)context.Operation).Event);
+            case IEventReferenceOperation eventReference:
+                AnalyzeMember(context, eventReference.Event);
                 break;
-            case OperationKind.MethodReference:
-                AnalyzeMember(context, ((IMethodReferenceOperation)context.Operation).Method);
+            case IMethodReferenceOperation methodReference:
+                AnalyzeMember(context, methodReference.Method);
                 break;
-            case OperationKind.ObjectCreation when ((IObjectCreationOperation)context.Operation).Constructor is { } constructor:
+            case IObjectCreationOperation { Constructor: { } constructor }:
                 AnalyzeMember(context, constructor);
                 break;
-            case OperationKind.Invocation:
-                AnalyzeInvocation(context, (IInvocationOperation)context.Operation);
+            case IInvocationOperation invocation:
+                AnalyzeInvocation(context, invocation);
                 break;
-            case OperationKind.VariableDeclaration:
-                AnalyzeVariableDeclaration(context, ((IVariableDeclarationOperation)context.Operation));
+            case IVariableDeclarationOperation variableDeclaration:
+                AnalyzeVariableDeclaration(context, variableDeclaration);
                 break;
-            case OperationKind.TypeOf:
-                AnalyzeTypeof(context, ((ITypeOfOperation)context.Operation));
+            case ITypeOfOperation typeOf:
+                AnalyzeTypeof(context, typeOf);
                 break;
             default:
-                throw new ArgumentException($"Unexpected {nameof(OperationKind)}: {context.Operation.Kind}");
+                throw new ArgumentException($"Unexpected operation: {context.Operation.Kind}");
         }
     }
 
     private static void AnalyzeMember(OperationAnalysisContext context, ISymbol symbol)
     {
-        // ReSharper disable once RedundantCast
-        if ((object)symbol.ContainingAssembly == context.Compilation.Assembly)
+        if (ReferenceEquals(symbol.ContainingAssembly, context.Compilation.Assembly))
         {
             // Skip all methods inside the same assembly - internal access is fine
             return;
@@ -99,7 +97,7 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
 
         if (HasInternalAttribute(symbol))
         {
-            ReportDiagnostic(context, symbol.Name == ".ctor" ? (object)containingType : $"{containingType}.{symbol.Name}");
+            ReportDiagnostic(context, symbol.Name == WellKnownMemberNames.InstanceConstructorName ? containingType : $"{containingType}.{symbol.Name}");
             return;
         }
 
@@ -295,13 +293,11 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
         };
 
     private static bool IsInternal(SymbolAnalysisContext context, ITypeSymbol symbol)
-        // ReSharper disable once RedundantCast
-        => (object)symbol.ContainingAssembly != context.Compilation.Assembly
+        => !ReferenceEquals(symbol.ContainingAssembly, context.Compilation.Assembly)
             && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
     private static bool IsInternal(OperationAnalysisContext context, ITypeSymbol symbol)
-        // ReSharper disable once RedundantCast
-        => (object)symbol.ContainingAssembly != context.Compilation.Assembly
+        => !ReferenceEquals(symbol.ContainingAssembly, context.Compilation.Assembly)
             && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
     private static bool HasInternalAttribute(ISymbol symbol)


### PR DESCRIPTION
- ~~Removed HACK with target-typed new since the underlying roslyn analyzers issue has been fixed~~ Changed comment to reference new roslyn-analyzers issue 🫤
- Removed workarounds when in order to reference-compare assembly symbols redundant cast to `object` was used
- Instead of comparing to `.ctor` string use well-known members API to improve readability
- Simpliy operation switch. Since there is a 1 to 1 relation between operation interfaces and their kinds, we can switch on operation directly instead of checking kinds and then immideatelly casting to proper interface type

These changes are very minor and don't affect any sort of behaviour, therefore I didn't create an issue upfront.