### PR TITLE
[release/7.0] Fix to #29572 - Json: predicate on json bool property generates incorrect sql

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -13,6 +13,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
 {
+    private static readonly bool UseOldBehavior29572
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue29572", out var enabled29572) && enabled29572;
+
     private bool _isSearchCondition;
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
@@ -764,5 +767,7 @@ public class SearchConditionConvertingExpressionVisitor : SqlExpressionVisitor
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     protected override Expression VisitJsonScalar(JsonScalarExpression jsonScalarExpression)
-        => jsonScalarExpression;
+        => !UseOldBehavior29572
+            ? ApplyConversion(jsonScalarExpression, condition: false)
+            : jsonScalarExpression;
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -918,4 +918,34 @@ public abstract class JsonQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     x.Reference.TestNullableEnumWithIntConverter,
                     x.Reference.TestNullableEnumWithConverterThatHandlesNulls,
                 }));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_boolean_predicate(bool async)
+          => AssertQuery(
+              async,
+              ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestBoolean),
+              entryCount: 6);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_boolean_predicate_negated(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => !x.Reference.TestBoolean),
+            entryCount: 0);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_boolean_projection(bool async)
+        => AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityAllTypes>().Select(x => x.Reference.TestBoolean));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Json_boolean_projection_negated(bool async)
+        => AssertQueryScalar(
+            async,
+            ss => ss.Set<JsonEntityAllTypes>().Select(x => !x.Reference.TestBoolean));
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -935,6 +935,55 @@ FROM [JsonEntitiesAllTypes] AS [j]
 """);
     }
 
+    public override async Task Json_boolean_predicate(bool async)
+    {
+        await base.Json_boolean_predicate(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[Collection],'$'), JSON_QUERY([j].[Reference],'$')
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(1 AS bit)
+""");
+    }
+
+    public override async Task Json_boolean_predicate_negated(bool async)
+    {
+        await base.Json_boolean_predicate_negated(async);
+
+        AssertSql(
+"""
+SELECT [j].[Id], JSON_QUERY([j].[Collection],'$'), JSON_QUERY([j].[Reference],'$')
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(0 AS bit)
+""");
+    }
+
+    public override async Task Json_boolean_projection(bool async)
+    {
+        await base.Json_boolean_projection(async);
+
+        AssertSql(
+"""
+SELECT CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit)
+FROM [JsonEntitiesAllTypes] AS [j]
+""");
+    }
+
+    public override async Task Json_boolean_projection_negated(bool async)
+    {
+        await base.Json_boolean_projection_negated(async);
+
+        AssertSql(
+"""
+SELECT CASE
+    WHEN CAST(JSON_VALUE([j].[Reference],'$.TestBoolean') AS bit) = CAST(0 AS bit) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [JsonEntitiesAllTypes] AS [j]
+""");
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual async Task FromSql_on_entity_with_json_basic(bool async)


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/29574
Fixes https://github.com/dotnet/efcore/issues/29572 

**Description**

Search condition visitor wasn't handling json scalar expressions properly - we should convert them into search conditions/values just like we do with regular columns

**Customer impact**

Queries that perform filtering based on bool value inside JSON generate invalid SQL. There is a workaround, but it's not straightforward for some of the cases. (need to convert bool column to object and then back to bool to trick our query optimizer)

**How found**

Multiple customer reports on 7.0

Regression

No. JSON support is new functionality in 7.0.

**Testing**

Added regression tests for affected scenarios.

**Risk**

Minimal: the bug is result of an oversight and one line/trivial change. We were not performing search condition conversion for JSON scalars, like we do for every other operator. Change only affects JSON scenarios of type bool. Also added quirk to revert to old behavior if necessary.