### PR TITLE
Add `migrations has-pending-model-changes` Command

### DIFF
--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -249,7 +249,7 @@ public class MigrationsOperations
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual void CheckPendingMigrations(string? contextType)
+    public virtual void HasPendingModelChanges(string? contextType)
     {
         using var context = _contextOperations.CreateContext(contextType);
 

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Design.Internal;
 
@@ -240,6 +241,26 @@ public class MigrationsOperations
         _reporter.WriteInformation(DesignStrings.Done);
 
         return files;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual void CheckPendingMigrations(string? contextType)
+    {
+        using var context = _contextOperations.CreateContext(contextType);
+
+        var hasPendingModelChanges = context.Database.HasPendingModelChanges();
+
+        if (hasPendingModelChanges)
+        {
+            throw new OperationException(DesignStrings.PendingModelChanges);
+        }
+
+        _reporter.WriteInformation(DesignStrings.NoPendingModelChanges);
     }
 
     private static void EnsureServices(IServiceProvider services)

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -684,6 +684,40 @@ public class OperationExecutor : MarshalByRefObject
         => ContextOperations.ScriptDbContext(contextType);
 
     /// <summary>
+    ///     Represents an operation to check if there are any pending migrations.
+    /// </summary>
+    public class CheckPendingMigrations : OperationBase
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CheckPendingMigrations" /> class.
+        /// </summary>
+        /// <remarks>
+        ///     <para>The arguments supported by <paramref name="args" /> are:</para>
+        ///     <para><c>contextType</c>--The <see cref="DbContext" /> to use.</para>
+        /// </remarks>
+        /// <param name="executor">The operation executor.</param>
+        /// <param name="resultHandler">The <see cref="IOperationResultHandler" />.</param>
+        /// <param name="args">The operation arguments.</param>
+        public CheckPendingMigrations(
+            OperationExecutor executor,
+            IOperationResultHandler resultHandler,
+            IDictionary args)
+            : base(resultHandler)
+        {
+            Check.NotNull(executor, nameof(executor));
+            Check.NotNull(args, nameof(args));
+
+            var contextType = (string?)args["contextType"];
+
+            Execute(() => executor.CheckPendingMigrationsImpl(contextType));
+        }
+    }
+
+    private void CheckPendingMigrationsImpl(string? contextType)
+        => MigrationsOperations.CheckPendingMigrations(contextType);
+
+
+    /// <summary>
     ///     Represents an operation.
     /// </summary>
     public abstract class OperationBase : MarshalByRefObject

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -686,10 +686,10 @@ public class OperationExecutor : MarshalByRefObject
     /// <summary>
     ///     Represents an operation to check if there are any pending migrations.
     /// </summary>
-    public class CheckPendingMigrations : OperationBase
+    public class HasPendingModelChanges : OperationBase
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="CheckPendingMigrations" /> class.
+        ///     Initializes a new instance of the <see cref="HasPendingModelChanges" /> class.
         /// </summary>
         /// <remarks>
         ///     <para>The arguments supported by <paramref name="args" /> are:</para>
@@ -698,7 +698,7 @@ public class OperationExecutor : MarshalByRefObject
         /// <param name="executor">The operation executor.</param>
         /// <param name="resultHandler">The <see cref="IOperationResultHandler" />.</param>
         /// <param name="args">The operation arguments.</param>
-        public CheckPendingMigrations(
+        public HasPendingModelChanges(
             OperationExecutor executor,
             IOperationResultHandler resultHandler,
             IDictionary args)
@@ -709,12 +709,12 @@ public class OperationExecutor : MarshalByRefObject
 
             var contextType = (string?)args["contextType"];
 
-            Execute(() => executor.CheckPendingMigrationsImpl(contextType));
+            Execute(() => executor.HasPendingModelChangesImpl(contextType));
         }
     }
 
-    private void CheckPendingMigrationsImpl(string? contextType)
-        => MigrationsOperations.CheckPendingMigrations(contextType);
+    private void HasPendingModelChangesImpl(string? contextType)
+        => MigrationsOperations.HasPendingModelChanges(contextType);
 
 
     /// <summary>

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -552,6 +552,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 provider);
 
         /// <summary>
+        ///     No changes have been made to the model since the last migration.
+        /// </summary>
+        public static string NoPendingModelChanges
+            => GetString("NoPendingModelChanges");
+
+        /// <summary>
         ///     No referenced design-time services were found.
         /// </summary>
         public static string NoReferencedServices
@@ -590,6 +596,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("NotExistDatabase", nameof(name)),
                 name);
+
+        /// <summary>
+        ///     Changes have been made to the model since the last migration. Add a new migration.
+        /// </summary>
+        public static string PendingModelChanges
+            => GetString("PendingModelChanges");
 
         /// <summary>
         ///     Prefix output with level.

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -332,6 +332,9 @@ Change your target project to the migrations project by using the Package Manage
   <data name="NonRelationalProvider" xml:space="preserve">
     <value>The provider '{provider}' is not a Relational provider and therefore cannot be used with Migrations.</value>
   </data>
+  <data name="NoPendingModelChanges" xml:space="preserve">
+    <value>No changes have been made to the model since the last migration.</value>
+  </data>
   <data name="NoReferencedServices" xml:space="preserve">
     <value>No referenced design-time services were found.</value>
   </data>
@@ -349,6 +352,9 @@ Change your target project to the migrations project by using the Package Manage
   </data>
   <data name="NotExistDatabase" xml:space="preserve">
     <value>Database '{name}' did not exist, no action was taken.</value>
+  </data>
+  <data name="PendingModelChanges" xml:space="preserve">
+    <value>Changes have been made to the model since the last migration. Add a new migration.</value>
   </data>
   <data name="PrefixDescription" xml:space="preserve">
     <value>Prefix output with level.</value>

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -955,10 +955,10 @@ public static class RelationalDatabaseFacadeExtensions
     /// <summary>
     ///     Returns <see langword="true" /> if the model has pending changes to be applied.
     /// </summary>
-    /// <param name="databaseFacade">Tbe facade from <see cref="DbContext.Database"/>.</param>
+    /// <param name="databaseFacade">The facade from <see cref="DbContext.Database"/>.</param>
     /// <returns>
-    ///     <see langword="true"/> if the database model has pending changes.
-    ///     <see langword="false"/> if a new migration has to be added.
+    ///     <see langword="true"/> if the database model has pending changes
+    ///     and a new migration has to be added.
     /// </returns>
     public static bool HasPendingModelChanges(this DatabaseFacade databaseFacade)
     {

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -242,6 +242,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("MigrationsDescription");
 
         /// <summary>
+        ///     Checks if any changes have been made to the model since the last migration.
+        /// </summary>
+        public static string MigrationsHasPendingModelChangesDescription
+            => GetString("MigrationsHasPendingModelChangesDescription");
+
+        /// <summary>
         ///     Lists available migrations.
         /// </summary>
         public static string MigrationsListDescription
@@ -505,3 +511,4 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         }
     }
 }
+

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -228,6 +228,9 @@
   <data name="MigrationsDescription" xml:space="preserve">
     <value>Commands to manage migrations.</value>
   </data>
+  <data name="MigrationsHasPendingModelChangesDescription" xml:space="preserve">
+    <value>Checks if any changes have been made to the model since the last migration.</value>
+  </data>
   <data name="MigrationsListDescription" xml:space="preserve">
     <value>Lists available migrations.</value>
   </data>

--- a/src/ef/Commands/MigrationsCommand.cs
+++ b/src/ef/Commands/MigrationsCommand.cs
@@ -14,6 +14,7 @@ internal class MigrationsCommand : HelpCommandBase
 
         command.Command("add", new MigrationsAddCommand().Configure);
         command.Command("bundle", new MigrationsBundleCommand().Configure);
+        command.Command("has-pending-model-changes", new MigrationsHasPendingModelChangesCommand().Configure);
         command.Command("list", new MigrationsListCommand().Configure);
         command.Command("remove", new MigrationsRemoveCommand().Configure);
         command.Command("script", new MigrationsScriptCommand().Configure);

--- a/src/ef/Commands/MigrationsHasPendingModelChangesCommand.Configure.cs
+++ b/src/ef/Commands/MigrationsHasPendingModelChangesCommand.Configure.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.EntityFrameworkCore.Tools.Properties;
+
+namespace Microsoft.EntityFrameworkCore.Tools.Commands;
+
+internal partial class MigrationsHasPendingModelChangesCommand : ContextCommandBase
+{
+    public override void Configure(CommandLineApplication command)
+    {
+        command.Description = Resources.MigrationsHasPendingModelChangesDescription;
+
+        base.Configure(command);
+    }
+}

--- a/src/ef/Commands/MigrationsHasPendingModelChangesCommand.cs
+++ b/src/ef/Commands/MigrationsHasPendingModelChangesCommand.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Tools.Commands;
+
+internal partial class MigrationsHasPendingModelChangesCommand
+{
+    protected override int Execute(string[] args)
+    {
+        using var executor = CreateExecutor(args);
+
+        executor.CheckPendingMigrations(Context!.Value());
+
+        return base.Execute(args);
+    }
+}

--- a/src/ef/Commands/MigrationsHasPendingModelChangesCommand.cs
+++ b/src/ef/Commands/MigrationsHasPendingModelChangesCommand.cs
@@ -9,7 +9,7 @@ internal partial class MigrationsHasPendingModelChangesCommand
     {
         using var executor = CreateExecutor(args);
 
-        executor.CheckPendingMigrations(Context!.Value());
+        executor.HasPendingModelChanges(Context!.Value());
 
         return base.Execute(args);
     }

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -37,4 +37,5 @@ internal interface IOperationExecutor : IDisposable
     string ScriptMigration(string? fromMigration, string? toMigration, bool idempotent, bool noTransactions, string? contextType);
 
     string ScriptDbContext(string? contextType);
+    void CheckPendingMigrations(string? contextType);
 }

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -37,5 +37,5 @@ internal interface IOperationExecutor : IDisposable
     string ScriptMigration(string? fromMigration, string? toMigration, bool idempotent, bool noTransactions, string? contextType);
 
     string ScriptDbContext(string? contextType);
-    void CheckPendingMigrations(string? contextType);
+    void HasPendingModelChanges(string? contextType);
 }

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -206,4 +206,9 @@ internal abstract class OperationExecutorBase : IOperationExecutor
         => InvokeOperation<string>(
             "ScriptDbContext",
             new Dictionary<string, object?> { ["contextType"] = contextType });
+
+    public void CheckPendingMigrations(string? contextType)
+        => InvokeOperation<string>(
+            "CheckPendingMigrations",
+            new Dictionary<string, object?> { ["contextType"] = contextType });
 }

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -207,8 +207,8 @@ internal abstract class OperationExecutorBase : IOperationExecutor
             "ScriptDbContext",
             new Dictionary<string, object?> { ["contextType"] = contextType });
 
-    public void CheckPendingMigrations(string? contextType)
+    public void HasPendingModelChanges(string? contextType)
         => InvokeOperation<string>(
-            "CheckPendingMigrations",
+            "HasPendingModelChanges",
             new Dictionary<string, object?> { ["contextType"] = contextType });
 }

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -318,6 +318,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("MigrationsDescription");
 
         /// <summary>
+        ///     Checks if any changes have been made to the model since the last migration.
+        /// </summary>
+        public static string MigrationsHasPendingModelChangesDescription
+            => GetString("MigrationsHasPendingModelChangesDescription");
+
+        /// <summary>
         ///     Lists available migrations.
         /// </summary>
         public static string MigrationsListDescription
@@ -647,3 +653,4 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         }
     }
 }
+

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -258,6 +258,9 @@
   <data name="MigrationsDescription" xml:space="preserve">
     <value>Commands to manage migrations.</value>
   </data>
+  <data name="MigrationsHasPendingModelChangesDescription" xml:space="preserve">
+    <value>Checks if any changes have been made to the model since the last migration.</value>
+  </data>
   <data name="MigrationsListDescription" xml:space="preserve">
     <value>Lists available migrations.</value>
   </data>

--- a/test/EFCore.Relational.Tests/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalDatabaseFacadeExtensionsTest.cs
@@ -3,7 +3,6 @@
 
 using System.Transactions;
 using Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
-using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using IsolationLevel = System.Data.IsolationLevel;
 
@@ -275,14 +274,11 @@ public class RelationalDatabaseFacadeExtensionsTest
     {
         var fakeModelSnapshot = new FakeModelSnapshot(builder =>
         {
-            // TODO: This seems fragile, what should I do?
-            builder.HasAnnotation("ProductVersion", "8.0.0-dev");
-
             builder.Entity("Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensionsTests.TestDbContext.Simple", b =>
             {
                 b.Property<int>("Id")
                     .ValueGeneratedOnAdd()
-                    .HasColumnType("int");
+                    .HasColumnType("default_int_mapping");
 
                 b.HasKey("Id");
 
@@ -291,7 +287,7 @@ public class RelationalDatabaseFacadeExtensionsTest
         });
         var migrationsAssembly = new FakeIMigrationsAssembly
         {
-            ModelSnapshot = null,
+            ModelSnapshot = fakeModelSnapshot,
             Migrations = new Dictionary<string, TypeInfo>(),
         };
 
@@ -302,7 +298,7 @@ public class RelationalDatabaseFacadeExtensionsTest
 
         var testContext = new TestDbContext(contextOptions);
 
-        Assert.True(testContext.Database.HasPendingModelChanges());
+        Assert.False(testContext.Database.HasPendingModelChanges());
     }
 
     private class TestDbContext : DbContext


### PR DESCRIPTION
<!--
Please check whether the PR fulfills these requirements
-->

Fixes #26348

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

I could not find anything that tests `MigrationOperations` methods or anything that directly tests the CLI. Please let me know if I missed anything and I'd be happy to write some tests.

My biggest question is the code I added in `MigrationsOperations`. It seems like a bit to much code for what normally goes in those methods but I don't know where the ideal location for this logic would sit. The code I wrote is a combination of the existing [code here](https://github.com/dotnet/efcore/blob/81c2440d848ecfe2ad9b8147150d607526d036b8/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs#L143-L149) and from the comment on the [issue here](https://github.com/dotnet/efcore/issues/26348#issuecomment-1243730207).

Also feel free to let me know the exact wording you would like for the resource strings, I doubt what I have there is great. 
