### PR TITLE
[release/7.x] Disable trigger enumeration on Azure Synapse Analytics, where triggers are not supported

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -648,7 +648,11 @@ WHERE "
         GetColumns(connection, tables, filter, viewFilter, typeAliases, databaseCollation);
         GetIndexes(connection, tables, filter);
         GetForeignKeys(connection, tables, filter);
-        GetTriggers(connection, tables, filter);
+
+        if (SupportsTriggers())
+        {
+            GetTriggers(connection, tables, filter);
+        }
 
         foreach (var table in tables)
         {
@@ -1342,6 +1346,9 @@ ORDER BY [table_schema], [table_name], [tr].[name]";
 
     private bool SupportsSequences()
         => _compatibilityLevel >= 110 && _engineEdition != 6;
+
+    private bool SupportsTriggers()
+        => _engineEdition != 6;
 
     private static string DisplayName(string? schema, string name)
         => (!string.IsNullOrEmpty(schema) ? schema + "." : "") + name;


### PR DESCRIPTION
See https://learn.microsoft.com/azure/synapse-analytics/sql/overview-features

Fixes #30998

## Description

Azure Synapse databases do not support triggers. We started checking for triggers in EF Core 7, which causes scaffolding from a Synapse database to fail.

## Customer impact

Crash attempting to scaffold from a Synapse database. Workaround is to use the EF Core Power Tools, which have already been fixed.

## How found

Customer reports 7.0

## Regression

Yes.

## Testing

Manual testing.

## Risk

Low. Not quirked, because this is a design-time change.
