### PR TITLE
Update handling for bools and enums with database defaults

### DIFF
--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -2505,7 +2505,14 @@ public static class RelationalLoggerExtensions
 
         if (diagnostics.ShouldLog(definition))
         {
-            definition.Log(diagnostics, property.Name, property.DeclaringEntityType.DisplayName());
+            var defaultValue = property.ClrType.GetDefaultValue();
+            definition.Log(
+                diagnostics,
+                property.ClrType.ShortDisplayName(),
+                property.Name,
+                property.DeclaringEntityType.DisplayName(),
+                defaultValue == null ? "null" : defaultValue.ToString()!,
+                property.ClrType.ShortDisplayName());
         }
 
         if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -2521,9 +2528,15 @@ public static class RelationalLoggerExtensions
 
     private static string BoolWithDefaultWarning(EventDefinitionBase definition, EventData payload)
     {
-        var d = (EventDefinition<string, string>)definition;
+        var d = (EventDefinition<string, string, string, string, string>)definition;
         var p = (PropertyEventData)payload;
-        return d.GenerateMessage(p.Property.Name, p.Property.DeclaringEntityType.DisplayName());
+        var defaultValue = p.Property.ClrType.GetDefaultValue();
+        return d.GenerateMessage(
+            p.Property.ClrType.ShortDisplayName(),
+            p.Property.Name,
+            p.Property.DeclaringEntityType.DisplayName(),
+            defaultValue == null ? "null" : defaultValue.ToString()!,
+            p.Property.ClrType.ShortDisplayName());
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -675,21 +675,24 @@ public class RelationalModelValidator : ModelValidator
         {
             foreach (var property in entityType.GetDeclaredProperties())
             {
-                if (property.ClrType == typeof(bool)
+                if (!property.ClrType.IsNullableType()
+                    && (property.ClrType.IsEnum || property.ClrType == typeof(bool))
                     && property.ValueGenerated != ValueGenerated.Never
-                    && property.FieldInfo?.FieldType != typeof(bool?)
+                    && property.FieldInfo?.FieldType.IsNullableType() != true
+                    && !((IConventionProperty)property).GetSentinelConfigurationSource().HasValue
                     && (StoreObjectIdentifier.Create(property.DeclaringEntityType, StoreObjectType.Table) is { } table
-                        && (IsNotNullAndFalse(property.GetDefaultValue(table))
+                        && (IsNotNullAndNotDefault(property.GetDefaultValue(table))
                             || property.GetDefaultValueSql(table) != null)))
                 {
                     logger.BoolWithDefaultWarning(property);
                 }
+
+                bool IsNotNullAndNotDefault(object? value)
+                    => value != null
+                        && !property.ClrType.IsDefaultValue(value);
             }
         }
 
-        static bool IsNotNullAndFalse(object? value)
-            => value != null
-                && (value is not bool asBool || asBool);
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -689,7 +689,9 @@ public class RelationalModelValidator : ModelValidator
 
                 bool IsNotNullAndNotDefault(object? value)
                     => value != null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         && !property.ClrType.IsDefaultValue(value);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
         }
 

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalValueGenerationConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalValueGenerationConvention.cs
@@ -56,6 +56,16 @@ public class RelationalValueGenerationConvention :
         switch (name)
         {
             case RelationalAnnotationNames.DefaultValue:
+                if ((((IProperty)property).TryGetMemberInfo(forMaterialization: false, forSet: false, out var member, out _)
+                        ? member!.GetMemberType()
+                        : property.ClrType)
+                    == typeof(bool)
+                    && Equals(true, property.GetDefaultValue()))
+                {
+                    propertyBuilder.HasSentinel(true);
+                }
+
+                goto case RelationalAnnotationNames.DefaultValueSql;
             case RelationalAnnotationNames.DefaultValueSql:
             case RelationalAnnotationNames.ComputedColumnSql:
                 propertyBuilder.ValueGenerated(GetValueGenerated(property));

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalValueGenerationConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalValueGenerationConvention.cs
@@ -64,7 +64,7 @@ public class RelationalValueGenerationConvention :
                     == typeof(bool)
                     && Equals(true, property.GetDefaultValue()))
                 {
-                    propertyBuilder.HasSentinel(true);
+                    propertyBuilder.HasSentinel(annotation != null ? true : null);
                 }
 
                 goto case RelationalAnnotationNames.DefaultValueSql;

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalValueGenerationConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalValueGenerationConvention.cs
@@ -56,9 +56,11 @@ public class RelationalValueGenerationConvention :
         switch (name)
         {
             case RelationalAnnotationNames.DefaultValue:
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 if ((((IProperty)property).TryGetMemberInfo(forMaterialization: false, forSet: false, out var member, out _)
                         ? member!.GetMemberType()
                         : property.ClrType)
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     == typeof(bool)
                     && Equals(true, property.GetDefaultValue()))
                 {

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -2337,9 +2337,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The 'bool' property '{property}' on entity type '{entityType}' is configured with a database-generated default. This default will always be used for inserts when the property has the value 'false', since this is the CLR default for the 'bool' type. Consider using the nullable 'bool?' type instead, so that the default will only be used for inserts when the property value is 'null'.
+        ///     The '{type}' property '{property}' on entity type '{entityType}' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '{defaultValue}', since this is the CLR default for the '{type2}' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.
         /// </summary>
-        public static EventDefinition<string, string> LogBoolWithDefaultWarning(IDiagnosticsLogger logger)
+        public static EventDefinition<string, string, string, string, string> LogBoolWithDefaultWarning(IDiagnosticsLogger logger)
         {
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogBoolWithDefaultWarning;
             if (definition == null)
@@ -2347,18 +2347,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                 definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogBoolWithDefaultWarning,
                     logger,
-                    static logger => new EventDefinition<string, string>(
+                    static logger => new EventDefinition<string, string, string, string, string>(
                         logger.Options,
                         RelationalEventId.BoolWithDefaultWarning,
                         LogLevel.Warning,
                         "RelationalEventId.BoolWithDefaultWarning",
-                        level => LoggerMessage.Define<string, string>(
+                        level => LoggerMessage.Define<string, string, string, string, string>(
                             level,
                             RelationalEventId.BoolWithDefaultWarning,
                             _resourceManager.GetString("LogBoolWithDefaultWarning")!)));
             }
 
-            return (EventDefinition<string, string>)definition;
+            return (EventDefinition<string, string, string, string, string>)definition;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -593,8 +593,8 @@
     <comment>Debug RelationalEventId.TransactionStarting string</comment>
   </data>
   <data name="LogBoolWithDefaultWarning" xml:space="preserve">
-    <value>The 'bool' property '{property}' on entity type '{entityType}' is configured with a database-generated default. This default will always be used for inserts when the property has the value 'false', since this is the CLR default for the 'bool' type. Consider using the nullable 'bool?' type instead, so that the default will only be used for inserts when the property value is 'null'.</value>
-    <comment>Warning RelationalEventId.BoolWithDefaultWarning string string</comment>
+    <value>The '{type}' property '{property}' on entity type '{entityType}' is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value '{defaultValue}', since this is the CLR default for the '{type2}' type. Consider using a nullable type, using a nullable backing field, or setting the sentinel value for the property to ensure the database default is used when, and only when, appropriate. See https://aka.ms/efcore-docs-default-values for more information.</value>
+    <comment>Warning RelationalEventId.BoolWithDefaultWarning string string string string string</comment>
   </data>
   <data name="LogClosedConnection" xml:space="preserve">
     <value>Closed connection to database '{database}' on server '{server}' ({elapsed}ms).</value>

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSentinelSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSentinelSqlServerTest.cs
@@ -175,6 +175,16 @@ public class StoreGeneratedSentinelSqlServerTest : StoreGeneratedSqlServerTestBa
                     b.Property(e => e.NonNullableAsNullable).HasSentinel(IntSentinel);
                 });
 
+            modelBuilder.Entity<WithNoBackingFields>(
+                b =>
+                {
+                    b.Property(e => e.Id).HasSentinel(IntSentinel);
+                    b.Property(e => e.TrueDefault).HasSentinel(BoolSentinel);
+                    b.Property(e => e.NonZeroDefault).HasSentinel(IntSentinel);
+                    b.Property(e => e.FalseDefault).HasSentinel(BoolSentinel);
+                    b.Property(e => e.ZeroDefault).HasSentinel(IntSentinel);
+                });
+
             modelBuilder.Entity<WithNullableBackingFields>(
                 b =>
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTestBase.cs
@@ -888,6 +888,15 @@ public abstract class StoreGeneratedSqlServerTestBase<TFixture> : StoreGenerated
                     b.Property(e => e.NonNullableAsNullable).HasComputedColumnSql("1");
                 });
 
+            modelBuilder.Entity<WithNoBackingFields>(
+                b =>
+                {
+                    b.Property(e => e.TrueDefault).HasDefaultValue(true);
+                    b.Property(e => e.NonZeroDefault).HasDefaultValue(-1);
+                    b.Property(e => e.FalseDefault).HasDefaultValue(false);
+                    b.Property(e => e.ZeroDefault).HasDefaultValue(0);
+                });
+
             modelBuilder.Entity<WithNullableBackingFields>(
                 b =>
                 {

--- a/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
@@ -103,6 +103,15 @@ public class StoreGeneratedSqliteTest : StoreGeneratedTestBase<StoreGeneratedSql
                     b.Property(e => e.OnUpdateThrowBeforeThrowAfter).HasDefaultValue("Rabbit");
                 });
 
+            modelBuilder.Entity<WithNoBackingFields>(
+                b =>
+                {
+                    b.Property(e => e.TrueDefault).HasDefaultValue(true);
+                    b.Property(e => e.NonZeroDefault).HasDefaultValue(-1);
+                    b.Property(e => e.FalseDefault).HasDefaultValue(false);
+                    b.Property(e => e.ZeroDefault).HasDefaultValue(0);
+                });
+
             modelBuilder.Entity<WithNullableBackingFields>(
                 b =>
                 {

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -180,6 +180,33 @@ public abstract class ModelValidatorTestBase
         }
     }
 
+    protected enum X
+    {
+        A,
+        B
+    }
+
+    protected class WithEnum
+    {
+        public int Id { get; set; }
+        public X EnumWithDefaultConstraint { get; set; }
+        public X EnumNoDefaultConstraint { get; set; }
+        public X? NullableEnum { get; set; }
+    }
+
+    protected class WithEnum2
+    {
+        private X? _enumWithDefaultConstraint;
+
+        public int Id { get; set; }
+
+        public X EnumWithDefaultConstraint
+        {
+            get => _enumWithDefaultConstraint ?? X.B;
+            set => _enumWithDefaultConstraint = value;
+        }
+    }
+
     protected class EntityWithInvalidProperties
     {
         public int Id { get; set; }


### PR DESCRIPTION
Fixes #15070

- Warn for enums like we do for bools
- Don't warn if a sentinel value has been configured
- Update warning message to mention sentinel value
- Set the sentinel by convention for non-nullable bools with a default value

