### PR TITLE
[release/7.0] Stop skipping shadow skip navigation slots when creating the shadow values array

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
@@ -20,8 +20,7 @@ public class ShadowValuesFactoryFactory : SnapshotFactoryFactory<ValueBuffer>
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override int GetPropertyIndex(IPropertyBase propertyBase)
-        // Navigations are not included in the supplied value buffer
-        => (propertyBase as IProperty)?.GetShadowIndex() ?? -1;
+        => propertyBase.GetShadowIndex();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
@@ -13,6 +13,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 /// </summary>
 public class ShadowValuesFactoryFactory : SnapshotFactoryFactory<ValueBuffer>
 {
+    private static readonly bool UseOldBehavior30764
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30764", out var enabled) && enabled;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -20,7 +23,7 @@ public class ShadowValuesFactoryFactory : SnapshotFactoryFactory<ValueBuffer>
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override int GetPropertyIndex(IPropertyBase propertyBase)
-        => propertyBase.GetShadowIndex();
+        => UseOldBehavior30764 ? ((propertyBase as IProperty)?.GetShadowIndex() ?? -1) : propertyBase.GetShadowIndex();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -43,7 +43,7 @@ public abstract class SnapshotFactoryFactory
         var count = GetPropertyCount(entityType);
 
         var types = new Type[count];
-        var propertyBases = new IPropertyBase[count];
+        var propertyBases = new IPropertyBase?[count];
 
         foreach (var propertyBase in entityType.GetPropertiesAndNavigations())
         {
@@ -95,7 +95,7 @@ public abstract class SnapshotFactoryFactory
         Type? entityType,
         ParameterExpression parameter,
         Type[] types,
-        IList<IPropertyBase> propertyBases)
+        IList<IPropertyBase?> propertyBases)
     {
         var count = types.Length;
 

--- a/src/EFCore/ChangeTracking/Internal/TemporaryValuesFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/TemporaryValuesFactoryFactory.cs
@@ -23,7 +23,7 @@ public class TemporaryValuesFactoryFactory : SidecarValuesFactoryFactory
         [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type? entityType,
         ParameterExpression parameter,
         Type[] types,
-        IList<IPropertyBase> propertyBases)
+        IList<IPropertyBase?> propertyBases)
     {
         var constructorExpression = Expression.Convert(
             Expression.New(

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -288,11 +288,13 @@ public static class ExpressionExtensions
         Type type,
         int index,
         IPropertyBase? property)
-        => Expression.Call(
-            MakeValueBufferTryReadValueMethod(type),
-            valueBuffer,
-            Expression.Constant(index),
-            Expression.Constant(property, typeof(IPropertyBase)));
+        => property is INavigationBase
+            ? Expression.Constant(null, typeof(object))
+            : Expression.Call(
+                MakeValueBufferTryReadValueMethod(type),
+                valueBuffer,
+                Expression.Constant(index),
+                Expression.Constant(property, typeof(IPropertyBase)));
 
     /// <summary>
     ///     <para>

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -22,6 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure;
 /// </remarks>
 public static class ExpressionExtensions
 {
+    private static readonly bool UseOldBehavior30764
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30764", out var enabled) && enabled;
+
     /// <summary>
     ///     Creates a printable string representation of the given expression.
     /// </summary>
@@ -288,7 +291,7 @@ public static class ExpressionExtensions
         Type type,
         int index,
         IPropertyBase? property)
-        => property is INavigationBase
+        => (property is INavigationBase && !UseOldBehavior30764)
             ? Expression.Constant(null, typeof(object))
             : Expression.Call(
                 MakeValueBufferTryReadValueMethod(type),

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -586,7 +586,12 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             {
                 var valueBufferExpression = Expression.Call(
                     materializationContextVariable, MaterializationContext.GetValueBufferMethod);
-                var shadowProperties = concreteEntityType.GetProperties().Where(p => p.IsShadowProperty());
+
+                var shadowProperties = concreteEntityType.GetProperties()
+                    .Concat<IPropertyBase>(concreteEntityType.GetNavigations())
+                    .Concat(concreteEntityType.GetSkipNavigations())
+                    .Where(n => n.IsShadowProperty())
+                    .OrderBy(e => e.GetShadowIndex());
 
                 blockExpressions.Add(
                     Expression.Assign(

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -549,6 +549,17 @@ public abstract partial class GraphUpdatesTestBase<TFixture> : IClassFixture<TFi
             modelBuilder.Entity<Bayaz>();
             modelBuilder.Entity<SecondLaw>();
             modelBuilder.Entity<ThirdLaw>();
+
+            modelBuilder.Entity<Beetroot2>().HasData(
+                new { Id = 1, Key = "root-1", Name = "Root One" });
+
+            modelBuilder.Entity<Lettuce2>().HasData(
+                new { Id = 4, Key = "root-1/leaf-1", Name = "Leaf One-One", RootId = 1 });
+
+            modelBuilder.Entity<Radish2>()
+                .HasMany(entity => entity.Entities)
+                .WithMany()
+                .UsingEntity<RootStructure>();
         }
 
         protected virtual object CreateFullGraph()
@@ -3982,6 +3993,68 @@ public abstract partial class GraphUpdatesTestBase<TFixture> : IClassFixture<TFi
             get => _secondLaw;
             set => SetWithNotify(value, ref _secondLaw);
         }
+    }
+
+    protected abstract class Parsnip2 : NotifyingEntity
+    {
+        private int _id;
+
+        public int Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+    }
+
+    protected class Lettuce2 : Parsnip2
+    {
+        private Beetroot2 _root;
+
+        public Beetroot2 Root
+        {
+            get => _root;
+            set => SetWithNotify(value, ref _root);
+        }
+    }
+
+    protected class RootStructure : NotifyingEntity
+    {
+        private Guid _radish2Id;
+        private int _parsnip2Id;
+
+        public Guid Radish2Id
+        {
+            get => _radish2Id;
+            set => SetWithNotify(value, ref _radish2Id);
+        }
+
+        public int Parsnip2Id
+        {
+            get => _parsnip2Id;
+            set => SetWithNotify(value, ref _parsnip2Id);
+        }
+    }
+
+    protected class Radish2 : NotifyingEntity
+    {
+        private Guid _id;
+        private ICollection<Parsnip2> _entities = new ObservableHashSet<Parsnip2>();
+
+        public Guid Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public ICollection<Parsnip2> Entities
+        {
+            get => _entities;
+            set => SetWithNotify(value, ref _entities);
+        }
+    }
+
+    protected class Beetroot2 : Parsnip2
+    {
     }
 
     protected class NotifyingEntity : INotifyPropertyChanging, INotifyPropertyChanged

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseMiscellaneous.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseMiscellaneous.cs
@@ -1932,4 +1932,19 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
         return secondLevel;
     }
+
+    [ConditionalTheory] // Issue #30764
+    [InlineData(false)]
+    [InlineData(true)]
+    public virtual Task Shadow_skip_navigation_in_base_class_is_handled(bool async)
+        => ExecuteWithStrategyInTransactionAsync(
+            async context =>
+            {
+                var entities = async
+                    ? await context.Set<Lettuce2>().ToListAsync()
+                    : context.Set<Lettuce2>().ToList();
+
+                Assert.Equal(1, entities.Count);
+                Assert.Equal(nameof(Lettuce2), context.Entry(entities[0]).Property<string>("Discriminator").CurrentValue);
+            });
 }

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -554,20 +554,6 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
                     b.Property(e => e.IdUserState).HasDefaultValue(1);
                     b.HasOne(e => e.UserState).WithMany(e => e.Users).HasForeignKey(e => e.IdUserState);
                 });
-
-            modelBuilder.Entity<AccessStateWithSentinel>(
-                b =>
-                {
-                    b.Property(e => e.AccessStateWithSentinelId).ValueGeneratedNever();
-                    b.HasData(new AccessStateWithSentinel { AccessStateWithSentinelId = 1 });
-                });
-
-            modelBuilder.Entity<CruiserWithSentinel>(
-                b =>
-                {
-                    b.Property(e => e.IdUserState).HasDefaultValue(1).HasSentinel(667);
-                    b.HasOne(e => e.UserState).WithMany(e => e.Users).HasForeignKey(e => e.IdUserState);
-                });
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -38,6 +38,10 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
     public override Task Sever_relationship_that_will_later_be_deleted(bool async)
         => Task.CompletedTask;
 
+    // No owned types
+    public override Task Shadow_skip_navigation_in_base_class_is_handled(bool async)
+        => Task.CompletedTask;
+
     // Owned dependents are always loaded
     public override void Required_one_to_one_are_cascade_deleted_in_store(
         CascadeTiming? cascadeDeleteTiming,
@@ -548,6 +552,20 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
                 b =>
                 {
                     b.Property(e => e.IdUserState).HasDefaultValue(1);
+                    b.HasOne(e => e.UserState).WithMany(e => e.Users).HasForeignKey(e => e.IdUserState);
+                });
+
+            modelBuilder.Entity<AccessStateWithSentinel>(
+                b =>
+                {
+                    b.Property(e => e.AccessStateWithSentinelId).ValueGeneratedNever();
+                    b.HasData(new AccessStateWithSentinel { AccessStateWithSentinelId = 1 });
+                });
+
+            modelBuilder.Entity<CruiserWithSentinel>(
+                b =>
+                {
+                    b.Property(e => e.IdUserState).HasDefaultValue(1).HasSentinel(667);
                     b.HasOne(e => e.UserState).WithMany(e => e.Users).HasForeignKey(e => e.IdUserState);
                 });
         }


### PR DESCRIPTION
Port of #30902
Fixes #30764

## Description

We were previously not allocating a slot for shadow skip navigations when values come from query, since they are always null. This is fine for the common case where the navigation values are at the end of the array. However, for a shadow navigation in an abstract base class, the slot may be in the middle of the array, which then means all our indexes are off by one (or more). To fix this, we now create slots for the shadow navigations, even though they will always contain null.

## Customer impact

Crash on executing queries reported by multiple customers. Perhaps more importantly, could result in silently corrupted data in other cases.

## How found

Customer reports 7.0

## Regression

Yes. (Even though shadow navigations are new in 7.0, we were incorrectly handling some cases in 6.0 which meant that they accidentally worked.)

## Testing

Added regression tests.

Risk

Low; simple fix. Also quirked.
