### PR TITLE
Use IDbSetCache.GetSets() when checking for resettable services

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -1030,10 +1030,7 @@ public class DbContext :
             _cachedResettableServices = resettableServices;
         }
 
-        if (_sets is not null)
-        {
-            resettableServices.AddRange(_sets.Values.OfType<IResettableService>());
-        }
+        resettableServices.AddRange(((IDbSetCache)this).GetSets().OfType<IResettableService>());
 
         return resettableServices;
     }


### PR DESCRIPTION
Use IDbSetCache.GetSets() and not private _sets variable when checking for resettabe services. This is better code style and can be neccessary if somebody decides to implement IDbSetCache on a DbContext child class. If there is an interface method that provides logic, it should also be used internally.

This patch was tested with 7.0.8 and 7.0-release branches but should also work on main branch.

- [x]  I've read the guidelines for contributing and seen the walkthrough
- [ ]  I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x]  The code builds and tests pass locally (also verified by our automated build checks)
- [x]  Commit messages follow this format:
 Tests for the changes have been added (for bug fixes / features)
- [x]  Code follows the same patterns and style as existing code in this repo