### PR TITLE
Generate OPENJSON with WITH unless ordering is required

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -697,8 +697,7 @@ public class QuerySqlGenerator : SqlExpressionVisitor
     /// <inheritdoc />
     protected override Expression VisitOrdering(OrderingExpression orderingExpression)
     {
-        if (orderingExpression.Expression is SqlConstantExpression
-            || orderingExpression.Expression is SqlParameterExpression)
+        if (orderingExpression.Expression is SqlConstantExpression or SqlParameterExpression)
         {
             _relationalCommandBuilder.Append("(SELECT 1)");
         }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -575,7 +575,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateCount(ShapedQueryExpression source, LambdaExpression? predicate)
-        => TranslateAggregateWithPredicate(source, predicate, QueryableMethods.CountWithoutPredicate);
+        => TranslateAggregateWithPredicate(source, predicate, QueryableMethods.CountWithoutPredicate, liftOrderings: false);
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateDefaultIfEmpty(ShapedQueryExpression source, Expression? defaultValue)
@@ -914,7 +914,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateLongCount(ShapedQueryExpression source, LambdaExpression? predicate)
-        => TranslateAggregateWithPredicate(source, predicate, QueryableMethods.LongCountWithoutPredicate);
+        => TranslateAggregateWithPredicate(source, predicate, QueryableMethods.LongCountWithoutPredicate, liftOrderings: false);
 
     /// <inheritdoc />
     protected override ShapedQueryExpression? TranslateMax(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
@@ -2377,7 +2377,8 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
     private ShapedQueryExpression? TranslateAggregateWithPredicate(
         ShapedQueryExpression source,
         LambdaExpression? predicate,
-        MethodInfo predicateLessMethodInfo)
+        MethodInfo predicateLessMethodInfo,
+        bool liftOrderings)
     {
         if (predicate != null)
         {
@@ -2396,7 +2397,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             selectExpression.ReplaceProjection(new List<Expression>());
         }
 
-        selectExpression.PrepareForAggregate();
+        selectExpression.PrepareForAggregate(liftOrderings);
         var selector = _sqlExpressionFactory.Fragment("*");
         var methodCall = Expression.Call(
             predicateLessMethodInfo.MakeGenericMethod(selector.Type),

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -1014,6 +1014,9 @@ public sealed partial class SelectExpression
                     return newTpcTable;
                 }
 
+                case IClonableTableExpressionBase cloneable:
+                    return cloneable.Clone();
+
                 case TableValuedFunctionExpression tableValuedFunctionExpression:
                 {
                     var newArguments = new SqlExpression[tableValuedFunctionExpression.Arguments.Count];
@@ -1035,9 +1038,6 @@ public sealed partial class SelectExpression
 
                     return newTableValuedFunctionExpression;
                 }
-
-                case IClonableTableExpressionBase cloneable:
-                    return cloneable.Clone();
 
                 // join and set operations are fine, because they contain other TableExpressionBases inside, that will get cloned
                 // and therefore set expression's Update function will generate a new instance.

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -3919,14 +3919,14 @@ public sealed partial class SelectExpression : TableExpressionBase
     /// <summary>
     ///     Prepares the <see cref="SelectExpression" /> to apply aggregate operation over it.
     /// </summary>
-    public void PrepareForAggregate()
+    public void PrepareForAggregate(bool liftOrderings = true)
     {
         if (IsDistinct
             || Limit != null
             || Offset != null
             || _groupBy.Count > 0)
         {
-            PushdownIntoSubquery();
+            PushdownIntoSubqueryInternal(liftOrderings);
         }
     }
 
@@ -4663,10 +4663,6 @@ public sealed partial class SelectExpression : TableExpressionBase
         {
             expressionPrinter.AppendLine().Append("ORDER BY ");
             expressionPrinter.VisitCollection(Orderings);
-        }
-        else if (Offset != null)
-        {
-            expressionPrinter.AppendLine().Append("ORDER BY (SELECT 1)");
         }
 
         if (Offset != null)

--- a/src/EFCore.Relational/Query/SqlExpressions/ValuesExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ValuesExpression.cs
@@ -116,6 +116,7 @@ public class ValuesExpression : TableExpressionBase, IClonableTableExpressionBas
     protected override TableExpressionBase CreateWithAnnotations(IEnumerable<IAnnotation> annotations)
         => new ValuesExpression(Alias, RowValues, ColumnNames, annotations);
 
+    // TODO: Deep clone, see #30982
     /// <inheritdoc />
     public virtual TableExpressionBase Clone()
         => CreateWithAnnotations(GetAnnotations());

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerOpenJsonExpression.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerOpenJsonExpression.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 ///         doing so can result in application failures when updating to a new Entity Framework Core release.
 ///     </para>
 /// </remarks>
-public class SqlServerOpenJsonExpression : TableValuedFunctionExpression
+public class SqlServerOpenJsonExpression : TableValuedFunctionExpression, IClonableTableExpressionBase
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -79,6 +79,26 @@ public class SqlServerOpenJsonExpression : TableValuedFunctionExpression
         && (columnInfos is null ? ColumnInfos is null : ColumnInfos is not null && columnInfos.SequenceEqual(ColumnInfos))
             ? this
             : new SqlServerOpenJsonExpression(Alias, jsonExpression, path, columnInfos);
+
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    // TODO: Deep clone, see #30982
+    public virtual TableExpressionBase Clone()
+    {
+        var clone = new SqlServerOpenJsonExpression(Alias, JsonExpression, Path, ColumnInfos);
+
+        foreach (var annotation in GetAnnotations())
+        {
+            clone.AddAnnotation(annotation.Name, annotation.Value);
+        }
+
+        return clone;
+    }
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
@@ -145,5 +165,5 @@ public class SqlServerOpenJsonExpression : TableValuedFunctionExpression
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public readonly record struct ColumnInfo(string Name, string? StoreType, string? Path = null, bool AsJson = false);
+    public readonly record struct ColumnInfo(string Name, string StoreType, string? Path = null, bool AsJson = false);
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessor.cs
@@ -15,8 +15,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerQueryTranslationPostprocessor : RelationalQueryTranslationPostprocessor
 {
-    private readonly SkipWithoutOrderByInSplitQueryVerifyingExpressionVisitor
-        _skipWithoutOrderByInSplitQueryVerifyingExpressionVisitor = new();
+    private readonly OpenJsonPostprocessor _openJsonPostprocessor;
+    private readonly SkipWithoutOrderByInSplitQueryVerifier _skipWithoutOrderByInSplitQueryVerifier = new();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -27,9 +27,11 @@ public class SqlServerQueryTranslationPostprocessor : RelationalQueryTranslation
     public SqlServerQueryTranslationPostprocessor(
         QueryTranslationPostprocessorDependencies dependencies,
         RelationalQueryTranslationPostprocessorDependencies relationalDependencies,
-        QueryCompilationContext queryCompilationContext)
+        QueryCompilationContext queryCompilationContext,
+        IRelationalTypeMappingSource typeMappingSource)
         : base(dependencies, relationalDependencies, queryCompilationContext)
     {
+        _openJsonPostprocessor = new(typeMappingSource, relationalDependencies.SqlExpressionFactory);
     }
 
     /// <summary>
@@ -40,14 +42,15 @@ public class SqlServerQueryTranslationPostprocessor : RelationalQueryTranslation
     /// </summary>
     public override Expression Process(Expression query)
     {
-        var result = base.Process(query);
+        query = base.Process(query);
 
-        _skipWithoutOrderByInSplitQueryVerifyingExpressionVisitor.Visit(result);
+        query = _openJsonPostprocessor.Process(query);
+        _skipWithoutOrderByInSplitQueryVerifier.Visit(query);
 
-        return result;
+        return query;
     }
 
-    private sealed class SkipWithoutOrderByInSplitQueryVerifyingExpressionVisitor : ExpressionVisitor
+    private sealed class SkipWithoutOrderByInSplitQueryVerifier : ExpressionVisitor
     {
         [return: NotNullIfNotNull("expression")]
         public override Expression? Visit(Expression? expression)
@@ -68,13 +71,110 @@ public class SqlServerQueryTranslationPostprocessor : RelationalQueryTranslation
 
                     return relationalSplitCollectionShaperExpression;
 
-                case SelectExpression selectExpression
-                    when selectExpression.Offset != null
-                    && selectExpression.Orderings.Count == 0:
+                case SelectExpression { Offset: not null, Orderings.Count: 0 }:
                     throw new InvalidOperationException(SqlServerStrings.SplitQueryOffsetWithoutOrderBy);
 
                 case NonQueryExpression nonQueryExpression:
                     return nonQueryExpression;
+
+                default:
+                    return base.Visit(expression);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Converts <see cref="SqlServerOpenJsonExpression" /> expressions with WITH (the default) to OPENJSON without WITH when an
+    ///     ordering still exists on the [key] column, i.e. when the ordering of the original JSON array needs to be preserved
+    ///     (e.g. limit/offset).
+    /// </summary>
+    private sealed class OpenJsonPostprocessor : ExpressionVisitor
+    {
+        private readonly IRelationalTypeMappingSource _typeMappingSource;
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly Dictionary<(SqlServerOpenJsonExpression, string), RelationalTypeMapping> _castsToApply = new();
+
+        public OpenJsonPostprocessor(IRelationalTypeMappingSource typeMappingSource, ISqlExpressionFactory sqlExpressionFactory)
+            => (_typeMappingSource, _sqlExpressionFactory) = (typeMappingSource, sqlExpressionFactory);
+
+        public Expression Process(Expression expression)
+        {
+            _castsToApply.Clear();
+            return Visit(expression);
+        }
+
+        [return: NotNullIfNotNull("expression")]
+        public override Expression? Visit(Expression? expression)
+        {
+            switch (expression)
+            {
+                case ShapedQueryExpression shapedQueryExpression:
+                    return shapedQueryExpression.UpdateQueryExpression(Visit(shapedQueryExpression.QueryExpression));
+
+                case SelectExpression
+                {
+                    Tables: [SqlServerOpenJsonExpression { ColumnInfos: not null } openJsonExpression, ..],
+                    Orderings:
+                    [
+                        {
+                            Expression: SqlUnaryExpression
+                            {
+                                OperatorType: ExpressionType.Convert,
+                                Operand: ColumnExpression { Name: "key", Table: var keyColumnTable }
+                            }
+                        }
+                    ]
+                } selectExpression
+                    when keyColumnTable == openJsonExpression:
+                {
+                    // Remove the WITH clause from the OPENJSON expression
+                    var newOpenJsonExpression = openJsonExpression.Update(
+                        openJsonExpression.JsonExpression,
+                        openJsonExpression.Path,
+                        columnInfos: null);
+
+                    var newTables = selectExpression.Tables.ToArray();
+                    newTables[0] = newOpenJsonExpression;
+
+                    var newSelectExpression = selectExpression.Update(
+                        selectExpression.Projection,
+                        newTables,
+                        selectExpression.Predicate,
+                        selectExpression.GroupBy,
+                        selectExpression.Having,
+                        selectExpression.Orderings,
+                        selectExpression.Limit,
+                        selectExpression.Offset);
+
+                    // Record the OPENJSON expression and its projected column(s), along with the store type we just removed from the WITH
+                    // clause. Then visit the select expression, adding a cast around the matching ColumnExpressions.
+                    // TODO: Need to pass through the type mapping API for converting the JSON value (nvarchar) to the relational store type
+                    // (e.g. datetime2), see #30677
+                    foreach (var column in openJsonExpression.ColumnInfos)
+                    {
+                        var typeMapping = _typeMappingSource.FindMapping(column.StoreType);
+                        Check.DebugAssert(
+                            typeMapping is not null,
+                            $"Could not find mapping for store type {column.StoreType} when converting OPENJSON/WITH");
+
+                        _castsToApply.Add((newOpenJsonExpression, column.Name), typeMapping);
+                    }
+
+                    var result = base.Visit(newSelectExpression);
+
+                    foreach (var column in openJsonExpression.ColumnInfos)
+                    {
+                        _castsToApply.Remove((newOpenJsonExpression, column.Name));
+                    }
+
+                    return result;
+                }
+
+                case ColumnExpression { Table: SqlServerOpenJsonExpression openJsonTable, Name: var name } columnExpression
+                    when _castsToApply.TryGetValue((openJsonTable, name), out var typeMapping):
+                {
+                    return _sqlExpressionFactory.Convert(columnExpression, columnExpression.Type, typeMapping);
+                }
 
                 default:
                     return base.Visit(expression);

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessorFactory.cs
@@ -11,6 +11,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerQueryTranslationPostprocessorFactory : IQueryTranslationPostprocessorFactory
 {
+    private readonly IRelationalTypeMappingSource _typeMappingSource;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -19,10 +21,12 @@ public class SqlServerQueryTranslationPostprocessorFactory : IQueryTranslationPo
     /// </summary>
     public SqlServerQueryTranslationPostprocessorFactory(
         QueryTranslationPostprocessorDependencies dependencies,
-        RelationalQueryTranslationPostprocessorDependencies relationalDependencies)
+        RelationalQueryTranslationPostprocessorDependencies relationalDependencies,
+        IRelationalTypeMappingSource typeMappingSource)
     {
         Dependencies = dependencies;
         RelationalDependencies = relationalDependencies;
+        _typeMappingSource = typeMappingSource;
     }
 
     /// <summary>
@@ -42,8 +46,5 @@ public class SqlServerQueryTranslationPostprocessorFactory : IQueryTranslationPo
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
-        => new SqlServerQueryTranslationPostprocessor(
-            Dependencies,
-            RelationalDependencies,
-            queryCompilationContext);
+        => new SqlServerQueryTranslationPostprocessor(Dependencies, RelationalDependencies, queryCompilationContext, _typeMappingSource);
 }

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -423,6 +423,17 @@ public class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBase<TFixtur
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_OrderByDescending_ElementAt(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>()
+                .Where(c => c.Ints.OrderByDescending(i => i).ElementAt(0) == 111),
+            ss => ss.Set<PrimitiveCollectionsEntity>()
+                .Where(c => c.Ints.Length > 0 && c.Ints.OrderByDescending(i => i).ElementAt(0) == 111),
+            entryCount: 1);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Column_collection_Any(bool async)
         => AssertQuery(
             async,
@@ -440,15 +451,25 @@ public class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBase<TFixtur
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
-    public virtual Task Column_collection_and_parameter_collection_Join(bool async)
+    public virtual Task Column_collection_Join_parameter_collection(bool async)
     {
         var ints = new[] { 11, 111 };
 
         return AssertQuery(
             async,
-            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Join(ints, i => i, j => j, (i, j) => new { I = i, J = j }).Count() == 2),
+            ss => ss.Set<PrimitiveCollectionsEntity>()
+                .Where(c => c.Ints.Join(ints, i => i, j => j, (i, j) => new { I = i, J = j }).Count() == 2),
             entryCount: 1);
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Inline_collection_Join_ordered_column_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>()
+                .Where(c => new[] { 11, 111 }.Join(c.Ints, i => i, j => j, (i, j) => new { I = i, J = j }).Count() == 2),
+            entryCount: 1);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -1225,7 +1225,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__validIds_0) AS [v]
+    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
     WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
 ORDER BY [l].[Id], [l0].[Id]
 """);
@@ -2338,7 +2338,7 @@ FROM (
     FROM [LevelOne] AS [l]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
         WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
     GROUP BY [l].[Date]
 ) AS [t]
@@ -2347,7 +2347,7 @@ LEFT JOIN (
     FROM [LevelOne] AS [l0]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v0]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
         WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -2876,7 +2876,7 @@ LEFT JOIN (
 END = [t1].[OneToMany_Required_Inverse3Id]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__validIds_0) AS [v]
+    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
     WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
 ORDER BY [l].[Id], [t0].[Id], [t0].[Id0]
 """);
@@ -3022,7 +3022,7 @@ FROM (
     FROM [Level1] AS [l]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
         WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
     GROUP BY [l].[Date]
 ) AS [t]
@@ -3031,7 +3031,7 @@ LEFT JOIN (
     FROM [Level1] AS [l0]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v0]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
         WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
@@ -3197,7 +3197,7 @@ FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__validIds_0) AS [v]
+    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
     WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
 ORDER BY [l].[Id], [l0].[Id]
 """,
@@ -3211,7 +3211,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__validIds_0) AS [v]
+    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
     WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
 ORDER BY [l].[Id], [l0].[Id]
 """);
@@ -3750,7 +3750,7 @@ SELECT [l].[Date]
 FROM [LevelOne] AS [l]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__validIds_0) AS [v]
+    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
     WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
 GROUP BY [l].[Date]
 ORDER BY [l].[Date]
@@ -3765,7 +3765,7 @@ FROM (
     FROM [LevelOne] AS [l]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
         WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
     GROUP BY [l].[Date]
 ) AS [t]
@@ -3774,7 +3774,7 @@ INNER JOIN (
     FROM [LevelOne] AS [l0]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v0]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
         WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3084,7 +3084,7 @@ FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__names_0) AS [n]
+    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
     WHERE [n].[value] = [l0].[Name] OR ([n].[value] IS NULL AND [l0].[Name] IS NULL))
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -5419,7 +5419,7 @@ LEFT JOIN (
 ) AS [t] ON [l].[Id] = [t].[Level1_Optional_Id]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__names_0) AS [n]
+    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
     WHERE [n].[value] = [t].[Level2_Name] OR ([n].[value] IS NULL AND [t].[Level2_Name] IS NULL))
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -218,8 +218,8 @@ FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -242,8 +242,8 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [c].[Location] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -265,8 +265,8 @@ FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -2106,8 +2106,8 @@ SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS varchar(100)) = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
+    WHERE [c0].[value] = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
 """);
     }
 
@@ -3107,8 +3107,8 @@ END
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 WHERE [t].[Id] IN (
-    SELECT CAST([i].[value] AS uniqueidentifier) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
 )
 """);
     }
@@ -3632,8 +3632,8 @@ FROM [Gears] AS [g]
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
 WHERE [g].[SquadId] < 2 AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS nvarchar(450)) = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(450) '$') AS [c0]
+    WHERE [c0].[value] = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
 """);
     }
 
@@ -5924,8 +5924,8 @@ LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__nicknames_0) AS [n]
-        WHERE CAST([n].[value] AS nvarchar(450)) = [g].[Nickname]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
+        WHERE [n].[value] = [g].[Nickname]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [g].[Nickname], [g].[SquadId]
 """);
@@ -6668,8 +6668,8 @@ WHERE (
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE @__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @__end_1 AND [m].[Timeline] IN (
-    SELECT CAST([d].[value] AS datetimeoffset) AS [value]
-    FROM OPENJSON(@__dates_2) AS [d]
+    SELECT [d].[value]
+    FROM OPENJSON(@__dates_2) WITH ([value] datetimeoffset '$') AS [d]
 )
 """);
     }
@@ -7383,8 +7383,8 @@ SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthNa
 FROM [Gears] AS [g]
 ORDER BY CASE
     WHEN [g].[SquadId] IN (
-        SELECT CAST([i].[value] AS int) AS [value]
-        FROM OPENJSON(@__ids_0) AS [i]
+        SELECT [i].[value]
+        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -8145,8 +8145,8 @@ FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 WHERE [w0].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__types_0) AS [t]
-    WHERE CAST([t].[value] AS int) = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
+    FROM OPENJSON(@__types_0) WITH ([value] int '$') AS [t]
+    WHERE [t].[value] = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
 """);
     }
 
@@ -9380,8 +9380,8 @@ ORDER BY [t0].[Nickname], [t0].[SquadId], [t0].[HasSoulPatch0]
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
-    SELECT CAST([v].[value] AS bit) AS [value]
-    FROM OPENJSON(@__values_0) AS [v]
+    SELECT [v].[value]
+    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -9397,8 +9397,8 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
-    SELECT CAST([v].[value] AS bit) AS [value]
-    FROM OPENJSON(@__values_0) AS [v]
+    SELECT [v].[value]
+    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -19,8 +19,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS int) = 1) = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] int '$') AS [s]
+    WHERE [s].[value] = 1) = 2
 """);
     }
 
@@ -34,8 +34,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS bigint) = CAST(1 AS bigint)) = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] bigint '$') AS [s]
+    WHERE [s].[value] = CAST(1 AS bigint)) = 2
 """);
     }
 
@@ -49,8 +49,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS smallint) = CAST(1 AS smallint)) = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] smallint '$') AS [s]
+    WHERE [s].[value] = CAST(1 AS smallint)) = 2
 """);
     }
 
@@ -64,8 +64,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS float) = 1.0E0) = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] float '$') AS [s]
+    WHERE [s].[value] = 1.0E0) = 2
 """);
     }
 
@@ -79,8 +79,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS real) = CAST(1 AS real)) = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] real '$') AS [s]
+    WHERE [s].[value] = CAST(1 AS real)) = 2
 """);
     }
 
@@ -94,8 +94,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS decimal(18,2)) = 1.0) = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] decimal(18,2) '$') AS [s]
+    WHERE [s].[value] = 1.0) = 2
 """);
     }
 
@@ -109,8 +109,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS datetime2) = '2023-01-01T12:30:00.0000000') = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] datetime2 '$') AS [s]
+    WHERE [s].[value] = '2023-01-01T12:30:00.0000000') = 2
 """);
     }
 
@@ -124,8 +124,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS date) = '2023-01-01') = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] date '$') AS [s]
+    WHERE [s].[value] = '2023-01-01') = 2
 """);
     }
 
@@ -139,8 +139,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS time) = '12:30:00') = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] time '$') AS [s]
+    WHERE [s].[value] = '12:30:00') = 2
 """);
     }
 
@@ -154,8 +154,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS datetimeoffset) = '2023-01-01T12:30:00.0000000+02:00') = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] datetimeoffset '$') AS [s]
+    WHERE [s].[value] = '2023-01-01T12:30:00.0000000+02:00') = 2
 """);
     }
 
@@ -169,8 +169,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS bit) = CAST(1 AS bit)) = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] bit '$') AS [s]
+    WHERE [s].[value] = CAST(1 AS bit)) = 2
 """);
     }
 
@@ -184,8 +184,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS uniqueidentifier) = 'dc8c903d-d655-4144-a0fd-358099d40ae1') = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] uniqueidentifier '$') AS [s]
+    WHERE [s].[value] = 'dc8c903d-d655-4144-a0fd-358099d40ae1') = 2
 """);
     }
 
@@ -203,8 +203,8 @@ SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
 FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([t].[SomeArray]) AS [s]
-    WHERE CAST([s].[value] AS int) = 0) = 2
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] int '$') AS [s]
+    WHERE [s].[value] = 0) = 2
 """);
     }
 
@@ -304,11 +304,11 @@ WHERE JSON_VALUE(JSON_VALUE([t].[Owned], '$.Strings'), '$[1]') = N'bar'
 SELECT [t].[Id], [t].[DateTime], [t].[DateTime2], [t].[Ints]
 FROM [TestEntity] AS [t]
 WHERE [t].[DateTime] IN (
-    SELECT CAST([d].[value] AS datetime) AS [value]
-    FROM OPENJSON(@__dateTimes_0) AS [d]
+    SELECT [d].[value]
+    FROM OPENJSON(@__dateTimes_0) WITH ([value] datetime '$') AS [d]
 ) AND [t].[DateTime2] IN (
-    SELECT CAST([d0].[value] AS datetime2) AS [value]
-    FROM OPENJSON(@__dateTimes_0_1) AS [d0]
+    SELECT [d0].[value]
+    FROM OPENJSON(@__dateTimes_0_1) WITH ([value] datetime2 '$') AS [d0]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -1555,8 +1555,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """,
             //
@@ -1566,8 +1566,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1587,8 +1587,8 @@ WHERE EXISTS (
     FROM [Customers] AS [c0]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__ids_0) AS [i]
-        WHERE CAST([i].[value] AS nvarchar(15)) = [c0].[City] OR ([i].[value] IS NULL AND [c0].[City] IS NULL)) AND [c0].[CustomerID] = [c].[CustomerID])
+        FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(15) '$') AS [i]
+        WHERE [i].[value] = [c0].[City] OR ([i].[value] IS NULL AND [c0].[City] IS NULL)) AND [c0].[CustomerID] = [c].[CustomerID])
 """,
             //
 """
@@ -1601,8 +1601,8 @@ WHERE EXISTS (
     FROM [Customers] AS [c0]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__ids_0) AS [i]
-        WHERE CAST([i].[value] AS nvarchar(15)) = [c0].[City] OR ([i].[value] IS NULL AND [c0].[City] IS NULL)) AND [c0].[CustomerID] = [c].[CustomerID])
+        FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(15) '$') AS [i]
+        WHERE [i].[value] = [c0].[City] OR ([i].[value] IS NULL AND [c0].[City] IS NULL)) AND [c0].[CustomerID] = [c].[CustomerID])
 """);
     }
 
@@ -1617,8 +1617,8 @@ WHERE EXISTS (
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
 )
 """,
             //
@@ -1628,8 +1628,8 @@ WHERE [e].[EmployeeID] IN (
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -1645,8 +1645,8 @@ WHERE [e].[EmployeeID] IN (
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
 )
 """,
             //
@@ -1656,8 +1656,8 @@ WHERE [e].[EmployeeID] IN (
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -1685,8 +1685,8 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1702,8 +1702,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1719,8 +1719,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1748,8 +1748,8 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([p].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__p_0) AS [p]
+    SELECT [p].[value]
+    FROM OPENJSON(@__p_0) WITH ([value] nchar(5) '$') AS [p]
 )
 """,
             //
@@ -1759,8 +1759,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([p].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__p_0) AS [p]
+    SELECT [p].[value]
+    FROM OPENJSON(@__p_0) WITH ([value] nchar(5) '$') AS [p]
 )
 """);
     }
@@ -1776,8 +1776,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([s].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__Select_0) AS [s]
+    SELECT [s].[value]
+    FROM OPENJSON(@__Select_0) WITH ([value] nchar(5) '$') AS [s]
 )
 """,
             //
@@ -1787,8 +1787,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([s].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__Select_0) AS [s]
+    SELECT [s].[value]
+    FROM OPENJSON(@__Select_0) WITH ([value] nchar(5) '$') AS [s]
 )
 """);
     }
@@ -1804,8 +1804,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([s].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__Select_0) AS [s]
+    SELECT [s].[value]
+    FROM OPENJSON(@__Select_0) WITH ([value] nchar(5) '$') AS [s]
 )
 """);
     }
@@ -1822,8 +1822,8 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS nchar(5)) = [c].[CustomerID])
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    WHERE [i].[value] = [c].[CustomerID])
 """);
     }
 
@@ -1838,8 +1838,8 @@ WHERE NOT EXISTS (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (N'ALFKI', N'ABCDE') AND [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -1879,8 +1879,8 @@ WHERE [c].[CustomerID] IN (N'ALFKI', N'ABCDE') AND [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 ) OR [c].[CustomerID] IN (N'ALFKI', N'ABCDE')
 """);
     }
@@ -1896,8 +1896,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2354,8 +2354,8 @@ FROM [Employees] AS [e]
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2383,8 +2383,8 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI', N'ANATR')
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2400,8 +2400,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """,
             //
@@ -2411,8 +2411,8 @@ WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'México D.F.' AND [c].[CustomerID] IN (
-    SELECT CAST([i].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
 )
 """);
     }
@@ -2429,8 +2429,8 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS nchar(5)) = [c].[CustomerID])
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    WHERE [i].[value] = [c].[CustomerID])
 """);
     }
 
@@ -2458,8 +2458,8 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS nchar(5)) = [c].[CustomerID])
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    WHERE [i].[value] = [c].[CustomerID])
 """);
     }
 
@@ -2475,8 +2475,8 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'México D.F.' AND NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS nchar(5)) = [c].[CustomerID])
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    WHERE [i].[value] = [c].[CustomerID])
 """,
             //
 """
@@ -2486,8 +2486,8 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'México D.F.' AND NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS nchar(5)) = [c].[CustomerID])
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+    WHERE [i].[value] = [c].[CustomerID])
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -183,8 +183,8 @@ WHERE [c].[CustomerID] = @__customerID
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([a].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__args) AS [a]
+    SELECT [a].[value]
+    FROM OPENJSON(@__args) WITH ([value] nchar(5) '$') AS [a]
 )
 """,
             //
@@ -194,8 +194,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([a].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__args) AS [a]
+    SELECT [a].[value]
+    FROM OPENJSON(@__args) WITH ([value] nchar(5) '$') AS [a]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindEFPropertyIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindEFPropertyIncludeQuerySqlServerTest.cs
@@ -624,8 +624,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -633,8 +633,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -972,8 +972,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -981,8 +981,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1368,8 +1368,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1377,8 +1377,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1847,8 +1847,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1856,8 +1856,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
@@ -178,8 +178,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -187,8 +187,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -460,8 +460,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -469,8 +469,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2061,8 +2061,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -2070,8 +2070,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2095,8 +2095,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -2104,8 +2104,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
@@ -1511,8 +1511,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1520,8 +1520,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1545,8 +1545,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1554,8 +1554,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1579,8 +1579,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1588,8 +1588,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1613,8 +1613,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1622,8 +1622,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -907,7 +907,7 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 
 SELECT [e].[EmployeeID]
 FROM [Employees] AS [e]
-INNER JOIN OPENJSON(@__p_0) AS [p] ON [e].[EmployeeID] = [p].[value]
+INNER JOIN OPENJSON(@__p_0) WITH ([value] int '$') AS [p] ON [e].[EmployeeID] = [p].[value]
 """,
             //
 """
@@ -915,7 +915,7 @@ INNER JOIN OPENJSON(@__p_0) AS [p] ON [e].[EmployeeID] = [p].[value]
 
 SELECT [e].[EmployeeID]
 FROM [Employees] AS [e]
-INNER JOIN OPENJSON(@__p_0) AS [p] ON [e].[EmployeeID] = [p].[value]
+INNER JOIN OPENJSON(@__p_0) WITH ([value] int '$') AS [p] ON [e].[EmployeeID] = [p].[value]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
@@ -255,7 +255,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [m].[ContactTitle]
+    SELECT TOP(@__p_0) 1 AS empty
     FROM (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]
     ) AS [m]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -17,7 +17,7 @@ public class NorthwindMiscellaneousQuerySqlServerTest : NorthwindMiscellaneousQu
         : base(fixture)
     {
         ClearLog();
-        //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
     protected override bool CanExecuteQueryString
@@ -4041,8 +4041,8 @@ LEFT JOIN [Employees] AS [e0] ON [e].[EmployeeID] = [e0].[ReportsTo]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE CONVERT(date, [o].[OrderDate]) IN (
-    SELECT CAST([d].[value] AS datetime) AS [value]
-    FROM OPENJSON(@__dates_0) AS [d]
+    SELECT [d].[value]
+    FROM OPENJSON(@__dates_0) WITH ([value] datetime '$') AS [d]
 )
 """,
             //
@@ -4052,8 +4052,8 @@ WHERE CONVERT(date, [o].[OrderDate]) IN (
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE CONVERT(date, [o].[OrderDate]) IN (
-    SELECT CAST([d].[value] AS datetime) AS [value]
-    FROM OPENJSON(@__dates_0) AS [d]
+    SELECT [d].[value]
+    FROM OPENJSON(@__dates_0) WITH ([value] datetime '$') AS [d]
 )
 """);
     }
@@ -4461,7 +4461,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Country]
+    SELECT TOP(@__p_0) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
 ) AS [t]
@@ -4494,7 +4494,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Country]
+    SELECT TOP(@__p_0) [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
 ) AS [t]
@@ -4598,7 +4598,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Country]
+    SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
     OFFSET @__p_0 ROWS
@@ -4634,7 +4634,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Country]
+    SELECT [c].[CustomerID]
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
     OFFSET @__p_0 ROWS
@@ -5089,8 +5089,8 @@ FROM [Customers] AS [c]
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -5109,8 +5109,8 @@ FROM [Customers] AS [c]
 ORDER BY CASE
     WHEN NOT EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -6277,8 +6277,8 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [o].[OrderID] IN (
-    SELECT CAST([o0].[value] AS int) AS [value]
-    FROM OPENJSON(@__orderIds_0) AS [o0]
+    SELECT [o0].[value]
+    FROM OPENJSON(@__orderIds_0) WITH ([value] int '$') AS [o0]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
@@ -785,8 +785,8 @@ LEFT JOIN (
         FROM [Orders] AS [o]
         LEFT JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
         WHERE [o].[OrderID] IN (
-            SELECT CAST([o0].[value] AS int) AS [value]
-            FROM OPENJSON(@__orderIds_0) AS [o0]
+            SELECT [o0].[value]
+            FROM OPENJSON(@__orderIds_0) WITH ([value] int '$') AS [o0]
         )
     ) AS [t]
     WHERE [t].[row] <= 1

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -2090,8 +2090,8 @@ OUTER APPLY (
     SELECT [t].[CustomerID], [o0].[OrderID], [o0].[OrderDate]
     FROM [Orders] AS [o0]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CustomerID] = [o0].[CustomerID] AND [o0].[OrderID] IN (
-        SELECT CAST([f].[value] AS int) AS [value]
-        FROM OPENJSON(@__filteredOrderIds_0) AS [f]
+        SELECT [f].[value]
+        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
     )
 ) AS [t0]
 ORDER BY [t].[CustomerID], [t0].[OrderID]
@@ -2115,8 +2115,8 @@ OUTER APPLY (
     SELECT [t].[OrderID] AS [Outer], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
     FROM [Orders] AS [o0]
     WHERE [o0].[OrderID] = [t].[OrderID] AND [o0].[OrderID] IN (
-        SELECT CAST([f].[value] AS int) AS [value]
-        FROM OPENJSON(@__filteredOrderIds_0) AS [f]
+        SELECT [f].[value]
+        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
     )
 ) AS [t0]
 ORDER BY [t].[OrderID]
@@ -2140,8 +2140,8 @@ OUTER APPLY (
     SELECT [t].[OrderDate] AS [Outer1], [t].[CustomerID] AS [Outer2], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
     FROM [Orders] AS [o0]
     WHERE ([o0].[CustomerID] = [t].[CustomerID] OR ([o0].[CustomerID] IS NULL AND [t].[CustomerID] IS NULL)) AND [o0].[OrderID] IN (
-        SELECT CAST([f].[value] AS int) AS [value]
-        FROM OPENJSON(@__filteredOrderIds_0) AS [f]
+        SELECT [f].[value]
+        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
     )
 ) AS [t0]
 ORDER BY [t].[OrderDate], [t].[CustomerID]
@@ -2181,8 +2181,8 @@ OUTER APPLY (
     SELECT [t0].[OrderID] AS [Outer], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
     FROM [Orders] AS [o0]
     WHERE [o0].[OrderID] = [t0].[OrderID] AND [o0].[OrderID] IN (
-        SELECT CAST([f].[value] AS int) AS [value]
-        FROM OPENJSON(@__filteredOrderIds_0) AS [f]
+        SELECT [f].[value]
+        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
     )
 ) AS [t1]
 ORDER BY [t0].[OrderID]
@@ -2621,8 +2621,8 @@ OUTER APPLY (
     SELECT [t0].[CustomerID] AS [Outer], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
     FROM [Orders] AS [o0]
     WHERE ([o0].[CustomerID] = [t0].[CustomerID] OR ([o0].[CustomerID] IS NULL AND [t0].[CustomerID] IS NULL)) AND [o0].[OrderID] IN (
-        SELECT CAST([f].[value] AS int) AS [value]
-        FROM OPENJSON(@__filteredOrderIds_0) AS [f]
+        SELECT [f].[value]
+        FROM OPENJSON(@__filteredOrderIds_0) WITH ([value] int '$') AS [f]
     )
 ) AS [t1]
 ORDER BY [t0].[CustomerID], [t0].[Complex]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
@@ -116,8 +116,8 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN NOT EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -132,8 +132,8 @@ FROM (
     SELECT [c].[CustomerID], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -141,8 +141,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1113,8 +1113,8 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -1129,8 +1129,8 @@ FROM (
     SELECT [c].[CustomerID], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1138,8 +1138,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1560,8 +1560,8 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -1576,8 +1576,8 @@ FROM (
     SELECT [c].[CustomerID], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1585,8 +1585,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1739,8 +1739,8 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN NOT EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -1755,8 +1755,8 @@ FROM (
     SELECT [c].[CustomerID], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1764,8 +1764,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
@@ -2055,8 +2055,8 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -2071,8 +2071,8 @@ FROM (
     SELECT [c].[CustomerID], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -2080,8 +2080,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2106,8 +2106,8 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN NOT EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -2122,8 +2122,8 @@ FROM (
     SELECT [c].[CustomerID], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -2131,8 +2131,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2157,8 +2157,8 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -2173,8 +2173,8 @@ FROM (
     SELECT [c].[CustomerID], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -2182,8 +2182,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -2208,8 +2208,8 @@ WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY CASE
     WHEN NOT EXISTS (
         SELECT 1
-        FROM OPENJSON(@__list_0) AS [l]
-        WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+        WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END, [c].[CustomerID]
 OFFSET @__p_1 ROWS
@@ -2224,8 +2224,8 @@ FROM (
     SELECT [c].[CustomerID], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -2233,8 +2233,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
@@ -624,8 +624,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -633,8 +633,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -972,8 +972,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -981,8 +981,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1368,8 +1368,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1377,8 +1377,8 @@ FROM (
     ORDER BY CASE
         WHEN EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS
@@ -1847,8 +1847,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [c]
     FROM [Customers] AS [c]
@@ -1856,8 +1856,8 @@ FROM (
     ORDER BY CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM OPENJSON(@__list_0) AS [l]
-            WHERE CAST([l].[value] AS nchar(5)) = [c].[CustomerID]) THEN CAST(1 AS bit)
+            FROM OPENJSON(@__list_0) WITH ([value] nchar(5) '$') AS [l]
+            WHERE [l].[value] = [c].[CustomerID]) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     OFFSET @__p_1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -2075,8 +2075,8 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS nvarchar(15)) = [c].[City] OR ([c0].[value] IS NULL AND [c].[City] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(15) '$') AS [c0]
+    WHERE [c0].[value] = [c].[City] OR ([c0].[value] IS NULL AND [c].[City] IS NULL))
 """);
     }
 
@@ -2442,8 +2442,8 @@ ORDER BY [o].[OrderID], [o1].[OrderID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] IN (
-    SELECT CAST([o0].[value] AS int) AS [value]
-    FROM OPENJSON(@__orderIds_0) AS [o0]
+    SELECT [o0].[value]
+    FROM OPENJSON(@__orderIds_0) WITH ([value] int '$') AS [o0]
 )
 """);
     }
@@ -2459,8 +2459,8 @@ WHERE [o].[OrderID] IN (
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] IN (
-    SELECT CAST([o0].[value] AS int) AS [value]
-    FROM OPENJSON(@__orderIds_0) AS [o0]
+    SELECT [o0].[value]
+    FROM OPENJSON(@__orderIds_0) WITH ([value] int '$') AS [o0]
 )
 """);
     }
@@ -2566,8 +2566,8 @@ WHERE [c].[CustomerID] <> @__prm1_0 AND [c].[CustomerID] <> @__prm2_1 AND [c].[C
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([p].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__p_0) AS [p]
+    SELECT [p].[value]
+    FROM OPENJSON(@__p_0) WITH ([value] nchar(5) '$') AS [p]
 ) OR [c].[CustomerID] = N'ANTON'
 """);
     }
@@ -2596,8 +2596,8 @@ WHERE [c].[Region] IN (N'WA', N'OR') OR [c].[Region] IS NULL OR [c].[Region] = N
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([a].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__array_0) AS [a]
+    SELECT [a].[value]
+    FROM OPENJSON(@__array_0) WITH ([value] nchar(5) '$') AS [a]
 ) OR [c].[CustomerID] = N'ANTON'
 """);
     }
@@ -2615,8 +2615,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = @__prm1_0 OR [c].[CustomerID] IN (
-    SELECT CAST([a].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__array_1) AS [a]
+    SELECT [a].[value]
+    FROM OPENJSON(@__array_1) WITH ([value] nchar(5) '$') AS [a]
 ) OR [c].[CustomerID] = @__prm2_2
 """);
     }
@@ -2924,8 +2924,8 @@ WHERE EXISTS (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([c0].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__customerIds_0) AS [c0]
+    SELECT [c0].[value]
+    FROM OPENJSON(@__customerIds_0) WITH ([value] nchar(5) '$') AS [c0]
 ) AND [c].[City] = N'Seattle'
 """);
     }
@@ -2941,8 +2941,8 @@ WHERE [c].[CustomerID] IN (
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (
-    SELECT CAST([c0].[value] AS nchar(5)) AS [value]
-    FROM OPENJSON(@__customerIds_0) AS [c0]
+    SELECT [c0].[value]
+    FROM OPENJSON(@__customerIds_0) WITH ([value] nchar(5) '$') AS [c0]
 ) OR [c].[City] = N'Seattle'
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -917,7 +917,7 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
+    FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
     WHERE [i].[value] = [e].[NullableStringA] OR ([i].[value] IS NULL AND [e].[NullableStringA] IS NULL))
 """);
     }
@@ -934,7 +934,7 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
+    FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
     WHERE [i].[value] = [e].[NullableStringA] OR ([i].[value] IS NULL AND [e].[NullableStringA] IS NULL))
 """);
     }
@@ -951,7 +951,7 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
+    FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
     WHERE [i].[value] = [e].[NullableStringA] OR ([i].[value] IS NULL AND [e].[NullableStringA] IS NULL))
 """);
     }
@@ -968,7 +968,7 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
+    FROM OPENJSON(@__ids_0) WITH ([value] nvarchar(max) '$') AS [i]
     WHERE [i].[value] = [e].[NullableStringA] OR ([i].[value] IS NULL AND [e].[NullableStringA] IS NULL))
 """);
     }
@@ -1249,7 +1249,7 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[StringA] IN (
     SELECT [l].[value]
-    FROM OPENJSON(@__list_0) AS [l]
+    FROM OPENJSON(@__list_0) WITH ([value] nvarchar(max) '$') AS [l]
 )
 """,
             //
@@ -1295,7 +1295,7 @@ SELECT [e].[NullableStringA]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) AS [n]
+    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
 )
 """);
     }
@@ -1312,7 +1312,7 @@ SELECT [e].[NullableStringA]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) AS [n]
+    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
 )
 """);
     }
@@ -1329,7 +1329,7 @@ SELECT [e].[NullableStringA]
 FROM [Entities1] AS [e]
 WHERE [e].[NullableStringA] IN (
     SELECT [n].[value]
-    FROM OPENJSON(@__names_0) AS [n]
+    FROM OPENJSON(@__names_0) WITH ([value] nvarchar(max) '$') AS [n]
 )
 """);
     }
@@ -1786,8 +1786,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
 """,
             //
 """
@@ -1797,8 +1797,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
 """,
             //
 """
@@ -1808,8 +1808,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids2_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
 """,
             //
 """
@@ -1819,8 +1819,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids2_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
 """,
             //
 """
@@ -1860,8 +1860,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
 """,
             //
 """
@@ -1871,8 +1871,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
 """,
             //
 """
@@ -1882,8 +1882,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids2_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
 """,
             //
 """
@@ -1893,8 +1893,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids2_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
+    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[NullableIntA] OR ([i].[value] IS NULL AND [e].[NullableIntA] IS NULL))
 """,
             //
 """
@@ -2028,8 +2028,8 @@ WHERE NOT EXISTS (
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
 )
 """,
             //
@@ -2040,8 +2040,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[IntA])
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[IntA])
 """,
             //
 """
@@ -2050,8 +2050,8 @@ WHERE NOT EXISTS (
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ids2_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
 )
 """,
             //
@@ -2062,8 +2062,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids2_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[IntA])
+    FROM OPENJSON(@__ids2_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[IntA])
 """,
             //
 """
@@ -2072,8 +2072,8 @@ WHERE NOT EXISTS (
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ids3_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids3_0) WITH ([value] int '$') AS [i]
 )
 """,
             //
@@ -2084,8 +2084,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids3_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[IntA])
+    FROM OPENJSON(@__ids3_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[IntA])
 """,
             //
 """
@@ -2094,8 +2094,8 @@ WHERE NOT EXISTS (
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE [e].[IntA] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ids4_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids4_0) WITH ([value] int '$') AS [i]
 )
 """,
             //
@@ -2106,8 +2106,8 @@ SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
-    FROM OPENJSON(@__ids4_0) AS [i]
-    WHERE CAST([i].[value] AS int) = [e].[IntA])
+    FROM OPENJSON(@__ids4_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] = [e].[IntA])
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -364,6 +364,9 @@ WHERE (
     public override Task Column_collection_Skip_Take(bool async)
         => AssertTranslationFailed(() => base.Column_collection_Skip_Take(async));
 
+    public override Task Column_collection_OrderByDescending_ElementAt(bool async)
+        => AssertTranslationFailed(() => base.Column_collection_OrderByDescending_ElementAt(async));
+
     public override Task Column_collection_Any(bool async)
         => AssertTranslationFailed(() => base.Column_collection_Any(async));
 
@@ -379,8 +382,11 @@ ORDER BY [p].[Id]
 """);
     }
 
-    public override Task Column_collection_and_parameter_collection_Join(bool async)
-        => AssertTranslationFailed(() => base.Column_collection_and_parameter_collection_Join(async));
+    public override Task Column_collection_Join_parameter_collection(bool async)
+        => AssertTranslationFailed(() => base.Column_collection_Join_parameter_collection(async));
+
+    public override Task Inline_collection_Join_ordered_column_collection(bool async)
+        => AssertTranslationFailed(() => base.Inline_collection_Join_ordered_column_collection(async));
 
     public override Task Parameter_collection_Concat_column_collection(bool async)
         => AssertTranslationFailed(() => base.Parameter_collection_Concat_column_collection(async));

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -153,8 +153,8 @@ WHERE [p].[Id] IN (2, 999, 1000)
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Id] IN (
-    SELECT CAST([p0].[value] AS int) AS [value]
-    FROM OPENJSON(@__p_0) AS [p0]
+    SELECT [p0].[value]
+    FROM OPENJSON(@__p_0) WITH ([value] int '$') AS [p0]
 )
 """);
     }
@@ -202,8 +202,8 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON(@__ids_0) AS [i]
-    WHERE CAST([i].[value] AS int) > [p].[Id]) = 1
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+    WHERE [i].[value] > [p].[Id]) = 1
 """);
     }
 
@@ -218,8 +218,8 @@ WHERE (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
-    FROM OPENJSON(@__ints_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -235,8 +235,8 @@ WHERE [p].[Int] IN (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
-    SELECT CAST([n].[value] AS int) AS [value]
-    FROM OPENJSON(@__nullableInts_0) AS [n]
+    SELECT [n].[value]
+    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -253,8 +253,8 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__nullableInts_0) AS [n]
-    WHERE CAST([n].[value] AS int) = [p].[NullableInt] OR ([n].[value] IS NULL AND [p].[NullableInt] IS NULL))
+    FROM OPENJSON(@__nullableInts_0) WITH ([value] int '$') AS [n]
+    WHERE [n].[value] = [p].[NullableInt] OR ([n].[value] IS NULL AND [p].[NullableInt] IS NULL))
 """);
     }
 
@@ -270,7 +270,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__strings_0) AS [s]
+    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
     WHERE [s].[value] = [p].[String] OR ([s].[value] IS NULL AND [p].[String] IS NULL))
 """);
     }
@@ -286,8 +286,8 @@ WHERE EXISTS (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[DateTime] IN (
-    SELECT CAST([d].[value] AS datetime) AS [value]
-    FROM OPENJSON(@__dateTimes_0) AS [d]
+    SELECT [d].[value]
+    FROM OPENJSON(@__dateTimes_0) WITH ([value] datetime '$') AS [d]
 )
 """);
     }
@@ -303,8 +303,8 @@ WHERE [p].[DateTime] IN (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Bool] IN (
-    SELECT CAST([b].[value] AS bit) AS [value]
-    FROM OPENJSON(@__bools_0) AS [b]
+    SELECT [b].[value]
+    FROM OPENJSON(@__bools_0) WITH ([value] bit '$') AS [b]
 )
 """);
     }
@@ -320,8 +320,8 @@ WHERE [p].[Bool] IN (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Enum] IN (
-    SELECT CAST([e].[value] AS int) AS [value]
-    FROM OPENJSON(@__enums_0) AS [e]
+    SELECT [e].[value]
+    FROM OPENJSON(@__enums_0) WITH ([value] int '$') AS [e]
 )
 """);
     }
@@ -335,7 +335,7 @@ WHERE [p].[Enum] IN (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE [p].[Int] IN (
-    SELECT CAST([i].[value] AS int) AS [value]
+    SELECT [i].[value]
     FROM OPENJSON(N'[]') AS [i]
 )
 """);
@@ -350,8 +350,8 @@ WHERE [p].[Int] IN (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE 10 IN (
-    SELECT CAST([i].[value] AS int)
-    FROM OPENJSON([p].[Ints]) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
 )
 """);
     }
@@ -365,8 +365,8 @@ WHERE 10 IN (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE 10 IN (
-    SELECT CAST([n].[value] AS int)
-    FROM OPENJSON([p].[NullableInts]) AS [n]
+    SELECT [n].[value]
+    FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
 )
 """);
     }
@@ -381,7 +381,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON([p].[NullableInts]) AS [n]
+    FROM OPENJSON([p].[NullableInts]) WITH ([value] int '$') AS [n]
     WHERE [n].[value] IS NULL)
 """);
     }
@@ -396,7 +396,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON([p].[Strings]) AS [s]
+    FROM OPENJSON([p].[Strings]) WITH ([value] nvarchar(max) '$') AS [s]
     WHERE [s].[value] IS NULL)
 """);
     }
@@ -410,8 +410,8 @@ WHERE EXISTS (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE CAST(1 AS bit) IN (
-    SELECT CAST([b].[value] AS bit)
-    FROM OPENJSON([p].[Bools]) AS [b]
+    SELECT [b].[value]
+    FROM OPENJSON([p].[Bools]) WITH ([value] bit '$') AS [b]
 )
 """);
     }
@@ -436,7 +436,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([p].[Ints]) AS [i]) = 2
+    FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]) = 2
 """);
     }
 
@@ -450,7 +450,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([p].[Ints]) AS [i]) = 2
+    FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]) = 2
 """);
     }
 
@@ -571,7 +571,7 @@ FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([i].[key] AS int) AS [c]
+        SELECT 1 AS empty
         FROM OPENJSON([p].[Ints]) AS [i]
         ORDER BY CAST([i].[key] AS int)
         OFFSET 1 ROWS
@@ -588,7 +588,7 @@ WHERE (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE 11 IN (
-    SELECT TOP(2) CAST([i].[value] AS int)
+    SELECT TOP(2) CAST([i].[value] AS int) AS [value]
     FROM OPENJSON([p].[Ints]) AS [i]
     ORDER BY CAST([i].[key] AS int)
 )
@@ -604,11 +604,27 @@ WHERE 11 IN (
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE 11 IN (
-    SELECT CAST([i].[value] AS int)
+    SELECT CAST([i].[value] AS int) AS [value]
     FROM OPENJSON([p].[Ints]) AS [i]
     ORDER BY CAST([i].[key] AS int)
     OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
 )
+""");
+    }
+
+    public override async Task Column_collection_OrderByDescending_ElementAt(bool async)
+    {
+        await base.Column_collection_OrderByDescending_ElementAt(async);
+
+        AssertSql(
+"""
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT [i].[value]
+    FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
+    ORDER BY [i].[value] DESC
+    OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) = 111
 """);
     }
 
@@ -622,7 +638,7 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON([p].[Ints]) AS [i])
+    FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i])
 """);
     }
 
@@ -638,9 +654,9 @@ ORDER BY [p].[Id]
 """);
     }
 
-    public override async Task Column_collection_and_parameter_collection_Join(bool async)
+    public override async Task Column_collection_Join_parameter_collection(bool async)
     {
-        await base.Column_collection_and_parameter_collection_Join(async);
+        await base.Column_collection_Join_parameter_collection(async);
 
         AssertSql(
 """
@@ -650,8 +666,23 @@ SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
-    FROM OPENJSON([p].[Ints]) AS [i]
-    INNER JOIN OPENJSON(@__ints_0) AS [i0] ON CAST([i].[value] AS int) = [i0].[value]) = 2
+    FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
+    INNER JOIN OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0] ON [i].[value] = [i0].[value]) = 2
+""");
+    }
+
+    public override async Task Inline_collection_Join_ordered_column_collection(bool async)
+    {
+        await base.Inline_collection_Join_ordered_column_collection(async);
+
+        AssertSql(
+"""
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT COUNT(*)
+    FROM (VALUES (CAST(11 AS int)), (111)) AS [v]([Value])
+    INNER JOIN OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i] ON [v].[Value] = [i].[value]) = 2
 """);
     }
 
@@ -668,11 +699,11 @@ FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([i].[value] AS int) AS [value]
-        FROM OPENJSON(@__ints_0) AS [i]
+        SELECT [i].[value]
+        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i]
         UNION ALL
-        SELECT CAST([i0].[value] AS int) AS [value]
-        FROM OPENJSON([p].[Ints]) AS [i0]
+        SELECT [i0].[value]
+        FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i0]
     ) AS [t]) = 2
 """);
     }
@@ -690,11 +721,11 @@ FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([i].[value] AS int) AS [c]
-        FROM OPENJSON([p].[Ints]) AS [i]
+        SELECT [i].[value]
+        FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
         UNION
-        SELECT CAST([i0].[value] AS int) AS [c]
-        FROM OPENJSON(@__ints_0) AS [i0]
+        SELECT [i0].[value]
+        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0]
     ) AS [t]) = 2
 """);
     }
@@ -710,10 +741,10 @@ FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([i].[value] AS int) AS [c]
-        FROM OPENJSON([p].[Ints]) AS [i]
+        SELECT [i].[value]
+        FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
         INTERSECT
-        SELECT [v].[Value] AS [c]
+        SELECT [v].[Value] AS [value]
         FROM (VALUES (CAST(11 AS int)), (111)) AS [v]([Value])
     ) AS [t]) = 2
 """);
@@ -733,8 +764,8 @@ WHERE (
         SELECT [v].[Value]
         FROM (VALUES (CAST(11 AS int)), (111)) AS [v]([Value])
         EXCEPT
-        SELECT CAST([i].[value] AS int) AS [Value]
-        FROM OPENJSON([p].[Ints]) AS [i]
+        SELECT [i].[value] AS [Value]
+        FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
     ) AS [t]
     WHERE [t].[Value] % 2 = 1) = 2
 """);
@@ -794,8 +825,8 @@ WHERE (
             OFFSET 1 ROWS
         ) AS [t]
         UNION
-        SELECT CAST([i0].[value] AS int) AS [value]
-        FROM OPENJSON([p].[Ints]) AS [i0]
+        SELECT [i0].[value]
+        FROM OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i0]
     ) AS [t0]) = 3
 """);
     }
@@ -811,7 +842,7 @@ WHERE (
     {
         await base.Parameter_collection_in_subquery_Count_as_compiled_query(async);
 
-        // TODO: the subquery projection contains two extra columns which we should remove
+        // TODO: the subquery projection contains extra columns which we should remove
         AssertSql(
 """
 @__ints='[10,111]' (Size = 4000)
@@ -843,16 +874,16 @@ FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT [t].[c]
+        SELECT [t].[value]
         FROM (
-            SELECT CAST([i].[value] AS int) AS [c]
+            SELECT CAST([i].[value] AS int) AS [value]
             FROM OPENJSON([p].[Ints]) AS [i]
             ORDER BY CAST([i].[key] AS int)
             OFFSET 1 ROWS
         ) AS [t]
         UNION
-        SELECT CAST([i0].[value] AS int) AS [c]
-        FROM OPENJSON(@__ints_0) AS [i0]
+        SELECT [i0].[value]
+        FROM OPENJSON(@__ints_0) WITH ([value] int '$') AS [i0]
     ) AS [t0]) = 3
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -187,38 +187,38 @@ WHERE [d].[SmallDateTime] = '1970-09-03T12:00:00' AND [d].[DateTime] = '1971-09-
 SELECT [d].[Id], [d].[DateTime], [d].[DateTime2], [d].[DateTime2_0], [d].[DateTime2_1], [d].[DateTime2_2], [d].[DateTime2_3], [d].[DateTime2_4], [d].[DateTime2_5], [d].[DateTime2_6], [d].[DateTime2_7], [d].[SmallDateTime]
 FROM [Dates] AS [d]
 WHERE [d].[SmallDateTime] IN (
-    SELECT CAST([d0].[value] AS smalldatetime) AS [value]
-    FROM OPENJSON(@__dateTimes_0) AS [d0]
+    SELECT [d0].[value]
+    FROM OPENJSON(@__dateTimes_0) WITH ([value] smalldatetime '$') AS [d0]
 ) AND [d].[DateTime] IN (
-    SELECT CAST([d1].[value] AS datetime) AS [value]
-    FROM OPENJSON(@__dateTimes_0_1) AS [d1]
+    SELECT [d1].[value]
+    FROM OPENJSON(@__dateTimes_0_1) WITH ([value] datetime '$') AS [d1]
 ) AND [d].[DateTime2] IN (
-    SELECT CAST([d2].[value] AS datetime2) AS [value]
-    FROM OPENJSON(@__dateTimes_0_2) AS [d2]
+    SELECT [d2].[value]
+    FROM OPENJSON(@__dateTimes_0_2) WITH ([value] datetime2 '$') AS [d2]
 ) AND [d].[DateTime2_0] IN (
-    SELECT CAST([d3].[value] AS datetime2(0)) AS [value]
-    FROM OPENJSON(@__dateTimes_0_3) AS [d3]
+    SELECT [d3].[value]
+    FROM OPENJSON(@__dateTimes_0_3) WITH ([value] datetime2(0) '$') AS [d3]
 ) AND [d].[DateTime2_1] IN (
-    SELECT CAST([d4].[value] AS datetime2(1)) AS [value]
-    FROM OPENJSON(@__dateTimes_0_4) AS [d4]
+    SELECT [d4].[value]
+    FROM OPENJSON(@__dateTimes_0_4) WITH ([value] datetime2(1) '$') AS [d4]
 ) AND [d].[DateTime2_2] IN (
-    SELECT CAST([d5].[value] AS datetime2(2)) AS [value]
-    FROM OPENJSON(@__dateTimes_0_5) AS [d5]
+    SELECT [d5].[value]
+    FROM OPENJSON(@__dateTimes_0_5) WITH ([value] datetime2(2) '$') AS [d5]
 ) AND [d].[DateTime2_3] IN (
-    SELECT CAST([d6].[value] AS datetime2(3)) AS [value]
-    FROM OPENJSON(@__dateTimes_0_6) AS [d6]
+    SELECT [d6].[value]
+    FROM OPENJSON(@__dateTimes_0_6) WITH ([value] datetime2(3) '$') AS [d6]
 ) AND [d].[DateTime2_4] IN (
-    SELECT CAST([d7].[value] AS datetime2(4)) AS [value]
-    FROM OPENJSON(@__dateTimes_0_7) AS [d7]
+    SELECT [d7].[value]
+    FROM OPENJSON(@__dateTimes_0_7) WITH ([value] datetime2(4) '$') AS [d7]
 ) AND [d].[DateTime2_5] IN (
-    SELECT CAST([d8].[value] AS datetime2(5)) AS [value]
-    FROM OPENJSON(@__dateTimes_0_8) AS [d8]
+    SELECT [d8].[value]
+    FROM OPENJSON(@__dateTimes_0_8) WITH ([value] datetime2(5) '$') AS [d8]
 ) AND [d].[DateTime2_6] IN (
-    SELECT CAST([d9].[value] AS datetime2(6)) AS [value]
-    FROM OPENJSON(@__dateTimes_0_9) AS [d9]
+    SELECT [d9].[value]
+    FROM OPENJSON(@__dateTimes_0_9) WITH ([value] datetime2(6) '$') AS [d9]
 ) AND [d].[DateTime2_7] IN (
-    SELECT CAST([d10].[value] AS datetime2(7)) AS [value]
-    FROM OPENJSON(@__dateTimes_0_10) AS [d10]
+    SELECT [d10].[value]
+    FROM OPENJSON(@__dateTimes_0_10) WITH ([value] datetime2(7) '$') AS [d10]
 )
 """);
     }
@@ -3925,8 +3925,8 @@ FROM [Prices] AS [p]
 SELECT [r].[Id], [r].[MyTime]
 FROM [ReproEntity] AS [r]
 WHERE [r].[MyTime] IN (
-    SELECT CAST([t].[value] AS smalldatetime) AS [value]
-    FROM OPENJSON(@__testDateList_0) AS [t]
+    SELECT [t].[value]
+    FROM OPENJSON(@__testDateList_0) WITH ([value] smalldatetime '$') AS [t]
 )
 """);
         }
@@ -3994,8 +3994,8 @@ WHERE CASE
     WHEN [t].[Type] = 0 THEN @__key_2
     ELSE @__key_2
 END IN (
-    SELECT CAST([k].[value] AS uniqueidentifier) AS [value]
-    FROM OPENJSON(@__keys_0) AS [k]
+    SELECT [k].[value]
+    FROM OPENJSON(@__keys_0) WITH ([value] uniqueidentifier '$') AS [k]
 )
 """);
         }
@@ -8899,8 +8899,8 @@ ORDER BY [t].[Id], [t].[SecondOwner23211Id]
 SELECT [e].[Id], [e].[Name]
 FROM [Entities] AS [e]
 WHERE [e].[Id] NOT IN (
-    SELECT CAST([e0].[value] AS int) AS [value]
-    FROM OPENJSON(@__ef_filter___ids_0) AS [e0]
+    SELECT [e0].[value]
+    FROM OPENJSON(@__ef_filter___ids_0) WITH ([value] int '$') AS [e0]
 )
 """);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -97,7 +97,7 @@ WHERE [m].[Tenant] = @__ef_filter__p_0
 SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]
 WHERE [l].[Tenant] IN (
-    SELECT CAST([e].[value] AS int) AS [value]
+    SELECT [e].[value]
     FROM OPENJSON(N'[]') AS [e]
 )
 """,
@@ -108,8 +108,8 @@ WHERE [l].[Tenant] IN (
 SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]
 WHERE [l].[Tenant] IN (
-    SELECT CAST([e].[value] AS int) AS [value]
-    FROM OPENJSON(@__ef_filter__TenantIds_0) AS [e]
+    SELECT [e].[value]
+    FROM OPENJSON(@__ef_filter__TenantIds_0) WITH ([value] int '$') AS [e]
 )
 """,
             //
@@ -119,8 +119,8 @@ WHERE [l].[Tenant] IN (
 SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]
 WHERE [l].[Tenant] IN (
-    SELECT CAST([e].[value] AS int) AS [value]
-    FROM OPENJSON(@__ef_filter__TenantIds_0) AS [e]
+    SELECT [e].[value]
+    FROM OPENJSON(@__ef_filter__TenantIds_0) WITH ([value] int '$') AS [e]
 )
 """,
             //
@@ -130,8 +130,8 @@ WHERE [l].[Tenant] IN (
 SELECT [l].[Id], [l].[Tenant]
 FROM [ListFilter] AS [l]
 WHERE [l].[Tenant] IN (
-    SELECT CAST([e].[value] AS int) AS [value]
-    FROM OPENJSON(@__ef_filter__TenantIds_0) AS [e]
+    SELECT [e].[value]
+    FROM OPENJSON(@__ef_filter__TenantIds_0) WITH ([value] int '$') AS [e]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -318,8 +318,8 @@ FROM (
 LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
 WHERE [t0].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t1]
-    WHERE CAST([t1].[value] AS uniqueidentifier) = [t0].[Id] OR ([t1].[value] IS NULL AND [t0].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t1]
+    WHERE [t1].[value] = [t0].[Id] OR ([t1].[value] IS NULL AND [t0].[Id] IS NULL))
 """);
     }
 
@@ -348,8 +348,8 @@ INNER JOIN [Cities] AS [c] ON [t].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
 WHERE [c].[Location] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t1]
-    WHERE CAST([t1].[value] AS uniqueidentifier) = [t0].[Id] OR ([t1].[value] IS NULL AND [t0].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t1]
+    WHERE [t1].[value] = [t0].[Id] OR ([t1].[value] IS NULL AND [t0].[Id] IS NULL))
 """);
     }
 
@@ -377,8 +377,8 @@ FROM (
 LEFT JOIN [Tags] AS [t0] ON [t].[Nickname] = [t0].[GearNickName] AND [t].[SquadId] = [t0].[GearSquadId]
 WHERE [t0].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t1]
-    WHERE CAST([t1].[value] AS uniqueidentifier) = [t0].[Id] OR ([t1].[value] IS NULL AND [t0].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t1]
+    WHERE [t1].[value] = [t0].[Id] OR ([t1].[value] IS NULL AND [t0].[Id] IS NULL))
 """);
     }
 
@@ -2928,8 +2928,8 @@ SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS varchar(100)) = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
+    WHERE [c0].[value] = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
 """);
     }
 
@@ -4146,8 +4146,8 @@ END
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 WHERE [t].[Id] IN (
-    SELECT CAST([i].[value] AS uniqueidentifier) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
 )
 """);
     }
@@ -4807,8 +4807,8 @@ FROM (
 LEFT JOIN [Cities] AS [c] ON [t].[AssignedCityName] = [c].[Name]
 WHERE [t].[SquadId] < 2 AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS nvarchar(450)) = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(450) '$') AS [c0]
+    WHERE [c0].[value] = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
 """);
     }
 
@@ -8083,8 +8083,8 @@ LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__nicknames_0) AS [n]
-        WHERE CAST([n].[value] AS nvarchar(450)) = [t].[Nickname]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
+        WHERE [n].[value] = [t].[Nickname]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [t].[Nickname], [t].[SquadId]
 """);
@@ -8961,8 +8961,8 @@ WHERE (
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE @__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @__end_1 AND [m].[Timeline] IN (
-    SELECT CAST([d].[value] AS datetimeoffset) AS [value]
-    FROM OPENJSON(@__dates_2) AS [d]
+    SELECT [d].[value]
+    FROM OPENJSON(@__dates_2) WITH ([value] datetimeoffset '$') AS [d]
 )
 """);
     }
@@ -9842,8 +9842,8 @@ FROM (
 ) AS [t]
 ORDER BY CASE
     WHEN [t].[SquadId] IN (
-        SELECT CAST([i].[value] AS int) AS [value]
-        FROM OPENJSON(@__ids_0) AS [i]
+        SELECT [i].[value]
+        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -10852,8 +10852,8 @@ FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 WHERE [w0].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__types_0) AS [t]
-    WHERE CAST([t].[value] AS int) = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
+    FROM OPENJSON(@__types_0) WITH ([value] int '$') AS [t]
+    WHERE [t].[value] = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
 """);
     }
 
@@ -11964,8 +11964,8 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [t]
 WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t].[HasSoulPatch] IN (
-    SELECT CAST([v].[value] AS bit) AS [value]
-    FROM OPENJSON(@__values_0) AS [v]
+    SELECT [v].[value]
+    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -11987,8 +11987,8 @@ FROM (
     FROM [Officers] AS [o]
 ) AS [t]
 WHERE [t].[HasSoulPatch] = CAST(1 AS bit) AND [t].[HasSoulPatch] IN (
-    SELECT CAST([v].[value] AS bit) AS [value]
-    FROM OPENJSON(@__values_0) AS [v]
+    SELECT [v].[value]
+    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -299,8 +299,8 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -326,8 +326,8 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [c].[Location] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -352,8 +352,8 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -2486,8 +2486,8 @@ SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS varchar(100)) = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
+    WHERE [c0].[value] = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
 """);
     }
 
@@ -3570,8 +3570,8 @@ END
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note]
 FROM [Tags] AS [t]
 WHERE [t].[Id] IN (
-    SELECT CAST([i].[value] AS uniqueidentifier) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
 )
 """);
     }
@@ -4161,8 +4161,8 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 LEFT JOIN [Cities] AS [c] ON [g].[AssignedCityName] = [c].[Name]
 WHERE [g].[SquadId] < 2 AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS nvarchar(450)) = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(450) '$') AS [c0]
+    WHERE [c0].[value] = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
 """);
     }
 
@@ -6832,8 +6832,8 @@ LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__nicknames_0) AS [n]
-        WHERE CAST([n].[value] AS nvarchar(450)) = [g].[Nickname]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
+        WHERE [n].[value] = [g].[Nickname]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [g].[Nickname], [g].[SquadId]
 """);
@@ -7627,8 +7627,8 @@ WHERE (
 SELECT [m].[Id], [m].[CodeName], [m].[Date], [m].[Duration], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE @__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @__end_1 AND [m].[Timeline] IN (
-    SELECT CAST([d].[value] AS datetimeoffset) AS [value]
-    FROM OPENJSON(@__dates_2) AS [d]
+    SELECT [d].[value]
+    FROM OPENJSON(@__dates_2) WITH ([value] datetimeoffset '$') AS [d]
 )
 """);
     }
@@ -8437,8 +8437,8 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 ORDER BY CASE
     WHEN [g].[SquadId] IN (
-        SELECT CAST([i].[value] AS int) AS [value]
-        FROM OPENJSON(@__ids_0) AS [i]
+        SELECT [i].[value]
+        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -9287,8 +9287,8 @@ FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 WHERE [w0].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__types_0) AS [t]
-    WHERE CAST([t].[value] AS int) = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
+    FROM OPENJSON(@__types_0) WITH ([value] int '$') AS [t]
+    WHERE [t].[value] = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
 """);
     }
 
@@ -10265,8 +10265,8 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
-    SELECT CAST([v].[value] AS bit) AS [value]
-    FROM OPENJSON(@__values_0) AS [v]
+    SELECT [v].[value]
+    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -10285,8 +10285,8 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
-    SELECT CAST([v].[value] AS bit) AS [value]
-    FROM OPENJSON(@__values_0) AS [v]
+    SELECT [v].[value]
+    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -2309,7 +2309,7 @@ FROM (
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
         WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
     GROUP BY [l].[Date]
 ) AS [t]
@@ -2318,7 +2318,7 @@ LEFT JOIN (
     FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v0]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
         WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]
@@ -2629,7 +2629,7 @@ LEFT JOIN [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
 LEFT JOIN [LevelThree] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__validIds_0) AS [v]
+    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
     WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
 ORDER BY [l].[Id], [l0].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -1878,7 +1878,7 @@ LEFT JOIN (
 END = [t1].[OneToMany_Required_Inverse3Id]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__validIds_0) AS [v]
+    FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
     WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
 ORDER BY [l].[Id], [t0].[Id], [t0].[Id0]
 """);
@@ -3042,7 +3042,7 @@ FROM (
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v]
         WHERE [v].[value] = [l].[Name] OR ([v].[value] IS NULL AND [l].[Name] IS NULL))
     GROUP BY [l].[Date]
 ) AS [t]
@@ -3051,7 +3051,7 @@ LEFT JOIN (
     FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
     WHERE EXISTS (
         SELECT 1
-        FROM OPENJSON(@__validIds_0) AS [v0]
+        FROM OPENJSON(@__validIds_0) WITH ([value] nvarchar(max) '$') AS [v0]
         WHERE [v0].[value] = [l0].[Name] OR ([v0].[value] IS NULL AND [l0].[Name] IS NULL))
 ) AS [t0] ON [t].[Date] = [t0].[Date]
 ORDER BY [t].[Date]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -70,8 +70,8 @@ FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -97,8 +97,8 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [c].[Location] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -123,8 +123,8 @@ FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON [g].[Nickname] = [t].[GearNickName] AND [g].[SquadId] = [t].[GearSquadId]
 WHERE [t].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__tags_0) AS [t0]
-    WHERE CAST([t0].[value] AS uniqueidentifier) = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
+    FROM OPENJSON(@__tags_0) WITH ([value] uniqueidentifier '$') AS [t0]
+    WHERE [t0].[value] = [t].[Id] OR ([t0].[value] IS NULL AND [t].[Id] IS NULL))
 """);
     }
 
@@ -1633,8 +1633,8 @@ ORDER BY [f].[Name]
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
-    SELECT CAST([v].[value] AS bit) AS [value]
-    FROM OPENJSON(@__values_0) AS [v]
+    SELECT [v].[value]
+    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
 """);
     }
@@ -1746,8 +1746,8 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 LEFT JOIN [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c] ON [g].[AssignedCityName] = [c].[Name]
 WHERE [g].[SquadId] < 2 AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS nvarchar(450)) = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] nvarchar(450) '$') AS [c0]
+    WHERE [c0].[value] = [c].[Name] OR ([c0].[value] IS NULL AND [c].[Name] IS NULL))
 """);
     }
 
@@ -5590,8 +5590,8 @@ FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 WHERE [w0].[Id] IS NOT NULL AND EXISTS (
     SELECT 1
-    FROM OPENJSON(@__types_0) AS [t]
-    WHERE CAST([t].[value] AS int) = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
+    FROM OPENJSON(@__types_0) WITH ([value] int '$') AS [t]
+    WHERE [t].[value] = [w0].[AmmunitionType] OR ([t].[value] IS NULL AND [w0].[AmmunitionType] IS NULL))
 """);
     }
 
@@ -6164,8 +6164,8 @@ SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthNa
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 ORDER BY CASE
     WHEN [g].[SquadId] IN (
-        SELECT CAST([i].[value] AS int) AS [value]
-        FROM OPENJSON(@__ids_0) AS [i]
+        SELECT [i].[value]
+        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
     ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
@@ -6284,8 +6284,8 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit)
 SELECT [m].[Id], [m].[BriefingDocument], [m].[BriefingDocumentFileExtension], [m].[CodeName], [m].[Date], [m].[Duration], [m].[PeriodEnd], [m].[PeriodStart], [m].[Rating], [m].[Time], [m].[Timeline]
 FROM [Missions] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [m]
 WHERE @__start_0 <= CAST(CONVERT(date, [m].[Timeline]) AS datetimeoffset) AND [m].[Timeline] < @__end_1 AND [m].[Timeline] IN (
-    SELECT CAST([d].[value] AS datetimeoffset) AS [value]
-    FROM OPENJSON(@__dates_2) AS [d]
+    SELECT [d].[value]
+    FROM OPENJSON(@__dates_2) WITH ([value] datetimeoffset '$') AS [d]
 )
 """);
     }
@@ -6669,8 +6669,8 @@ SELECT [c].[Name], [c].[Location], [c].[Nation], [c].[PeriodEnd], [c].[PeriodSta
 FROM [Cities] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [c]
 WHERE EXISTS (
     SELECT 1
-    FROM OPENJSON(@__cities_0) AS [c0]
-    WHERE CAST([c0].[value] AS varchar(100)) = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
+    FROM OPENJSON(@__cities_0) WITH ([value] varchar(100) '$') AS [c0]
+    WHERE [c0].[value] = [c].[Location] OR ([c0].[value] IS NULL AND [c].[Location] IS NULL))
 """);
     }
 
@@ -7983,8 +7983,8 @@ LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w] O
 ORDER BY CASE
     WHEN EXISTS (
         SELECT 1
-        FROM OPENJSON(@__nicknames_0) AS [n]
-        WHERE CAST([n].[value] AS nvarchar(450)) = [g].[Nickname]) THEN CAST(1 AS bit)
+        FROM OPENJSON(@__nicknames_0) WITH ([value] nvarchar(450) '$') AS [n]
+        WHERE [n].[value] = [g].[Nickname]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END DESC, [g].[Nickname], [g].[SquadId]
 """);
@@ -8304,8 +8304,8 @@ ORDER BY [t].[Nickname], [t].[SquadId]
 SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[IssueDate], [t].[Note], [t].[PeriodEnd], [t].[PeriodStart]
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]
 WHERE [t].[Id] IN (
-    SELECT CAST([i].[value] AS uniqueidentifier) AS [value]
-    FROM OPENJSON(@__ids_0) AS [i]
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
 )
 """);
     }
@@ -8962,8 +8962,8 @@ WHERE @__prm_0 & [g].[Rank] = [g].[Rank]
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
 FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
-    SELECT CAST([v].[value] AS bit) AS [value]
-    FROM OPENJSON(@__values_0) AS [v]
+    SELECT [v].[value]
+    FROM OPENJSON(@__values_0) WITH ([value] bit '$') AS [v]
 )
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -257,7 +257,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT "c"."CustomerID", "c"."Country"
+    SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
     ORDER BY "c"."Country"
     LIMIT -1 OFFSET @__p_0
@@ -275,7 +275,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT "c"."CustomerID", "c"."Country"
+    SELECT "c"."CustomerID"
     FROM "Customers" AS "c"
     ORDER BY "c"."Country"
     LIMIT @__p_0

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -558,7 +558,7 @@ FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT "i"."key"
+        SELECT 1
         FROM json_each("p"."Ints") AS "i"
         ORDER BY "i"."key"
         LIMIT -1 OFFSET 1
@@ -600,6 +600,22 @@ WHERE 11 IN (
 """);
     }
 
+    public override async Task Column_collection_OrderByDescending_ElementAt(bool async)
+    {
+        await base.Column_collection_OrderByDescending_ElementAt(async);
+
+        AssertSql(
+"""
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT "i"."value"
+    FROM json_each("p"."Ints") AS "i"
+    ORDER BY "i"."value" DESC
+    LIMIT 1 OFFSET 0) = 111
+""");
+    }
+
     public override async Task Column_collection_Any(bool async)
     {
         await base.Column_collection_Any(async);
@@ -626,9 +642,9 @@ ORDER BY "p"."Id"
 """);
     }
 
-    public override async Task Column_collection_and_parameter_collection_Join(bool async)
+    public override async Task Column_collection_Join_parameter_collection(bool async)
     {
-        await base.Column_collection_and_parameter_collection_Join(async);
+        await base.Column_collection_Join_parameter_collection(async);
 
         AssertSql(
 """
@@ -640,6 +656,21 @@ WHERE (
     SELECT COUNT(*)
     FROM json_each("p"."Ints") AS "i"
     INNER JOIN json_each(@__ints_0) AS "i0" ON "i"."value" = "i0"."value") = 2
+""");
+    }
+
+    public override async Task Inline_collection_Join_ordered_column_collection(bool async)
+    {
+        await base.Inline_collection_Join_ordered_column_collection(async);
+
+        AssertSql(
+"""
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE (
+    SELECT COUNT(*)
+    FROM (SELECT CAST(11 AS INTEGER) AS "Value" UNION ALL VALUES (111)) AS "v"
+    INNER JOIN json_each("p"."Ints") AS "i" ON "v"."Value" = "i"."value") = 2
 """);
     }
 


### PR DESCRIPTION
~This PR based based on top of #30976 and #30956, review those first and ignore the first commits here.~

We currently generate SQL Server OPENJSON expressions without WITH, applying a regular relational cast to applying the element store type to the output:

```sql
WHERE [t].[Id] IN (
    SELECT CAST([i].[value] AS uniqueidentifier) AS [value]
    FROM OPENJSON(@__ids_0) AS [i]
```

We use this form because it allows preserving the ordering of the JSON array (not needed in the above specific query), and that's not possible with the OPENJSON form that accepts WITH.

This PR switches to using OPENJSON with WITH in contexts where preserving the ordering isn't needed, such as the above query:

```sql
WHERE [t].[Id] IN (
    SELECT [i].[value]
    FROM OPENJSON(@__ids_0) WITH ([value] uniqueidentifier '$') AS [i]
```

Where ordering is important, we continue to use OPENJSON without WITH as today.

Compared to OPENJSON with WITH, OPENJSON without WITH has some performance drawbacks (see https://github.com/dotnet/efcore/issues/13617#issuecomment-1556016939, https://github.com/dotnet/efcore/issues/13617#issuecomment-1561125154). In addition, some conversions from JSON are only possible when using the WITH variant (see https://github.com/dotnet/efcore/issues/30727#issuecomment-1561765456).

/cc @yv989c, @pfritschi