### PR TITLE
Perform alias uniquification in ExecuteUpdate setters (#31133)

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -24,6 +24,8 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
         = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30528", out var enabled) && enabled;
     private static readonly bool QuirkEnabled30572
         = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30572", out var enabled) && enabled;
+    private static readonly bool QuirkEnabled31078
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue31078", out var enabled) && enabled;
 
     /// <summary>
     ///     Creates a new instance of the <see cref="QueryableMethodTranslatingExpressionVisitor" /> class.
@@ -1374,7 +1376,12 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                         OperatorType: ExpressionType.Equal, Left: ColumnExpression column
                     } sqlBinaryExpression)
                 {
-                    columnValueSetters.Add(new ColumnValueSetter(column, sqlBinaryExpression.Right));
+                    columnValueSetters.Add(
+                        new ColumnValueSetter(
+                            column,
+                            QuirkEnabled31078
+                                ? sqlBinaryExpression.Right
+                                : selectExpression.AssignUniqueAliases(sqlBinaryExpression.Right)));
                 }
                 else
                 {

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -4126,7 +4126,14 @@ public sealed partial class SelectExpression : TableExpressionBase
         _tableReferences.Add(tableReferenceExpression);
     }
 
-    private SqlExpression AssignUniqueAliases(SqlExpression expression)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public SqlExpression AssignUniqueAliases(SqlExpression expression)
         => (SqlExpression)new AliasUniquifier(_usedAliases).Visit(expression);
 
     private static string GenerateUniqueAlias(HashSet<string> usedAliases, string currentAlias)

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -90,6 +90,22 @@ WHERE ([b].[Title] IS NOT NULL) AND ([b].[Title] LIKE N'Arthur%')
 """);
     }
 
+    public override async Task Update_with_alias_uniquification_in_setter_subquery(bool async)
+    {
+        await base.Update_with_alias_uniquification_in_setter_subquery(async);
+
+        AssertSql(
+"""
+UPDATE [o]
+SET [o].[Total] = (
+    SELECT COALESCE(SUM([o0].[Amount]), 0)
+    FROM [OrderProduct] AS [o0]
+    WHERE [o].[Id] = [o0].[OrderId])
+FROM [Orders] AS [o]
+WHERE [o].[Id] = 1
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -79,6 +79,21 @@ WHERE EXISTS (
 """);
     }
 
+    public override async Task Update_with_alias_uniquification_in_setter_subquery(bool async)
+    {
+        await base.Update_with_alias_uniquification_in_setter_subquery(async);
+
+        AssertSql(
+"""
+UPDATE "Orders" AS "o"
+SET "Total" = (
+    SELECT COALESCE(SUM("o0"."Amount"), 0)
+    FROM "OrderProduct" AS "o0"
+    WHERE "o"."Id" = "o0"."OrderId")
+WHERE "o"."Id" = 1
+""");
+    }
+
     protected override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
         => base.AddOptions(builder).ConfigureWarnings(wcb => wcb.Log(SqliteEventId.CompositeKeyWithValueGeneration));
 


### PR DESCRIPTION
Fixes #31078
Backports #31133

## Description

When generating SQL for the setters in an ExecuteUpdate query, we weren't doing proper SQL alias uniquification on the setter value expression

## Customer impact

When an ExecuteUpdate is used with a setter than contains a subquery, the resulting SQL may have incorrect duplicate aliases, resulting in incorrect data.

## How found

Customer reported for 7.0

## Regression

No, ExecuteUpdate was a new feature in 7.0.

## Testing

Added regression tests.

Risk

Very low; single-line fix, and this PR also introduces a quirk.

