### PR TITLE
Add using static Expression to ShapedQueryCompiling visitors

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.JObjectInjectingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.JObjectInjectingExpressionVisitor.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Newtonsoft.Json.Linq;
+using static System.Linq.Expressions.Expression;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
@@ -24,25 +25,25 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
 
                     var valueBufferExpression = shaperExpression.ValueBufferExpression;
 
-                    var jObjectVariable = Expression.Variable(
+                    var jObjectVariable = Variable(
                         typeof(JObject),
                         "jObject" + _currentEntityIndex);
                     var variables = new List<ParameterExpression> { jObjectVariable };
 
                     var expressions = new List<Expression>
                     {
-                        Expression.Assign(
+                        Assign(
                             jObjectVariable,
-                            Expression.TypeAs(
+                            TypeAs(
                                 valueBufferExpression,
                                 typeof(JObject))),
-                        Expression.Condition(
-                            Expression.Equal(jObjectVariable, Expression.Constant(null, jObjectVariable.Type)),
-                            Expression.Constant(null, shaperExpression.Type),
+                        Condition(
+                            Equal(jObjectVariable, Constant(null, jObjectVariable.Type)),
+                            Constant(null, shaperExpression.Type),
                             shaperExpression)
                     };
 
-                    return Expression.Block(
+                    return Block(
                         shaperExpression.Type,
                         variables,
                         expressions);
@@ -52,25 +53,25 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 {
                     _currentEntityIndex++;
 
-                    var jArrayVariable = Expression.Variable(
+                    var jArrayVariable = Variable(
                         typeof(JArray),
                         "jArray" + _currentEntityIndex);
                     var variables = new List<ParameterExpression> { jArrayVariable };
 
                     var expressions = new List<Expression>
                     {
-                        Expression.Assign(
+                        Assign(
                             jArrayVariable,
-                            Expression.TypeAs(
+                            TypeAs(
                                 collectionShaperExpression.Projection,
                                 typeof(JArray))),
-                        Expression.Condition(
-                            Expression.Equal(jArrayVariable, Expression.Constant(null, jArrayVariable.Type)),
-                            Expression.Constant(null, collectionShaperExpression.Type),
+                        Condition(
+                            Equal(jArrayVariable, Constant(null, jArrayVariable.Type)),
+                            Constant(null, collectionShaperExpression.Type),
                             collectionShaperExpression)
                     };
 
-                    return Expression.Block(
+                    return Block(
                         collectionShaperExpression.Type,
                         variables,
                         expressions);

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using Newtonsoft.Json.Linq;
+using static System.Linq.Expressions.Expression;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
@@ -49,7 +50,7 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor : ShapedQueryCo
     /// </summary>
     protected override Expression VisitShapedQuery(ShapedQueryExpression shapedQueryExpression)
     {
-        var jObjectParameter = Expression.Parameter(typeof(JObject), "jObject");
+        var jObjectParameter = Parameter(typeof(JObject), "jObject");
 
         var shaperBody = shapedQueryExpression.ShaperExpression;
         shaperBody = new JObjectInjectingExpressionVisitor().Visit(shaperBody);
@@ -63,25 +64,25 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor : ShapedQueryCo
                         QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll)
                     .Visit(shaperBody);
 
-                var shaperLambda = Expression.Lambda(
+                var shaperLambda = Lambda(
                     shaperBody,
                     QueryCompilationContext.QueryContextParameter,
                     jObjectParameter);
 
-                return Expression.New(
+                return New(
                     typeof(QueryingEnumerable<>).MakeGenericType(shaperLambda.ReturnType).GetConstructors()[0],
-                    Expression.Convert(
+                    Convert(
                         QueryCompilationContext.QueryContextParameter,
                         typeof(CosmosQueryContext)),
-                    Expression.Constant(_sqlExpressionFactory),
-                    Expression.Constant(_querySqlGeneratorFactory),
-                    Expression.Constant(selectExpression),
-                    Expression.Constant(shaperLambda.Compile()),
-                    Expression.Constant(_contextType),
-                    Expression.Constant(_partitionKeyFromExtension, typeof(string)),
-                    Expression.Constant(
+                    Constant(_sqlExpressionFactory),
+                    Constant(_querySqlGeneratorFactory),
+                    Constant(selectExpression),
+                    Constant(shaperLambda.Compile()),
+                    Constant(_contextType),
+                    Constant(_partitionKeyFromExtension, typeof(string)),
+                    Constant(
                         QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-                    Expression.Constant(_threadSafetyChecksEnabled));
+                    Constant(_threadSafetyChecksEnabled));
 
             case ReadItemExpression readItemExpression:
                 shaperBody = new CosmosProjectionBindingRemovingReadItemExpressionVisitor(
@@ -89,22 +90,22 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor : ShapedQueryCo
                         QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll)
                     .Visit(shaperBody);
 
-                var shaperReadItemLambda = Expression.Lambda(
+                var shaperReadItemLambda = Lambda(
                     shaperBody,
                     QueryCompilationContext.QueryContextParameter,
                     jObjectParameter);
 
-                return Expression.New(
+                return New(
                     typeof(ReadItemQueryingEnumerable<>).MakeGenericType(shaperReadItemLambda.ReturnType).GetConstructors()[0],
-                    Expression.Convert(
+                    Convert(
                         QueryCompilationContext.QueryContextParameter,
                         typeof(CosmosQueryContext)),
-                    Expression.Constant(readItemExpression),
-                    Expression.Constant(shaperReadItemLambda.Compile()),
-                    Expression.Constant(_contextType),
-                    Expression.Constant(
+                    Constant(readItemExpression),
+                    Constant(shaperReadItemLambda.Compile()),
+                    Constant(_contextType),
+                    Constant(
                         QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-                    Expression.Constant(_threadSafetyChecksEnabled));
+                    Constant(_threadSafetyChecksEnabled));
 
             default:
                 throw new NotSupportedException(CoreStrings.UnhandledExpressionNode(shapedQueryExpression.QueryExpression));

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal;
 
+using static System.Linq.Expressions.Expression;
+
 public partial class InMemoryShapedQueryCompilingExpressionVisitor : ShapedQueryCompilingExpressionVisitor
 {
     private readonly Type _contextType;
@@ -34,10 +36,10 @@ public partial class InMemoryShapedQueryCompilingExpressionVisitor : ShapedQuery
         switch (extensionExpression)
         {
             case InMemoryTableExpression inMemoryTableExpression:
-                return Expression.Call(
+                return Call(
                     TableMethodInfo,
                     QueryCompilationContext.QueryContextParameter,
-                    Expression.Constant(inMemoryTableExpression.EntityType));
+                    Constant(inMemoryTableExpression.EntityType));
         }
 
         return base.VisitExtension(extensionExpression);
@@ -59,15 +61,15 @@ public partial class InMemoryShapedQueryCompilingExpressionVisitor : ShapedQuery
             .ProcessShaper(shapedQueryExpression.ShaperExpression);
         var innerEnumerable = Visit(inMemoryQueryExpression.ServerQueryExpression);
 
-        return Expression.New(
+        return New(
             typeof(QueryingEnumerable<>).MakeGenericType(shaperExpression.ReturnType).GetConstructors()[0],
             QueryCompilationContext.QueryContextParameter,
             innerEnumerable,
-            Expression.Constant(shaperExpression.Compile()),
-            Expression.Constant(_contextType),
-            Expression.Constant(
+            Constant(shaperExpression.Compile()),
+            Constant(_contextType),
+            Constant(
                 QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-            Expression.Constant(_threadSafetyChecksEnabled));
+            Constant(_threadSafetyChecksEnabled));
     }
 
     private static readonly MethodInfo TableMethodInfo

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using static System.Linq.Expressions.Expression;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -76,13 +77,13 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
             innerExpression,
             _useRelationalNulls);
 
-        return Expression.Call(
+        return Call(
             QueryCompilationContext.IsAsync ? NonQueryAsyncMethodInfo : NonQueryMethodInfo,
-            Expression.Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-            Expression.Constant(relationalCommandCache),
-            Expression.Constant(_contextType),
-            Expression.Constant(nonQueryExpression.CommandSource),
-            Expression.Constant(_threadSafetyChecksEnabled));
+            Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
+            Constant(relationalCommandCache),
+            Constant(_contextType),
+            Constant(nonQueryExpression.CommandSource),
+            Constant(_threadSafetyChecksEnabled));
     }
 
     private static readonly MethodInfo NonQueryMethodInfo
@@ -266,50 +267,50 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
             }
             if (splitQuery)
             {
-                var relatedDataLoadersParameter = Expression.Constant(
+                var relatedDataLoadersParameter = Constant(
                     QueryCompilationContext.IsAsync ? null : relatedDataLoaders?.Compile(),
                     typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>));
 
-                var relatedDataLoadersAsyncParameter = Expression.Constant(
+                var relatedDataLoadersAsyncParameter = Constant(
                     QueryCompilationContext.IsAsync ? relatedDataLoaders?.Compile() : null,
                     typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
 
-                return Expression.New(
+                return New(
                     typeof(GroupBySplitQueryingEnumerable<,>).MakeGenericType(
                         keySelector.ReturnType,
                         elementSelector.ReturnType).GetConstructors()[0],
-                    Expression.Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                    Expression.Constant(relationalCommandCache),
-                    Expression.Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                    Expression.Constant(keySelector.Compile()),
-                    Expression.Constant(keyIdentifier.Compile()),
-                    Expression.Constant(relationalGroupByResultExpression.KeyIdentifierValueComparers, typeof(IReadOnlyList<ValueComparer>)),
-                    Expression.Constant(elementSelector.Compile()),
+                    Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
+                    Constant(relationalCommandCache),
+                    Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                    Constant(keySelector.Compile()),
+                    Constant(keyIdentifier.Compile()),
+                    Constant(relationalGroupByResultExpression.KeyIdentifierValueComparers, typeof(IReadOnlyList<ValueComparer>)),
+                    Constant(elementSelector.Compile()),
                     relatedDataLoadersParameter,
                     relatedDataLoadersAsyncParameter,
-                    Expression.Constant(_contextType),
-                    Expression.Constant(
+                    Constant(_contextType),
+                    Constant(
                         QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-                    Expression.Constant(_detailedErrorsEnabled),
-                    Expression.Constant(_threadSafetyChecksEnabled));
+                    Constant(_detailedErrorsEnabled),
+                    Constant(_threadSafetyChecksEnabled));
             }
 
-            return Expression.New(
+            return New(
                 typeof(GroupBySingleQueryingEnumerable<,>).MakeGenericType(
                     keySelector.ReturnType,
                     elementSelector.ReturnType).GetConstructors()[0],
-                Expression.Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                Expression.Constant(relationalCommandCache),
-                Expression.Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                Expression.Constant(keySelector.Compile()),
-                Expression.Constant(keyIdentifier.Compile()),
-                Expression.Constant(relationalGroupByResultExpression.KeyIdentifierValueComparers, typeof(IReadOnlyList<ValueComparer>)),
-                Expression.Constant(elementSelector.Compile()),
-                Expression.Constant(_contextType),
-                Expression.Constant(
+                Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
+                Constant(relationalCommandCache),
+                Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                Constant(keySelector.Compile()),
+                Constant(keyIdentifier.Compile()),
+                Constant(relationalGroupByResultExpression.KeyIdentifierValueComparers, typeof(IReadOnlyList<ValueComparer>)),
+                Constant(elementSelector.Compile()),
+                Constant(_contextType),
+                Constant(
                     QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-                Expression.Constant(_detailedErrorsEnabled),
-                Expression.Constant(_threadSafetyChecksEnabled));
+                Constant(_detailedErrorsEnabled),
+                Constant(_threadSafetyChecksEnabled));
         }
         else
         {
@@ -326,58 +327,58 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
 
             if (nonComposedFromSql)
             {
-                return Expression.New(
+                return New(
                     typeof(FromSqlQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors()[0],
-                    Expression.Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                    Expression.Constant(relationalCommandCache),
-                    Expression.Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                    Expression.Constant(
+                    Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
+                    Constant(relationalCommandCache),
+                    Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                    Constant(
                         selectExpression.Projection.Select(pe => ((ColumnExpression)pe.Expression).Name).ToList(),
                         typeof(IReadOnlyList<string>)),
-                    Expression.Constant(shaper.Compile()),
-                    Expression.Constant(_contextType),
-                    Expression.Constant(
+                    Constant(shaper.Compile()),
+                    Constant(_contextType),
+                    Constant(
                         QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-                    Expression.Constant(_detailedErrorsEnabled),
-                    Expression.Constant(_threadSafetyChecksEnabled));
+                    Constant(_detailedErrorsEnabled),
+                    Constant(_threadSafetyChecksEnabled));
             }
 
             if (splitQuery)
             {
-                var relatedDataLoadersParameter = Expression.Constant(
+                var relatedDataLoadersParameter = Constant(
                     QueryCompilationContext.IsAsync ? null : relatedDataLoaders?.Compile(),
                     typeof(Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>));
 
-                var relatedDataLoadersAsyncParameter = Expression.Constant(
+                var relatedDataLoadersAsyncParameter = Constant(
                     QueryCompilationContext.IsAsync ? relatedDataLoaders?.Compile() : null,
                     typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
 
-                return Expression.New(
+                return New(
                     typeof(SplitQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors().Single(),
-                    Expression.Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                    Expression.Constant(relationalCommandCache),
-                    Expression.Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                    Expression.Constant(shaper.Compile()),
+                    Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
+                    Constant(relationalCommandCache),
+                    Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                    Constant(shaper.Compile()),
                     relatedDataLoadersParameter,
                     relatedDataLoadersAsyncParameter,
-                    Expression.Constant(_contextType),
-                    Expression.Constant(
+                    Constant(_contextType),
+                    Constant(
                         QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-                    Expression.Constant(_detailedErrorsEnabled),
-                    Expression.Constant(_threadSafetyChecksEnabled));
+                    Constant(_detailedErrorsEnabled),
+                    Constant(_threadSafetyChecksEnabled));
             }
 
-            return Expression.New(
+            return New(
                 typeof(SingleQueryingEnumerable<>).MakeGenericType(shaper.ReturnType).GetConstructors()[0],
-                Expression.Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                Expression.Constant(relationalCommandCache),
-                Expression.Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
-                Expression.Constant(shaper.Compile()),
-                Expression.Constant(_contextType),
-                Expression.Constant(
+                Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
+                Constant(relationalCommandCache),
+                Constant(readerColumns, typeof(IReadOnlyList<ReaderColumn?>)),
+                Constant(shaper.Compile()),
+                Constant(_contextType),
+                Constant(
                     QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-                Expression.Constant(_detailedErrorsEnabled),
-                Expression.Constant(_threadSafetyChecksEnabled));
+                Constant(_detailedErrorsEnabled),
+                Constant(_threadSafetyChecksEnabled));
         }
     }
 }


### PR DESCRIPTION
This adds `using static System.Linq.Expressions.Expression` to all the ShapedQueryCompiling visitors, allowing us to drop the `Expression.` prefix wherever we construct nodes. There are various other places in the codebase which construct expressions and could benefit from this simplification, but I'm starting just with this one since ShapedQueryCompiling are the obvious candidate.