### PR TITLE
Introduce Visit for IReadOnlyList<T>

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/RowValueExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/RowValueExpression.cs
@@ -36,32 +36,10 @@ public class RowValueExpression : SqlExpression
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
-    {
-        Check.NotNull(visitor, nameof(visitor));
-
-        SqlExpression[]? newValues = null;
-
-        for (var i = 0; i < Values.Count; i++)
-        {
-            var value = Values[i];
-            var visited = (SqlExpression)visitor.Visit(value);
-            if (visited != value && newValues is null)
-            {
-                newValues = new SqlExpression[Values.Count];
-                for (var j = 0; j < i; j++)
-                {
-                    newValues[j] = Values[j];
-                }
-            }
-
-            if (newValues is not null)
-            {
-                newValues[i] = visited;
-            }
-        }
-
-        return newValues is null ? this : new RowValueExpression(newValues);
-    }
+        => visitor.VisitAndConvert(Values) is var newValues
+            && ReferenceEquals(newValues, Values)
+                ? this
+                : new RowValueExpression(newValues);
 
     /// <summary>
     ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will

--- a/src/EFCore.Relational/Query/SqlExpressions/ValuesExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ValuesExpression.cs
@@ -76,32 +76,10 @@ public class ValuesExpression : TableExpressionBase, IClonableTableExpressionBas
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
-    {
-        Check.NotNull(visitor, nameof(visitor));
-
-        RowValueExpression[]? newRowValues = null;
-
-        for (var i = 0; i < RowValues.Count; i++)
-        {
-            var rowValue = RowValues[i];
-            var visited = (RowValueExpression)visitor.Visit(rowValue);
-            if (visited != rowValue && newRowValues is null)
-            {
-                newRowValues = new RowValueExpression[RowValues.Count];
-                for (var j = 0; j < i; j++)
-                {
-                    newRowValues[j] = RowValues[j];
-                }
-            }
-
-            if (newRowValues is not null)
-            {
-                newRowValues[i] = visited;
-            }
-        }
-
-        return newRowValues is null ? this : new ValuesExpression(Alias, newRowValues, ColumnNames);
-    }
+        => visitor.VisitAndConvert(RowValues) is var newRowValues
+            && ReferenceEquals(newRowValues, RowValues)
+                ? this
+                : new ValuesExpression(Alias, newRowValues, ColumnNames);
 
     /// <summary>
     ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1606,6 +1606,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 storeNames);
 
         /// <summary>
+        ///     When called from '{0}', rewriting a node of type '{1}' must return a non-null value of the same type. Alternatively, override '{0}' and change it to not visit children of this type.
+        /// </summary>
+        public static string MustRewriteToSameNode(object? caller, object? type)
+            => string.Format(
+                GetString("MustRewriteToSameNode", nameof(caller), nameof(type)),
+                caller, type);
+
+        /// <summary>
         ///     The property '{keyProperty}' cannot be configured as 'ValueGeneratedOnUpdate' or 'ValueGeneratedOnAddOrUpdate' because it's part of a key and its value cannot be changed after the entity has been added to the store.
         /// </summary>
         public static string MutableKeyProperty(object? keyProperty)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1028,6 +1028,9 @@
   <data name="MultipleProvidersConfigured" xml:space="preserve">
     <value>Services for database providers {storeNames} have been registered in the service provider. Only a single database provider can be registered in a service provider. If possible, ensure that Entity Framework is managing its service provider by removing the call to 'UseInternalServiceProvider'. Otherwise, consider conditionally registering the database provider, or maintaining one service provider per database provider.</value>
   </data>
+  <data name="MustRewriteToSameNode" xml:space="preserve">
+    <value>When called from '{0}', rewriting a node of type '{1}' must return a non-null value of the same type. Alternatively, override '{0}' and change it to not visit children of this type.</value>
+  </data>
   <data name="MutableKeyProperty" xml:space="preserve">
     <value>The property '{keyProperty}' cannot be configured as 'ValueGeneratedOnUpdate' or 'ValueGeneratedOnAddOrUpdate' because it's part of a key and its value cannot be changed after the entity has been added to the store.</value>
   </data>

--- a/src/EFCore/Query/InlineQueryRootExpression.cs
+++ b/src/EFCore/Query/InlineQueryRootExpression.cs
@@ -47,31 +47,10 @@ public class InlineQueryRootExpression : QueryRootExpression
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
-    {
-        Expression[]? newValues = null;
-
-        for (var i = 0; i < Values.Count; i++)
-        {
-            var value = Values[i];
-            var newValue = visitor.Visit(value);
-
-            if (newValue != value && newValues is null)
-            {
-                newValues = new Expression[Values.Count];
-                for (var j = 0; j < i; j++)
-                {
-                    newValues[j] = Values[j];
-                }
-            }
-
-            if (newValues is not null)
-            {
-                newValues[i] = newValue;
-            }
-        }
-
-        return newValues is null ? this : new InlineQueryRootExpression(newValues, Type);
-    }
+        => visitor.Visit(Values) is var visitedValues
+            && ReferenceEquals(visitedValues, Values)
+                ? this
+                : new InlineQueryRootExpression(visitedValues, Type);
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)

--- a/src/EFCore/Query/QueryRootProcessor.cs
+++ b/src/EFCore/Query/QueryRootProcessor.cs
@@ -93,21 +93,19 @@ public class QueryRootProcessor : ExpressionVisitor
 
             visitedArgument ??= Visit(argument);
 
-            if (visitedArgument != argument)
-            {
-                if (newArguments is null)
-                {
-                    newArguments = new Expression[methodCallExpression.Arguments.Count];
-
-                    for (var j = 0; j < i; j++)
-                    {
-                        newArguments[j] = methodCallExpression.Arguments[j];
-                    }
-                }
-            }
-
             if (newArguments is not null)
             {
+                newArguments[i] = visitedArgument;
+            }
+            else if (!ReferenceEquals(visitedArgument, argument))
+            {
+                newArguments = new Expression[methodCallExpression.Arguments.Count];
+
+                for (var j = 0; j < i; j++)
+                {
+                    newArguments[j] = methodCallExpression.Arguments[j];
+                }
+
                 newArguments[i] = visitedArgument;
             }
         }

--- a/src/Shared/ExpressionVisitorExtensions.cs
+++ b/src/Shared/ExpressionVisitorExtensions.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+
+using System.Runtime.CompilerServices;
+
+namespace System.Linq.Expressions;
+
+#nullable enable
+
+[DebuggerStepThrough]
+internal static class ExpressionVisitorExtensions
+{
+    /// <summary>
+    ///     Dispatches the list of expressions to one of the more specialized visit methods in this class.
+    /// </summary>
+    /// <param name="visitor">The expression visitor.</param>
+    /// <param name="nodes">The expressions to visit.</param>
+    /// <returns>
+    ///     The modified expression list, if any of the elements were modified; otherwise, returns the original expression list.
+    /// </returns>
+    public static IReadOnlyList<Expression> Visit(this ExpressionVisitor visitor, IReadOnlyList<Expression> nodes)
+    {
+        Expression[]? newNodes = null;
+        for (int i = 0, n = nodes.Count; i < n; i++)
+        {
+            var node = visitor.Visit(nodes[i]);
+
+            if (newNodes is not null)
+            {
+                newNodes[i] = node;
+            }
+            else if (!ReferenceEquals(node, nodes[i]))
+            {
+                newNodes = new Expression[n];
+                for (var j = 0; j < i; j++)
+                {
+                    newNodes[j] = nodes[j];
+                }
+                newNodes[i] = node;
+            }
+        }
+
+        return newNodes ?? nodes;
+    }
+
+    /// <summary>
+    ///     Visits an expression, casting the result back to the original expression type.
+    /// </summary>
+    /// <typeparam name="T">The type of the expression.</typeparam>
+    /// <param name="visitor">The expression visitor.</param>
+    /// <param name="nodes">The expression to visit.</param>
+    /// <param name="callerName">The name of the calling method; used to report to report a better error message.</param>
+    /// <returns>
+    ///     The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">The visit method for this node returned a different type.</exception>
+    public static IReadOnlyList<T> VisitAndConvert<T>(
+        this ExpressionVisitor visitor,
+        IReadOnlyList<T> nodes,
+        [CallerMemberName] string? callerName = null)
+        where T : Expression
+    {
+        T[]? newNodes = null;
+        for (int i = 0, n = nodes.Count; i < n; i++)
+        {
+            if (visitor.Visit(nodes[i]) is not T node)
+            {
+                throw new InvalidOperationException(CoreStrings.MustRewriteToSameNode(callerName, typeof(T).Name));
+            }
+
+            if (newNodes is not null)
+            {
+                newNodes[i] = node;
+            }
+            else if (!ReferenceEquals(node, nodes[i]))
+            {
+                newNodes = new T[n];
+                for (var j = 0; j < i; j++)
+                {
+                    newNodes[j] = nodes[j];
+                }
+                newNodes[i] = node;
+            }
+        }
+
+        return newNodes ?? nodes;
+    }
+
+    /// <summary>
+    ///     Visits all nodes in the collection using a specified element visitor.
+    /// </summary>
+    /// <typeparam name="T">The type of the nodes.</typeparam>
+    /// <param name="visitor">The expression visitor.</param>
+    /// <param name="nodes">The nodes to visit.</param>
+    /// <param name="elementVisitor">A delegate that visits a single element,
+    /// optionally replacing it with a new element.</param>
+    /// <returns>The modified node list, if any of the elements were modified;
+    /// otherwise, returns the original node list.</returns>
+    public static IReadOnlyList<T> Visit<T>(this ExpressionVisitor visitor, IReadOnlyList<T> nodes, Func<T, T> elementVisitor)
+    {
+        T[]? newNodes = null;
+        for (int i = 0, n = nodes.Count; i < n; i++)
+        {
+            var node = elementVisitor(nodes[i]);
+            if (newNodes is not null)
+            {
+                newNodes[i] = node;
+            }
+            else if (!ReferenceEquals(node, nodes[i]))
+            {
+                newNodes = new T[n];
+                for (var j = 0; j < i; j++)
+                {
+                    newNodes[j] = nodes[j];
+                }
+                newNodes[i] = node;
+            }
+        }
+
+        return newNodes ?? nodes;
+    }
+}


### PR DESCRIPTION
ExpressionVisitor contains various methods for working with lists of expressions (e.g. [Visit over a collection](https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions.expressionvisitor.visit?view=net-7.0#system-linq-expressions-expressionvisitor-visit(system-collections-objectmodel-readonlycollection((system-linq-expressions-expression))))), these are very useful for when a node contains a list of sub-nodes.

However, these methods work with the standard [ReadOnlyCollection](https://learn.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.readonlycollection-1?view=net-7.0), which for some reason we don't use in our custom expression types - we use `IReadOnlyList<SqlExpression>`. So this introduces extension methods that duplicate the built-in ones, but for that.