### PR TITLE
Fixes and cleanup around JSON collection SQL value conversions

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -2772,7 +2772,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
         /// <returns>Whether an inferred type mapping could be found.</returns>
         protected virtual bool TryGetInferredTypeMapping(
             TableExpressionBase table,
-             string columnName,
+            string columnName,
             [NotNullWhen(true)] out RelationalTypeMapping? inferredTypeMapping)
         {
             if (_inferredTypeMappings.TryGetValue((table, columnName), out inferredTypeMapping))

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -228,6 +228,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             => GetString("NoSavepointRelease");
 
         /// <summary>
+        ///     The query is attempting to query a JSON collection of binary data in a context that requires preserving the ordering of the collection; this isn't supported by SQL Server.
+        /// </summary>
+        public static string QueryingOrderedBinaryJsonCollectionsNotSupported
+            => GetString("QueryingOrderedBinaryJsonCollectionsNotSupported");
+
+        /// <summary>
         ///     Could not save changes because the target table has computed column with a function that performs data access. Please configure your table accordingly, see https://aka.ms/efcore-docs-sqlserver-save-changes-and-output-clause for more information.
         /// </summary>
         public static string SaveChangesFailedBecauseOfComputedColumnWithFunction

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -290,6 +290,9 @@
   <data name="NoSavepointRelease" xml:space="preserve">
     <value>SQL Server does not support releasing a savepoint.</value>
   </data>
+  <data name="QueryingOrderedBinaryJsonCollectionsNotSupported" xml:space="preserve">
+    <value>The query is attempting to query a JSON collection of binary data in a context that requires preserving the ordering of the collection; this isn't supported by SQL Server.</value>
+  </data>
   <data name="SaveChangesFailedBecauseOfComputedColumnWithFunction" xml:space="preserve">
     <value>Could not save changes because the target table has computed column with a function that performs data access. Please configure your table accordingly, see https://aka.ms/efcore-docs-sqlserver-save-changes-and-output-clause for more information.</value>
   </data>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -206,7 +206,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 IsDistinct: false,
                 Limit: null,
                 Offset: null,
-                // We can only applying the indexing if the JSON array is ordered by its natural ordered, i.e. by the "key" column that
+                // We can only apply the indexing if the JSON array is ordered by its natural ordered, i.e. by the "key" column that
                 // we created in TranslateCollection. For example, if another ordering has been applied (e.g. by the JSON elements
                 // themselves), we can no longer simply index into the original array.
                 Orderings:
@@ -396,7 +396,6 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     protected class SqlServerInferredTypeMappingApplier : RelationalInferredTypeMappingApplier
     {
         private readonly IRelationalTypeMappingSource _typeMappingSource;
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -409,7 +408,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
             ISqlExpressionFactory sqlExpressionFactory,
             IReadOnlyDictionary<(TableExpressionBase, string), RelationalTypeMapping?> inferredTypeMappings)
             : base(sqlExpressionFactory, inferredTypeMappings)
-            => (_typeMappingSource, _sqlExpressionFactory) = (typeMappingSource, sqlExpressionFactory);
+            => _typeMappingSource = typeMappingSource;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -480,18 +479,5 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 path: null,
                 new[] { new SqlServerOpenJsonExpression.ColumnInfo("value", elementTypeMapping.StoreType, "$") });
         }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual SqlExpression ApplyTypeMappingOnColumn(ColumnExpression columnExpression, RelationalTypeMapping typeMapping)
-            // TODO: this should be part of #30677
-            // OPENJSON's value column has type nvarchar(max); apply a CAST() unless that's the inferred element type mapping
-            => typeMapping.StoreType is "nvarchar(max)"
-                ? columnExpression
-                : _sqlExpressionFactory.Convert(columnExpression, typeMapping.ClrType, typeMapping);
     }
 }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -493,11 +493,7 @@ public class SqlServerTypeMappingSource : RelationalTypeMappingSource
         stringTypeMapping = (SqlServerStringTypeMapping)stringTypeMapping
             .Clone(new CollectionToJsonStringConverter(mappingInfo.ClrType, elementTypeMapping));
 
-        // The JSON representation for new[] { 1, 2 } is AQI= (base64), this cannot simply be cast to varbinary(max) (0x0102)
-        if (elementTypeMapping is not SqlServerByteArrayTypeMapping)
-        {
-            stringTypeMapping = (SqlServerStringTypeMapping)stringTypeMapping.CloneWithElementTypeMapping(elementTypeMapping);
-        }
+        stringTypeMapping = (SqlServerStringTypeMapping)stringTypeMapping.CloneWithElementTypeMapping(elementTypeMapping);
 
         return stringTypeMapping;
     }

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -90,6 +90,14 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
                 type);
 
         /// <summary>
+        ///     Querying JSON collections with element provider type '{type}' isn't supported because of SQLite limitations.
+        /// </summary>
+        public static string QueryingJsonCollectionOfGivenTypeNotSupported(object? type)
+            => string.Format(
+                GetString("QueryingJsonCollectionOfGivenTypeNotSupported", nameof(type)),
+                type);
+
+        /// <summary>
         ///     SQLite does not support sequences. See https://go.microsoft.com/fwlink/?LinkId=723262 for more information and examples.
         /// </summary>
         public static string SequencesNotSupported

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
@@ -216,6 +216,9 @@
   <data name="OrderByNotSupported" xml:space="preserve">
     <value>SQLite does not support expressions of type '{type}' in ORDER BY clauses. Convert the values to a supported type, or use LINQ to Objects to order the results on the client side.</value>
   </data>
+  <data name="QueryingJsonCollectionOfGivenTypeNotSupported" xml:space="preserve">
+    <value>Querying JSON collections with element provider type '{type}' isn't supported because of SQLite limitations.</value>
+  </data>
   <data name="SequencesNotSupported" xml:space="preserve">
     <value>SQLite does not support sequences. See https://go.microsoft.com/fwlink/?LinkId=723262 for more information and examples.</value>
   </data>

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
@@ -205,23 +205,7 @@ public class SqliteTypeMappingSource : RelationalTypeMappingSource
             stringTypeMapping = (SqliteStringTypeMapping)stringTypeMapping
                 .Clone(new CollectionToJsonStringConverter(mappingInfo.ClrType, elementTypeMapping));
 
-            switch (elementTypeMapping)
-            {
-                // The JSON representation for DateTimeOffset is ISO8601 (2023-01-01T12:30:00+02:00), but our SQL literal representation
-                // is 2023-01-01 12:30:00+02:00 (no T).
-                // datetime('2023-01-01T12:30:00+02:00') yields '2023-01-01 10:30:00' - converted to UTC, no timezone.
-                case SqliteDateTimeOffsetTypeMapping:
-                // The JSON representation for decimal is e.g. 1 (JSON int), whereas our literal representation is "1.0" (string)
-                case SqliteDecimalTypeMapping:
-                // The JSON representation for new[] { 1, 2 } is AQI= (base64?), our SQL literal representation is X'0102'
-                case ByteArrayTypeMapping:
-                    break;
-
-
-                default:
-                    stringTypeMapping = (SqliteStringTypeMapping)stringTypeMapping.CloneWithElementTypeMapping(elementTypeMapping);
-                    break;
-            }
+            stringTypeMapping = (SqliteStringTypeMapping)stringTypeMapping.CloneWithElementTypeMapping(elementTypeMapping);
 
             return stringTypeMapping;
         }

--- a/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
+using static System.Linq.Expressions.Expression;
+
 public abstract class NonSharedPrimitiveCollectionsQueryTestBase : NonSharedModelTestBase
 {
     #region Support for specific element types
@@ -75,7 +77,7 @@ public abstract class NonSharedPrimitiveCollectionsQueryTestBase : NonSharedMode
     public virtual Task Array_of_enum()
         => TestArray(MyEnum.Label1, MyEnum.Label2);
 
-    enum MyEnum { Label1, Label2 }
+    private enum MyEnum { Label1, Label2 }
 
     // This ensures that collections of Geometry (e.g. Geometry[]) aren't mapped; NTS has GeometryCollection for that.
     // See SQL Server/SQLite for a sample implementation.
@@ -238,24 +240,23 @@ public abstract class NonSharedPrimitiveCollectionsQueryTestBase : NonSharedMode
 
         await using var context = contextFactory.CreateContext();
 
-        var entityParam = Expression.Parameter(typeof(TestEntity), "m");
-        var efPropertyCall = Expression.Call(
+        var entityParam = Parameter(typeof(TestEntity), "m");
+        var efPropertyCall = Call(
             typeof(EF).GetMethod(nameof(EF.Property), BindingFlags.Public | BindingFlags.Static)!.MakeGenericMethod(arrayClrType),
             entityParam,
-            Expression.Constant("SomeArray"));
+            Constant("SomeArray"));
 
-        var elementParam = Expression.Parameter(typeof(TElement), "a");
-        var predicate = Expression.Lambda<Func<TestEntity, bool>>(
-            Expression.Equal(
-                Expression.Call(
+        var elementParam = Parameter(typeof(TElement), "a");
+        var predicate = Lambda<Func<TestEntity, bool>>(
+            Equal(
+                Call(
                     EnumerableMethods.CountWithPredicate.MakeGenericMethod(typeof(TElement)),
                     efPropertyCall,
-                    Expression.Lambda(
-                        Expression.Equal(elementParam, Expression.Constant(value1)),
-                        elementParam)),
-            Expression.Constant(2)),
+                    Lambda(Equal(elementParam, Constant(value1)), elementParam)),
+            Constant(2)),
             entityParam);
 
+        // context.Set<TestEntity>().SingleAsync(m => EF.Property<int[]>(m, "SomeArray").Count(a => a == <value1>) == 2)
         var result = await context.Set<TestEntity>().SingleAsync(predicate);
         Assert.Equal(1, result.Id);
     }

--- a/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NonSharedPrimitiveCollectionsQueryTestBase.cs
@@ -46,12 +46,28 @@ public abstract class NonSharedPrimitiveCollectionsQueryTestBase : NonSharedMode
         => TestArray(new DateTime(2023, 1, 1, 12, 30, 0), new DateTime(2023, 1, 2, 12, 30, 0));
 
     [ConditionalFact]
+    public virtual Task Array_of_DateTime_with_milliseconds()
+        => TestArray(new DateTime(2023, 1, 1, 12, 30, 0, 123), new DateTime(2023, 1, 1, 12, 30, 0, 124));
+
+    [ConditionalFact]
+    public virtual Task Array_of_DateTime_with_microseconds()
+        => TestArray(new DateTime(2023, 1, 1, 12, 30, 0, 123, 456), new DateTime(2023, 1, 1, 12, 30, 0, 123, 457));
+
+    [ConditionalFact]
     public virtual Task Array_of_DateOnly()
         => TestArray(new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 2));
 
     [ConditionalFact]
     public virtual Task Array_of_TimeOnly()
         => TestArray(new TimeOnly(12, 30, 0), new TimeOnly(12, 30, 1));
+
+    [ConditionalFact]
+    public virtual Task Array_of_TimeOnly_with_milliseconds()
+        => TestArray(new TimeOnly(12, 30, 0, 123), new TimeOnly(12, 30, 0, 124));
+
+    [ConditionalFact]
+    public virtual Task Array_of_TimeOnly_with_microseconds()
+        => TestArray(new TimeOnly(12, 30, 0, 123, 456), new TimeOnly(12, 30, 0, 124, 457));
 
     [ConditionalFact]
     public virtual Task Array_of_DateTimeOffset()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -136,6 +136,36 @@ WHERE (
 """);
     }
 
+    public override async Task Array_of_DateTime_with_milliseconds()
+    {
+        await base.Array_of_DateTime_with_milliseconds();
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] datetime2 '$') AS [s]
+    WHERE [s].[value] = '2023-01-01T12:30:00.1230000') = 2
+""");
+    }
+
+    public override async Task Array_of_DateTime_with_microseconds()
+    {
+        await base.Array_of_DateTime_with_microseconds();
+
+        AssertSql(
+            """
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] datetime2 '$') AS [s]
+    WHERE [s].[value] = '2023-01-01T12:30:00.1234560') = 2
+""");
+    }
+
     public override async Task Array_of_DateOnly()
     {
         await base.Array_of_DateOnly();
@@ -163,6 +193,36 @@ WHERE (
     SELECT COUNT(*)
     FROM OPENJSON([t].[SomeArray]) WITH ([value] time '$') AS [s]
     WHERE [s].[value] = '12:30:00') = 2
+""");
+    }
+
+    public override async Task Array_of_TimeOnly_with_milliseconds()
+    {
+        await base.Array_of_TimeOnly_with_milliseconds();
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] time '$') AS [s]
+    WHERE [s].[value] = '12:30:00.123') = 2
+""");
+    }
+
+    public override async Task Array_of_TimeOnly_with_microseconds()
+    {
+        await base.Array_of_TimeOnly_with_microseconds();
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] time '$') AS [s]
+    WHERE [s].[value] = '12:30:00.123456') = 2
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -1,13 +1,31 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
+using static System.Linq.Expressions.Expression;
+
 public class NonSharedPrimitiveCollectionsQuerySqlServerTest : NonSharedPrimitiveCollectionsQueryRelationalTestBase
 {
     #region Support for specific element types
+
+    public override async Task Array_of_string()
+    {
+        await base.Array_of_string();
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] nvarchar(max) '$') AS [s]
+    WHERE [s].[value] = N'a') = 2
+""");
+    }
 
     public override async Task Array_of_int()
     {
@@ -53,6 +71,10 @@ WHERE (
     WHERE [s].[value] = CAST(1 AS smallint)) = 2
 """);
     }
+
+    [ConditionalFact]
+    public override Task Array_of_byte()
+        => base.Array_of_byte();
 
     public override async Task Array_of_double()
     {
@@ -189,9 +211,20 @@ WHERE (
 """);
     }
 
-    // The JSON representation for new[] { 1, 2 } is AQI= (base64), this cannot simply be cast to varbinary(max) (0x0102). See #30727.
-    public override Task Array_of_byte_array()
-        => AssertTranslationFailed(() => base.Array_of_byte_array());
+    public override async Task Array_of_byte_array()
+    {
+        await base.Array_of_byte_array();
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM OPENJSON([t].[SomeArray]) WITH ([value] varbinary(max) '$') AS [s]
+    WHERE [s].[value] = 0x0102) = 2
+""");
+    }
 
     public override async Task Array_of_enum()
     {
@@ -220,7 +253,413 @@ WHERE (
         Assert.Equal(CoreStrings.PropertyNotMapped("Point[]", "TestEntity", "Points"), exception.Message);
     }
 
+    [ConditionalFact]
+    public override Task Array_of_array_is_not_supported()
+        => base.Array_of_array_is_not_supported();
+
+    [ConditionalFact]
+    public override Task Multidimensional_array_is_not_supported()
+        => base.Multidimensional_array_is_not_supported();
+
     #endregion Support for specific element types
+
+    #region Specific element types in ordered context
+
+    // When we don't need to preserve the collection's ordering (e.g. when Contains/Count is composed on top of it), we use OPENJSON with
+    // WITH, which handles all conversions out of JSON well.
+    // However, OPENJSON with WITH doesn't support preserving the ordering, so when that's needed we switch to OPENJSON without WITH, at
+    // which point we need to manually convert JSON values into their relational counterparts (this isn't always possible, e.g. varbinary
+    // which is base64 in JSON).
+    // The regular element type tests above test in unordered context, so we repeat them here but with an order-preserving context.
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_string()
+    {
+        await TestOrderedArray("a", "b");
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS nvarchar(max)) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = N'a') = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_int()
+    {
+        await TestOrderedArray(1, 2);
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS int) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = 1) = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_long()
+    {
+        await TestOrderedArray(1L, 2L);
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS bigint) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = CAST(1 AS bigint)) = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_short()
+    {
+        await TestOrderedArray((short)1, (short)2);
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS smallint) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = CAST(1 AS smallint)) = 2
+""");
+    }
+
+    // On relational databases, byte[] gets mapped to a special binary data type, which isn't queryable as a regular primitive collection.
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_byte()
+        => await AssertTranslationFailed(() => TestOrderedArray((byte)1, (byte)2));
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_double()
+    {
+        await TestOrderedArray(1d, 2d);
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS float) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = 1.0E0) = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_float()
+    {
+        await TestOrderedArray(1f, 2f);
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS real) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = CAST(1 AS real)) = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_decimal()
+    {
+        await TestOrderedArray(1m, 2m);
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS decimal(18,2)) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = 1.0) = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_DateTime()
+    {
+        await TestOrderedArray(new DateTime(2023, 1, 1, 12, 30, 0), new DateTime(2023, 1, 2, 12, 30, 0));
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS datetime2) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = '2023-01-01T12:30:00.0000000') = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_DateOnly()
+    {
+        await TestOrderedArray(new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 2));
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS date) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = '2023-01-01') = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_TimeOnly()
+    {
+        await TestOrderedArray(new TimeOnly(12, 30, 0), new TimeOnly(12, 30, 1));
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS time) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = '12:30:00') = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_DateTimeOffset()
+    {
+        await TestOrderedArray(
+            new DateTimeOffset(2023, 1, 1, 12, 30, 0, TimeSpan.FromHours(2)),
+            new DateTimeOffset(2023, 1, 2, 12, 30, 0, TimeSpan.FromHours(2)));
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS datetimeoffset) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = '2023-01-01T12:30:00.0000000+02:00') = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_bool()
+    {
+        await TestOrderedArray(true, false);
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS bit) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = CAST(1 AS bit)) = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_guid()
+    {
+        await TestOrderedArray(
+            new Guid("dc8c903d-d655-4144-a0fd-358099d40ae1"),
+            new Guid("008719a5-1999-4798-9cf3-92a78ffa94a2"));
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS uniqueidentifier) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = 'dc8c903d-d655-4144-a0fd-358099d40ae1') = 2
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_byte_array()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => TestOrderedArray(new byte[] { 1, 2 }, new byte[] { 3, 4 }));
+
+        Assert.Equal(SqlServerStrings.QueryingOrderedBinaryJsonCollectionsNotSupported, exception.Message);
+    }
+
+    [ConditionalFact]
+    public virtual async Task Ordered_array_of_enum()
+    {
+        await TestOrderedArray(MyEnum.Label1, MyEnum.Label2);
+
+        AssertSql(
+"""
+SELECT TOP(2) [t].[Id], [t].[Ints], [t].[SomeArray]
+FROM [TestEntity] AS [t]
+WHERE (
+    SELECT COUNT(*)
+    FROM (
+        SELECT CAST([s].[value] AS int) AS [value], CAST([s].[key] AS int) AS [c]
+        FROM OPENJSON([t].[SomeArray]) AS [s]
+        ORDER BY CAST([s].[key] AS int)
+        OFFSET 1 ROWS
+    ) AS [t0]
+    WHERE [t0].[value] = 0) = 2
+""");
+    }
+
+    private enum MyEnum { Label1, Label2 }
+
+    private async Task TestOrderedArray<TElement>(
+        TElement value1,
+        TElement value2,
+        Action<ModelBuilder> onModelCreating = null)
+    {
+        var arrayClrType = typeof(TElement).MakeArrayType();
+
+        var contextFactory = await InitializeAsync<TestContext>(
+            onModelCreating: onModelCreating ?? (mb => mb.Entity<TestEntity>().Property(arrayClrType, "SomeArray")),
+            seed: context =>
+            {
+                var instance1 = new TestEntity { Id = 1 };
+                context.Add(instance1);
+                var array1 = new TElement[3];
+                array1.SetValue(value1, 0); // We have an extra copy of the first value which we'll Skip, to preserve the ordering
+                array1.SetValue(value1, 1);
+                array1.SetValue(value1, 2);
+                context.Entry(instance1).Property("SomeArray").CurrentValue = array1;
+
+                var instance2 = new TestEntity { Id = 2 };
+                context.Add(instance2);
+                var array2 = new TElement[3];
+                array2.SetValue(value1, 0);
+                array2.SetValue(value1, 1);
+                array2.SetValue(value2, 2);
+                context.Entry(instance2).Property("SomeArray").CurrentValue = array2;
+
+                context.SaveChanges();
+            });
+
+        await using var context = contextFactory.CreateContext();
+
+        var entityParam = Parameter(typeof(TestEntity), "m");
+        var efPropertyCall = Call(
+            typeof(EF).GetMethod(nameof(EF.Property), BindingFlags.Public | BindingFlags.Static)!.MakeGenericMethod(arrayClrType),
+            entityParam,
+            Constant("SomeArray"));
+
+        var elementParam = Parameter(typeof(TElement), "a");
+        var predicate = Lambda<Func<TestEntity, bool>>(
+            Equal(
+                Call(
+                    CountWithPredicateMethod.MakeGenericMethod(typeof(TElement)),
+                    Call(
+                        SkipMethod.MakeGenericMethod(typeof(TElement)),
+                        efPropertyCall,
+                        Constant(1)),
+                    Lambda(Equal(elementParam, Constant(value1)), elementParam)),
+                Constant(2)),
+            entityParam);
+
+        // context.Set<TestEntity>().SingleAsync(m => EF.Property<int[]>(m, "SomeArray").Skip(1).Count(a => a == <value1>) == 2)
+        var result = await context.Set<TestEntity>().SingleAsync(predicate);
+        Assert.Equal(1, result.Id);
+    }
+
+    private static readonly MethodInfo CountWithPredicateMethod
+        = typeof(Enumerable).GetRuntimeMethods().Single(m => m.Name == nameof(Enumerable.Count) && m.GetParameters().Length == 2);
+
+    private static readonly MethodInfo SkipMethod
+        = typeof(Enumerable).GetRuntimeMethods().Single(m => m.Name == nameof(Enumerable.Skip) && m.GetParameters().Length == 2);
+
+    #endregion
+
+    [ConditionalFact]
+    public override Task Column_with_custom_converter()
+        => base.Column_with_custom_converter();
+
+    public override async Task Parameter_with_inferred_value_converter()
+    {
+        await base.Parameter_with_inferred_value_converter();
+
+        AssertSql("");
+    }
 
     #region Type mapping inference
 
@@ -384,6 +823,10 @@ WHERE EXISTS (
     }
 
     #endregion Type mapping inference
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     protected override ITestStoreFactory TestStoreFactory
         => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -305,7 +305,7 @@ WHERE EXISTS (
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE "p"."DateTime" IN (
-    SELECT datetime("d"."value") AS "value"
+    SELECT rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', "d"."value"), '0'), '.') AS "value"
     FROM json_each(@__dateTimes_0) AS "d"
 )
 """);
@@ -491,7 +491,7 @@ WHERE "p"."Strings" ->> 1 = '10'
 """
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
-WHERE datetime("p"."DateTimes" ->> 1) = '2020-01-10 12:30:00'
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', "p"."DateTimes" ->> 1), '0'), '.') = '2020-01-10 12:30:00'
 """);
     }
 


### PR DESCRIPTION
This does work around SQL logic for converting values out of JSON so they can be further queried in SQL. Originally I thought we may want to add a general API on the type mappings, but I don't think that makes sense at this point. The conversions needed for SQLite are concentrated in a single simple method, and there's no real value in refactoring that out to the type mappings (SQL Server doesn't need any). We can always change this in the future, but for now I think we should leave this as an internal implementation detail of each provider.

The update pipeline doesn't need to perform server-side conversions to JSON; we simply generate the JSON representation we want client-side, and send the appropriate parameter for that (e.g. a JSON string representation of a timestamp). An alternative approach would be to e.g. send a regular DateTime parameter, and then use SQL to convert that to the JSON string representation. But there's no real advantage in that, and it's complex/not always possible. I've done some cleanup/improvement to partial updating in #31232, but I don't think anything else is needed at this point.

(Note that if we ever want to allow a JSON property to be a key/concurrency token, the update pipeline would need to apply the same conversions as the query pipeline (because it would need to appear in the UPDATE WHERE clause)

Specific notes on what's converted and what's not supported:

* On SQL Server, no SQL conversions are needed.
  * When using OPENJSON with WITH (no ordering preservation), it does the conversion job just fine.
  * When using OPENJSON without WITH (because order needs to be preserved), we add SQL CAST() to convert the JSON value out; this works fine in all cases except for varbinary, since CAST() doesn't handle base64. So varbinary is specifically unsupported in scenarios which require ordering preservation.
* On SQLite:
  * We apply special conversions for DateTime (apply `datetime()` to remove the T) and Guid (uppercase)
  * Decimal, binary and DateTimeOffset are not supported, because there doesn't seem to be a good way to convert them out of JSON.

Related to #30727

