### PR TITLE
[release/8.0-preview4] Reintroduce the SDK workaround for OSX on Helix

### DIFF
--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -33,6 +33,13 @@
     <XUnitProject Remove="$(RepoRoot)/test/EFCore.Trimming.Tests/*.csproj"/>
   </ItemGroup>
 
+  <!-- Work-around for https://github.com/dotnet/runtime/issues/70758 -->
+  <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`OSX`))'">
+    <XUnitProject Update="$(RepoRoot)/test/EFCore.InMemory.FunctionalTests/*.csproj;$(RepoRoot)/test/EFCore.Sqlite.FunctionalTests/*.csproj;$(RepoRoot)/test/ef.Tests/*.csproj">
+      <PreCommands>$(PreCommands); export COMPlus_EnableWriteXorExecute=0</PreCommands>
+    </XUnitProject>
+  </ItemGroup>
+
   <!-- Start LocalDb instance for test projects which uses SqlServer on windows -->
   <ItemGroup Condition = "'$(HelixTargetQueue.StartsWith(`Windows`))'">
     <XUnitProject Update="$(SqlServerTests);$(RepoRoot)/test/EFCore.CrossStore.FunctionalTests/*.csproj">


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/30790. If https://dev.azure.com/dnceng/internal/_build/results?buildId=2169702&view=results passes, we should merge this for preview4