### PR TITLE
Additional cleanup and modernization

### DIFF
--- a/src/EFCore.Abstractions/ChangeTracking/Internal/ObservableBackedBindingList.cs
+++ b/src/EFCore.Abstractions/ChangeTracking/Internal/ObservableBackedBindingList.cs
@@ -201,8 +201,7 @@ public class ObservableBackedBindingList<T> : SortableBindingList<T>
                     Clear();
                 }
 
-                if (e.Action == NotifyCollectionChangedAction.Remove
-                    || e.Action == NotifyCollectionChangedAction.Replace)
+                if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace)
                 {
                     foreach (T entity in e.OldItems!)
                     {
@@ -210,8 +209,7 @@ public class ObservableBackedBindingList<T> : SortableBindingList<T>
                     }
                 }
 
-                if (e.Action == NotifyCollectionChangedAction.Add
-                    || e.Action == NotifyCollectionChangedAction.Replace)
+                if (e.Action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Replace)
                 {
                     foreach (T entity in e.NewItems!)
                     {

--- a/src/EFCore.Analyzers/InterpolatedStringUsageInRawQueriesCodeFixProvider.cs
+++ b/src/EFCore.Analyzers/InterpolatedStringUsageInRawQueriesCodeFixProvider.cs
@@ -24,7 +24,6 @@ public sealed class InterpolatedStringUsageInRawQueriesCodeFixProvider : CodeFix
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var document = context.Document;
-        var span = context.Span;
         var cancellationToken = context.CancellationToken;
 
         // We report only 1 diagnostic per span, so this is ok

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosManyToManyJoinEntityTypeConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosManyToManyJoinEntityTypeConvention.cs
@@ -41,8 +41,7 @@ public class CosmosManyToManyJoinEntityTypeConvention :
         IConventionAnnotation? oldAnnotation,
         IConventionContext<IConventionAnnotation> context)
     {
-        if (name == CosmosAnnotationNames.PartitionKeyName
-            || name == CosmosAnnotationNames.ContainerName)
+        if (name is CosmosAnnotationNames.PartitionKeyName or CosmosAnnotationNames.ContainerName)
         {
             foreach (var skipNavigation in entityTypeBuilder.Metadata.GetSkipNavigations())
             {

--- a/src/EFCore.Cosmos/Query/Internal/CosmosEqualsTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosEqualsTranslator.cs
@@ -58,8 +58,8 @@ public class CosmosEqualsTranslator : IMethodCallTranslator
             && right != null)
         {
             return left.Type.UnwrapNullableType() == right.Type.UnwrapNullableType()
-                || (right.Type == typeof(object) && (right is SqlParameterExpression || right is SqlConstantExpression))
-                || (left.Type == typeof(object) && (left is SqlParameterExpression || left is SqlConstantExpression))
+                || (right.Type == typeof(object) && right is SqlParameterExpression or SqlConstantExpression)
+                || (left.Type == typeof(object) && left is SqlParameterExpression or SqlConstantExpression)
                     ? _sqlExpressionFactory.Equal(left, right)
                     : _sqlExpressionFactory.Constant(false);
         }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosEqualsTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosEqualsTranslator.cs
@@ -58,8 +58,8 @@ public class CosmosEqualsTranslator : IMethodCallTranslator
             && right != null)
         {
             return left.Type.UnwrapNullableType() == right.Type.UnwrapNullableType()
-                || (right.Type == typeof(object) && right is SqlParameterExpression or SqlConstantExpression)
-                || (left.Type == typeof(object) && left is SqlParameterExpression or SqlConstantExpression)
+                || (right.Type == typeof(object) && (right is SqlParameterExpression or SqlConstantExpression))
+                || (left.Type == typeof(object) && (left is SqlParameterExpression or SqlConstantExpression))
                     ? _sqlExpressionFactory.Equal(left, right)
                     : _sqlExpressionFactory.Constant(false);
         }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
@@ -92,9 +92,7 @@ public class CosmosProjectionBindingExpressionVisitor : ExpressionVisitor
             return null;
         }
 
-        if (expression is NewExpression
-            || expression is MemberInitExpression
-            || expression is EntityShaperExpression)
+        if (expression is NewExpression or MemberInitExpression or EntityShaperExpression)
         {
             return base.Visit(expression);
         }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosStringMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosStringMethodTranslator.cs
@@ -235,9 +235,10 @@ public class CosmosStringMethodTranslator : IMethodCallTranslator
         {
             var comparisonTypeArgument = arguments[^1];
 
-            if (comparisonTypeArgument is SqlConstantExpression { Value: StringComparison comparisonTypeArgumentValue }
-                && (comparisonTypeArgumentValue == StringComparison.OrdinalIgnoreCase
-                    || comparisonTypeArgumentValue == StringComparison.Ordinal))
+            if (comparisonTypeArgument is SqlConstantExpression
+                {
+                    Value: StringComparison comparisonTypeArgumentValue and (StringComparison.OrdinalIgnoreCase or StringComparison.Ordinal)
+                })
             {
                 return StringComparisonWithComparisonTypeArgumentInstance.Equals(method)
                     ? comparisonTypeArgumentValue == StringComparison.OrdinalIgnoreCase

--- a/src/EFCore.Cosmos/Query/Internal/CosmosValueConverterCompensatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosValueConverterCompensatingExpressionVisitor.cs
@@ -104,9 +104,7 @@ public class CosmosValueConverterCompensatingExpressionVisitor : ExpressionVisit
                 TryCompensateForBoolWithValueConverter(sqlUnaryExpression.Operand));
         }
 
-        if (sqlExpression is SqlBinaryExpression sqlBinaryExpression
-            && (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso
-                || sqlBinaryExpression.OperatorType == ExpressionType.OrElse))
+        if (sqlExpression is SqlBinaryExpression { OperatorType: ExpressionType.AndAlso or ExpressionType.OrElse } sqlBinaryExpression)
         {
             return sqlBinaryExpression.Update(
                 TryCompensateForBoolWithValueConverter(sqlBinaryExpression.Left),

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategy.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategy.cs
@@ -103,10 +103,7 @@ public class CosmosExecutionStrategy : ExecutionStrategy
         };
 
         static bool IsTransient(HttpStatusCode statusCode)
-            => statusCode == HttpStatusCode.ServiceUnavailable
-                || statusCode == HttpStatusCode.TooManyRequests
-                || statusCode == HttpStatusCode.RequestTimeout
-                || statusCode == HttpStatusCode.Gone;
+            => statusCode is HttpStatusCode.ServiceUnavailable or HttpStatusCode.TooManyRequests or HttpStatusCode.RequestTimeout or HttpStatusCode.Gone;
     }
 
     /// <summary>

--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -1501,9 +1501,7 @@ public class CSharpHelper : ICSharpHelper
     {
         if (ch < 'a')
         {
-            return ch >= 'A'
-                && (ch <= 'Z'
-                    || ch == '_');
+            return ch is >= 'A' and (<= 'Z' or '_');
         }
 
         if (ch <= 'z')

--- a/src/EFCore.Design/Migrations/Design/MigrationsBundle.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsBundle.cs
@@ -46,8 +46,7 @@ public static class MigrationsBundle
         }
         catch (Exception ex)
         {
-            if (ex is CommandParsingException
-                || ex is OperationException)
+            if (ex is CommandParsingException or OperationException)
             {
                 Reporter.WriteVerbose(ex.ToString());
             }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpUtilities.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpUtilities.cs
@@ -223,9 +223,7 @@ public class CSharpUtilities : ICSharpUtilities
     {
         if (ch < 'a')
         {
-            return ch >= 'A'
-                && (ch <= 'Z'
-                    || ch == '_');
+            return ch is >= 'A' and (<= 'Z' or '_');
         }
 
         if (ch <= 'z')
@@ -242,8 +240,7 @@ public class CSharpUtilities : ICSharpUtilities
         {
             return ch < 'A'
                 ? ch is >= '0' and <= '9'
-                : ch <= 'Z'
-                || ch == '_';
+                : ch is <= 'Z' or '_';
         }
 
         if (ch <= 'z')

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -162,7 +162,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
             return Visit(ConvertObjectArrayEqualityComparison(binaryExpression.Left, binaryExpression.Right));
         }
 
-        if ((binaryExpression.NodeType == ExpressionType.Equal || binaryExpression.NodeType == ExpressionType.NotEqual)
+        if (binaryExpression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual
             && (binaryExpression.Left.IsNullConstantExpression() || binaryExpression.Right.IsNullConstantExpression()))
         {
             var nonNullExpression = binaryExpression.Left.IsNullConstantExpression() ? binaryExpression.Right : binaryExpression.Left;
@@ -232,8 +232,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
             return QueryCompilationContext.NotTranslatedExpression;
         }
 
-        if ((binaryExpression.NodeType == ExpressionType.Equal
-                || binaryExpression.NodeType == ExpressionType.NotEqual)
+        if (binaryExpression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual
             // Visited expression could be null, We need to pass MemberInitExpression
             && TryRewriteEntityEquality(
                 binaryExpression.NodeType,
@@ -252,8 +251,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
             newRight = ConvertToNullable(newRight);
         }
 
-        if ((binaryExpression.NodeType == ExpressionType.Equal
-                || binaryExpression.NodeType == ExpressionType.NotEqual)
+        if (binaryExpression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual
             && TryUseComparer(newLeft, newRight, out var updatedExpression))
         {
             if (binaryExpression.NodeType == ExpressionType.NotEqual)
@@ -578,7 +576,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
         static bool ShouldApplyNullProtectionForMemberAccess(Type callerType, string memberName)
             => !(callerType.IsGenericType
                 && callerType.GetGenericTypeDefinition() == typeof(Nullable<>)
-                && (memberName == nameof(Nullable<int>.Value) || memberName == nameof(Nullable<int>.HasValue)));
+                && memberName is nameof(Nullable<int>.Value) or nameof(Nullable<int>.HasValue));
     }
 
     /// <summary>
@@ -1061,9 +1059,7 @@ public class InMemoryExpressionTranslatingExpressionVisitor : ExpressionVisitor
         }
 
         if (newOperand is EntityReferenceExpression entityReferenceExpression
-            && (unaryExpression.NodeType == ExpressionType.Convert
-                || unaryExpression.NodeType == ExpressionType.ConvertChecked
-                || unaryExpression.NodeType == ExpressionType.TypeAs))
+            && unaryExpression.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked or ExpressionType.TypeAs)
         {
             return entityReferenceExpression.Convert(unaryExpression.Type);
         }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -499,8 +499,7 @@ public class InMemoryProjectionBindingExpressionVisitor : ExpressionVisitor
     {
         var operand = Visit(unaryExpression.Operand);
 
-        return (unaryExpression.NodeType == ExpressionType.Convert
-                || unaryExpression.NodeType == ExpressionType.ConvertChecked)
+        return unaryExpression.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked
             && unaryExpression.Type == operand.Type
                 ? operand
                 : unaryExpression.Update(MatchTypes(operand, unaryExpression.Operand.Type));

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -441,7 +441,7 @@ public class InMemoryQueryableMethodTranslatingExpressionVisitor : QueryableMeth
 
                 return memberInitExpression.Update(updatedNewExpression, newBindings);
 
-            case EntityShaperExpression { ValueBufferExpression: ProjectionBindingExpression projectionBindingExpression } entityShaperExpression:
+            case EntityShaperExpression { ValueBufferExpression: ProjectionBindingExpression } entityShaperExpression:
                 return entityShaperExpression;
 
             default:
@@ -1174,11 +1174,9 @@ public class InMemoryQueryableMethodTranslatingExpressionVisitor : QueryableMeth
         }
 
         protected override Expression VisitExtension(Expression extensionExpression)
-            => extensionExpression is EntityShaperExpression
-                || extensionExpression is ShapedQueryExpression
-                || extensionExpression is GroupByShaperExpression
-                    ? extensionExpression
-                    : base.VisitExtension(extensionExpression);
+            => extensionExpression is EntityShaperExpression or ShapedQueryExpression or GroupByShaperExpression
+                ? extensionExpression
+                : base.VisitExtension(extensionExpression);
 
         private Expression? TryExpand(Expression? source, MemberIdentity member)
         {

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -1737,8 +1737,7 @@ public static class RelationalPropertyExtensions
             yield return declaringStoreObject.Value;
         }
 
-        if (storeObjectType == StoreObjectType.Function
-            || storeObjectType == StoreObjectType.SqlQuery)
+        if (storeObjectType is StoreObjectType.Function or StoreObjectType.SqlQuery)
         {
             yield break;
         }

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -2047,9 +2047,9 @@ public class RelationalModelValidator : ModelValidator
 
     private static void ValidateTphMapping(IEntityType rootEntityType, StoreObjectType storeObjectType)
     {
-        var isSproc = storeObjectType == StoreObjectType.DeleteStoredProcedure
-            || storeObjectType == StoreObjectType.InsertStoredProcedure
-            || storeObjectType == StoreObjectType.UpdateStoredProcedure;
+        var isSproc = storeObjectType is StoreObjectType.DeleteStoredProcedure
+            or StoreObjectType.InsertStoredProcedure
+            or StoreObjectType.UpdateStoredProcedure;
         var rootSproc = isSproc ? StoredProcedure.FindDeclaredStoredProcedure(rootEntityType, storeObjectType) : null;
         var rootId = StoreObjectIdentifier.Create(rootEntityType, storeObjectType);
         foreach (var entityType in rootEntityType.GetDerivedTypes())
@@ -2344,8 +2344,7 @@ public class RelationalModelValidator : ModelValidator
                 yield return declaringStoreObject.Value;
             }
 
-            if (storeObjectType == StoreObjectType.Function
-                || storeObjectType == StoreObjectType.SqlQuery)
+            if (storeObjectType is StoreObjectType.Function or StoreObjectType.SqlQuery)
             {
                 yield break;
             }
@@ -2372,8 +2371,7 @@ public class RelationalModelValidator : ModelValidator
         else
         {
             var declaringStoreObject = StoreObjectIdentifier.Create(property.DeclaringEntityType, storeObjectType);
-            if (storeObjectType == StoreObjectType.Function
-                || storeObjectType == StoreObjectType.SqlQuery)
+            if (storeObjectType is StoreObjectType.Function or StoreObjectType.SqlQuery)
             {
                 if (declaringStoreObject != null)
                 {

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalQueryFilterRewritingConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalQueryFilterRewritingConvention.cs
@@ -67,9 +67,9 @@ public class RelationalQueryFilterRewritingConvention : QueryFilterRewritingConv
         {
             var methodName = methodCallExpression.Method.Name;
             if (methodCallExpression.Method.DeclaringType == typeof(RelationalQueryableExtensions)
-                && (methodName == nameof(RelationalQueryableExtensions.FromSqlRaw)
-                    || methodName == nameof(RelationalQueryableExtensions.FromSqlInterpolated)
-                    || methodName == nameof(RelationalQueryableExtensions.FromSql)))
+                && methodName is nameof(RelationalQueryableExtensions.FromSqlRaw)
+                    or nameof(RelationalQueryableExtensions.FromSqlInterpolated)
+                    or nameof(RelationalQueryableExtensions.FromSql))
             {
                 var newSource = (EntityQueryRootExpression)Visit(methodCallExpression.Arguments[0]);
 

--- a/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
@@ -239,10 +239,8 @@ public class SharedTableConvention : IModelFinalizingConvention
             {
                 if (property.GetAfterSaveBehavior() == PropertySaveBehavior.Save
                     && otherProperty.GetAfterSaveBehavior() == PropertySaveBehavior.Save
-                    && (property.ValueGenerated == ValueGenerated.Never
-                        || property.ValueGenerated == ValueGenerated.OnUpdateSometimes)
-                    && (otherProperty.ValueGenerated == ValueGenerated.Never
-                        || otherProperty.ValueGenerated == ValueGenerated.OnUpdateSometimes))
+                    && property.ValueGenerated is ValueGenerated.Never or ValueGenerated.OnUpdateSometimes
+                    && otherProperty.ValueGenerated is ValueGenerated.Never or ValueGenerated.OnUpdateSometimes)
                 {
                     // Handle this with a default value convention #9329
                     property.Builder.ValueGenerated(ValueGenerated.OnUpdateSometimes);

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -622,8 +622,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
     {
         var operand = Visit(unaryExpression.Operand);
 
-        return (unaryExpression.NodeType == ExpressionType.Convert
-                || unaryExpression.NodeType == ExpressionType.ConvertChecked)
+        return unaryExpression.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked
             && unaryExpression.Type == operand.Type
                 ? operand
                 : unaryExpression.Update(MatchTypes(operand, unaryExpression.Operand.Type));

--- a/src/EFCore.Relational/Query/Internal/RelationalValueConverterCompensatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalValueConverterCompensatingExpressionVisitor.cs
@@ -157,9 +157,7 @@ public class RelationalValueConverterCompensatingExpressionVisitor : ExpressionV
                 TryCompensateForBoolWithValueConverter(sqlUnaryExpression.Operand));
         }
 
-        if (sqlExpression is SqlBinaryExpression sqlBinaryExpression
-            && (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso
-                || sqlBinaryExpression.OperatorType == ExpressionType.OrElse))
+        if (sqlExpression is SqlBinaryExpression { OperatorType: ExpressionType.AndAlso or ExpressionType.OrElse } sqlBinaryExpression)
         {
             return sqlBinaryExpression.Update(
                 TryCompensateForBoolWithValueConverter(sqlBinaryExpression.Left),

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -1072,7 +1072,7 @@ public class QuerySqlGenerator : SqlExpressionVisitor
             if (selectExpression.Limit == null
                 && selectExpression.Offset == null)
             {
-                orderings.RemoveAll(oe => oe.Expression is SqlConstantExpression || oe.Expression is SqlParameterExpression);
+                orderings.RemoveAll(oe => oe.Expression is SqlConstantExpression or SqlParameterExpression);
             }
 
             if (orderings.Count > 0)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -2002,7 +2002,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                 if (expression is MemberExpression
                     {
                         Expression: RelationalEntityShaperExpression { ValueBufferExpression: JsonQueryExpression memberJqe }
-                    } memberExpression
+                    }
                     && JsonQueryExpressionIsRootedIn(memberJqe, baselineJsonQuery))
                 {
                     return true;

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -522,7 +522,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 }
 
                 case RelationalEntityShaperExpression entityShaperExpression
-                    when _inline && entityShaperExpression.ValueBufferExpression is ProjectionBindingExpression projectionBindingExpression:
+                    when _inline && entityShaperExpression.ValueBufferExpression is ProjectionBindingExpression:
                 {
                     if (entityShaperExpression.EntityType.GetMappingStrategy() == RelationalAnnotationNames.TpcMappingStrategy)
                     {
@@ -1876,8 +1876,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     return expression;
                 }
 
-                if (expression is RelationalCollectionShaperExpression
-                    || expression is RelationalSplitCollectionShaperExpression)
+                if (expression is RelationalCollectionShaperExpression or RelationalSplitCollectionShaperExpression)
                 {
                     _containsCollection = true;
 

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -335,7 +335,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             right = rightOperand!;
         }
 
-        if ((binaryExpression.NodeType == ExpressionType.Equal || binaryExpression.NodeType == ExpressionType.NotEqual)
+        if (binaryExpression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual
             && (left.IsNullConstantExpression() || right.IsNullConstantExpression()))
         {
             var nonNullExpression = left.IsNullConstantExpression() ? right : left;
@@ -398,8 +398,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         var visitedLeft = Visit(left);
         var visitedRight = Visit(right);
 
-        if ((binaryExpression.NodeType == ExpressionType.Equal
-                || binaryExpression.NodeType == ExpressionType.NotEqual)
+        if (binaryExpression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual
             // Visited expression could be null, We need to pass MemberInitExpression
             && TryRewriteEntityEquality(
                 binaryExpression.NodeType,
@@ -577,9 +576,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
         static bool TryUnwrapConvertToObject(Expression expression, out Expression? operand)
         {
-            if (expression is UnaryExpression convertExpression
-                && (convertExpression.NodeType == ExpressionType.Convert
-                    || convertExpression.NodeType == ExpressionType.ConvertChecked)
+            if (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } convertExpression
                 && expression.Type == typeof(object))
             {
                 operand = convertExpression.Operand;
@@ -1529,9 +1526,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
     private static Expression TryRemoveImplicitConvert(Expression expression)
     {
-        if (expression is UnaryExpression unaryExpression
-            && (unaryExpression.NodeType == ExpressionType.Convert
-                || unaryExpression.NodeType == ExpressionType.ConvertChecked))
+        if (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression)
         {
             var innerType = unaryExpression.Operand.Type.UnwrapNullableType();
             if (innerType.IsEnum)
@@ -1557,8 +1552,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
     }
 
     private static Expression RemoveObjectConvert(Expression expression)
-        => expression is UnaryExpression unaryExpression
-            && (unaryExpression.NodeType == ExpressionType.Convert || unaryExpression.NodeType == ExpressionType.ConvertChecked)
+        => expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression
             && unaryExpression.Type == typeof(object)
                 ? unaryExpression.Operand
                 : expression;
@@ -1885,7 +1879,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         };
 
     private static bool IsNullSqlConstantExpression(Expression expression)
-        => expression is SqlConstantExpression { Value: null } sqlConstant;
+        => expression is SqlConstantExpression { Value: null };
 
     [DebuggerStepThrough]
     private static bool TranslationFailed(Expression? original, Expression? translation, out SqlExpression? castTranslation)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
@@ -139,7 +139,7 @@ public class SqlBinaryExpression : SqlExpression
         }
 
         static bool RequiresBrackets(SqlExpression expression)
-            => expression is SqlBinaryExpression || expression is LikeExpression;
+            => expression is SqlBinaryExpression or LikeExpression;
     }
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -1081,8 +1081,7 @@ public class SqlNullabilityProcessor
         var optimize = allowOptimizedExpansion;
 
         allowOptimizedExpansion = allowOptimizedExpansion
-            && (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso
-                || sqlBinaryExpression.OperatorType == ExpressionType.OrElse);
+            && sqlBinaryExpression.OperatorType is ExpressionType.AndAlso or ExpressionType.OrElse;
 
         var currentNonNullableColumnsCount = _nonNullableColumns.Count;
         var currentNullValueColumnsCount = _nullValueColumns.Count;
@@ -1154,8 +1153,7 @@ public class SqlNullabilityProcessor
             return sqlBinaryExpression.Update(left, right);
         }
 
-        if (sqlBinaryExpression.OperatorType == ExpressionType.Equal
-            || sqlBinaryExpression.OperatorType == ExpressionType.NotEqual)
+        if (sqlBinaryExpression.OperatorType is ExpressionType.Equal or ExpressionType.NotEqual)
         {
             var updated = sqlBinaryExpression.Update(left, right);
 
@@ -1211,13 +1209,12 @@ public class SqlNullabilityProcessor
         var result = sqlBinaryExpression.Update(left, right);
 
         return result is SqlBinaryExpression sqlBinaryResult
-            && (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso
-                || sqlBinaryExpression.OperatorType == ExpressionType.OrElse)
+            && sqlBinaryExpression.OperatorType is ExpressionType.AndAlso or ExpressionType.OrElse
                 ? SimplifyLogicalSqlBinaryExpression(sqlBinaryResult)
                 : result;
 
         SqlExpression AddNullConcatenationProtection(SqlExpression argument, RelationalTypeMapping typeMapping)
-            => argument is SqlConstantExpression || argument is SqlParameterExpression
+            => argument is SqlConstantExpression or SqlParameterExpression
                 ? _sqlExpressionFactory.Constant(string.Empty, typeMapping)
                 : _sqlExpressionFactory.Coalesce(argument, _sqlExpressionFactory.Constant(string.Empty, typeMapping));
     }
@@ -1346,8 +1343,7 @@ public class SqlNullabilityProcessor
         var operand = Visit(sqlUnaryExpression.Operand, out var operandNullable);
         var updated = sqlUnaryExpression.Update(operand);
 
-        if (sqlUnaryExpression.OperatorType == ExpressionType.Equal
-            || sqlUnaryExpression.OperatorType == ExpressionType.NotEqual)
+        if (sqlUnaryExpression.OperatorType is ExpressionType.Equal or ExpressionType.NotEqual)
         {
             var result = ProcessNullNotNull(updated, operandNullable);
 
@@ -1438,12 +1434,12 @@ public class SqlNullabilityProcessor
                 return result;
             }
 
-            if (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso
-                || sqlBinaryExpression.OperatorType == ExpressionType.NotEqual
-                || sqlBinaryExpression.OperatorType == ExpressionType.GreaterThan
-                || sqlBinaryExpression.OperatorType == ExpressionType.GreaterThanOrEqual
-                || sqlBinaryExpression.OperatorType == ExpressionType.LessThan
-                || sqlBinaryExpression.OperatorType == ExpressionType.LessThanOrEqual)
+            if (sqlBinaryExpression.OperatorType is ExpressionType.AndAlso
+                or ExpressionType.NotEqual
+                or ExpressionType.GreaterThan
+                or ExpressionType.GreaterThanOrEqual
+                or ExpressionType.LessThan
+                or ExpressionType.LessThanOrEqual)
             {
                 return Visit(sqlBinaryExpression, allowOptimizedExpansion: true, out _);
             }
@@ -1461,8 +1457,8 @@ public class SqlNullabilityProcessor
         bool rightNullable,
         out bool nullable)
     {
-        var leftNullValue = leftNullable && (left is SqlConstantExpression || left is SqlParameterExpression);
-        var rightNullValue = rightNullable && (right is SqlConstantExpression || right is SqlParameterExpression);
+        var leftNullValue = leftNullable && left is SqlConstantExpression or SqlParameterExpression;
+        var rightNullValue = rightNullable && right is SqlConstantExpression or SqlParameterExpression;
 
         // a == null -> a IS NULL
         // a != null -> a IS NOT NULL
@@ -1537,8 +1533,7 @@ public class SqlNullabilityProcessor
 
         if (!leftNullable
             && !rightNullable
-            && (sqlBinaryExpression.OperatorType == ExpressionType.Equal
-                || sqlBinaryExpression.OperatorType == ExpressionType.NotEqual))
+            && sqlBinaryExpression.OperatorType is ExpressionType.Equal or ExpressionType.NotEqual)
         {
             var leftUnary = left as SqlUnaryExpression;
             var rightUnary = right as SqlUnaryExpression;
@@ -1796,8 +1791,7 @@ public class SqlNullabilityProcessor
             {
                 // optimizations below are only correct in 2-value logic
                 // De Morgan's
-                if (sqlBinaryOperand.OperatorType == ExpressionType.AndAlso
-                    || sqlBinaryOperand.OperatorType == ExpressionType.OrElse)
+                if (sqlBinaryOperand.OperatorType is ExpressionType.AndAlso or ExpressionType.OrElse)
                 {
                     // since entire AndAlso/OrElse expression is non-nullable, both sides of it (left and right) must also be non-nullable
                     // so it's safe to perform recursive optimization here

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -460,8 +460,7 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
         {
             storeType = storeTypeNameBase + "(" + (size < 0 ? "max" : size.ToString()) + ")";
         }
-        else if (parameters.StoreTypePostfix == StoreTypePostfix.PrecisionAndScale
-                 || parameters.StoreTypePostfix == StoreTypePostfix.Precision)
+        else if (parameters.StoreTypePostfix is StoreTypePostfix.PrecisionAndScale or StoreTypePostfix.Precision)
         {
             var precision = parameters.Precision;
             if (precision != null)

--- a/src/EFCore.SqlServer/Extensions/SqlServerIndexExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerIndexExtensions.cs
@@ -257,7 +257,7 @@ public static class SqlServerIndexExtensions
     /// <param name="fillFactor">The value to set.</param>
     public static void SetFillFactor(this IMutableIndex index, int? fillFactor)
     {
-        if (fillFactor != null && (fillFactor <= 0 || fillFactor > 100))
+        if (fillFactor is <= 0 or > 100)
         {
             throw new ArgumentOutOfRangeException(nameof(fillFactor));
         }
@@ -279,7 +279,7 @@ public static class SqlServerIndexExtensions
         int? fillFactor,
         bool fromDataAnnotation = false)
     {
-        if (fillFactor != null && (fillFactor <= 0 || fillFactor > 100))
+        if (fillFactor is <= 0 or > 100)
         {
             throw new ArgumentOutOfRangeException(nameof(fillFactor));
         }

--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -811,8 +811,7 @@ public static class SqlServerPropertyExtensions
     {
         var modelStrategy = property.DeclaringEntityType.Model.GetValueGenerationStrategy();
 
-        if ((modelStrategy == SqlServerValueGenerationStrategy.SequenceHiLo
-                || modelStrategy == SqlServerValueGenerationStrategy.Sequence)
+        if (modelStrategy is SqlServerValueGenerationStrategy.SequenceHiLo or SqlServerValueGenerationStrategy.Sequence
             && IsCompatibleWithValueGeneration(property))
         {
             return modelStrategy.Value;
@@ -831,8 +830,7 @@ public static class SqlServerPropertyExtensions
     {
         var modelStrategy = property.DeclaringEntityType.Model.GetValueGenerationStrategy();
 
-        if ((modelStrategy == SqlServerValueGenerationStrategy.SequenceHiLo
-                || modelStrategy == SqlServerValueGenerationStrategy.Sequence)
+        if (modelStrategy is SqlServerValueGenerationStrategy.SequenceHiLo or SqlServerValueGenerationStrategy.Sequence
             && IsCompatibleWithValueGeneration(property, storeObject, typeMappingSource))
         {
             return modelStrategy.Value;
@@ -950,8 +948,7 @@ public static class SqlServerPropertyExtensions
                     property.Name, property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
         }
 
-        if ((value == SqlServerValueGenerationStrategy.SequenceHiLo
-                || value == SqlServerValueGenerationStrategy.Sequence)
+        if (value is SqlServerValueGenerationStrategy.SequenceHiLo or SqlServerValueGenerationStrategy.Sequence
             && !IsCompatibleWithValueGeneration(property))
         {
             throw new ArgumentException(

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -125,8 +125,7 @@ public class SqlServerOnDeleteConvention : CascadeDeleteConvention,
         IConventionAnnotation? oldAnnotation,
         IConventionContext<IConventionAnnotation> context)
     {
-        if (name == RelationalAnnotationNames.TableName
-            || name == RelationalAnnotationNames.Schema)
+        if (name is RelationalAnnotationNames.TableName or RelationalAnnotationNames.Schema)
         {
             ProcessSkipNavigations(entityTypeBuilder.Metadata.GetDeclaredSkipNavigations());
 

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerTemporalConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerTemporalConvention.cs
@@ -85,8 +85,7 @@ public class SqlServerTemporalConvention : IEntityTypeAnnotationChangedConventio
             }
         }
 
-        if (name == SqlServerAnnotationNames.TemporalPeriodStartPropertyName
-            || name == SqlServerAnnotationNames.TemporalPeriodEndPropertyName)
+        if (name is SqlServerAnnotationNames.TemporalPeriodStartPropertyName or SqlServerAnnotationNames.TemporalPeriodEndPropertyName)
         {
             if (oldAnnotation?.Value is string oldPeriodPropertyName)
             {

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -2813,13 +2813,13 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             }
 
             return unmatched.All(
-                a => a.Name == SqlServerAnnotationNames.IsTemporal
-                    || a.Name == SqlServerAnnotationNames.TemporalHistoryTableName
-                    || a.Name == SqlServerAnnotationNames.TemporalHistoryTableSchema
-                    || a.Name == SqlServerAnnotationNames.TemporalPeriodStartPropertyName
-                    || a.Name == SqlServerAnnotationNames.TemporalPeriodEndPropertyName
-                    || a.Name == SqlServerAnnotationNames.TemporalPeriodStartColumnName
-                    || a.Name == SqlServerAnnotationNames.TemporalPeriodEndColumnName);
+                a => a.Name is SqlServerAnnotationNames.IsTemporal
+                    or SqlServerAnnotationNames.TemporalHistoryTableName
+                    or SqlServerAnnotationNames.TemporalHistoryTableSchema
+                    or SqlServerAnnotationNames.TemporalPeriodStartPropertyName
+                    or SqlServerAnnotationNames.TemporalPeriodEndPropertyName
+                    or SqlServerAnnotationNames.TemporalPeriodStartColumnName
+                    or SqlServerAnnotationNames.TemporalPeriodEndColumnName);
         }
 
         static TOperation CopyColumnOperation<TOperation>(ColumnOperation source)

--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -386,14 +386,14 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
         _isSearchCondition = parentIsSearchCondition;
 
         sqlBinaryExpression = sqlBinaryExpression.Update(newLeft, newRight);
-        var condition = sqlBinaryExpression.OperatorType == ExpressionType.AndAlso
-            || sqlBinaryExpression.OperatorType == ExpressionType.OrElse
-            || sqlBinaryExpression.OperatorType == ExpressionType.Equal
-            || sqlBinaryExpression.OperatorType == ExpressionType.NotEqual
-            || sqlBinaryExpression.OperatorType == ExpressionType.GreaterThan
-            || sqlBinaryExpression.OperatorType == ExpressionType.GreaterThanOrEqual
-            || sqlBinaryExpression.OperatorType == ExpressionType.LessThan
-            || sqlBinaryExpression.OperatorType == ExpressionType.LessThanOrEqual;
+        var condition = sqlBinaryExpression.OperatorType is ExpressionType.AndAlso
+            or ExpressionType.OrElse
+            or ExpressionType.Equal
+            or ExpressionType.NotEqual
+            or ExpressionType.GreaterThan
+            or ExpressionType.GreaterThanOrEqual
+            or ExpressionType.LessThan
+            or ExpressionType.LessThanOrEqual;
 
         return ApplyConversion(sqlBinaryExpression, condition);
     }
@@ -493,7 +493,7 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
         _isSearchCondition = parentSearchCondition;
         var newFunction = sqlFunctionExpression.Update(instance, arguments);
 
-        var condition = sqlFunctionExpression.Name == "FREETEXT" || sqlFunctionExpression.Name == "CONTAINS";
+        var condition = sqlFunctionExpression.Name is "FREETEXT" or "CONTAINS";
 
         return ApplyConversion(newFunction, condition);
     }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerStringMethodTranslator.cs
@@ -500,7 +500,7 @@ public class SqlServerStringMethodTranslator : IMethodCallTranslator
 
     // See https://docs.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql
     private static bool IsLikeWildChar(char c)
-        => c == '%' || c == '_' || c == '[';
+        => c is '%' or '_' or '[';
 
     private static string EscapeLikePattern(string pattern)
     {

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -297,7 +297,7 @@ SELECT 1 ELSE SELECT 0");
     // Unable to attach database file is thrown when file does not exist (See Issue #2810)
     // Unable to open the physical file is thrown when file does not exist (See Issue #2810)
     private static bool IsDoesNotExist(SqlException exception)
-        => exception.Number == 4060 || exception.Number == 1832 || exception.Number == 5120;
+        => exception.Number is 4060 or 1832 or 5120;
 
     // See Issue #985
     private bool RetryOnExistsFailure(SqlException exception)
@@ -322,12 +322,7 @@ SELECT 1 ELSE SELECT 0");
         //   Microsoft.Data.SqlClient.SqlException: Unable to open the physical file xxxxxxx.
         // And (Number 18456)
         //   Microsoft.Data.SqlClient.SqlException: Login failed for user 'xxxxxxx'.
-        if (exception.Number == 233
-            || exception.Number == -2
-            || exception.Number == 4060
-            || exception.Number == 1832
-            || exception.Number == 5120
-            || exception.Number == 18456)
+        if (exception.Number is 233 or -2 or 4060 or 1832 or 5120 or 18456)
         {
             ClearPool();
             return true;

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -406,7 +406,7 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
                 var isFixedLength = mappingInfo.IsFixedLength == true;
 
                 var size = mappingInfo.Size ?? (mappingInfo.IsKeyOrIndex ? 900 : null);
-                if (size < 0 || size > 8000)
+                if (size is < 0 or > 8000)
                 {
                     size = isFixedLength ? 8000 : null;
                 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteMathTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteMathTranslator.cs
@@ -84,7 +84,7 @@ public class SqliteMathTranslator : IMethodCallTranslator
         {
             RelationalTypeMapping? typeMapping;
             List<SqlExpression>? newArguments = null;
-            if (sqlFunctionName == "max" || sqlFunctionName == "min")
+            if (sqlFunctionName is "max" or "min")
             {
                 typeMapping = ExpressionExtensions.InferTypeMapping(arguments[0], arguments[1]);
                 newArguments = new List<SqlExpression>

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessor.cs
@@ -57,7 +57,7 @@ public class SqliteQueryTranslationPostprocessor : RelationalQueryTranslationPos
             }
 
             if (extensionExpression is SelectExpression selectExpression
-                && selectExpression.Tables.Any(t => t is CrossApplyExpression || t is OuterApplyExpression))
+                && selectExpression.Tables.Any(t => t is CrossApplyExpression or OuterApplyExpression))
             {
                 throw new InvalidOperationException(SqliteStrings.ApplyNotSupported);
             }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteStringMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteStringMethodTranslator.cs
@@ -389,7 +389,7 @@ public class SqliteStringMethodTranslator : IMethodCallTranslator
 
     // See https://www.sqlite.org/lang_expr.html
     private static bool IsLikeWildChar(char c)
-        => c == '%' || c == '_';
+        => c is '%' or '_';
 
     private static string EscapeLikePattern(string pattern)
     {

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -368,25 +368,20 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
             StateManager.StopTracking(this, oldState);
         }
 
-        if ((newState == EntityState.Deleted
-                || newState == EntityState.Detached)
+        if (newState is EntityState.Deleted or EntityState.Detached
             && HasConceptualNull)
         {
             _stateData.FlagAllProperties(entityType.PropertyCount(), PropertyFlag.Null, flagged: false);
         }
 
-        if (oldState == EntityState.Detached
-            || oldState == EntityState.Unchanged)
+        if (oldState is EntityState.Detached or EntityState.Unchanged)
         {
-            if (newState == EntityState.Added
-                || newState == EntityState.Deleted
-                || newState == EntityState.Modified)
+            if (newState is EntityState.Added or EntityState.Deleted or EntityState.Modified)
             {
                 StateManager.ChangedCount++;
             }
         }
-        else if (newState == EntityState.Detached
-                 || newState == EntityState.Unchanged)
+        else if (newState is EntityState.Detached or EntityState.Unchanged)
         {
             StateManager.ChangedCount--;
         }
@@ -395,8 +390,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
 
         HandleSharedIdentityEntry(newState);
 
-        if ((newState == EntityState.Deleted
-                || newState == EntityState.Detached)
+        if (newState is EntityState.Deleted or EntityState.Detached
             && sharedIdentityEntry == null
             && StateManager.CascadeDeleteTiming == CascadeTiming.Immediate)
         {
@@ -419,8 +413,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
                 break;
             case EntityState.Added:
             case EntityState.Modified:
-                if (sharedIdentityEntry.EntityState == EntityState.Added
-                    || sharedIdentityEntry.EntityState == EntityState.Modified)
+                if (sharedIdentityEntry.EntityState is EntityState.Added or EntityState.Modified)
                 {
                     if (StateManager.SensitiveLoggingEnabled)
                     {
@@ -1333,9 +1326,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
                 && valueType == CurrentValueType.Normal
                 && (!asProperty.ClrType.IsNullableType()
                     || asProperty.GetContainingForeignKeys().Any(
-                        fk => fk.IsRequired
-                            && (fk.DeleteBehavior == DeleteBehavior.Cascade
-                                || fk.DeleteBehavior == DeleteBehavior.ClientCascade)
+                        fk => fk is { IsRequired: true, DeleteBehavior: DeleteBehavior.Cascade or DeleteBehavior.ClientCascade }
                             && fk.DeclaringEntityType.IsAssignableFrom(EntityType))))
             {
                 if (value == null)
@@ -1616,9 +1607,7 @@ public sealed partial class InternalEntityEntry : IUpdateEntry
             }
         }
 
-        var cascadeFk = fks.FirstOrDefault(
-            fk => fk.DeleteBehavior == DeleteBehavior.Cascade
-                || fk.DeleteBehavior == DeleteBehavior.ClientCascade);
+        var cascadeFk = fks.FirstOrDefault(fk => fk.DeleteBehavior is DeleteBehavior.Cascade or DeleteBehavior.ClientCascade);
         if (cascadeFk != null
             && (force
                 || (!isCascadeDelete

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -505,9 +505,7 @@ public class NavigationFixer : INavigationFixer
                 }
 
                 if (newValue == null
-                    && foreignKey.IsRequired
-                    && (foreignKey.DeleteBehavior == DeleteBehavior.Cascade
-                        || foreignKey.DeleteBehavior == DeleteBehavior.ClientCascade))
+                    && foreignKey is { IsRequired: true, DeleteBehavior: DeleteBehavior.Cascade or DeleteBehavior.ClientCascade })
                 {
                     entry.HandleNullForeignKey(property);
                 }
@@ -610,8 +608,7 @@ public class NavigationFixer : INavigationFixer
             {
                 InitialFixup(entry, null, fromQuery);
             }
-            else if ((oldState == EntityState.Deleted
-                         || oldState == EntityState.Added)
+            else if (oldState is EntityState.Deleted or EntityState.Added
                      && entry.EntityState == EntityState.Detached)
             {
                 DeleteFixup(entry);
@@ -993,8 +990,7 @@ public class NavigationFixer : INavigationFixer
     }
 
     private static bool IsAmbiguous(InternalEntityEntry dependentEntry)
-        => (dependentEntry.EntityState == EntityState.Detached
-                || dependentEntry.EntityState == EntityState.Deleted)
+        => dependentEntry.EntityState is EntityState.Detached or EntityState.Deleted
             && (dependentEntry.SharedIdentityEntry != null
                 || dependentEntry.EntityType.HasSharedClrType
                 && dependentEntry.StateManager.TryGetEntry(dependentEntry.Entity, throwOnNonUniqueness: false) != dependentEntry);
@@ -1356,8 +1352,7 @@ public class NavigationFixer : INavigationFixer
         InternalEntityEntry principalEntry)
     {
         if (dependentEntry.EntityState == EntityState.Deleted
-            && (principalEntry.EntityState == EntityState.Unchanged
-                || principalEntry.EntityState == EntityState.Modified))
+            && principalEntry.EntityState is EntityState.Unchanged or EntityState.Modified)
         {
             dependentEntry.SetEntityState(EntityState.Modified);
         }

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -1223,8 +1223,7 @@ public class StateManager : IStateManager
                     && (dependent.EntityState == EntityState.Added
                         || KeysEqual(entry, fk, dependent)))
                 {
-                    if ((fk.DeleteBehavior == DeleteBehavior.Cascade
-                            || fk.DeleteBehavior == DeleteBehavior.ClientCascade)
+                    if (fk.DeleteBehavior is DeleteBehavior.Cascade or DeleteBehavior.ClientCascade
                         && doCascadeDelete)
                     {
                         var cascadeState = principalIsDetached

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -104,7 +104,7 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
     private void LocalViewCollectionChanged(object? _, NotifyCollectionChangedEventArgs args)
     {
         Check.DebugAssert(
-            args.Action == NotifyCollectionChangedAction.Add || args.Action == NotifyCollectionChangedAction.Remove,
+            args.Action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Remove,
             "action is not Add or Remove");
 
         if (_triggeringLocalViewChange)
@@ -150,8 +150,7 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
             }
             else
             {
-                if (args.Action == NotifyCollectionChangedAction.Remove
-                    || args.Action == NotifyCollectionChangedAction.Replace)
+                if (args.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace)
                 {
                     foreach (TEntity entity in args.OldItems!)
                     {
@@ -159,8 +158,7 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
                     }
                 }
 
-                if (args.Action == NotifyCollectionChangedAction.Add
-                    || args.Action == NotifyCollectionChangedAction.Replace)
+                if (args.Action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Replace)
                 {
                     foreach (TEntity entity in args.NewItems!)
                     {
@@ -213,8 +211,7 @@ public class LocalView<[DynamicallyAccessedMembers(IEntityType.DynamicallyAccess
         // was wanted in this case.
 
         var entry = _context.GetDependencies().StateManager.GetOrCreateEntry(item, _entityType);
-        if (entry.EntityState == EntityState.Deleted
-            || entry.EntityState == EntityState.Detached)
+        if (entry.EntityState is EntityState.Deleted or EntityState.Detached)
         {
             try
             {

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -171,8 +171,7 @@ public static class ExpressionExtensions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public static bool IsLogicalOperation(this Expression expression)
-        => expression.NodeType == ExpressionType.AndAlso
-            || expression.NodeType == ExpressionType.OrElse;
+        => expression.NodeType is ExpressionType.AndAlso or ExpressionType.OrElse;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -200,16 +199,9 @@ public static class ExpressionExtensions
 
     [return: NotNullIfNotNull("expression")]
     private static Expression? RemoveConvert(Expression? expression)
-    {
-        if (expression is UnaryExpression unaryExpression
-            && (expression.NodeType == ExpressionType.Convert
-                || expression.NodeType == ExpressionType.ConvertChecked))
-        {
-            return RemoveConvert(unaryExpression.Operand);
-        }
-
-        return expression;
-    }
+        => expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression
+            ? RemoveConvert(unaryExpression.Operand)
+            : expression;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -3322,8 +3322,8 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
                 return CoreStrings.ChangeTrackingInterfaceMissing(entityType.DisplayName(), value, nameof(INotifyPropertyChanged));
             }
 
-            if ((value == ChangeTrackingStrategy.ChangingAndChangedNotifications
-                    || value == ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues)
+            if (value is ChangeTrackingStrategy.ChangingAndChangedNotifications
+                    or ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues
                 && !typeof(INotifyPropertyChanging).IsAssignableFrom(entityType.ClrType))
             {
                 return CoreStrings.ChangeTrackingInterfaceMissing(entityType.DisplayName(), value, nameof(INotifyPropertyChanging));

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -178,8 +178,7 @@ public static class EntityTypeExtensions
     {
         var changeTrackingStrategy = entityType.GetChangeTrackingStrategy();
 
-        return changeTrackingStrategy == ChangeTrackingStrategy.Snapshot
-            || changeTrackingStrategy == ChangeTrackingStrategy.ChangedNotifications;
+        return changeTrackingStrategy is ChangeTrackingStrategy.Snapshot or ChangeTrackingStrategy.ChangedNotifications;
     }
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -48,7 +48,6 @@ public class PropertyAccessorsFactory
     {
         var entityClrType = propertyBase.DeclaringType.ClrType;
         var entryParameter = Expression.Parameter(typeof(InternalEntityEntry), "entry");
-        var property = propertyBase as IProperty;
         var propertyIndex = propertyBase.GetIndex();
         var shadowIndex = propertyBase.GetShadowIndex();
         var storeGeneratedIndex = propertyBase.GetStoreGeneratedIndex();

--- a/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -248,9 +248,9 @@ public static class PropertyBaseExtensions
                 }
             }
 
-            if (mode == PropertyAccessMode.PreferProperty
-                || mode == PropertyAccessMode.FieldDuringConstruction
-                || mode == PropertyAccessMode.PreferFieldDuringConstruction)
+            if (mode is PropertyAccessMode.PreferProperty
+                or PropertyAccessMode.FieldDuringConstruction
+                or PropertyAccessMode.PreferFieldDuringConstruction)
             {
                 if (hasSetter)
                 {
@@ -317,9 +317,9 @@ public static class PropertyBaseExtensions
             }
         }
 
-        if (mode == PropertyAccessMode.PreferProperty
-            || mode == PropertyAccessMode.FieldDuringConstruction
-            || mode == PropertyAccessMode.PreferFieldDuringConstruction)
+        if (mode is PropertyAccessMode.PreferProperty
+            or PropertyAccessMode.FieldDuringConstruction
+            or PropertyAccessMode.PreferFieldDuringConstruction)
         {
             if (hasGetter)
             {

--- a/src/EFCore/Metadata/Internal/TypeConfigurationTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeConfigurationTypeExtensions.cs
@@ -27,7 +27,7 @@ public static class TypeConfigurationTypeExtensions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public static bool IsEntityType(this TypeConfigurationType configurationType)
-        => configurationType == TypeConfigurationType.EntityType
-            || configurationType == TypeConfigurationType.SharedTypeEntityType
-            || configurationType == TypeConfigurationType.OwnedEntityType;
+        => configurationType is TypeConfigurationType.EntityType
+            or TypeConfigurationType.SharedTypeEntityType
+            or TypeConfigurationType.OwnedEntityType;
 }

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -514,17 +514,14 @@ public partial class NavigationExpandingExpressionVisitor
             : base(navigationExpandingExpressionVisitor, source, extensibilityHelper)
         {
             _logger = navigationExpandingExpressionVisitor._queryCompilationContext.Logger;
-            _queryStateManager = navigationExpandingExpressionVisitor._queryCompilationContext.QueryTrackingBehavior
-                == QueryTrackingBehavior.TrackAll
-                || navigationExpandingExpressionVisitor._queryCompilationContext.QueryTrackingBehavior
-                == QueryTrackingBehavior.NoTrackingWithIdentityResolution;
+            _queryStateManager = navigationExpandingExpressionVisitor._queryCompilationContext.QueryTrackingBehavior is
+                QueryTrackingBehavior.TrackAll or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
             _ignoreAutoIncludes = navigationExpandingExpressionVisitor._queryCompilationContext.IgnoreAutoIncludes;
         }
 
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
-            if (binaryExpression.NodeType == ExpressionType.Equal
-                || binaryExpression.NodeType == ExpressionType.NotEqual)
+            if (binaryExpression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual)
             {
                 // This could be entity equality. We don't want to expand include nodes over them
                 // as either they translate or throw.
@@ -1225,8 +1222,7 @@ public partial class NavigationExpandingExpressionVisitor
         }
 
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
-            => (binaryExpression.NodeType == ExpressionType.Equal
-                    || binaryExpression.NodeType == ExpressionType.NotEqual)
+            => binaryExpression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual
                 && TryRemoveNavigationComparison(
                     binaryExpression.NodeType, binaryExpression.Left, binaryExpression.Right, out var result)
                     ? result

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1085,7 +1085,7 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
             }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            if (expression is ConstantExpression { Value: string navigationChain } includeConstant)
+            if (expression is ConstantExpression { Value: string navigationChain })
             {
                 var navigationPaths = navigationChain.Split(new[] { "." }, StringSplitOptions.None);
                 var includeTreeNodes = new Queue<IncludeTreeNode>();

--- a/src/EFCore/Query/Internal/NullCheckRemovingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NullCheckRemovingExpressionVisitor.cs
@@ -39,9 +39,7 @@ public class NullCheckRemovingExpressionVisitor : ExpressionVisitor
     {
         var test = Visit(conditionalExpression.Test);
 
-        if (test is BinaryExpression binaryTest
-            && (binaryTest.NodeType == ExpressionType.Equal
-                || binaryTest.NodeType == ExpressionType.NotEqual))
+        if (test is BinaryExpression { NodeType: ExpressionType.Equal or ExpressionType.NotEqual } binaryTest)
         {
             var isLeftNullConstant = IsNullConstant(binaryTest.Left);
             var isRightNullConstant = IsNullConstant(binaryTest.Right);
@@ -60,14 +58,10 @@ public class NullCheckRemovingExpressionVisitor : ExpressionVisitor
                 ? conditionalExpression.IfFalse
                 : conditionalExpression.IfTrue;
 
-            if (accessOperation is UnaryExpression outerUnary
-                && (outerUnary.NodeType == ExpressionType.Convert
-                    || outerUnary.NodeType == ExpressionType.ConvertChecked)
+            if (accessOperation is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } outerUnary
                 && accessOperation.Type.IsNullableType()
                 && accessOperation.Type.UnwrapNullableType() == outerUnary.Operand.Type
-                && outerUnary.Operand is UnaryExpression innerUnary
-                && (innerUnary.NodeType == ExpressionType.Convert
-                    || innerUnary.NodeType == ExpressionType.ConvertChecked))
+                && outerUnary.Operand is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } innerUnary)
             {
                 // If expression is of type Convert(Convert(a, type), type?)
                 // then we convert it to Convert(a, type?) since a can be nullable after removing check
@@ -157,8 +151,7 @@ public class NullCheckRemovingExpressionVisitor : ExpressionVisitor
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
         {
             var operand = Visit(unaryExpression.Operand);
-            if ((unaryExpression.NodeType == ExpressionType.Convert
-                    || unaryExpression.NodeType == ExpressionType.ConvertChecked)
+            if (unaryExpression.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked
                 && _nullSafeAccesses.Contains(operand))
             {
                 _nullSafeAccesses.Add(unaryExpression);

--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -115,7 +115,7 @@ public class ParameterExtractingExpressionVisitor : ExpressionVisitor
     }
 
     private static bool PreserveInitializationConstant(Expression expression, bool generateParameter)
-        => !generateParameter && (expression is NewExpression || expression is MemberInitExpression);
+        => !generateParameter && expression is NewExpression or MemberInitExpression;
 
     private bool PreserveConvertNode(Expression expression)
     {

--- a/src/EFCore/Query/Internal/QueryOptimizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizingExpressionVisitor.cs
@@ -259,12 +259,16 @@ public class QueryOptimizingExpressionVisitor : ExpressionVisitor
 
         // In VB.NET, comparison operators between strings (equality, greater-than, less-than) yield
         // calls to a VB-specific CompareString method. Normalize that to string.Compare.
-        if (visited.Method.Name == "CompareString"
-            && (visited.Method.DeclaringType?.Name == "Operators"
-                || visited.Method.DeclaringType?.Name == "EmbeddedOperators")
-            && visited.Method.DeclaringType?.Namespace == "Microsoft.VisualBasic.CompilerServices"
-            && visited.Object == null
-            && visited.Arguments is [_, _, ConstantExpression textCompareConstantExpression])
+        if (visited is
+            {
+                Method:
+                {
+                    Name: "CompareString",
+                    DeclaringType: { Name: "Operators" or "EmbeddedOperators", Namespace: "Microsoft.VisualBasic.CompilerServices" }
+                },
+                Object: null,
+                Arguments: [_, _, ConstantExpression textCompareConstantExpression]
+            })
         {
             return textCompareConstantExpression.Value is true
                 ? Expression.Call(
@@ -481,5 +485,5 @@ public class QueryOptimizingExpressionVisitor : ExpressionVisitor
     }
 
     private static bool IsNullConstant(Expression expression)
-        => expression is ConstantExpression { Value: null } constantExpression;
+        => expression is ConstantExpression { Value: null };
 }

--- a/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
@@ -306,8 +306,7 @@ public class QueryableMethodNormalizingExpressionVisitor : ExpressionVisitor
         var enumerableMethod = methodCallExpression.Method;
         var enumerableParameters = enumerableMethod.GetParameters();
         var genericTypeArguments = Array.Empty<Type>();
-        if (enumerableMethod.Name == nameof(Enumerable.Min)
-            || enumerableMethod.Name == nameof(Enumerable.Max))
+        if (enumerableMethod.Name is nameof(Enumerable.Min) or nameof(Enumerable.Max))
         {
             genericTypeArguments = new Type[methodCallExpression.Arguments.Count];
 

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -48,10 +48,7 @@ public class ReplacingExpressionVisitor : ExpressionVisitor
     [return: NotNullIfNotNull("expression")]
     public override Expression? Visit(Expression? expression)
     {
-        if (expression == null
-            || expression is ShapedQueryExpression
-            || expression is EntityShaperExpression
-            || expression is GroupByShaperExpression)
+        if (expression is null or ShapedQueryExpression or EntityShaperExpression or GroupByShaperExpression)
         {
             return expression;
         }

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -250,16 +250,13 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
         }
 
         protected override Expression VisitExtension(Expression extensionExpression)
-            => extensionExpression is EntityShaperExpression
-                || extensionExpression is ProjectionBindingExpression
-                    ? extensionExpression
-                    : base.VisitExtension(extensionExpression);
+            => extensionExpression is EntityShaperExpression or ProjectionBindingExpression
+                ? extensionExpression
+                : base.VisitExtension(extensionExpression);
 
         private static Expression? RemoveConvert(Expression? expression)
         {
-            while (expression != null
-                   && (expression.NodeType == ExpressionType.Convert
-                       || expression.NodeType == ExpressionType.ConvertChecked))
+            while (expression is { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked })
             {
                 expression = RemoveConvert(((UnaryExpression)expression).Operand);
             }
@@ -309,8 +306,8 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
         {
             _entityMaterializerSource = entityMaterializerSource;
             _queryTrackingBehavior = queryTrackingBehavior;
-            _queryStateManager = queryTrackingBehavior == QueryTrackingBehavior.TrackAll
-                || queryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution;
+            _queryStateManager =
+                queryTrackingBehavior is QueryTrackingBehavior.TrackAll or QueryTrackingBehavior.NoTrackingWithIdentityResolution;
         }
 
         public Expression Inject(Expression expression)

--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -544,8 +544,6 @@ namespace Microsoft.Data.Sqlite
         }
 
         private static bool IsBusy(int rc)
-            => rc == SQLITE_LOCKED
-                || rc == SQLITE_BUSY
-                || rc == SQLITE_LOCKED_SHAREDCACHE;
+            => rc is SQLITE_LOCKED or SQLITE_BUSY or SQLITE_LOCKED_SHAREDCACHE;
     }
 }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionInternal.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionInternal.cs
@@ -233,8 +233,6 @@ namespace Microsoft.Data.Sqlite
         }
 
         private static bool IsBusy(int rc)
-            => rc == SQLITE_LOCKED
-                || rc == SQLITE_BUSY
-                || rc == SQLITE_LOCKED_SHAREDCACHE;
+            => rc is SQLITE_LOCKED or SQLITE_BUSY or SQLITE_LOCKED_SHAREDCACHE;
     }
 }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
@@ -311,15 +311,9 @@ namespace Microsoft.Data.Sqlite
         }
 
         private static bool? ConvertToNullableBoolean(object value)
-        {
-            if (value == null
-                || value is string { Length: 0 })
-            {
-                return null;
-            }
-
-            return Convert.ToBoolean(value, CultureInfo.InvariantCulture);
-        }
+            => value is null or string { Length: 0 }
+                ? null
+                : Convert.ToBoolean(value, CultureInfo.InvariantCulture);
 
         /// <summary>
         ///     Clears the contents of the builder.

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -216,9 +216,7 @@ namespace Microsoft.Data.Sqlite
         }
 
         private static bool IsBusy(int rc)
-            => rc == SQLITE_LOCKED
-                || rc == SQLITE_BUSY
-                || rc == SQLITE_LOCKED_SHAREDCACHE;
+            => rc is SQLITE_LOCKED or SQLITE_BUSY or SQLITE_LOCKED_SHAREDCACHE;
 
         /// <summary>
         ///     Closes the data reader.

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -185,9 +185,7 @@ namespace Microsoft.Data.Sqlite
                     return "TEXT";
 
                 default:
-                    Debug.Assert(
-                        sqliteType == SQLITE_BLOB || sqliteType == SQLITE_NULL,
-                        "Unexpected column type: " + sqliteType);
+                    Debug.Assert(sqliteType is SQLITE_BLOB or SQLITE_NULL, "Unexpected column type: " + sqliteType);
                     return "BLOB";
             }
         }
@@ -228,9 +226,7 @@ namespace Microsoft.Data.Sqlite
                     return typeof(string);
 
                 default:
-                    Debug.Assert(
-                        sqliteType == SQLITE_BLOB || sqliteType == SQLITE_NULL,
-                        "Unexpected column type: " + sqliteType);
+                    Debug.Assert(sqliteType is SQLITE_BLOB or SQLITE_NULL, "Unexpected column type: " + sqliteType);
                     return typeof(byte[]);
             }
         }
@@ -252,7 +248,7 @@ namespace Microsoft.Data.Sqlite
                     return typeof(string);
 
                 default:
-                    Debug.Assert(type == "blob" || type == null, "Unexpected column type: " + type);
+                    Debug.Assert(type is "blob" or null, "Unexpected column type: " + type);
                     return typeof(byte[]);
             }
         }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteException.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteException.cs
@@ -61,9 +61,7 @@ namespace Microsoft.Data.Sqlite
         /// </remarks>
         public static void ThrowExceptionForRC(int rc, sqlite3? db)
         {
-            if (rc == SQLITE_OK
-                || rc == SQLITE_ROW
-                || rc == SQLITE_DONE)
+            if (rc is SQLITE_OK or SQLITE_ROW or SQLITE_DONE)
             {
                 return;
             }

--- a/src/Shared/ExpressionExtensions.cs
+++ b/src/Shared/ExpressionExtensions.cs
@@ -40,16 +40,9 @@ internal static class ExpressionExtensions
     }
 
     private static Expression RemoveConvert(Expression expression)
-    {
-        if (expression is UnaryExpression unaryExpression
-            && (expression.NodeType == ExpressionType.Convert
-                || expression.NodeType == ExpressionType.ConvertChecked))
-        {
-            return RemoveConvert(unaryExpression.Operand);
-        }
-
-        return expression;
-    }
+        => expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression
+            ? RemoveConvert(unaryExpression.Operand)
+            : expression;
 
     public static T GetConstantValue<T>(this Expression expression)
         => expression is ConstantExpression constantExpression

--- a/src/dotnet-ef/Program.cs
+++ b/src/dotnet-ef/Program.cs
@@ -19,8 +19,7 @@ internal static class Program
         }
         catch (Exception ex)
         {
-            if (ex is CommandException
-                || ex is CommandParsingException)
+            if (ex is CommandException or CommandParsingException)
             {
                 Reporter.WriteVerbose(ex.ToString());
             }

--- a/src/ef/CommandLineUtils/CommandLineApplication.cs
+++ b/src/ef/CommandLineUtils/CommandLineApplication.cs
@@ -245,8 +245,7 @@ internal class CommandLineApplication
             }
             else
             {
-                if (option.OptionType == CommandOptionType.NoValue
-                    || option.OptionType == CommandOptionType.BoolValue)
+                if (option.OptionType is CommandOptionType.NoValue or CommandOptionType.BoolValue)
                 {
                     // No value is needed for this option
                     option.TryParse(null);

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CustomPartitionKeyIdGenerator.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CustomPartitionKeyIdGenerator.cs
@@ -44,13 +44,10 @@ public class CustomPartitionKeyIdGenerator<T> : ValueGenerator<T>
                 value = converter.ConvertToProvider(value);
             }
 
-            if (value is int x)
+            // We don't allow the Id to be zero for our custom generator.
+            if (value is 0)
             {
-                // We don't allow the Id to be zero for our custom generator.
-                if (x == 0)
-                {
-                    return default;
-                }
+                return default;
             }
 
             AppendString(builder, value);

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             Assert.Equal(2, model.GetAnnotations().Count());
 
             var actual = (string)model["Relational:DefaultSchema"];
-            Assert.True(actual == "Value1" || actual == "Value2");
+            Assert.True(actual is "Value1" or "Value2");
         }
 
         [ConditionalFact]
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             Assert.Equal(2, model.GetAnnotations().Count());
 
             var actual = (string)model["Relational:DefaultSchema"];
-            Assert.True(actual == "Value1" || actual == "Value2");
+            Assert.True(actual is "Value1" or "Value2");
         }
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -678,7 +678,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
             .Where(e => names.Contains(e.NullableStringA))
             .Select(e => e.NullableStringA).ToList();
 
-        Assert.True(result.All(r => r == "Foo" || r == "Bar"));
+        Assert.True(result.All(r => r is "Foo" or "Bar"));
     }
 
     [ConditionalFact]
@@ -1825,7 +1825,7 @@ public abstract class NullSemanticsQueryTestBase<TFixture> : QueryTestBase<TFixt
     {
         var ctx = CreateContext(useRelationalNulls: true);
 
-        var expected = ctx.Entities1.AsEnumerable().Where(e => e.NullableIntA == 1 || e.NullableIntA == null).ToList();
+        var expected = ctx.Entities1.AsEnumerable().Where(e => e.NullableIntA is 1 or null).ToList();
         ClearLog();
         var query = ctx.Entities1.Where(e => e.NullableIntA == 1 || e.NullableIntA == null);
 

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMappingSource.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMappingSource.cs
@@ -203,7 +203,7 @@ public class TestRelationalTypeMappingSource : RelationalTypeMappingSource
                     return _defaultDecimalMapping;
                 }
 
-                if (scale == null || scale == 0)
+                if (scale is null or 0)
                 {
                     return new DecimalTypeMapping(
                         "decimal_mapping(" + precision + ")",

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToMany.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToMany.cs
@@ -1491,8 +1491,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Modified
                         : EntityState.Unchanged;
@@ -1911,8 +1910,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Deleted
                         : EntityState.Unchanged;
@@ -2008,8 +2006,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Modified
                         : EntityState.Unchanged;
@@ -2125,8 +2122,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                if ((cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                if (cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction)
                 {
                     Assert.Equal(EntityState.Detached, context.Entry(added).State);

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToManyAk.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToManyAk.cs
@@ -1092,8 +1092,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Modified
                         : EntityState.Unchanged;
@@ -1191,8 +1190,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Deleted
                         : EntityState.Unchanged;
@@ -1311,8 +1309,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                if ((cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                if (cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction)
                 {
                     Assert.Equal(EntityState.Detached, context.Entry(added).State);

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
@@ -727,8 +727,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Modified
                         : EntityState.Unchanged;
@@ -2102,8 +2101,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Deleted
                         : EntityState.Unchanged;
@@ -2198,8 +2196,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Deleted
                         : EntityState.Unchanged;
@@ -2299,8 +2296,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Detached
                         : EntityState.Added;
@@ -2409,8 +2405,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Detached
                         : EntityState.Added;

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOneAk.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOneAk.cs
@@ -902,8 +902,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Modified
                         : EntityState.Unchanged;
@@ -2325,8 +2324,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Deleted
                         : EntityState.Unchanged;
@@ -2430,8 +2428,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Deleted
                         : EntityState.Unchanged;
@@ -2541,8 +2538,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Detached
                         : EntityState.Added;
@@ -2659,8 +2655,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     context.ChangeTracker.CascadeChanges();
                 }
 
-                var expectedState = (cascadeDeleteTiming == CascadeTiming.Immediate
-                        || cascadeDeleteTiming == null)
+                var expectedState = cascadeDeleteTiming is CascadeTiming.Immediate or null
                     && !Fixture.ForceClientNoAction
                         ? EntityState.Detached
                         : EntityState.Added;

--- a/test/EFCore.Specification.Tests/ManyToManyFieldsLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyFieldsLoadTestBase.cs
@@ -836,7 +836,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture> : IClassFixture<TFi
             Assert.Contains(left, right.OneSkipShared);
             foreach (var three in right.ThreeSkipFull)
             {
-                Assert.True(three.Id == 11 || three.Id == 13);
+                Assert.True(three.Id is 11 or 13);
                 Assert.Contains(right, three.TwoSkipFull);
             }
         }

--- a/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
@@ -1312,7 +1312,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture> : IClassFixture<T
             Assert.Contains(left, right.OneSkipShared);
             foreach (var three in right.ThreeSkipFull)
             {
-                Assert.True(three.Id == 11 || three.Id == 13);
+                Assert.True(three.Id is 11 or 13);
                 Assert.Contains(right, three.TwoSkipFull);
             }
         }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -2614,7 +2614,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture> : QueryTestBase<TFixture
         => weapons.OrderBy(w => w.Id).FirstOrDefault();
 
     private static IEnumerable<Gear> Veterans(IEnumerable<Gear> gears)
-        => gears.Where(g => g.Nickname == "Marcus" || g.Nickname == "Dom" || g.Nickname == "Cole Train" || g.Nickname == "Baird");
+        => gears.Where(g => g.Nickname is "Marcus" or "Dom" or "Cole Train" or "Baird");
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindEFPropertyIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindEFPropertyIncludeQueryTestBase.cs
@@ -204,26 +204,15 @@ public abstract class NorthwindEFPropertyIncludeQueryTestBase<TFixture> : Northw
         }
 
         private static string GetPath(Expression expression)
-        {
-            switch (expression)
+            => expression switch
             {
-                case MemberExpression memberExpression:
-                    if (memberExpression.Expression is ParameterExpression)
-                    {
-                        return memberExpression.Member.Name;
-                    }
-
-                    return $"{GetPath(memberExpression.Expression)}.{memberExpression.Member.Name}";
-
-                case UnaryExpression unaryExpression
-                    when unaryExpression.NodeType == ExpressionType.Convert
-                    || unaryExpression.NodeType == ExpressionType.Convert
-                    || unaryExpression.NodeType == ExpressionType.TypeAs:
-                    return GetPath(unaryExpression.Operand);
-
-                default:
-                    return null;
-            }
-        }
+                MemberExpression { Expression: ParameterExpression } memberExpression
+                    => memberExpression.Member.Name,
+                MemberExpression memberExpression
+                    => $"{GetPath(memberExpression.Expression)}.{memberExpression.Member.Name}",
+                UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.Convert or ExpressionType.TypeAs } unaryExpression
+                    => GetPath(unaryExpression.Operand),
+                _ => null
+            };
     }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
@@ -223,26 +223,15 @@ public abstract class NorthwindStringIncludeQueryTestBase<TFixture> : NorthwindI
         }
 
         private static string GetPath(Expression expression)
-        {
-            switch (expression)
+            => expression switch
             {
-                case MemberExpression memberExpression:
-                    if (memberExpression.Expression is ParameterExpression)
-                    {
-                        return memberExpression.Member.Name;
-                    }
-
-                    return $"{GetPath(memberExpression.Expression)}.{memberExpression.Member.Name}";
-
-                case UnaryExpression unaryExpression
-                    when unaryExpression.NodeType == ExpressionType.Convert
-                    || unaryExpression.NodeType == ExpressionType.Convert
-                    || unaryExpression.NodeType == ExpressionType.TypeAs:
-                    return GetPath(unaryExpression.Operand);
-
-                default:
-                    throw new NotImplementedException("Unhandled expression tree in Include lambda");
-            }
-        }
+                MemberExpression { Expression: ParameterExpression } memberExpression
+                    => memberExpression.Member.Name,
+                MemberExpression memberExpression
+                    => $"{GetPath(memberExpression.Expression)}.{memberExpression.Member.Name}",
+                UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.Convert or ExpressionType.TypeAs } unaryExpression
+                    => GetPath(unaryExpression.Operand),
+                _ => throw new NotImplementedException("Unhandled expression tree in Include lambda")
+            };
     }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/ExpectedQueryRewritingVisitor.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ExpectedQueryRewritingVisitor.cs
@@ -246,7 +246,7 @@ public class ExpectedQueryRewritingVisitor : ExpressionVisitor
                     var methodInfo = _getShadowPropertyValueMethodInfo.MakeGenericMethod(caller.Type, methodCallExpression.Type);
                     result = Expression.Call(methodInfo, caller, Expression.Constant(shadowPropertyMapping));
                 }
-                else if (caller.Type.GetMembers().Where(m => m.Name == propertyName).SingleOrDefault() is MemberInfo matchingMember)
+                else if (caller.Type.GetMembers().SingleOrDefault(m => m.Name == propertyName) is MemberInfo)
                 {
                     result = Expression.Property(caller, propertyName);
                 }
@@ -268,9 +268,7 @@ public class ExpectedQueryRewritingVisitor : ExpressionVisitor
         return expression;
 
         static Expression RemoveConvertToObject(Expression expression)
-            => expression is UnaryExpression unaryExpression
-                && (expression.NodeType == ExpressionType.Convert
-                    || expression.NodeType == ExpressionType.ConvertChecked)
+            => expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression
                 && expression.Type == typeof(object)
                     ? RemoveConvertToObject(unaryExpression.Operand)
                     : expression;
@@ -307,12 +305,16 @@ public class ExpectedQueryRewritingVisitor : ExpressionVisitor
 
     protected override Expression VisitUnary(UnaryExpression unaryExpression)
     {
-        if ((unaryExpression.NodeType == ExpressionType.Convert
-                || unaryExpression.NodeType == ExpressionType.ConvertChecked
-                || unaryExpression.NodeType == ExpressionType.TypeAs)
-            && unaryExpression.Operand is MemberExpression { Type.IsValueType: true } memberOperand
+        if (unaryExpression is
+            {
+                NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked or ExpressionType.TypeAs,
+                Operand: MemberExpression
+                {
+                    Type.IsValueType: true,
+                    Expression: not null
+                } memberOperand
+            }
             && !memberOperand.Type.IsNullableValueType()
-            && memberOperand.Expression != null
             && unaryExpression.Type.IsNullableValueType()
             && unaryExpression.Type.UnwrapNullableType() == memberOperand.Type)
         {
@@ -341,12 +343,12 @@ public class ExpectedQueryRewritingVisitor : ExpressionVisitor
 
     protected override Expression VisitBinary(BinaryExpression binaryExpression)
     {
-        if (binaryExpression.NodeType == ExpressionType.Equal
-            || binaryExpression.NodeType == ExpressionType.NotEqual
-            || binaryExpression.NodeType == ExpressionType.GreaterThan
-            || binaryExpression.NodeType == ExpressionType.GreaterThanOrEqual
-            || binaryExpression.NodeType == ExpressionType.LessThan
-            || binaryExpression.NodeType == ExpressionType.LessThanOrEqual)
+        if (binaryExpression.NodeType is ExpressionType.Equal
+            or ExpressionType.NotEqual
+            or ExpressionType.GreaterThan
+            or ExpressionType.GreaterThanOrEqual
+            or ExpressionType.LessThan
+            or ExpressionType.LessThanOrEqual)
         {
             var left = AddNullProtectionForNonNullableMemberAccess(binaryExpression.Left);
             var right = AddNullProtectionForNonNullableMemberAccess(binaryExpression.Right);

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectJoinWithSelfExpressionMutator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectJoinWithSelfExpressionMutator.cs
@@ -60,9 +60,9 @@ public class InjectJoinWithSelfExpressionMutator : ExpressionMutator
 
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
-            if (node?.Method.Name == nameof(Queryable.ThenBy)
-                || node?.Method.Name == nameof(Queryable.ThenByDescending)
-                || node?.Method.Name == nameof(EntityFrameworkQueryableExtensions.ThenInclude))
+            if (node?.Method.Name is nameof(Queryable.ThenBy)
+                or nameof(Queryable.ThenByDescending)
+                or nameof(EntityFrameworkQueryableExtensions.ThenInclude))
             {
                 return node;
             }

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectOrderByPropertyExpressionMutator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectOrderByPropertyExpressionMutator.cs
@@ -82,10 +82,7 @@ public class InjectOrderByPropertyExpressionMutator : ExpressionMutator
         {
             // can't inject OrderBy inside of include - would have to rewrite the ThenInclude method to one that accepts ordered input
             var insideThenInclude = default(bool?);
-            if (expression is MethodCallExpression methodCallExpression
-                && (methodCallExpression.Method.Name == "ThenInclude"
-                    || methodCallExpression.Method.Name == "ThenBy"
-                    || methodCallExpression.Method.Name == "ThenByDescending"))
+            if (expression is MethodCallExpression { Method.Name: "ThenInclude" or "ThenBy" or "ThenByDescending" })
             {
                 insideThenInclude = _insideThenInclude;
                 _insideThenInclude = true;

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectThenByPropertyExpressionMutator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectThenByPropertyExpressionMutator.cs
@@ -82,8 +82,7 @@ public class InjectThenByPropertyExpressionMutator : ExpressionMutator
         {
             // can't inject OrderBy inside of include - would have to rewrite the ThenInclude method to one that accepts ordered input
             var insideThenInclude = default(bool?);
-            if (expression is MethodCallExpression methodCallExpression
-                && (methodCallExpression.Method.Name == "ThenInclude" || methodCallExpression.Method.Name == "ThenIncludeDescending"))
+            if (expression is MethodCallExpression { Method.Name: "ThenInclude" or "ThenIncludeDescending" })
             {
                 insideThenInclude = _insideThenInclude;
                 _insideThenInclude = true;

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectWhereExpressionMutator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectWhereExpressionMutator.cs
@@ -85,8 +85,6 @@ public class InjectWhereExpressionMutator : ExpressionMutator
                         any,
                         Expression.Property(prm, collectionNavigation.PropertyInfo)));
             }
-
-            var navigation = random.Choose(navigations);
         }
 
         var lambdaBody = random.Choose(candidateExpressions);
@@ -117,12 +115,7 @@ public class InjectWhereExpressionMutator : ExpressionMutator
 
         public override Expression Visit(Expression expression)
         {
-            if (expression is MethodCallExpression methodCallExpression
-                && (methodCallExpression.Method.Name == "ThenInclude"
-                    || methodCallExpression.Method.Name == "ThenBy"
-                    || methodCallExpression.Method.Name == "ThenByDescending"
-                    || methodCallExpression.Method.Name == "Skip"
-                    || methodCallExpression.Method.Name == "Take"))
+            if (expression is MethodCallExpression { Method.Name: "ThenInclude" or "ThenBy" or "ThenByDescending" or "Skip" or "Take" })
             {
                 return expression;
             }

--- a/test/EFCore.Specification.Tests/UnidirectionalManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/UnidirectionalManyToManyLoadTestBase.cs
@@ -886,7 +886,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
             Assert.Contains(left, context.Entry(right).Collection("UnidirectionalEntityOne").CurrentValue!.Cast<object>());
             foreach (var three in context.Entry(right).Collection<UnidirectionalEntityThree>("UnidirectionalEntityThree").CurrentValue!)
             {
-                Assert.True(three.Id == 11 || three.Id == 13);
+                Assert.True(three.Id is 11 or 13);
                 Assert.Contains(right, three.TwoSkipFull);
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -67,7 +67,7 @@ public static class TestEnvironment
             {
                 _engineEdition = GetEngineEdition();
 
-                _isAzureSqlDb = (_engineEdition == 5 || _engineEdition == 8);
+                _isAzureSqlDb = _engineEdition is 5 or 8;
             }
             catch (PlatformNotSupportedException)
             {

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -2879,8 +2879,7 @@ public class ChangeTrackerTest
             Assert.Equal(EntityState.Unchanged, context.Entry(attachedContainer).State);
             Assert.Equal(EntityState.Unchanged, context.Entry(attachedTroduct!).State);
 
-            if (orphanTiming == null
-                || orphanTiming == CascadeTiming.Immediate)
+            if (orphanTiming is null or CascadeTiming.Immediate)
             {
                 Assert.Equal(EntityState.Deleted, context.Entry(attachedRoom).State);
             }

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -3323,8 +3323,7 @@ public class FixupTest
         foreach (var entry in context.ChangeTracker.Entries<Product>())
         {
             var product = entry.Entity;
-            if (product.CategoryId == 11
-                || product.CategoryId == 12)
+            if (product.CategoryId is 11 or 12)
             {
                 Assert.Equal(product.CategoryId, product.Category.Id);
                 Assert.Contains(product, product.Category.Products);
@@ -3338,8 +3337,7 @@ public class FixupTest
         foreach (var entry in context.ChangeTracker.Entries<SpecialOffer>())
         {
             var offer = entry.Entity;
-            if (offer.ProductId == 22
-                || offer.ProductId == 24)
+            if (offer.ProductId is 22 or 24)
             {
                 Assert.Equal(offer.ProductId, offer.Product.Id);
                 Assert.Contains(offer, offer.Product.SpecialOffers);

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
@@ -125,7 +125,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
         entry.AcceptChanges();
 
         Assert.Equal(
-            entityState == EntityState.Deleted || entityState == EntityState.Detached
+            entityState is EntityState.Deleted or EntityState.Detached
                 ? EntityState.Detached
                 : EntityState.Unchanged,
             entry.EntityState);
@@ -138,7 +138,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
         {
             Assert.Equal("Pickle", entry[valueProperty]);
             Assert.Equal(
-                entityState == EntityState.Detached || entityState == EntityState.Deleted ? "Cheese" : "Pickle",
+                entityState is EntityState.Detached or EntityState.Deleted ? "Cheese" : "Pickle",
                 entry.GetOriginalValue(valueProperty));
         }
     }


### PR DESCRIPTION
Another round of modernization/cleanup; mainly collapsing of `x == 1 || x == 2` to `x is 1 or 2` and stuff following from that.

I've restricted this to what looks very uncontroversial to me, but will leave this for a few days in any case to let everyone take a peek.