### PR TITLE
Parse simple default constraint literals when scaffolding

### DIFF
--- a/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
+++ b/src/EFCore.Design/Extensions/ScaffoldingModelExtensions.cs
@@ -818,6 +818,23 @@ public static class ScaffoldingModelExtensions
     {
         FluentApiCodeFragment? root = null;
 
+        if (annotatable is IProperty property
+            && annotations.TryGetValue(RelationalAnnotationNames.DefaultValueSql, out _)
+            && annotations.TryGetValue(RelationalAnnotationNames.DefaultValue, out var parsedAnnotation))
+        {
+            if (Equals(property.ClrType.GetDefaultValue(), parsedAnnotation.Value))
+            {
+                // Default value is CLR default for property, so exclude it from scaffolded model
+                annotations.Remove(RelationalAnnotationNames.DefaultValueSql);
+                annotations.Remove(RelationalAnnotationNames.DefaultValue);
+            }
+            else
+            {
+                // SQL was parsed, so use parsed value and exclude raw value
+                annotations.Remove(RelationalAnnotationNames.DefaultValueSql);
+            }
+        }
+
         foreach (var methodCall in annotationCodeGenerator.GenerateFluentApiCalls(annotatable, annotations))
         {
             var fluentApiCall = FluentApiCodeFragment.From(methodCall);

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -453,6 +453,11 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
             property.ValueGeneratedOnAddOrUpdate();
         }
 
+        if (column.DefaultValue != null)
+        {
+            property.HasDefaultValue(column.DefaultValue);
+        }
+
         if (column.DefaultValueSql != null)
         {
             property.HasDefaultValueSql(column.DefaultValueSql);

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseColumn.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseColumn.cs
@@ -33,6 +33,11 @@ public class DatabaseColumn : Annotatable
     public virtual string? StoreType { get; set; }
 
     /// <summary>
+    ///     The default value for the column, or <see langword="null" /> if there is no default value or it could not be parsed.
+    /// </summary>
+    public virtual object? DefaultValue { get; set; }
+
+    /// <summary>
     ///     The default constraint for the column, or <see langword="null" /> if none.
     /// </summary>
     public virtual string? DefaultValueSql { get; set; }

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -184,12 +184,6 @@ public class SqlServerAnnotationCodeGenerator : AnnotationCodeGenerator
         return fragments;
     }
 
-    /// <inheritdoc />
-    public override IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
-        IRelationalPropertyOverrides overrides,
-        IDictionary<string, IAnnotation> annotations)
-        => base.GenerateFluentApiCalls(overrides, annotations);
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
 public class SqlServerDatabaseModelFactory : DatabaseModelFactory
 {
     private readonly IDiagnosticsLogger<DbLoggerCategory.Scaffolding> _logger;
+    private readonly IRelationalTypeMappingSource _typeMappingSource;
 
     private static readonly ISet<string> DateTimePrecisionTypes = new HashSet<string>
     {
@@ -82,9 +83,12 @@ public class SqlServerDatabaseModelFactory : DatabaseModelFactory
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public SqlServerDatabaseModelFactory(IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger)
+    public SqlServerDatabaseModelFactory(
+        IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
+        IRelationalTypeMappingSource typeMappingSource)
     {
         _logger = logger;
+        _typeMappingSource = typeMappingSource;
     }
 
     /// <summary>
@@ -788,7 +792,7 @@ LEFT JOIN [sys].[default_constraints] AS [dc] ON [c].[object_id] = [dc].[parent_
                 var scale = dataRecord.GetValueOrDefault<int>("scale");
                 var nullable = dataRecord.GetValueOrDefault<bool>("is_nullable");
                 var isIdentity = dataRecord.GetValueOrDefault<bool>("is_identity");
-                var defaultValue = dataRecord.GetValueOrDefault<string>("default_sql");
+                var defaultValueSql = dataRecord.GetValueOrDefault<string>("default_sql");
                 var computedValue = dataRecord.GetValueOrDefault<string>("computed_sql");
                 var computedIsPersisted = dataRecord.GetValueOrDefault<bool>("computed_is_persisted");
                 var comment = dataRecord.GetValueOrDefault<string>("comment");
@@ -811,7 +815,7 @@ LEFT JOIN [sys].[default_constraints] AS [dc] ON [c].[object_id] = [dc].[parent_
                     scale,
                     nullable,
                     isIdentity,
-                    defaultValue,
+                    defaultValueSql,
                     computedValue,
                     computedIsPersisted);
 
@@ -830,15 +834,14 @@ LEFT JOIN [sys].[default_constraints] AS [dc] ON [c].[object_id] = [dc].[parent_
                     systemTypeName = dataTypeName;
                 }
 
-                defaultValue = FilterClrDefaults(systemTypeName, nullable, defaultValue);
-
                 var column = new DatabaseColumn
                 {
                     Table = table,
                     Name = columnName,
                     StoreType = storeType,
                     IsNullable = nullable,
-                    DefaultValueSql = defaultValue,
+                    DefaultValue = TryParseClrDefault(systemTypeName, defaultValueSql),
+                    DefaultValueSql = defaultValueSql,
                     ComputedColumnSql = computedValue,
                     IsStored = computedIsPersisted,
                     Comment = comment,
@@ -868,48 +871,110 @@ LEFT JOIN [sys].[default_constraints] AS [dc] ON [c].[object_id] = [dc].[parent_
         }
     }
 
-    private static string? FilterClrDefaults(string dataTypeName, bool nullable, string? defaultValue)
+    private object? TryParseClrDefault(string dataTypeName, string? defaultValueSql)
     {
-        if (defaultValue == null
-            || defaultValue == "(NULL)")
+        defaultValueSql = defaultValueSql?.Trim();
+        if (string.IsNullOrEmpty(defaultValueSql))
         {
             return null;
         }
 
-        if (nullable)
-        {
-            return defaultValue;
-        }
-
-        if (defaultValue == "((0))" || defaultValue == "(0)")
-        {
-            if (dataTypeName is "bigint" or "bit" or "decimal" or "float" or "int" or "money" or "numeric" or "real" or "smallint"
-                or "smallmoney" or "tinyint")
-            {
-                return null;
-            }
-        }
-        else if (defaultValue == "((0.0))" || defaultValue == "(0.0)")
-        {
-            if (dataTypeName is "decimal" or "float" or "money" or "numeric" or "real" or "smallmoney")
-            {
-                return null;
-            }
-        }
-        else if ((defaultValue == "(CONVERT([real],(0)))" && dataTypeName == "real")
-                 || (defaultValue == "((0.0000000000000000e+000))" && dataTypeName == "float")
-                 || (defaultValue == "(0.0000000000000000e+000)" && dataTypeName == "float")
-                 || (defaultValue == "('0001-01-01')" && dataTypeName == "date")
-                 || (defaultValue == "('1900-01-01T00:00:00.000')" && (dataTypeName == "datetime" || dataTypeName == "smalldatetime"))
-                 || (defaultValue == "('0001-01-01T00:00:00.000')" && dataTypeName == "datetime2")
-                 || (defaultValue == "('0001-01-01T00:00:00.000+00:00')" && dataTypeName == "datetimeoffset")
-                 || (defaultValue == "('00:00:00')" && dataTypeName == "time")
-                 || (defaultValue == "('00000000-0000-0000-0000-000000000000')" && dataTypeName == "uniqueidentifier"))
+        var mapping = _typeMappingSource.FindMapping(dataTypeName);
+        if (mapping == null)
         {
             return null;
         }
 
-        return defaultValue;
+        Unwrap();
+        if (defaultValueSql.StartsWith("CONVERT", StringComparison.OrdinalIgnoreCase))
+        {
+            defaultValueSql = defaultValueSql.Substring(defaultValueSql.IndexOf(',') + 1);
+            defaultValueSql = defaultValueSql.Substring(0, defaultValueSql.LastIndexOf(')'));
+            Unwrap();
+        }
+
+        if (defaultValueSql.Equals("NULL", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var type = mapping.ClrType;
+        if (type == typeof(bool)
+            && int.TryParse(defaultValueSql, out var intValue))
+        {
+            return intValue != 0;
+        }
+
+        if (type.IsNumeric())
+        {
+            try
+            {
+                return Convert.ChangeType(defaultValueSql, type);
+            }
+            catch
+            {
+                // Ignored
+                return null;
+            }
+        }
+
+        if ((defaultValueSql.StartsWith('\'') || defaultValueSql.StartsWith("N'", StringComparison.OrdinalIgnoreCase))
+            && defaultValueSql.EndsWith('\''))
+        {
+            var startIndex = defaultValueSql.IndexOf('\'');
+            defaultValueSql = defaultValueSql.Substring(startIndex + 1, defaultValueSql.Length - (startIndex + 2));
+
+            if (type == typeof(string))
+            {
+                return defaultValueSql;
+            }
+
+            if (type == typeof(bool)
+                && bool.TryParse(defaultValueSql, out var boolValue))
+            {
+                return boolValue;
+            }
+
+            if (type == typeof(Guid)
+                && Guid.TryParse(defaultValueSql, out var guid))
+            {
+                return guid;
+            }
+
+            if (type == typeof(DateTime)
+                && DateTime.TryParse(defaultValueSql, out var dateTime))
+            {
+                return dateTime;
+            }
+
+            if (type == typeof(DateOnly)
+                && DateOnly.TryParse(defaultValueSql, out var dateOnly))
+            {
+                return dateOnly;
+            }
+
+            if (type == typeof(TimeOnly)
+                && TimeOnly.TryParse(defaultValueSql, out var timeOnly))
+            {
+                return timeOnly;
+            }
+
+            if (type == typeof(DateTimeOffset)
+                && DateTimeOffset.TryParse(defaultValueSql, out var dateTimeOffset))
+            {
+                return dateTimeOffset;
+            }
+        }
+
+        return null;
+
+        void Unwrap()
+        {
+            while (defaultValueSql.StartsWith('(') && defaultValueSql.EndsWith(')'))
+            {
+                defaultValueSql = (defaultValueSql.Substring(1, defaultValueSql.Length - 2)).Trim();
+            }
+        }
     }
 
     private static string GetStoreType(string dataTypeName, int maxLength, int precision, int scale)
@@ -1190,11 +1255,11 @@ SELECT
     [t].[name] AS [table_name],
     [f].[name],
 	SCHEMA_NAME(tab2.[schema_id]) AS [principal_table_schema],
-	[tab2].name AS [principal_table_name],	
+	[tab2].name AS [principal_table_name],
 	[f].[delete_referential_action_desc],
     [col1].[name] AS [column_name],
     [col2].[name] AS [referenced_column_name]
-FROM [sys].[foreign_keys] AS [f] 
+FROM [sys].[foreign_keys] AS [f]
 JOIN [sys].[foreign_key_columns] AS fc ON [fc].[constraint_object_id] = [f].[object_id]
 JOIN [sys].[tables] AS [t] ON [t].[object_id] = [fc].[parent_object_id]
 JOIN [sys].[columns] AS [col1] ON [col1].[column_id] = [fc].[parent_column_id] AND [col1].[object_id] = [t].[object_id]

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerDatabaseCleaner.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerDatabaseCleaner.cs
@@ -1,24 +1,25 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
-using Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 public class SqlServerDatabaseCleaner : RelationalDatabaseCleaner
 {
     protected override IDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
-        => new SqlServerDatabaseModelFactory(
-            new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
-                loggerFactory,
-                new LoggingOptions(),
-                new DiagnosticListener("Fake"),
-                new SqlServerLoggingDefinitions(),
-                new NullDbContextLogger()));
+    {
+        var services = new ServiceCollection();
+        services.AddEntityFrameworkSqlServer();
+
+        new SqlServerDesignTimeServices().ConfigureDesignTimeServices(services);
+
+        return services
+            .BuildServiceProvider() // No scope validation; cleaner violates scopes, but only resolve services once.
+            .GetRequiredService<IDatabaseModelFactory>();
+    }
 
     protected override bool AcceptTable(DatabaseTable table)
         => !(table is DatabaseView);

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data;
-using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Sqlite.Design.Internal;
-using Microsoft.EntityFrameworkCore.Sqlite.Diagnostics.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -13,19 +11,9 @@ public class SqliteDatabaseCleaner : RelationalDatabaseCleaner
 {
     protected override IDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
     {
-        // NOTE: You may need to update AddEntityFrameworkDesignTimeServices() too
-        var services = new ServiceCollection()
-            .AddSingleton<TypeMappingSourceDependencies>()
-            .AddSingleton<RelationalTypeMappingSourceDependencies>()
-            .AddSingleton<ValueConverterSelectorDependencies>()
-            .AddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name))
-            .AddSingleton<ILoggingOptions, LoggingOptions>()
-            .AddSingleton<IDbContextLogger, NullDbContextLogger>()
-            .AddSingleton<LoggingDefinitions, SqliteLoggingDefinitions>()
-            .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>))
-            .AddSingleton<IValueConverterSelector, ValueConverterSelector>()
-            .AddSingleton<IInterceptors, Interceptors>()
-            .AddLogging();
+        var services = new ServiceCollection();
+        services.AddEntityFrameworkSqlite();
+
         new SqliteDesignTimeServices().ConfigureDesignTimeServices(services);
 
         return services


### PR DESCRIPTION
Part of #13613

This is a step closer to being able to scaffold bool columns with default values without using a nullable property or backing field.

