### PR TITLE
Fix to #30922 - Most cases of projecting a primitive collection don't work

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1516,6 +1516,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("SetOperationsOnDifferentStoreTypes");
 
         /// <summary>
+        ///     A set operation 'setOperationType' requires valid type mapping for at least one of its sides.
+        /// </summary>
+        public static string SetOperationsRequireAtLeastOneSideWithValidTypeMapping(object? setOperationType)
+        => string.Format(
+            GetString("SetOperationsRequireAtLeastOneSideWithValidTypeMapping", nameof(setOperationType)),
+            setOperationType);
+
+        /// <summary>
         ///     The SetProperty&lt;TProperty&gt; method can only be used within 'ExecuteUpdate' method.
         /// </summary>
         public static string SetPropertyMethodInvoked

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -995,6 +995,9 @@
   <data name="SetOperationsOnDifferentStoreTypes" xml:space="preserve">
     <value>Unable to translate set operation when matching columns on both sides have different store types.</value>
   </data>
+  <data name="SetOperationsRequireAtLeastOneSideWithValidTypeMapping" xml:space="preserve">
+    <value>A set operation 'setOperationType' requires valid type mapping for at least one of its sides.</value>
+  </data>
   <data name="SetPropertyMethodInvoked" xml:space="preserve">
     <value>The SetProperty&lt;TProperty&gt; method can only be used within 'ExecuteUpdate' method.</value>
   </data>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
@@ -112,80 +114,129 @@ public class SqlServerQueryTranslationPostprocessor : RelationalQueryTranslation
                 case ShapedQueryExpression shapedQueryExpression:
                     return shapedQueryExpression.UpdateQueryExpression(Visit(shapedQueryExpression.QueryExpression));
 
-                case SelectExpression
+                case SelectExpression selectExpression:
                 {
-                    Tables: [SqlServerOpenJsonExpression { ColumnInfos: not null } openJsonExpression, ..],
-                    Orderings:
-                    [
+                    var newTables = default(TableExpressionBase[]);
+                    var appliedCasts = new List<(SqlServerOpenJsonExpression, string)>();
+
+                    for (var i = 0; i < selectExpression.Tables.Count; i++)
+                    {
+                        var table = selectExpression.Tables[i];
+                        if ((table is SqlServerOpenJsonExpression { ColumnInfos: not null }
+                            or JoinExpressionBase { Table: SqlServerOpenJsonExpression { ColumnInfos: not null } })
+                            && selectExpression.Orderings.Select(o => o.Expression)
+                                .Concat(selectExpression.Projection.Select(p => p.Expression))
+                                .Any(x => IsKeyColumn(x, table)))
                         {
-                            Expression: SqlUnaryExpression
+                            // Remove the WITH clause from the OPENJSON expression
+                            var openJsonExpression = (SqlServerOpenJsonExpression)((table as JoinExpressionBase)?.Table ?? table);
+                            var newOpenJsonExpression = openJsonExpression.Update(
+                                openJsonExpression.JsonExpression,
+                                openJsonExpression.Path,
+                                columnInfos: null);
+
+                            TableExpressionBase newTable = table switch
                             {
-                                OperatorType: ExpressionType.Convert,
-                                Operand: ColumnExpression { Name: "key", Table: var keyColumnTable }
+                                InnerJoinExpression ij => ij.Update(newOpenJsonExpression, ij.JoinPredicate),
+                                LeftJoinExpression lj => lj.Update(newOpenJsonExpression, lj.JoinPredicate),
+                                CrossJoinExpression cj => cj.Update(newOpenJsonExpression),
+                                CrossApplyExpression ca => ca.Update(newOpenJsonExpression),
+                                OuterApplyExpression oa => oa.Update(newOpenJsonExpression),
+                                _ => newOpenJsonExpression,
+                            };
+
+                            if (newTables is not null)
+                            {
+                                newTables[i] = newTable;
                             }
+                            else if (!table.Equals(newTable))
+                            {
+                                newTables = new TableExpressionBase[selectExpression.Tables.Count];
+                                for (var j = 0; j < i; j++)
+                                {
+                                    newTables[j] = selectExpression.Tables[j];
+                                }
+
+                                newTables[i] = newTable;
+                            }
+
+                            foreach (var column in openJsonExpression.ColumnInfos!)
+                            {
+                                var typeMapping = _typeMappingSource.FindMapping(column.StoreType);
+                                Check.DebugAssert(
+                                    typeMapping is not null,
+                                    $"Could not find mapping for store type {column.StoreType} when converting OPENJSON/WITH");
+
+                                // Binary data (varbinary) is stored in JSON as base64, which OPENJSON knows how to decode as long the type is
+                                // specified in the WITH clause. We're now removing the WITH and applying a relational CAST, but that doesn't work
+                                // for base64 data.
+                                if (typeMapping is SqlServerByteArrayTypeMapping)
+                                {
+                                    throw new InvalidOperationException(SqlServerStrings.QueryingOrderedBinaryJsonCollectionsNotSupported);
+                                }
+
+                                _castsToApply.Add((newOpenJsonExpression, column.Name), typeMapping);
+                                appliedCasts.Add((newOpenJsonExpression, column.Name));
+                            }
+
+                            continue;
                         }
-                    ]
-                } selectExpression
-                    when keyColumnTable == openJsonExpression:
-                {
-                    // Remove the WITH clause from the OPENJSON expression
-                    var newOpenJsonExpression = openJsonExpression.Update(
-                        openJsonExpression.JsonExpression,
-                        openJsonExpression.Path,
-                        columnInfos: null);
 
-                    var newTables = selectExpression.Tables.ToArray();
-                    newTables[0] = newOpenJsonExpression;
+                        if (newTables is not null)
+                        {
+                            newTables[i] = table;
+                        }
+                    }
 
-                    var newSelectExpression = selectExpression.Update(
-                        selectExpression.Projection,
-                        newTables,
-                        selectExpression.Predicate,
-                        selectExpression.GroupBy,
-                        selectExpression.Having,
-                        selectExpression.Orderings,
-                        selectExpression.Limit,
-                        selectExpression.Offset);
+                    // SelectExpression.Update always creates a new instance - we should avoid it when tables haven't changed
+                    // see #31276
+                    var newSelectExpression = newTables is not null
+                        ? selectExpression.Update(
+                            selectExpression.Projection,
+                            newTables,
+                            selectExpression.Predicate,
+                            selectExpression.GroupBy,
+                            selectExpression.Having,
+                            selectExpression.Orderings,
+                            selectExpression.Limit,
+                            selectExpression.Offset)
+                        : selectExpression;
 
                     // Record the OPENJSON expression and its projected column(s), along with the store type we just removed from the WITH
                     // clause. Then visit the select expression, adding a cast around the matching ColumnExpressions.
-                    foreach (var column in openJsonExpression.ColumnInfos)
-                    {
-                        var typeMapping = _typeMappingSource.FindMapping(column.StoreType);
-                        Check.DebugAssert(
-                            typeMapping is not null,
-                            $"Could not find mapping for store type {column.StoreType} when converting OPENJSON/WITH");
-
-                        // Binary data (varbinary) is stored in JSON as base64, which OPENJSON knows how to decode as long the type is
-                        // specified in the WITH clause. We're now removing the WITH and applying a relational CAST, but that doesn't work
-                        // for base64 data.
-                        if (typeMapping is SqlServerByteArrayTypeMapping)
-                        {
-                            throw new InvalidOperationException(SqlServerStrings.QueryingOrderedBinaryJsonCollectionsNotSupported);
-                        }
-
-                        _castsToApply.Add((newOpenJsonExpression, column.Name), typeMapping);
-                    }
-
                     var result = base.Visit(newSelectExpression);
 
-                    foreach (var column in openJsonExpression.ColumnInfos)
+                    foreach (var appliedCast in appliedCasts)
                     {
-                        _castsToApply.Remove((newOpenJsonExpression, column.Name));
+                        _castsToApply.Remove(appliedCast);
                     }
 
                     return result;
                 }
 
-                case ColumnExpression { Table: SqlServerOpenJsonExpression openJsonTable, Name: var name } columnExpression
-                    when _castsToApply.TryGetValue((openJsonTable, name), out var typeMapping):
+                case ColumnExpression columnExpression:
                 {
-                    return _sqlExpressionFactory.Convert(columnExpression, columnExpression.Type, typeMapping);
+                    return columnExpression.Table switch
+                    {
+                        SqlServerOpenJsonExpression openJsonTable
+                            when _castsToApply.TryGetValue((openJsonTable, columnExpression.Name), out var typeMapping)
+                            => _sqlExpressionFactory.Convert(columnExpression, columnExpression.Type, typeMapping),
+                        JoinExpressionBase { Table: SqlServerOpenJsonExpression innerOpenJsonTable }
+                            when _castsToApply.TryGetValue((innerOpenJsonTable, columnExpression.Name), out var innerTypeMapping)
+                            => _sqlExpressionFactory.Convert(columnExpression, columnExpression.Type, innerTypeMapping),
+                        _ => base.Visit(expression)
+                    };
                 }
 
                 default:
                     return base.Visit(expression);
             }
+
+            static bool IsKeyColumn(SqlExpression sqlExpression, TableExpressionBase table)
+                => (sqlExpression is ColumnExpression { Name: "key", Table: var keyColumnTable }
+                    && keyColumnTable == table)
+                || (sqlExpression is SqlUnaryExpression { OperatorType: ExpressionType.Convert,
+                    Operand: SqlExpression operand } && IsKeyColumn(operand, table));
         }
     }
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -220,8 +220,17 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
         // TODO: This is a temporary CLR type-based check; when we have proper metadata to determine if the element is nullable, use it here
         var isColumnNullable = elementClrType.IsNullableType();
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
         var selectExpression = new SelectExpression(
-            jsonEachExpression, columnName: "value", columnType: elementClrType, columnTypeMapping: elementTypeMapping, isColumnNullable);
+            jsonEachExpression,
+            columnName: "value",
+            columnType: elementClrType,
+            columnTypeMapping: elementTypeMapping,
+            isColumnNullable,
+            identifierColumnName: "key",
+            identifierColumnType: typeof(int),
+            identifierColumnTypeMapping: _typeMappingSource.FindMapping(typeof(int)));
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         // If we have a collection column, we know the type mapping at this point (as opposed to parameters, whose type mapping will get
         // inferred later based on usage in SqliteInferredTypeMappingApplier); we should be able to apply any SQL logic needed to convert

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBase<TFixture>
@@ -33,7 +35,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new int?[] { null, 999 }.Contains(c.NullableInt)),
-            entryCount: 2);
+            entryCount: 3);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -58,7 +60,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 2, 999 }.Count(i => i > c.Id) == 1),
-            entryCount: 2);
+            entryCount: 4);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -66,7 +68,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 2, 999, 1000 }.Count(i => i > c.Id) == 2),
-            entryCount: 2);
+            entryCount: 4);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -153,7 +155,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 2, 999 }.All(i => i != c.Id)),
-            entryCount: 2);
+            entryCount: 4);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -164,7 +166,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         return AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => ids.Count(i => i > c.Id) == 1),
-            entryCount: 2);
+            entryCount: 4);
     }
 
     [ConditionalTheory]
@@ -200,7 +202,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         return AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => nullableInts.Contains(c.NullableInt)),
-            entryCount: 2);
+            entryCount: 3);
     }
 
     [ConditionalTheory]
@@ -240,7 +242,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         return AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => bools.Contains(c.Bool)),
-            entryCount: 1);
+            entryCount: 2);
     }
 
     [ConditionalTheory]
@@ -252,7 +254,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         return AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => enums.Contains(c.Enum)),
-            entryCount: 2);
+            entryCount: 3);
     }
 
     [ConditionalTheory]
@@ -273,7 +275,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Contains(10)),
-            entryCount: 1);
+            entryCount: 2);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -281,7 +283,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.NullableInts.Contains(10)),
-            entryCount: 1);
+            entryCount: 2);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -289,7 +291,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.NullableInts.Contains(null)),
-            entryCount: 1);
+            entryCount: 3);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -305,7 +307,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Bools.Contains(true)),
-            entryCount: 1);
+            entryCount: 2);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -340,7 +342,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Strings[1] == "10"),
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => (c.Strings.Length >= 2 ? c.Strings[1] : "-1") == "10"),
-            entryCount: 1);
+            entryCount: 2);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -351,7 +353,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
                 c => c.DateTimes[1] == new DateTime(2020, 1, 10, 12, 30, 0, DateTimeKind.Utc)),
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(
                 c => (c.DateTimes.Length >= 2 ? c.DateTimes[1] : default) == new DateTime(2020, 1, 10, 12, 30, 0, DateTimeKind.Utc)),
-            entryCount: 1);
+            entryCount: 2);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -443,7 +445,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
                 .Where(c => c.Ints.OrderByDescending(i => i).ElementAt(0) == 111),
             ss => ss.Set<PrimitiveCollectionsEntity>()
                 .Where(c => c.Ints.Length > 0 && c.Ints.OrderByDescending(i => i).ElementAt(0) == 111),
-            entryCount: 1);
+            entryCount: 2);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -451,7 +453,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Any()),
-            entryCount: 2);
+            entryCount: 4);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -514,7 +516,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         => AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Intersect(new[] { 11, 111 }).Count() == 2),
-            entryCount: 1);
+            entryCount: 2);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -525,7 +527,7 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(
                 c => new[] { 11, 111 }.Except(c.Ints).Count(i => i % 2 == 1) == 2),
-            entryCount: 2);
+            entryCount: 3);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -612,6 +614,30 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         var results = compiledQuery(context, ints).ToList();
     }
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Parameter_collection_in_subquery_Union_column_collection(bool async)
+    {
+        var ints = new[] { 10, 111 };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(p => ints.Skip(1).Union(p.Ints).Count() == 3),
+            entryCount: 4);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Parameter_collection_in_subquery_Union_column_collection_nested(bool async)
+    {
+        var ints = new[] { 10, 111 };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(p => ints.Skip(1).Union(p.Ints.OrderBy(x => x).Skip(1).Distinct().OrderByDescending(x => x).Take(20)).Count() == 3),
+            entryCount: 2);
+    }
+
     [ConditionalFact]
     public virtual void Parameter_collection_in_subquery_and_Convert_as_compiled_query()
     {
@@ -632,6 +658,26 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Parameter_collection_in_subquery_Union_another_parameter_collection_as_compiled_query(bool async)
+    {
+        var compiledQuery = EF.CompileQuery(
+            (PrimitiveCollectionsContext context, int[] ints1, int[] ints2)
+                => context.Set<PrimitiveCollectionsEntity>().Where(p => ints1.Skip(1).Union(ints2).Count() == 3));
+
+        await using var context = Fixture.CreateContext();
+        var ints1 = new[] { 10, 111 };
+        var ints2 = new[] { 7, 42 };
+
+        compiledQuery(context, ints1, ints2).ToList();
+
+        //var message = Assert.Throws<InvalidOperationException>(
+        //    () => compiledQuery(context, ints1, ints2).ToList()).Message;
+
+        //Assert.Equal(RelationalStrings.SetOperationsRequireAtLeastOneSideWithValidTypeMapping("Union"), message);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Column_collection_in_subquery_Union_parameter_collection(bool async)
     {
         var ints = new[] { 10, 111 };
@@ -641,8 +687,118 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
         return AssertQuery(
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Skip(1).Union(ints).Count() == 3),
-            entryCount: 1);
+            entryCount: 2);
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_collection_of_ints_simple(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => x.Ints),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_collection_of_ints_ordered(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => x.Ints.OrderByDescending(xx => xx).ToList()),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_collection_of_datetimes_filtered(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => x.DateTimes.Where(xx => xx.Day != 1).ToList()),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_collection_of_ints_with_paging(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => x.NullableInts.Take(20).ToList()),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_collection_of_ints_with_paging2(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => x.NullableInts.OrderBy(x => x).Skip(1).ToList()),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_collection_of_ints_with_paging3(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => x.NullableInts.Skip(2).ToList()),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_collection_of_ints_with_distinct(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => x.Ints.Distinct().ToList()),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee));
+
+    [ConditionalTheory(Skip = "issue #31277")]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_collection_of_nullable_ints_with_distinct(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => x.NullableInts.Distinct().ToList()),
+            assertOrder: true,
+            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_empty_collection_of_nullables_and_collection_only_containing_nulls(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => new
+            {
+                Empty = x.NullableInts.Where(x => false).ToList(),
+                OnlyNull = x.NullableInts.Where(x => x == null).ToList(),
+            }),
+            assertOrder: true,
+            elementAsserter: (e, a) =>
+            {
+                AssertCollection(e.Empty, a.Empty, ordered: true);
+                AssertCollection(e.OnlyNull, a.OnlyNull, ordered: true);
+            });
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_multiple_collections(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().OrderBy(x => x.Id).Select(x => new
+            {
+                Ints = x.Ints.ToList(),
+                OrderedInts = x.Ints.OrderByDescending(xx => xx).ToList(),
+                FilteredDateTimes = x.DateTimes.Where(xx => xx.Day != 1).ToList(),
+                FilteredDateTimes2 = x.DateTimes.Where(xx => xx > new DateTime(2000, 1, 1)).ToList()
+            }),
+            elementAsserter: (e, a) =>
+            {
+                AssertCollection(e.Ints, a.Ints, ordered: true);
+                AssertCollection(e.OrderedInts, a.OrderedInts, ordered: true);
+                AssertCollection(e.FilteredDateTimes, a.FilteredDateTimes, elementSorter: ee => ee);
+                AssertCollection(e.FilteredDateTimes2, a.FilteredDateTimes2, elementSorter: ee => ee);
+            },
+            assertOrder: true);
 
     public abstract class PrimitiveCollectionsQueryFixtureBase : SharedStoreFixtureBase<PrimitiveCollectionsContext>, IQueryFixtureBase
     {
@@ -801,6 +957,59 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
                 new()
                 {
                     Id = 3,
+
+                    Int = 20,
+                    String = "20",
+                    DateTime = new DateTime(2022, 1, 10, 12, 30, 0, DateTimeKind.Utc),
+                    Bool = true,
+                    Enum = MyEnum.Value1,
+                    NullableInt = 20,
+
+                    Ints = new[] { 1, 1, 10, 10, 10, 1, 10 },
+                    Strings = new[] { "1", "10", "10", "1", "1" },
+                    DateTimes = new DateTime[]
+                    {
+                        new(2020, 1, 1, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 10, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 1, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 1, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 10, 12, 30, 0, DateTimeKind.Utc),
+                    },
+                    Bools = new[] { true, false },
+                    Enums = new[] { MyEnum.Value1, MyEnum.Value2 },
+                    NullableInts = new int?[] { 1, 1, 10, 10, null, 1 },
+                },
+                new()
+                {
+                    Id = 4,
+
+                    Int = 41,
+                    String = "41",
+                    DateTime = new DateTime(2024, 1, 11, 12, 30, 0, DateTimeKind.Utc),
+                    Bool = false,
+                    Enum = MyEnum.Value2,
+                    NullableInt = null,
+
+                    Ints = new[] { 1, 1, 111, 11, 1, 111 },
+                    Strings = new[] { "1", "11", "111", "11" },
+                    DateTimes = new DateTime[]
+                    {
+                        new(2020, 1, 1, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 11, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 1, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 11, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 31, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 1, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 31, 12, 30, 0, DateTimeKind.Utc),
+                        new(2020, 1, 31, 12, 30, 0, DateTimeKind.Utc),
+                    },
+                    Bools = new[] { false },
+                    Enums = new[] { MyEnum.Value2, MyEnum.Value3 },
+                    NullableInts = new int?[] { null, null },
+                },
+                new()
+                {
+                    Id = 5,
 
                     Int = 0,
                     String = "",

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NonSharedPrimitiveCollectionsQuerySqlServerTest.cs
@@ -332,7 +332,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS nvarchar(max)) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS nvarchar(max)) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -353,7 +353,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS int) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS int) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -374,7 +374,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS bigint) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS bigint) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -395,7 +395,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS smallint) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS smallint) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -421,7 +421,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS float) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS float) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -442,7 +442,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS real) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS real) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -463,7 +463,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS decimal(18,2)) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS decimal(18,2)) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -484,7 +484,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS datetime2) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS datetime2) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -505,7 +505,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS date) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS date) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -526,7 +526,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS time) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS time) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -549,7 +549,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS datetimeoffset) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS datetimeoffset) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -570,7 +570,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS bit) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS bit) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -593,7 +593,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS uniqueidentifier) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS uniqueidentifier) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS
@@ -623,7 +623,7 @@ FROM [TestEntity] AS [t]
 WHERE (
     SELECT COUNT(*)
     FROM (
-        SELECT CAST([s].[value] AS int) AS [value], CAST([s].[key] AS int) AS [c]
+        SELECT CAST([s].[value] AS int) AS [value], [s].[key], CAST([s].[key] AS int) AS [c]
         FROM OPENJSON([t].[SomeArray]) AS [s]
         ORDER BY CAST([s].[key] AS int)
         OFFSET 1 ROWS

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -469,6 +469,12 @@ WHERE [p].[Ints] = N'[1,10]'
     public override Task Parameter_collection_in_subquery_Union_column_collection_as_compiled_query(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Parameter_collection_in_subquery_Union_column_collection_as_compiled_query(async));
 
+    public override Task Parameter_collection_in_subquery_Union_column_collection(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Parameter_collection_in_subquery_Union_column_collection(async));
+
+    public override Task Parameter_collection_in_subquery_Union_column_collection_nested(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Parameter_collection_in_subquery_Union_column_collection_nested(async));
+
     public override void Parameter_collection_in_subquery_and_Convert_as_compiled_query()
     {
         // Base implementation asserts that a different exception is thrown
@@ -479,6 +485,87 @@ WHERE [p].[Ints] = N'[1,10]'
 
     public override Task Column_collection_in_subquery_Union_parameter_collection(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Column_collection_in_subquery_Union_parameter_collection(async));
+
+    public override Task Parameter_collection_in_subquery_Union_another_parameter_collection_as_compiled_query(bool async)
+        => AssertCompatibilityLevelTooLow(() => base.Parameter_collection_in_subquery_Union_another_parameter_collection_as_compiled_query(async));
+
+    public override async Task Project_collection_of_ints_simple(bool async)
+    {
+        await base.Project_collection_of_ints_simple(async);
+
+        AssertSql(
+"""
+SELECT [p].[Ints]
+FROM [PrimitiveCollectionsEntity] AS [p]
+ORDER BY [p].[Id]
+""");
+    }
+
+    public override Task Project_collection_of_ints_ordered(bool async)
+        // we don't propagate error details from projection
+        => AssertTranslationFailed(() => base.Project_collection_of_ints_ordered(async));
+
+    public override Task Project_collection_of_datetimes_filtered(bool async)
+        // we don't propagate error details from projection
+        => AssertTranslationFailed(() => base.Project_collection_of_datetimes_filtered(async));
+
+    public override async Task Project_collection_of_ints_with_paging(bool async)
+    {
+        await base.Project_collection_of_ints_with_paging(async);
+
+        // client eval
+        AssertSql(
+"""
+SELECT [p].[NullableInts]
+FROM [PrimitiveCollectionsEntity] AS [p]
+ORDER BY [p].[Id]
+""");
+    }
+
+    public override Task Project_collection_of_ints_with_paging2(bool async)
+        // we don't propagate error details from projection
+        => AssertTranslationFailed(() => base.Project_collection_of_ints_with_paging2(async));
+
+    public override async Task Project_collection_of_ints_with_paging3(bool async)
+    {
+        await base.Project_collection_of_ints_with_paging3(async);
+
+        // client eval
+        AssertSql(
+"""
+SELECT [p].[NullableInts]
+FROM [PrimitiveCollectionsEntity] AS [p]
+ORDER BY [p].[Id]
+""");
+    }
+
+    public override async Task Project_collection_of_ints_with_distinct(bool async)
+    {
+        await base.Project_collection_of_ints_with_distinct(async);
+
+        // client eval
+        AssertSql(
+"""
+SELECT [p].[Ints]
+FROM [PrimitiveCollectionsEntity] AS [p]
+ORDER BY [p].[Id]
+""");
+    }
+
+    public override async Task Project_collection_of_nullable_ints_with_distinct(bool async)
+    {
+        await base.Project_collection_of_nullable_ints_with_distinct(async);
+
+        AssertSql("");
+    }
+
+    public override Task Project_multiple_collections(bool async)
+        // we don't propagate error details from projection
+        => AssertTranslationFailed(() => base.Project_multiple_collections(async));
+
+    public override Task Project_empty_collection_of_nullables_and_collection_only_containing_nulls(bool async)
+        // we don't propagate error details from projection
+        => AssertTranslationFailed(() => base.Project_empty_collection_of_nullables_and_collection_only_containing_nulls(async));
 
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()


### PR DESCRIPTION
Problem was that for cases that compose on the collection of primitives and then project it, we need identifier to properly bucket the results. On SqlServer we can use hidden key column that is a result of OPENJSON - we need something that is unique so we can't use the value itself. Fix is to add identifier to the SelectExpression based on OPENJSON and also modify the logic that figures out if we need key (and thus need to revert to OPENJSON without WITH clause). Also some minor fixes around nullability - when projecting element of a collection of primitives using OUTER APPLY/JOIN we must set the projection binding to nullable, as the value can always be null, in case of empty collection.

Fixes #30922