### PR TITLE
Update MS.CA version & remove hacks

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
     <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.23262.5</MicrosoftDotNetBuildTasksTemplatingVersion>
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
-    <MicrosoftCodeAnalysisVersion>4.5.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>4.6.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23251.2</MicrosoftCodeAnalysisTestingVersion>
   </PropertyGroup>
 </Project>

--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -9,6 +9,7 @@
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\rulesets\EFCore.noxmldocs.ruleset</CodeAnalysisRuleSet>
     <ImplicitUsings>true</ImplicitUsings>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -16,8 +16,7 @@ public sealed class InternalUsageDiagnosticAnalyzer : DiagnosticAnalyzer
     private static readonly int EFLen = "EntityFrameworkCore".Length;
 
     private static readonly DiagnosticDescriptor Descriptor
-        // HACK: Work around dotnet/roslyn-analyzers#5890 by not using target-typed new
-        = new DiagnosticDescriptor(
+        = new(
             Id,
             title: AnalyzerStrings.InternalUsageTitle,
             messageFormat: AnalyzerStrings.InternalUsageMessageFormat,

--- a/src/EFCore.Analyzers/InterpolatedStringUsageInRawQueriesDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InterpolatedStringUsageInRawQueriesDiagnosticAnalyzer.cs
@@ -15,8 +15,7 @@ public sealed class InterpolatedStringUsageInRawQueriesDiagnosticAnalyzer : Diag
     public const string Id = "EF1002";
 
     private static readonly DiagnosticDescriptor Descriptor
-        // HACK: Work around dotnet/roslyn-analyzers#5890 by not using target-typed new
-        = new DiagnosticDescriptor(
+        = new(
             Id,
             title: AnalyzerStrings.InterpolatedStringUsageInRawQueriesAnalyzerTitle,
             messageFormat: AnalyzerStrings.InterpolatedStringUsageInRawQueriesMessageFormat,


### PR DESCRIPTION
In https://github.com/dotnet/efcore/pull/30767 I tried to remove 'target-typed new' hack, but the CI failed. From my investigation it turned out that this error comes from `MS.CA.Analyzers` package. This package is a dependency of `MS.CA.CSharp`. `MS.CA.CSharp` v4.5.0 depend on `MS.CA.Analyzers` v3.3.3, but the fix for the hack was introduced only in v3.3.4. Therefore updating `MS.CA.CSharp` to v4.6.0 we get desired version of analyzers 3.3.4, so CI here should pass. A few notes:
- New version of analyzers added `RS1036` error, so I was forced to add `<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>` to analyzers project
- Since EF Core 8 will target .NET 8 I believe it is safe to update `MS.CA.CSharp` version, since the minimum version of VS, that supports .NET 8 will probably have bundled `MS.CA.CSharp` 4.8.0 anyway