### PR TITLE
[release/6.0] Microsoft.Data.Sqlite: Fix handling of queries with RETURNING clause

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -16,18 +16,22 @@ namespace Microsoft.Data.Sqlite
     internal class SqliteDataRecord : SqliteValueReader, IDisposable
     {
         private readonly SqliteConnection _connection;
+        private readonly Action<int> _addChanges;
         private byte[][]? _blobCache;
         private int?[]? _typeCache;
         private Dictionary<string, int>? _columnNameOrdinalCache;
         private string[]? _columnNameCache;
         private bool _stepped;
         private int? _rowidOrdinal;
+        private bool _alreadyThrown;
+        private bool _alreadyAddedChanges;
 
-        public SqliteDataRecord(sqlite3_stmt stmt, bool hasRows, SqliteConnection connection)
+        public SqliteDataRecord(sqlite3_stmt stmt, bool hasRows, SqliteConnection connection, Action<int> addChanges)
         {
             Handle = stmt;
             HasRows = hasRows;
             _connection = connection;
+            _addChanges = addChanges;
         }
 
         public virtual object this[string name]
@@ -397,19 +401,59 @@ namespace Microsoft.Data.Sqlite
                 return false;
             }
 
-            var rc = sqlite3_step(Handle);
-            SqliteException.ThrowExceptionForRC(rc, _connection.Handle);
+            int rc;
+            try
+            {
+                rc = sqlite3_step(Handle);
+                SqliteException.ThrowExceptionForRC(rc, _connection.Handle);
+            }
+            catch
+            {
+                _alreadyThrown = true;
+
+                throw;
+            }
 
             if (_blobCache != null)
             {
                 Array.Clear(_blobCache, 0, _blobCache.Length);
             }
 
-            return rc != SQLITE_DONE;
+            if (rc != SQLITE_DONE)
+            {
+                return true;
+            }
+            
+            AddChanges();
+            _alreadyAddedChanges = true;
+
+            return false;
         }
 
         public void Dispose()
-            => sqlite3_reset(Handle);
+        {
+            var rc = sqlite3_reset(Handle);
+            if (!_alreadyThrown)
+            {
+                SqliteException.ThrowExceptionForRC(rc, _connection.Handle);
+            }
+
+            if (!_alreadyAddedChanges)
+            {
+                AddChanges();
+            }
+        }
+
+        private void AddChanges()
+        {
+            if (sqlite3_stmt_readonly(Handle) != 0)
+            {
+                return;
+            }
+
+            var changes = sqlite3_changes(_connection.Handle);
+            _addChanges(changes);
+        }
 
         private byte[] GetCachedBlob(int ordinal)
         {

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -932,6 +932,120 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public Task ExecuteScalar_throws_when_busy_with_returning()
+            => Execute_throws_when_busy_with_returning(command =>
+            {
+                var ex = Assert.Throws<SqliteException>(
+                    () => command.ExecuteScalar());
+
+                Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
+            });
+
+        [Fact]
+        public Task ExecuteNonQuery_throws_when_busy_with_returning()
+            => Execute_throws_when_busy_with_returning(command =>
+            {
+                var ex = Assert.Throws<SqliteException>(
+                    () => command.ExecuteNonQuery());
+
+                Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
+            });
+
+        [Fact]
+        public Task ExecuteReader_throws_when_busy_with_returning()
+            => Execute_throws_when_busy_with_returning(command =>
+            {
+                var reader = command.ExecuteReader();
+                try
+                {
+                    Assert.True(reader.Read());
+                    Assert.Equal(2L, reader.GetInt64(0));
+                }
+                finally
+                {
+                    var ex = Assert.Throws<SqliteException>(
+                        () => reader.Dispose());
+
+                    Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
+                }
+            });
+
+        [Fact]
+        public Task ExecuteReader_throws_when_busy_with_returning_while_draining()
+            => Execute_throws_when_busy_with_returning(command =>
+            {
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+                Assert.Equal(2L, reader.GetInt64(0));
+                Assert.True(reader.Read());
+                Assert.Equal(3L, reader.GetInt64(0));
+
+                var ex = Assert.Throws<SqliteException>(
+                    () => reader.Read());
+
+                Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
+            });
+
+        private static async Task Execute_throws_when_busy_with_returning(Action<SqliteCommand> action)
+        {
+            const string connectionString = "Data Source=returning.db";
+
+            var selectedSignal = new AutoResetEvent(initialState: false);
+
+            try
+            {
+                using var connection1 = new SqliteConnection(connectionString);
+
+                if (new Version(connection1.ServerVersion) < new Version(3, 35, 0))
+                {
+                    // Skip. RETURNING clause not supported
+                    return;
+                }
+
+                connection1.Open();
+
+                connection1.ExecuteNonQuery(
+                    "CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
+
+                await Task.WhenAll(
+                    Task.Run(
+                        async () =>
+                        {
+                            using var connection = new SqliteConnection(connectionString);
+                            connection.Open();
+
+                            using (connection.ExecuteReader("SELECT * FROM Data;"))
+                            {
+                                selectedSignal.Set();
+
+                                await Task.Delay(1000);
+                            }
+                        }),
+                    Task.Run(
+                        () =>
+                        {
+                            using var connection = new SqliteConnection(connectionString);
+                            connection.Open();
+
+                            selectedSignal.WaitOne();
+
+                            var command = connection.CreateCommand();
+                            command.CommandText = "INSERT INTO Data VALUES (1),(2) RETURNING rowid;";
+
+                            action(command);
+                        }));
+
+                var count = connection1.ExecuteScalar<long>("SELECT COUNT(*) FROM Data;");
+                Assert.Equal(1L, count);
+            }
+            finally
+            {
+                SqliteConnection.ClearPool(new SqliteConnection(connectionString));
+                File.Delete("returning.db");
+            }
+        }
+
+        [Fact]
         public void ExecuteReader_honors_CommandTimeout()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -1852,6 +1852,73 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void RecordsAffected_works_with_returning()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                if (new Version(connection.ServerVersion) < new Version(3, 35, 0))
+                {
+                    // Skip. RETURNING clause not supported
+                    return;
+                }
+
+                connection.Open();
+                connection.ExecuteNonQuery("CREATE TABLE Test(Value);");
+
+                var reader = connection.ExecuteReader("INSERT INTO Test VALUES(1) RETURNING rowid;");
+                ((IDisposable)reader).Dispose();
+
+                Assert.Equal(1, reader.RecordsAffected);
+            }
+        }
+
+        [Fact]
+        public void RecordsAffected_works_with_returning_before_dispose_after_draining()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                if (new Version(connection.ServerVersion) < new Version(3, 35, 0))
+                {
+                    // Skip. RETURNING clause not supported
+                    return;
+                }
+
+                connection.Open();
+                connection.ExecuteNonQuery("CREATE TABLE Test(Value);");
+
+                using (var reader = connection.ExecuteReader("INSERT INTO Test VALUES(1) RETURNING rowid;"))
+                {
+                    while (reader.Read())
+                    {
+                    }
+
+                    Assert.Equal(1, reader.RecordsAffected);
+                }
+            }
+        }
+
+        [Fact]
+        public void RecordsAffected_works_with_returning_multiple()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                if (new Version(connection.ServerVersion) < new Version(3, 35, 0))
+                {
+                    // Skip. RETURNING clause not supported
+                    return;
+                }
+
+                connection.Open();
+                connection.ExecuteNonQuery("CREATE TABLE Test(Value);");
+
+                var reader = connection.ExecuteReader("INSERT INTO Test VALUES(1),(2) RETURNING rowid;");
+                ((IDisposable)reader).Dispose();
+
+                Assert.Equal(2, reader.RecordsAffected);
+            }
+        }
+
+        [Fact]
         public void GetSchemaTable_works()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))


### PR DESCRIPTION
Fixes #30851

When using the DELETE journaling mode in SQLite (Note, this is not the default for databases created by EF), the RETURNING clause on INSERT, UPDATE, and DELETE statements exhibits some unusual behavior. It will return results before the changes are actually persisted to the database. Only after consuming the entire DbDataReader (or disposing it) will it report that the table is busy and cannot be updated. This is the first statement we've encountered with this behavior.

This issue fixes a bug where errors encountered while disposing a DbDataReader were being swallowed/ignored by Microsoft.Data.Sqlite.

### Customer impact

Two users have reported this issue. Because the error was previously ignored, it appeared to your application that the changes were successfully made to the database when, in fact, they were not. From the application's perspective, this results in changes made by statements with RETURNING clauses occasionally being lost (or not persisted).

The RETURNING clause was added to SQLite in the .NET 6 timeframe, and we started using it in certain cases in .NET 7.

Once users discover that this is an issue, they can work around it in various ways. For example, by using WAL journaling mode (the EF default, and the recommended one), by using shared cache mode, by wrapping the statement inside a transaction, or by using a separate SELECT statement instead of the RETURNING clause.

### Regression

No. This bug has always existed but could only be hit by this unusual behavior of the RETURNING clause.

### Risk

Low. This just surfaces errors that are already happening to the application via exceptions.

### Verification

Automated tests added to verify a "busy" exception is always thrown.
Manually verified that the user-reported scenario using EF Core throws as well.
