### PR TITLE
Move away from unsupported version of .NET Framework

### DIFF
--- a/benchmark/EFCore.Benchmarks/Initialization/ColdStartSandbox.cs
+++ b/benchmark/EFCore.Benchmarks/Initialization/ColdStartSandbox.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET461
+#if NET462
 using System;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -15,12 +15,12 @@
     <file src="lib\**\*" target="lib/" />
     <file src="tools\**\*" target="tools/" />
     <file src="$intermediateOutputPath$*.psd1" target="tools/" />
-    <file src="../../artifacts/bin/ef/$configuration$/net461/ef.exe" target="tools/net461/any/" />
-    <file src="../../artifacts/bin/ef/$configuration$/net461/ef.pdb" target="tools/net461/any/" />
-    <file src="../../artifacts/bin/ef/x86/$configuration$/net461/ef.exe" target="tools/net461/win-x86/" />
-    <file src="../../artifacts/bin/ef/x86/$configuration$/net461/ef.pdb" target="tools/net461/win-x86/" />
-    <file src="../../artifacts/bin/ef/ARM64/$configuration$/net461/ef.exe" target="tools/net461/win-arm64/" />
-    <file src="../../artifacts/bin/ef/ARM64/$configuration$/net461/ef.pdb" target="tools/net461/win-arm64/" />
+    <file src="../../artifacts/bin/ef/$configuration$/net462/ef.exe" target="tools/net462/any/" />
+    <file src="../../artifacts/bin/ef/$configuration$/net462/ef.pdb" target="tools/net462/any/" />
+    <file src="../../artifacts/bin/ef/x86/$configuration$/net462/ef.exe" target="tools/net462/win-x86/" />
+    <file src="../../artifacts/bin/ef/x86/$configuration$/net462/ef.pdb" target="tools/net462/win-x86/" />
+    <file src="../../artifacts/bin/ef/ARM64/$configuration$/net462/ef.exe" target="tools/net462/win-arm64/" />
+    <file src="../../artifacts/bin/ef/ARM64/$configuration$/net462/ef.pdb" target="tools/net462/win-arm64/" />
     <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.dll" target="tools/netcoreapp2.0/any/" />
     <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.pdb" target="tools/netcoreapp2.0/any/" />
     <file src="../../artifacts/bin/ef/$configuration$/netcoreapp2.0/ef.runtimeconfig.json" target="tools/netcoreapp2.0/any/" />

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -1220,15 +1220,15 @@ function EF($project, $startupProject, $params, $applicationArgs, [switch] $skip
         $platformTarget = GetPlatformTarget $startupProject
         if ($platformTarget -eq 'x86')
         {
-            $exePath = Join-Path $PSScriptRoot 'net461\win-x86\ef.exe'
+            $exePath = Join-Path $PSScriptRoot 'net462\win-x86\ef.exe'
         }
         elseif ($platformTarget -eq 'ARM64')
         {
-            $exePath = Join-Path $PSScriptRoot 'net461\win-arm64\ef.exe'
+            $exePath = Join-Path $PSScriptRoot 'net462\win-arm64\ef.exe'
         }
         elseif ($platformTarget -in 'AnyCPU', 'x64')
         {
-            $exePath = Join-Path $PSScriptRoot 'net461\any\ef.exe'
+            $exePath = Join-Path $PSScriptRoot 'net462\any\ef.exe'
         }
         else
         {

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -106,7 +106,7 @@ internal class RootCommand : CommandBase
         {
             executable = Path.Combine(
                 toolsPath,
-                "net461",
+                "net462",
                 startupProject.PlatformTarget == "x86"
                     ? "win-x86"
                     : "any",
@@ -126,7 +126,7 @@ internal class RootCommand : CommandBase
             {
                 executable = Path.Combine(
                     toolsPath,
-                    "net461",
+                    "net462",
                     startupProject.PlatformTarget switch
                     {
                         "x86" => "win-x86",

--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -88,12 +88,12 @@ dotnet ef database update
       <NuspecProperty Include="OutputBinary=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.dll" />
       <NuspecProperty Include="OutputRuntimeConfig=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.runtimeconfig.json" />
       <NuspecProperty Include="OutputSymbol=..\..\artifacts\bin\ef\$(Configuration)\netcoreapp2.0\ef.pdb" />
-      <NuspecProperty Include="OutputExe=..\..\artifacts\bin\ef\$(Configuration)\net461\ef.exe" />
-      <NuspecProperty Include="OutputExeSymbol=..\..\artifacts\bin\ef\$(Configuration)\net461\ef.pdb" />
-      <NuspecProperty Include="OutputX86Exe=..\..\artifacts\bin\ef\x86\$(Configuration)\net461\ef.exe" />
-      <NuspecProperty Include="OutputX86ExeSymbol=..\..\artifacts\bin\ef\x86\$(Configuration)\net461\ef.pdb" />
-      <NuspecProperty Include="OutputARM64Exe=..\..\artifacts\bin\ef\ARM64\$(Configuration)\net461\ef.exe" />
-      <NuspecProperty Include="OutputARM64ExeSymbol=..\..\artifacts\bin\ef\ARM64\$(Configuration)\net461\ef.pdb" />
+      <NuspecProperty Include="OutputExe=..\..\artifacts\bin\ef\$(Configuration)\net462\ef.exe" />
+      <NuspecProperty Include="OutputExeSymbol=..\..\artifacts\bin\ef\$(Configuration)\net462\ef.pdb" />
+      <NuspecProperty Include="OutputX86Exe=..\..\artifacts\bin\ef\x86\$(Configuration)\net462\ef.exe" />
+      <NuspecProperty Include="OutputX86ExeSymbol=..\..\artifacts\bin\ef\x86\$(Configuration)\net462\ef.pdb" />
+      <NuspecProperty Include="OutputARM64Exe=..\..\artifacts\bin\ef\ARM64\$(Configuration)\net462\ef.exe" />
+      <NuspecProperty Include="OutputARM64ExeSymbol=..\..\artifacts\bin\ef\ARM64\$(Configuration)\net462\ef.pdb" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/dotnet-ef/dotnet-ef.nuspec
+++ b/src/dotnet-ef/dotnet-ef.nuspec
@@ -14,11 +14,11 @@
     <file src="$OutputBinary$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
     <file src="$OutputRuntimeConfig$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
     <file src="$OutputSymbol$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
-    <file src="$OutputExe$" target="tools\$targetFramework$\any\tools\net461\any" />
-    <file src="$OutputExeSymbol$" target="tools\$targetFramework$\any\tools\net461\any" />
-    <file src="$OutputX86Exe$" target="tools\$targetFramework$\any\tools\net461\win-x86" />
-    <file src="$OutputX86ExeSymbol$" target="tools\$targetFramework$\any\tools\net461\win-x86" />
-    <file src="$OutputARM64Exe$" target="tools\$targetFramework$\any\tools\net461\win-arm64" />
-    <file src="$OutputARM64ExeSymbol$" target="tools\$targetFramework$\any\tools\net461\win-arm64" />
+    <file src="$OutputExe$" target="tools\$targetFramework$\any\tools\net462\any" />
+    <file src="$OutputExeSymbol$" target="tools\$targetFramework$\any\tools\net462\any" />
+    <file src="$OutputX86Exe$" target="tools\$targetFramework$\any\tools\net462\win-x86" />
+    <file src="$OutputX86ExeSymbol$" target="tools\$targetFramework$\any\tools\net462\win-x86" />
+    <file src="$OutputARM64Exe$" target="tools\$targetFramework$\any\tools\net462\win-arm64" />
+    <file src="$OutputARM64ExeSymbol$" target="tools\$targetFramework$\any\tools\net462\win-arm64" />
   </files>
 </package>

--- a/src/ef/AppDomainOperationExecutor.cs
+++ b/src/ef/AppDomainOperationExecutor.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET461
+#if NET462
 using System;
 using System.Collections;
 using System.IO;

--- a/src/ef/Commands/MigrationsBundleCommand.cs
+++ b/src/ef/Commands/MigrationsBundleCommand.cs
@@ -32,7 +32,7 @@ internal partial class MigrationsBundleCommand
         }
     }
 
-#if NET461
+#if NET462
     protected override int Execute(string[] args)
         => throw new CommandException(Resources.VersionRequired("6.0.0"));
 #else

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Reflection;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.EntityFrameworkCore.Tools.Properties;
-#if NET461
+#if NET462
 using System;
 using System.Configuration;
 #endif
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         {
             try
             {
-#if NET461
+#if NET462
                 try
                 {
                     return new AppDomainOperationExecutor(

--- a/src/ef/Utilities/CallContext.cs
+++ b/src/ef/Utilities/CallContext.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET461
+#if !NET462
 namespace System.Runtime.Remoting.Messaging
 {
     internal static class CallContext

--- a/src/ef/Utilities/CompilerError.cs
+++ b/src/ef/Utilities/CompilerError.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET461
+#if !NET462
 namespace System.CodeDom.Compiler
 {
     internal class CompilerError

--- a/src/ef/Utilities/CompilerErrorCollection.cs
+++ b/src/ef/Utilities/CompilerErrorCollection.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !NET461
+#if !NET462
 namespace System.CodeDom.Compiler
 {
     internal class CompilerErrorCollection

--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
     <Description>Entity Framework Core Command-line Tools</Description>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
@@ -22,7 +22,7 @@
     <Compile Include="..\EFCore.Relational\Internal\SemanticVersionComparer.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
@@ -64,7 +64,7 @@
     </Compile>
   </ItemGroup>
 
-  <Target Name="BuildOtherPlatforms" AfterTargets="Build" Condition=" '$(TargetFramework)' == 'net461' And '$(Platform)' == 'AnyCPU' ">
+  <Target Name="BuildOtherPlatforms" AfterTargets="Build" Condition=" '$(TargetFramework)' == 'net462' And '$(Platform)' == 'AnyCPU' ">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="TargetFramework=$(TargetFramework);Platform=x86;Configuration=$(Configuration)" Targets="Build" />
     <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="TargetFramework=$(TargetFramework);Platform=ARM64;Configuration=$(Configuration)" Targets="Build" />
   </Target>


### PR DESCRIPTION
.NET Framework v4.6.1 [was retired in April 2022](https://aka.ms/framework-452-46-461-eos-blog). A year has already passed, so users have clearly had enough time to update. This also eliminates the need of installing legacy .NET Framework developer pack in VS