### PR TITLE
stackalloc for BytesToDecimal

### DIFF
--- a/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
@@ -250,23 +250,22 @@ public class NumberToBytesConverter<TNumber> : ValueConverter<TNumber, byte[]>
 
     private static decimal BytesToDecimal(byte[] bytes)
     {
-        var gotBytes = bytes;
+        Span<byte> gotBytes = BitConverter.IsLittleEndian ? stackalloc byte[16] : bytes;
         if (BitConverter.IsLittleEndian)
         {
-            gotBytes = new byte[16];
-            Array.Copy(bytes, gotBytes, 16);
-            Array.Reverse(gotBytes, 0, 4);
-            Array.Reverse(gotBytes, 4, 4);
-            Array.Reverse(gotBytes, 8, 4);
-            Array.Reverse(gotBytes, 12, 4);
+            bytes.CopyTo(gotBytes);
+            gotBytes.Slice(0, 4).Reverse();
+            gotBytes.Slice(4, 4).Reverse();
+            gotBytes.Slice(8, 4).Reverse();
+            gotBytes.Slice(12, 4).Reverse();
         }
 
-        var specialBits = BitConverter.ToUInt32(gotBytes, 0);
+        var specialBits = BitConverter.ToUInt32(gotBytes);
 
         return new decimal(
-            BitConverter.ToInt32(gotBytes, 12),
-            BitConverter.ToInt32(gotBytes, 8),
-            BitConverter.ToInt32(gotBytes, 4),
+            BitConverter.ToInt32(gotBytes.Slice(12)),
+            BitConverter.ToInt32(gotBytes.Slice(8)),
+            BitConverter.ToInt32(gotBytes.Slice(4)),
             (specialBits & 0x80000000) != 0,
             (byte)((specialBits & 0x00FF0000) >> 16));
     }


### PR DESCRIPTION
Use stackalloc in BytesToDecimal method when LittleEndian instead of GC allocating.
