### PR TITLE
Improve expression debugging

### DIFF
--- a/src/EFCore.Relational/Query/JsonQueryExpression.cs
+++ b/src/EFCore.Relational/Query/JsonQueryExpression.cs
@@ -212,9 +212,10 @@ public class JsonQueryExpression : Expression, IPrintableExpression
     /// <inheritdoc />
     public virtual void Print(ExpressionPrinter expressionPrinter)
     {
-        expressionPrinter.Append("JsonQueryExpression(");
         expressionPrinter.Visit(JsonColumn);
-        expressionPrinter.Append($""", "{string.Join(".", Path.Select(e => e.ToString()))}")""");
+        expressionPrinter
+            .Append(" Q-> ")
+            .Append(string.Join(".", Path.Select(e => e.ToString())));
     }
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///         not used in application code.
 ///     </para>
 /// </summary>
-[DebuggerDisplay("{DebuggerDisplay(),nq}")]
+[DebuggerDisplay("{TableAlias}.{Name}")]
 public abstract class ColumnExpression : SqlExpression
 {
     /// <summary>
@@ -64,7 +64,4 @@ public abstract class ColumnExpression : SqlExpression
         expressionPrinter.Append(TableAlias).Append(".");
         expressionPrinter.Append(Name);
     }
-
-    private string DebuggerDisplay()
-        => $"{TableAlias}.{Name}";
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/JsonScalarExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/JsonScalarExpression.cs
@@ -126,9 +126,10 @@ public class JsonScalarExpression : SqlExpression
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
-        expressionPrinter.Append("JsonScalarExpression(column: ");
         expressionPrinter.Visit(Json);
-        expressionPrinter.Append($""", "{string.Join(".", Path.Select(e => e.ToString()))}")""");
+        expressionPrinter
+            .Append(" -> ")
+            .Append(string.Join(".", Path.Select(e => e.ToString())));
     }
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Query/SqlExpressions/OrderingExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OrderingExpression.cs
@@ -12,6 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///         not used in application code.
 ///     </para>
 /// </summary>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
 public class OrderingExpression : Expression, IPrintableExpression
 {
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlExpressions/ProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ProjectionExpression.cs
@@ -12,6 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///     application or provider, then please file an issue at
 ///     <see href="https://github.com/dotnet/efcore">github.com/dotnet/efcore</see>.
 /// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
 public sealed class ProjectionExpression : Expression, IPrintableExpression
 {
     internal ProjectionExpression(SqlExpression expression, string alias)
@@ -57,6 +58,7 @@ public sealed class ProjectionExpression : Expression, IPrintableExpression
     void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
     {
         expressionPrinter.Visit(Expression);
+
         if (Alias != string.Empty
             && !(Expression is ColumnExpression column
                 && column.Name == Alias))

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///     an issue at <see href="https://github.com/dotnet/efcore">github.com/dotnet/efcore</see>.
 /// </remarks>
 // Class is sealed because there are no public/protected constructors. Can be unsealed if this is changed.
+[DebuggerDisplay("{PrintShortSql(), nq}")]
 public sealed partial class SelectExpression : TableExpressionBase
 {
     private const string DiscriminatorColumnAlias = "Discriminator";
@@ -4562,6 +4563,13 @@ public sealed partial class SelectExpression : TableExpressionBase
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
     {
+        PrintProjections(expressionPrinter);
+        expressionPrinter.AppendLine();
+        PrintSql(expressionPrinter);
+    }
+
+    private void PrintProjections(ExpressionPrinter expressionPrinter)
+    {
         if (_clientProjections.Count > 0)
         {
             expressionPrinter.AppendLine("Client Projections:");
@@ -4588,12 +4596,16 @@ public sealed partial class SelectExpression : TableExpressionBase
                 }
             }
         }
+    }
 
-        expressionPrinter.AppendLine();
-
-        foreach (var tag in Tags)
+    private void PrintSql(ExpressionPrinter expressionPrinter, bool withTags = true)
+    {
+        if (withTags)
         {
-            expressionPrinter.Append($"-- {tag}");
+            foreach (var tag in Tags)
+            {
+                expressionPrinter.Append($"-- {tag}");
+            }
         }
 
         IDisposable? indent = null;
@@ -4681,6 +4693,26 @@ public sealed partial class SelectExpression : TableExpressionBase
             expressionPrinter.AppendLine().Append(") AS " + Alias);
         }
     }
+
+    private string PrintShortSql()
+    {
+        var expressionPrinter = new ExpressionPrinter();
+        PrintSql(expressionPrinter, withTags: false);
+        return expressionPrinter.ToString();
+    }
+
+    /// <summary>
+    ///     <para>
+    ///         Expand this property in the debugger for a human-readable representation of this <see cref="SelectExpression" />.
+    ///     </para>
+    ///     <para>
+    ///         Warning: Do not rely on the format of the debug strings.
+    ///         They are designed for debugging only and may change arbitrarily between releases.
+    ///     </para>
+    /// </summary>
+    [EntityFrameworkInternal]
+    public string DebugView
+        => this.Print();
 
     /// <inheritdoc />
     public override bool Equals(object? obj)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlExpression.cs
@@ -12,9 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///         not used in application code.
 ///     </para>
 /// </summary>
-#if DEBUG
-[DebuggerDisplay("{new Microsoft.EntityFrameworkCore.Query.ExpressionPrinter().PrintExpression(this), nq}")]
-#endif
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
 public abstract class SqlExpression : Expression, IPrintableExpression
 {
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
@@ -12,6 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 ///         not used in application code.
 ///     </para>
 /// </summary>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(this), nq}")]
 public abstract class TableExpressionBase : Expression, IPrintableExpression
 {
     private readonly IReadOnlyDictionary<string, IAnnotation>? _annotations;

--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -166,16 +166,22 @@ public class ExpressionPrinter : ExpressionVisitor
 
         Visit(expression);
 
-        var queryPlan = PostProcess(_stringBuilder.ToString());
+        return ToString();
+    }
 
-        if (characterLimit is > 0)
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        var printed = PostProcess(_stringBuilder.ToString());
+
+        if (CharacterLimit is > 0)
         {
-            queryPlan = queryPlan.Length > characterLimit
-                ? queryPlan[..characterLimit.Value] + "..."
-                : queryPlan;
+            printed = printed.Length > CharacterLimit
+                ? printed[..CharacterLimit.Value] + "..."
+                : printed;
         }
 
-        return queryPlan;
+        return printed;
     }
 
     /// <summary>

--- a/src/EFCore/Query/ProjectionMember.cs
+++ b/src/EFCore/Query/ProjectionMember.cs
@@ -16,7 +16,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
 ///     and <see href="https://aka.ms/efcore-docs-how-query-works">How EF Core queries work</see> for more information and examples.
 /// </remarks>
-[DebuggerDisplay("{ToString(), nq}")]
 public sealed class ProjectionMember
 {
     private readonly IList<MemberInfo> _memberChain;

--- a/src/EFCore/Query/ShapedQueryExpression.cs
+++ b/src/EFCore/Query/ShapedQueryExpression.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
 ///     and <see href="https://aka.ms/efcore-docs-how-query-works">How EF Core queries work</see> for more information and examples.
 /// </remarks>
+[DebuggerDisplay("{Microsoft.EntityFrameworkCore.Query.ExpressionPrinter.Print(QueryExpression), nq}")]
 public class ShapedQueryExpression : Expression, IPrintableExpression
 {
     /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -761,7 +761,7 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
             ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[MyMethod(x.Id)]).AsNoTracking()))).Message;
 
         Assert.Equal(
-            CoreStrings.TranslationFailed("""JsonQueryExpression(j.OwnedCollectionRoot, "")"""),
+            CoreStrings.TranslationFailed("j.OwnedCollectionRoot Q-> "),
             message);
     }
 
@@ -775,7 +775,7 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
             ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[0].OwnedReferenceBranch.OwnedCollectionLeaf[MyMethod(x.Id)]).AsNoTracking()))).Message;
 
         Assert.Equal(
-            CoreStrings.TranslationFailed("""JsonQueryExpression(j.OwnedCollectionRoot, "[0].OwnedReferenceBranch.OwnedCollectionLeaf")"""),
+            CoreStrings.TranslationFailed("j.OwnedCollectionRoot Q-> [0].OwnedReferenceBranch.OwnedCollectionLeaf"),
             message);
     }
 
@@ -967,7 +967,7 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     CollectionElement = x.OwnedCollectionRoot[prm].OwnedCollectionBranch.Select(xx => "Foo").ElementAt(0)
                 })))).Message;
 
-        Assert.Equal(CoreStrings.TranslationFailed("""JsonQueryExpression(j.OwnedCollectionRoot, "[__prm_0].OwnedCollectionBranch")"""), message);
+        Assert.Equal(CoreStrings.TranslationFailed("j.OwnedCollectionRoot Q-> [__prm_0].OwnedCollectionBranch"), message);
     }
 
     [ConditionalTheory]
@@ -984,7 +984,7 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     CollectionElement = x.OwnedCollectionRoot[prm + x.Id].OwnedCollectionBranch.Select(xx => x.Id).ElementAt(0)
                 })))).Message;
 
-        Assert.Equal(CoreStrings.TranslationFailed("""JsonQueryExpression(j.OwnedCollectionRoot, "[(...)].OwnedCollectionBranch")"""), message);
+        Assert.Equal(CoreStrings.TranslationFailed("j.OwnedCollectionRoot Q-> [(...)].OwnedCollectionBranch"), message);
     }
 
     [ConditionalTheory]
@@ -1000,7 +1000,7 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     CollectionElement = x.OwnedCollectionRoot.Select(xx => x.OwnedReferenceRoot).ElementAt(0)
                 })))).Message;
 
-        Assert.Equal(CoreStrings.TranslationFailed("""JsonQueryExpression(j.OwnedCollectionRoot, "")"""), message);
+        Assert.Equal(CoreStrings.TranslationFailed("j.OwnedCollectionRoot Q-> "), message);
     }
 
     [ConditionalTheory]
@@ -1016,7 +1016,7 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     CollectionElement = x.OwnedCollectionRoot.Select(xx => x.OwnedCollectionRoot).ElementAt(0)
                 })))).Message;
 
-        Assert.Equal(CoreStrings.TranslationFailed("""JsonQueryExpression(j.OwnedCollectionRoot, "")"""), message);
+        Assert.Equal(CoreStrings.TranslationFailed("j.OwnedCollectionRoot Q-> "), message);
     }
 
     [ConditionalTheory]
@@ -1032,7 +1032,7 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     CollectionElement = x.OwnedCollectionRoot.Select(xx => new { xx.OwnedReferenceBranch }).ElementAt(0)
                 })))).Message;
 
-        Assert.Equal(CoreStrings.TranslationFailed("""JsonQueryExpression(j.OwnedCollectionRoot, "")"""), message);
+        Assert.Equal(CoreStrings.TranslationFailed("j.OwnedCollectionRoot Q-> "), message);
     }
 
     [ConditionalTheory]
@@ -1048,7 +1048,7 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     CollectionElement = x.OwnedCollectionRoot.Select(xx => new JsonEntityBasic { Id = x.Id }).ElementAt(0)
                 })))).Message;
 
-        Assert.Equal(CoreStrings.TranslationFailed("""JsonQueryExpression(j.OwnedCollectionRoot, "")"""), message);
+        Assert.Equal(CoreStrings.TranslationFailed("j.OwnedCollectionRoot Q-> "), message);
     }
 
     [ConditionalTheory]


### PR DESCRIPTION
* Add [DebuggerDisplay] to non-SqlExpressions too (OrderingExpression, ProjectionExpression).
* For SelectExpression, show the SQL only in [DebuggerDisplay] and add a DebugView for long/short versions; this is easier than manually calling ExpressionPrinter in the debugger.
* Also for ShapedQueryExpression, print the QueryExpression in [DebuggerDisplay]

Some questions...

* Should we just switch to printing the SQL only by default for ExpressionPrinter for SelectExpression (i.e. not the additional projection data)? I think this would maybe be a nicer default experience when e.g. seeing a SelectExpression embedded inside some other query. On the other hand, if you think that always seeing the projections is useful in embedded selects, we should leave it the way it is...
* Any idea why our `[DebuggerDisplay]` are always inside `#if DEBUG`?
