### PR TITLE
Use our new JSON serialization infra for partial updates

### DIFF
--- a/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommand.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommand.cs
@@ -34,34 +34,4 @@ public class SqlServerModificationCommand : ModificationCommand
         : base(modificationCommandParameters)
     {
     }
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    protected override object? GenerateValueForSinglePropertyUpdate(IProperty property, object? propertyValue)
-    {
-        var propertyProviderClrType = (property.GetTypeMapping().Converter?.ProviderClrType ?? property.ClrType).UnwrapNullableType();
-
-        // when we generate SqlParameter when updating single property in JSON entity
-        // we always use SqlServerJsonTypeMapping as type mapping for the parameter
-        // (since we don't have dedicated type mapping for individual JSON properties)
-        // later, when we generate DbParameter we assign the value and then the DbType from the type mapping.
-        // in case of byte value, when we assign the value to the DbParameter it sets its type to Byte and its size to 1
-        // then, we change DbType to String, but keep size as is
-        // so, if value was, say, 15 we initially generate DbParameter of type Byte, value 25 and size 1
-        // but when we change the type we end up with type String, value 25 and size 1, which effectively is "2"
-        // to mitigate this, we convert the value to string, to guarantee the correct parameter size.
-        // this can be removed when we have dedicated JSON type mapping for individual (leaf) properties
-        if (propertyProviderClrType == typeof(byte))
-        {
-            return JsonValue.Create(propertyValue)?.ToJsonString().Replace("\"", "");
-        }
-
-#pragma warning disable EF1001 // Internal EF Core API usage.
-        return base.GenerateValueForSinglePropertyUpdate(property, propertyValue);
-#pragma warning restore EF1001 // Internal EF Core API usage.
-    }
 }

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -154,24 +154,7 @@ public class SqlServerUpdateSqlGenerator : UpdateAndSelectSqlGenerator, ISqlServ
 
             if (columnModification.Property != null)
             {
-                var propertyClrType = columnModification.Property.GetTypeMapping().Converter?.ProviderClrType
-                    ?? columnModification.Property.ClrType;
-
-                var needsTypeConversion = propertyClrType.IsNumeric() || propertyClrType == typeof(bool);
-
-                if (needsTypeConversion)
-                {
-                    stringBuilder.Append("CAST(");
-                }
-
                 base.AppendUpdateColumnValue(updateSqlGeneratorHelper, columnModification, stringBuilder, name, schema);
-
-                if (needsTypeConversion)
-                {
-                    stringBuilder.Append(" AS ");
-                    stringBuilder.Append(columnModification.Property.GetRelationalTypeMapping().StoreType);
-                    stringBuilder.Append(")");
-                }
             }
             else
             {

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommand.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommand.cs
@@ -39,22 +39,37 @@ public class SqliteModificationCommand : ModificationCommand
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override object? GenerateValueForSinglePropertyUpdate(IProperty property, object? propertyValue)
+    protected override void ProcessSinglePropertyJsonUpdate(ref ColumnModificationParameters parameters)
     {
+        var property = parameters.Property!;
+
         var propertyProviderClrType = (property.GetTypeMapping().Converter?.ProviderClrType ?? property.ClrType).UnwrapNullableType();
 
-        if (propertyProviderClrType == typeof(bool) && propertyValue is bool boolPropertyValue)
+        // SQLite has no bool type, so if we simply sent the bool as-is, we'd get 1/0 in the JSON document.
+        // To get an actual unquoted true/false value, we pass "true"/"false" string through the json() minifier, which does this.
+        // See https://sqlite.org/forum/info/91d09974c3754ea6.
+        // Here we convert the .NET bool to a "true"/"false" string, and SqliteUpdateSqlGenerator will add the enclosing json().
+        if (propertyProviderClrType == typeof(bool))
         {
-            // Sqlite converts true/false into native 0/1 when using json_extract
-            // so we convert those values to strings so that they stay as true/false
-            // which is what we want to store in json object in the end
-            return boolPropertyValue
-                ? "true"
-                : "false";
+            var value = property.GetTypeMapping().Converter is ValueConverter converter
+                ? converter.ConvertToProvider(parameters.Value)
+                : parameters.Value;
+
+            parameters = parameters with
+            {
+                Value = value switch
+                {
+                    true => "true",
+                    false => "false",
+                    _ => throw new Exception("IMPOSSIBLE")
+                }
+            };
+
+            return;
         }
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
-        return base.GenerateValueForSinglePropertyUpdate(property, propertyValue);
+        base.ProcessSinglePropertyJsonUpdate(ref parameters);
 #pragma warning restore EF1001 // Internal EF Core API usage.
     }
 }

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
@@ -165,14 +165,13 @@ public class SqliteUpdateSqlGenerator : UpdateAndSelectSqlGenerator
                 var providerClrType = (columnModification.Property.GetTypeMapping().Converter?.ProviderClrType
                     ?? columnModification.Property.ClrType).UnwrapNullableType();
 
-                // special handling for bool
-                // json_extract converts true/false into native 0/1 values,
-                // but we want to store the values as true/false in JSON
-                // in order to do that we modify the parameter value to "true"/"false"
-                // and wrap json() function around it to avoid conversion to 0/1
+                // SQLite has no bool type, so if we simply sent the bool as-is, we'd get 1/0 in the JSON document.
+                // To get an actual unquoted true/false value, we pass "true"/"false" string through the json() minifier, which does this.
+                // See https://sqlite.org/forum/info/91d09974c3754ea6.
+                // SqliteModificationCommand converted the .NET bool to a "true"/"false" string, here we add the enclosing json().
                 //
-                // for decimal, sqlite generates string parameter for decimal values
-                // but don't want to store the values as strings, we use json to "unwrap" it
+                // For decimal, Microsoft.Data.Sqlite maps decimal to TEXT instead of to REAL, but we don't want decimals to be stored as
+                // strings inside JSON. So we again use json() to "unwrap" it.
                 if (providerClrType == typeof(bool) || providerClrType == typeof(decimal))
                 {
                     stringBuilder.Append("json(");

--- a/test/EFCore.SqlServer.FunctionalTests/Update/JsonUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/JsonUpdateSqlServerTest.cs
@@ -349,7 +349,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-@p0='Modified' (Nullable = false) (Size = 8)
+@p0='Modified' (Nullable = false) (Size = 4000)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -371,7 +371,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-@p0='Modified' (Nullable = false) (Size = 8)
+@p0='Modified' (Nullable = false) (Size = 4000)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -504,8 +504,8 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-@p0='Two' (Nullable = false) (Size = 3)
-@p1='Two' (Nullable = false) (Size = 3)
+@p0='Two' (Nullable = false) (Size = 4000)
+@p1='Two' (Nullable = false) (Size = 4000)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -527,13 +527,13 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-@p0='1024' (DbType = String)
-@p1='999' (DbType = String)
+@p0='1024'
+@p1='999'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[1].Number', CAST(@p0 AS int)), [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.Number', CAST(@p1 AS int))
+UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[1].Number', @p0), [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.Number', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -550,13 +550,13 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-@p0='True' (DbType = String)
-@p1='False' (DbType = String)
+@p0='True'
+@p1='False'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestBoolean', CAST(@p0 AS bit)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestBoolean', CAST(@p1 AS bit))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestBoolean', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestBoolean', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -574,13 +574,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='14' (Nullable = false) (Size = 2)
-@p1='25' (Nullable = false) (Size = 2)
+@p0='14' (Size = 1)
+@p1='25' (Size = 1)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestByte', CAST(@p0 AS tinyint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestByte', CAST(@p1 AS tinyint))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestByte', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestByte', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -669,13 +669,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='-13579.01' (DbType = String)
-@p1='-13579.01' (DbType = String)
+@p0='-13579.01' (Precision = 18) (Scale = 3)
+@p1='-13579.01' (Precision = 18) (Scale = 3)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDecimal', CAST(@p0 AS decimal(18,3))), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDecimal', CAST(@p1 AS decimal(18,3)))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDecimal', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDecimal', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -693,13 +693,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='-1.23579' (DbType = String)
-@p1='-1.23579' (DbType = String)
+@p0='-1.23579'
+@p1='-1.23579'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDouble', CAST(@p0 AS float)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDouble', CAST(@p1 AS float))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDouble', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDouble', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -741,13 +741,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='-3234' (DbType = String)
-@p1='-3234' (DbType = String)
+@p0='-3234'
+@p1='-3234'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt16', CAST(@p0 AS smallint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt16', CAST(@p1 AS smallint))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt16', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt16', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -765,13 +765,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='-3234' (DbType = String)
-@p1='-3234' (DbType = String)
+@p0='-3234'
+@p1='-3234'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt32', CAST(@p0 AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt32', CAST(@p1 AS int))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt32', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt32', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -789,13 +789,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='-3234' (DbType = String)
-@p1='-3234' (DbType = String)
+@p0='-3234'
+@p1='-3234'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt64', CAST(@p0 AS bigint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt64', CAST(@p1 AS bigint))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt64', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt64', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -813,13 +813,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='-108' (DbType = String)
-@p1='-108' (DbType = String)
+@p0='-108'
+@p1='-108'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestSignedByte', CAST(@p0 AS smallint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestSignedByte', CAST(@p1 AS smallint))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestSignedByte', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestSignedByte', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -837,13 +837,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='-7.234' (DbType = String)
-@p1='-7.234' (DbType = String)
+@p0='-7.234'
+@p1='-7.234'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestSingle', CAST(@p0 AS real)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestSingle', CAST(@p1 AS real))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestSingle', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestSingle', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -861,8 +861,8 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='10:01:01.0070000' (Nullable = false) (Size = 16)
-@p1='10:01:01.0070000' (Nullable = false) (Size = 16)
+@p0='10:01:01.007' (Nullable = false) (Size = 12)
+@p1='10:01:01.007' (Nullable = false) (Size = 12)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -885,13 +885,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='1534' (DbType = String)
-@p1='1534' (DbType = String)
+@p0='1534'
+@p1='1534'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt16', CAST(@p0 AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt16', CAST(@p1 AS int))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt16', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt16', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -909,13 +909,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='1237775789' (DbType = String)
-@p1='1237775789' (DbType = String)
+@p0='1237775789'
+@p1='1237775789'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt32', CAST(@p0 AS bigint)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt32', CAST(@p1 AS bigint))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt32', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt32', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -933,13 +933,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='1234555555123456789' (DbType = String)
-@p1='1234555555123456789' (DbType = String)
+@p0='1234555555123456789' (Precision = 20)
+@p1='1234555555123456789' (Precision = 20)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt64', CAST(@p0 AS decimal(20,0))), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt64', CAST(@p1 AS decimal(20,0)))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt64', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt64', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -957,13 +957,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='122354' (DbType = String)
-@p1='64528' (DbType = String)
+@p0='122354'
+@p1='64528'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableInt32', CAST(@p0 AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableInt32', CAST(@p1 AS int))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableInt32', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableInt32', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -981,13 +981,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0=NULL (Nullable = false)
-@p1=NULL (Nullable = false)
+@p0=NULL (Nullable = false) (DbType = Int32)
+@p1=NULL (Nullable = false) (DbType = Int32)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableInt32', CAST(@p0 AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableInt32', CAST(@p1 AS int))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableInt32', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableInt32', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -1005,8 +1005,8 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='Three' (Nullable = false) (Size = 5)
-@p1='Three' (Nullable = false) (Size = 5)
+@p0='Three' (Nullable = false) (Size = 4000)
+@p1='Three' (Nullable = false) (Size = 4000)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1029,13 +1029,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='2' (DbType = String)
-@p1='2' (DbType = String)
+@p0='2'
+@p1='2'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestEnumWithIntConverter', CAST(@p0 AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestEnumWithIntConverter', CAST(@p1 AS int))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestEnumWithIntConverter', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestEnumWithIntConverter', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -1053,8 +1053,8 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='Three' (Nullable = false) (Size = 5)
-@p1='Three' (Nullable = false) (Size = 5)
+@p0='Three' (Nullable = false) (Size = 4000)
+@p1='Three' (Nullable = false) (Size = 4000)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1077,8 +1077,8 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0=NULL (Nullable = false)
-@p1=NULL (Nullable = false)
+@p0=NULL (Nullable = false) (Size = 4000)
+@p1=NULL (Nullable = false) (Size = 4000)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1101,13 +1101,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='0' (DbType = String)
-@p1='2' (DbType = String)
+@p0='0'
+@p1='2'
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithIntConverter', CAST(@p0 AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithIntConverter', CAST(@p1 AS int))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithIntConverter', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithIntConverter', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -1125,13 +1125,13 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0=NULL (Nullable = false)
-@p1=NULL (Nullable = false)
+@p0=NULL (Nullable = false) (DbType = Int32)
+@p1=NULL (Nullable = false) (DbType = Int32)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithIntConverter', CAST(@p0 AS int)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithIntConverter', CAST(@p1 AS int))
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithIntConverter', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithIntConverter', @p1)
 OUTPUT 1
 WHERE [Id] = @p2;
 """,
@@ -1149,8 +1149,8 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='Three' (Nullable = false) (Size = 5)
-@p1='One' (Nullable = false) (Size = 3)
+@p0='Three' (Nullable = false) (Size = 4000)
+@p1='One' (Nullable = false) (Size = 4000)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1173,8 +1173,8 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='Null' (Nullable = false) (Size = 4)
-@p1='Null' (Nullable = false) (Size = 4)
+@p0='Null' (Nullable = false) (Size = 4000)
+@p1='Null' (Nullable = false) (Size = 4000)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1287,12 +1287,12 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
 """
-@p0='0' (DbType = String)
+@p0='0'
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.BoolConvertedToIntZeroOne', CAST(@p0 AS int))
+UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.BoolConvertedToIntZeroOne', @p0)
 OUTPUT 1
 WHERE [Id] = @p1;
 """,
@@ -1310,7 +1310,7 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='True' (Nullable = false) (Size = 4)
+@p0='True' (Nullable = false) (Size = 5)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1356,12 +1356,12 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='True' (DbType = String)
+@p0='True'
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.IntZeroOneConvertedToBool', CAST(@p0 AS bit))
+UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.IntZeroOneConvertedToBool', @p0)
 OUTPUT 1
 WHERE [Id] = @p1;
 """,
@@ -1380,12 +1380,12 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='False' (DbType = String)
+@p0='False'
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.StringTrueFalseConvertedToBool', CAST(@p0 AS bit))
+UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.StringTrueFalseConvertedToBool', @p0)
 OUTPUT 1
 WHERE [Id] = @p1;
 """,
@@ -1404,12 +1404,12 @@ WHERE [j].[Id] = 1
 
         AssertSql(
 """
-@p0='True' (DbType = String)
+@p0='True'
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
-UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.StringYNConvertedToBool', CAST(@p0 AS bit))
+UPDATE [JsonEntitiesConverters] SET [Reference] = JSON_MODIFY([Reference], 'strict $.StringYNConvertedToBool', @p0)
 OUTPUT 1
 WHERE [Id] = @p1;
 """,

--- a/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteTest.cs
@@ -501,8 +501,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='1024' (DbType = String)
-@p1='999' (DbType = String)
+@p0='1024'
+@p1='999'
 @p2='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[1].Number', @p0), "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.Number', @p1)
@@ -546,8 +546,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='14' (DbType = String)
-@p1='25' (DbType = String)
+@p0='14'
+@p1='25'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestByte', @p0), "Reference" = json_set("Reference", '$.TestByte', @p1)
@@ -637,8 +637,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='-13579.01' (DbType = String)
-@p1='-13579.01' (DbType = String)
+@p0='-13579.01'
+@p1='-13579.01'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDecimal', json(@p0)), "Reference" = json_set("Reference", '$.TestDecimal', json(@p1))
@@ -660,8 +660,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='-1.23579' (DbType = String)
-@p1='-1.23579' (DbType = String)
+@p0='-1.23579'
+@p1='-1.23579'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDouble', @p0), "Reference" = json_set("Reference", '$.TestDouble', @p1)
@@ -706,8 +706,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='-3234' (DbType = String)
-@p1='-3234' (DbType = String)
+@p0='-3234'
+@p1='-3234'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt16', @p0), "Reference" = json_set("Reference", '$.TestInt16', @p1)
@@ -729,8 +729,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='-3234' (DbType = String)
-@p1='-3234' (DbType = String)
+@p0='-3234'
+@p1='-3234'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt32', @p0), "Reference" = json_set("Reference", '$.TestInt32', @p1)
@@ -752,8 +752,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='-3234' (DbType = String)
-@p1='-3234' (DbType = String)
+@p0='-3234'
+@p1='-3234'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt64', @p0), "Reference" = json_set("Reference", '$.TestInt64', @p1)
@@ -775,8 +775,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='-108' (DbType = String)
-@p1='-108' (DbType = String)
+@p0='-108'
+@p1='-108'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestSignedByte', @p0), "Reference" = json_set("Reference", '$.TestSignedByte', @p1)
@@ -798,8 +798,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='-7.234' (DbType = String)
-@p1='-7.234' (DbType = String)
+@p0='-7.234'
+@p1='-7.234'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestSingle', @p0), "Reference" = json_set("Reference", '$.TestSingle', @p1)
@@ -821,8 +821,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='10:01:01.0070000' (Nullable = false) (Size = 16)
-@p1='10:01:01.0070000' (Nullable = false) (Size = 16)
+@p0='10:01:01.007' (Nullable = false) (Size = 12)
+@p1='10:01:01.007' (Nullable = false) (Size = 12)
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestTimeSpan', @p0), "Reference" = json_set("Reference", '$.TestTimeSpan', @p1)
@@ -844,8 +844,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='1534' (DbType = String)
-@p1='1534' (DbType = String)
+@p0='1534'
+@p1='1534'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt16', @p0), "Reference" = json_set("Reference", '$.TestUnsignedInt16', @p1)
@@ -867,8 +867,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='1237775789' (DbType = String)
-@p1='1237775789' (DbType = String)
+@p0='1237775789'
+@p1='1237775789'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt32', @p0), "Reference" = json_set("Reference", '$.TestUnsignedInt32', @p1)
@@ -890,8 +890,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='1234555555123456789' (DbType = String)
-@p1='1234555555123456789' (DbType = String)
+@p0='1234555555123456789'
+@p1='1234555555123456789'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt64', @p0), "Reference" = json_set("Reference", '$.TestUnsignedInt64', @p1)
@@ -913,8 +913,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='122354' (DbType = String)
-@p1='64528' (DbType = String)
+@p0='122354'
+@p1='64528'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableInt32', @p0), "Reference" = json_set("Reference", '$.TestNullableInt32', @p1)
@@ -936,8 +936,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0=NULL (Nullable = false)
-@p1=NULL (Nullable = false)
+@p0=NULL (Nullable = false) (DbType = Int32)
+@p1=NULL (Nullable = false) (DbType = Int32)
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableInt32', @p0), "Reference" = json_set("Reference", '$.TestNullableInt32', @p1)
@@ -982,8 +982,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='2' (DbType = String)
-@p1='2' (DbType = String)
+@p0='2'
+@p1='2'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestEnumWithIntConverter', @p0), "Reference" = json_set("Reference", '$.TestEnumWithIntConverter', @p1)
@@ -1051,8 +1051,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='0' (DbType = String)
-@p1='2' (DbType = String)
+@p0='0'
+@p1='2'
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithIntConverter', @p0), "Reference" = json_set("Reference", '$.TestNullableEnumWithIntConverter', @p1)
@@ -1074,8 +1074,8 @@ LIMIT 2
 
         AssertSql(
 """
-@p0=NULL (Nullable = false)
-@p1=NULL (Nullable = false)
+@p0=NULL (Nullable = false) (DbType = Int32)
+@p1=NULL (Nullable = false) (DbType = Int32)
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithIntConverter', @p0), "Reference" = json_set("Reference", '$.TestNullableEnumWithIntConverter', @p1)
@@ -1229,7 +1229,7 @@ LIMIT 2
 
         AssertSql(
 """
-@p0='0' (DbType = String)
+@p0='0'
 @p1='1'
 
 UPDATE "JsonEntitiesConverters" SET "Reference" = json_set("Reference", '$.BoolConvertedToIntZeroOne', @p0)


### PR DESCRIPTION
This uses the type mapping's new JsonValueReaderRewriter for generating the JSON representation for single-property partial updates.

In addition, when the database's partial update function (e.g. JSON_MODIFY) accepts a non-JSON relational value (e.g. int), simply send that value via the property's regular type mapping. We were previously always converting values (e.g. int) to a JSON string representation, and then applying a SQL cast inside JSON_MODIFY. This has been removed, and we just send regular relational int parameters instead.

@ajcvickers you'll probably be interested in this too.