### PR TITLE
Uses existing JSON primitive collection instead of creating a new one

### DIFF
--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -152,7 +152,8 @@ public class SqlServerUpdateSqlGenerator : UpdateAndSelectSqlGenerator, ISqlServ
             stringBuilder.Append(columnModification.JsonPath);
             stringBuilder.Append("', ");
 
-            if (columnModification.Property != null)
+            if (columnModification.Property != null
+                && columnModification.Property.GetTypeMapping().ElementTypeMapping == null)
             {
                 base.AppendUpdateColumnValue(updateSqlGeneratorHelper, columnModification, stringBuilder, name, schema);
             }

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
@@ -143,7 +143,6 @@ public class SqliteUpdateSqlGenerator : UpdateAndSelectSqlGenerator
     public override string GenerateNextSequenceValueOperation(string name, string? schema)
         => throw new NotSupportedException(SqliteStrings.SequencesNotSupported);
 
-
     /// <inheritdoc />
     protected override void AppendUpdateColumnValue(
         ISqlGenerationHelper updateSqlGeneratorHelper,
@@ -160,7 +159,8 @@ public class SqliteUpdateSqlGenerator : UpdateAndSelectSqlGenerator
             stringBuilder.Append(columnModification.JsonPath);
             stringBuilder.Append("', ");
 
-            if (columnModification.Property != null)
+            if (columnModification.Property != null
+                && columnModification.Property.GetTypeMapping().ElementTypeMapping == null)
             {
                 var providerClrType = (columnModification.Property.GetTypeMapping().Converter?.ProviderClrType
                     ?? columnModification.Property.ClrType).UnwrapNullableType();

--- a/test/EFCore.Relational.Specification.Tests/Query/JsonQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/JsonQueryFixtureBase.cs
@@ -324,6 +324,8 @@ public abstract class JsonQueryFixtureBase : SharedStoreFixtureBase<JsonQueryCon
     {
         Assert.Equal(expected.Name, actual.Name);
         Assert.Equal(expected.Number, actual.Number);
+        Assert.Equal(expected.Names, actual.Names);
+        Assert.Equal(expected.Numbers, actual.Numbers);
 
         AssertOwnedBranch(expected.OwnedReferenceBranch, actual.OwnedReferenceBranch);
         Assert.Equal(expected.OwnedCollectionBranch.Count, actual.OwnedCollectionBranch.Count);
@@ -339,6 +341,8 @@ public abstract class JsonQueryFixtureBase : SharedStoreFixtureBase<JsonQueryCon
         Assert.Equal(expected.Fraction, actual.Fraction);
         Assert.Equal(expected.Enum, actual.Enum);
         Assert.Equal(expected.NullableEnum, actual.NullableEnum);
+        Assert.Equal(expected.Enums, actual.Enums);
+        Assert.Equal(expected.NullableEnums, actual.NullableEnums);
 
         AssertOwnedLeaf(expected.OwnedReferenceLeaf, actual.OwnedReferenceLeaf);
         Assert.Equal(expected.OwnedCollectionLeaf.Count, actual.OwnedCollectionLeaf.Count);

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedAllTypes.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedAllTypes.cs
@@ -1,10 +1,22 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
 public class JsonOwnedAllTypes
 {
+    private List<long> _testInt64CollectionX = new();
+    private IList<double> _testDoubleCollectionX = new List<double>();
+    private List<float> _testSingleCollectionX = new() { 1.1f, 1.2f };
+    private IList<bool> _testBooleanCollectionX = new List<bool> { true };
+    private ObservableCollection<char> _testCharacterCollectionX = new();
+    private ObservableCollection<int?> _testNullableInt32CollectionX = new() { 99 };
+    private Collection<JsonEnum?> _testNullableEnumCollectionX = new();
+    private Collection<JsonEnum?> _testNullableEnumWithIntConverterCollectionX = new() { JsonEnum.Three };
+
     public string TestDefaultString { get; set; }
     public string TestMaxLengthString { get; set; }
     public short TestInt16 { get; set; }
@@ -34,26 +46,107 @@ public class JsonOwnedAllTypes
     public string[] TestDefaultStringCollection { get; set; }
     public List<string> TestMaxLengthStringCollection { get; set; }
     public IList<short> TestInt16Collection { get; set; }
-    public int[] TestInt32Collection { get; set; }
-    public List<long> TestInt64Collection { get; set; }
-    public IList<double> TestDoubleCollection { get; set; }
+
+    public int[] TestInt32Collection { get; set; } = Array.Empty<int>();
+
+    public List<long> TestInt64Collection
+    {
+        get => _testInt64CollectionX;
+        set
+        {
+            _testInt64CollectionX = value;
+            NewCollectionSet = true;
+        }
+    }
+
+    public IList<double> TestDoubleCollection
+    {
+        get => _testDoubleCollectionX;
+        set
+        {
+            _testDoubleCollectionX = value;
+            NewCollectionSet = true;
+        }
+    }
+
     public decimal[] TestDecimalCollection { get; set; }
     public List<DateTime> TestDateTimeCollection { get; set; }
     public IList<DateTimeOffset> TestDateTimeOffsetCollection { get; set; }
-    public TimeSpan[] TestTimeSpanCollection { get; set; }
-    public List<float> TestSingleCollection { get; set; }
-    public IList<bool> TestBooleanCollection { get; set; }
+    public TimeSpan[] TestTimeSpanCollection { get; set; } = { new(1, 1, 1) };
+
+    public List<float> TestSingleCollection
+    {
+        get => _testSingleCollectionX;
+        set
+        {
+            _testSingleCollectionX = value;
+            NewCollectionSet = true;
+        }
+    }
+
+    public IList<bool> TestBooleanCollection
+    {
+        get => _testBooleanCollectionX;
+        set
+        {
+            _testBooleanCollectionX = value;
+            NewCollectionSet = true;
+        }
+    }
+
     public byte[] TestByteCollection { get; set; }
     public List<Guid> TestGuidCollection { get; set; }
     public IList<ushort> TestUnsignedInt16Collection { get; set; }
     public uint[] TestUnsignedInt32Collection { get; set; }
-    public List<ulong> TestUnsignedInt64Collection { get; set; }
-    public IList<char> TestCharacterCollection { get; set; }
+    public ObservableCollection<ulong> TestUnsignedInt64Collection { get; set; }
+
+    public ObservableCollection<char> TestCharacterCollection
+    {
+        get => _testCharacterCollectionX;
+        set
+        {
+            _testCharacterCollectionX = value;
+            NewCollectionSet = true;
+        }
+    }
+
     public sbyte[] TestSignedByteCollection { get; set; }
-    public List<int?> TestNullableInt32Collection { get; set; }
+
+    public ObservableCollection<int?> TestNullableInt32Collection
+    {
+        get => _testNullableInt32CollectionX;
+        set
+        {
+            _testNullableInt32CollectionX = value;
+            NewCollectionSet = true;
+        }
+    }
+
     public IList<JsonEnum> TestEnumCollection { get; set; }
     public JsonEnum[] TestEnumWithIntConverterCollection { get; set; }
-    public List<JsonEnum?> TestNullableEnumCollection { get; set; }
-    public IList<JsonEnum?> TestNullableEnumWithIntConverterCollection { get; set; }
+
+    public Collection<JsonEnum?> TestNullableEnumCollection
+    {
+        get => _testNullableEnumCollectionX;
+        set
+        {
+            NewCollectionSet = true;
+            _testNullableEnumCollectionX = value;
+        }
+    }
+
+    public Collection<JsonEnum?> TestNullableEnumWithIntConverterCollection
+    {
+        get => _testNullableEnumWithIntConverterCollectionX;
+        set
+        {
+            _testNullableEnumWithIntConverterCollectionX = value;
+            NewCollectionSet = true;
+        }
+    }
+
     public JsonEnum?[] TestNullableEnumWithConverterThatHandlesNullsCollection { get; set; }
+
+    [NotMapped]
+    public bool NewCollectionSet { get; private set; }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedBranch.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedBranch.cs
@@ -9,8 +9,9 @@ public class JsonOwnedBranch
     public decimal Fraction { get; set; }
 
     public JsonEnum Enum { get; set; }
-
     public JsonEnum? NullableEnum { get; set; }
+    public JsonEnum[] Enums { get; set; }
+    public JsonEnum?[] NullableEnums { get; set; }
 
     public JsonOwnedLeaf OwnedReferenceLeaf { get; set; }
     public List<JsonOwnedLeaf> OwnedCollectionLeaf { get; set; }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedRoot.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonOwnedRoot.cs
@@ -7,6 +7,8 @@ public class JsonOwnedRoot
 {
     public string Name { get; set; }
     public int Number { get; set; }
+    public string[] Names { get; set; }
+    public int[] Numbers { get; set; }
 
     public JsonOwnedBranch OwnedReferenceBranch { get; set; }
     public List<JsonOwnedBranch> OwnedCollectionBranch { get; set; }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.ObjectModel;
+
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
 public class JsonQueryData : ISetSource
@@ -48,6 +50,8 @@ public class JsonQueryData : ISetSource
             Fraction = 10.0M,
             Enum = JsonEnum.One,
             NullableEnum = null,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_r_r_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_r_r_c1, e1_r_r_c2 }
         };
@@ -71,6 +75,8 @@ public class JsonQueryData : ISetSource
             Fraction = 10.1M,
             Enum = JsonEnum.Two,
             NullableEnum = JsonEnum.One,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_r_c1_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_r_c1_c1, e1_r_c1_c2 }
         };
@@ -94,6 +100,8 @@ public class JsonQueryData : ISetSource
             Fraction = 10.2M,
             Enum = JsonEnum.Three,
             NullableEnum = JsonEnum.Two,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_r_c2_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_r_c2_c1, e1_r_c2_c2 }
         };
@@ -109,6 +117,8 @@ public class JsonQueryData : ISetSource
         {
             Name = "e1_r",
             Number = 10,
+            Names = new[] { "e1_r1", "e1_r2" },
+            Numbers = new[] { int.MinValue, -1, 0, 1, int.MaxValue },
             OwnedReferenceBranch = e1_r_r,
             OwnedCollectionBranch = new List<JsonOwnedBranch> { e1_r_c1, e1_r_c2 }
         };
@@ -129,6 +139,8 @@ public class JsonQueryData : ISetSource
             Fraction = 11.0M,
             Enum = JsonEnum.One,
             NullableEnum = null,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_c1_r_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_c1_r_c1, e1_c1_r_c2 }
         };
@@ -152,6 +164,8 @@ public class JsonQueryData : ISetSource
             Fraction = 11.1M,
             Enum = JsonEnum.Two,
             NullableEnum = JsonEnum.One,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_c1_c1_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_c1_c1_c1, e1_c1_c1_c2 }
         };
@@ -175,6 +189,8 @@ public class JsonQueryData : ISetSource
             Fraction = 11.2M,
             Enum = JsonEnum.Three,
             NullableEnum = JsonEnum.Two,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_c1_c2_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_c1_c2_c1, e1_c1_c2_c2 }
         };
@@ -190,6 +206,8 @@ public class JsonQueryData : ISetSource
         {
             Name = "e1_c1",
             Number = 11,
+            Names = new[] { "e1_c11", "e1_c12" },
+            Numbers = new[] { -1000, 0, 1000 },
             OwnedReferenceBranch = e1_c1_r,
             OwnedCollectionBranch = new List<JsonOwnedBranch> { e1_c1_c1, e1_c1_c2 }
         };
@@ -210,6 +228,8 @@ public class JsonQueryData : ISetSource
             Fraction = 12.0M,
             Enum = JsonEnum.Three,
             NullableEnum = JsonEnum.Two,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_c2_r_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_c2_r_c1, e1_c2_r_c2 }
         };
@@ -233,6 +253,8 @@ public class JsonQueryData : ISetSource
             Fraction = 12.1M,
             Enum = JsonEnum.Two,
             NullableEnum = JsonEnum.One,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_c2_c1_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_c2_c1_c1, e1_c2_c1_c2 }
         };
@@ -256,6 +278,8 @@ public class JsonQueryData : ISetSource
             Fraction = 12.2M,
             Enum = JsonEnum.One,
             NullableEnum = null,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = e1_c2_c2_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { e1_c2_c2_c1, e1_c2_c2_c2 }
         };
@@ -271,6 +295,8 @@ public class JsonQueryData : ISetSource
         {
             Name = "e1_c2",
             Number = 12,
+            Names = new[] { "e1_c21", "e1_c22" },
+            Numbers = new[] { -1001, 0, 1001 },
             OwnedReferenceBranch = e1_c2_r,
             OwnedCollectionBranch = new List<JsonOwnedBranch> { e1_c2_c1, e1_c2_c2 }
         };
@@ -487,6 +513,8 @@ public class JsonQueryData : ISetSource
             Fraction = 1.0M,
             Enum = JsonEnum.One,
             NullableEnum = null,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = b1_r_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { b1_r_c1, b1_r_c2 }
         };
@@ -503,6 +531,8 @@ public class JsonQueryData : ISetSource
             Fraction = 11.1M,
             Enum = JsonEnum.Three,
             NullableEnum = JsonEnum.Two,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = b1_c1_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { b1_c1_c1, b1_c1_c2 }
         };
@@ -519,6 +549,8 @@ public class JsonQueryData : ISetSource
             Fraction = 12.1M,
             Enum = JsonEnum.Two,
             NullableEnum = JsonEnum.One,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = b1_c2_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { b1_c2_c1, b1_c2_c2 }
         };
@@ -535,6 +567,8 @@ public class JsonQueryData : ISetSource
             Fraction = 2.0M,
             Enum = JsonEnum.Two,
             NullableEnum = JsonEnum.One,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = b2_r_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { b2_r_c1, b2_r_c2 }
         };
@@ -551,6 +585,8 @@ public class JsonQueryData : ISetSource
             Fraction = 21.1M,
             Enum = JsonEnum.Three,
             NullableEnum = JsonEnum.Two,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = b2_c1_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { b2_c1_c1, b2_c1_c2 }
         };
@@ -567,6 +603,8 @@ public class JsonQueryData : ISetSource
             Fraction = 22.1M,
             Enum = JsonEnum.One,
             NullableEnum = null,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = b2_c2_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { b2_c2_c1, b2_c2_c2 }
         };
@@ -583,6 +621,8 @@ public class JsonQueryData : ISetSource
             Fraction = 22.0M,
             Enum = JsonEnum.One,
             NullableEnum = null,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = d2_r_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { d2_r_c1, d2_r_c2 }
         };
@@ -599,6 +639,8 @@ public class JsonQueryData : ISetSource
             Fraction = 221.1M,
             Enum = JsonEnum.Two,
             NullableEnum = JsonEnum.One,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = d2_c1_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { d2_c1_c1, d2_c1_c2 }
         };
@@ -615,6 +657,8 @@ public class JsonQueryData : ISetSource
             Fraction = 222.1M,
             Enum = JsonEnum.Three,
             NullableEnum = JsonEnum.Two,
+            Enums = new[] { JsonEnum.One, (JsonEnum)(-1), JsonEnum.Two },
+            NullableEnums = new JsonEnum?[] { null, (JsonEnum)(-1), JsonEnum.Two },
             OwnedReferenceLeaf = d2_c2_r,
             OwnedCollectionLeaf = new List<JsonOwnedLeaf> { d2_c2_c1, d2_c2_c2 }
         };
@@ -677,10 +721,16 @@ public class JsonQueryData : ISetSource
                 "S3"
             },
             TestBooleanCollection = new[] { true, false },
-            TestCharacterCollection = new[] { 'A', 'B', '\"' },
+            TestCharacterCollection = new ObservableCollection<char>
+            {
+                'A',
+                'B',
+                '\"'
+            },
             TestDateTimeCollection = new List<DateTime> { DateTime.Parse("01/01/2000 12:34:56"), DateTime.Parse("01/01/3000 12:34:56") },
             TestDateTimeOffsetCollection = new[] { new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)) },
             TestDoubleCollection = new[] { -1.23456789, 1.23456789, 0.0 },
+            TestDecimalCollection = new[] { -1234567890.01M },
             TestGuidCollection = new List<Guid> { new("12345678-1234-4321-7777-987654321000") },
             TestInt16Collection = new[] { short.MinValue, (short)0, short.MaxValue },
             TestInt32Collection = new[] { int.MinValue, 0, int.MaxValue },
@@ -698,15 +748,20 @@ public class JsonQueryData : ISetSource
                 -1.234F
             },
             TestTimeSpanCollection = new[] { new TimeSpan(0, 10, 9, 8, 7), new TimeSpan(0, -10, 9, 8, 7) },
-            TestUnsignedInt16Collection = new[] { ushort.MinValue, (ushort)0, ushort.MaxValue },
+            TestUnsignedInt16Collection = new List<ushort>
+            {
+                ushort.MinValue,
+                0,
+                ushort.MaxValue
+            },
             TestUnsignedInt32Collection = new[] { uint.MinValue, (uint)0, uint.MaxValue },
-            TestUnsignedInt64Collection = new List<ulong>
+            TestUnsignedInt64Collection = new ObservableCollection<ulong>
             {
                 ulong.MinValue,
                 0,
                 ulong.MaxValue
             },
-            TestNullableInt32Collection = new List<int?>
+            TestNullableInt32Collection = new ObservableCollection<int?>
             {
                 null,
                 int.MinValue,
@@ -717,14 +772,14 @@ public class JsonQueryData : ISetSource
             },
             TestEnumCollection = new[] { JsonEnum.One, JsonEnum.Three, (JsonEnum)(-7) },
             TestEnumWithIntConverterCollection = new[] { JsonEnum.One, JsonEnum.Three, (JsonEnum)(-7) },
-            TestNullableEnumCollection = new List<JsonEnum?>
+            TestNullableEnumCollection = new Collection<JsonEnum?>
             {
                 JsonEnum.One,
                 null,
                 JsonEnum.Three,
                 (JsonEnum)(-7)
             },
-            TestNullableEnumWithIntConverterCollection = new List<JsonEnum?>
+            TestNullableEnumWithIntConverterCollection = new Collection<JsonEnum?>
             {
                 JsonEnum.One,
                 null,
@@ -769,10 +824,16 @@ public class JsonQueryData : ISetSource
                 "S3"
             },
             TestBooleanCollection = new[] { true, false },
-            TestCharacterCollection = new[] { 'A', 'B', '\"' },
+            TestCharacterCollection = new ObservableCollection<char>
+            {
+                'A',
+                'B',
+                '\"'
+            },
             TestDateTimeCollection = new List<DateTime> { DateTime.Parse("01/01/2000 12:34:56"), DateTime.Parse("01/01/3000 12:34:56") },
             TestDateTimeOffsetCollection = new[] { new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)) },
             TestDoubleCollection = new[] { -1.23456789, 1.23456789, 0.0 },
+            TestDecimalCollection = new[] { -1234567890.01M },
             TestGuidCollection = new List<Guid> { new("12345678-1234-4321-7777-987654321000") },
             TestInt16Collection = new[] { short.MinValue, (short)0, short.MaxValue },
             TestInt32Collection = new[] { int.MinValue, 0, int.MaxValue },
@@ -792,13 +853,13 @@ public class JsonQueryData : ISetSource
             TestTimeSpanCollection = new[] { new TimeSpan(0, 10, 9, 8, 7), new TimeSpan(0, -10, 9, 8, 7) },
             TestUnsignedInt16Collection = new[] { ushort.MinValue, (ushort)0, ushort.MaxValue },
             TestUnsignedInt32Collection = new[] { uint.MinValue, (uint)0, uint.MaxValue },
-            TestUnsignedInt64Collection = new List<ulong>
+            TestUnsignedInt64Collection = new ObservableCollection<ulong>
             {
                 ulong.MinValue,
                 0,
                 ulong.MaxValue
             },
-            TestNullableInt32Collection = new List<int?>
+            TestNullableInt32Collection = new ObservableCollection<int?>
             {
                 null,
                 int.MinValue,
@@ -809,14 +870,14 @@ public class JsonQueryData : ISetSource
             },
             TestEnumCollection = new[] { JsonEnum.One, JsonEnum.Three, (JsonEnum)(-7) },
             TestEnumWithIntConverterCollection = new[] { JsonEnum.One, JsonEnum.Three, (JsonEnum)(-7) },
-            TestNullableEnumCollection = new List<JsonEnum?>
+            TestNullableEnumCollection = new Collection<JsonEnum?>
             {
                 JsonEnum.One,
                 null,
                 JsonEnum.Three,
                 (JsonEnum)(-7)
             },
-            TestNullableEnumWithIntConverterCollection = new List<JsonEnum?>
+            TestNullableEnumWithIntConverterCollection = new Collection<JsonEnum?>
             {
                 JsonEnum.One,
                 null,
@@ -861,10 +922,16 @@ public class JsonQueryData : ISetSource
                 "S3"
             },
             TestBooleanCollection = new[] { true, false },
-            TestCharacterCollection = new[] { 'A', 'B', '\"' },
+            TestCharacterCollection = new ObservableCollection<char>
+            {
+                'A',
+                'B',
+                '\"'
+            },
             TestDateTimeCollection = new List<DateTime> { DateTime.Parse("01/01/2000 12:34:56"), DateTime.Parse("01/01/3000 12:34:56") },
             TestDateTimeOffsetCollection = new[] { new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)) },
             TestDoubleCollection = new[] { -1.23456789, 1.23456789, 0.0 },
+            TestDecimalCollection = new[] { -1234567890.01M },
             TestGuidCollection = new List<Guid> { new("12345678-1234-4321-7777-987654321000") },
             TestInt16Collection = new[] { short.MinValue, (short)0, short.MaxValue },
             TestInt32Collection = new[] { int.MinValue, 0, int.MaxValue },
@@ -884,13 +951,13 @@ public class JsonQueryData : ISetSource
             TestTimeSpanCollection = new[] { new TimeSpan(0, 10, 9, 8, 7), new TimeSpan(0, -10, 9, 8, 7) },
             TestUnsignedInt16Collection = new[] { ushort.MinValue, (ushort)0, ushort.MaxValue },
             TestUnsignedInt32Collection = new[] { uint.MinValue, (uint)0, uint.MaxValue },
-            TestUnsignedInt64Collection = new List<ulong>
+            TestUnsignedInt64Collection = new ObservableCollection<ulong>
             {
                 ulong.MinValue,
                 0,
                 ulong.MaxValue
             },
-            TestNullableInt32Collection = new List<int?>
+            TestNullableInt32Collection = new ObservableCollection<int?>
             {
                 null,
                 int.MinValue,
@@ -901,14 +968,14 @@ public class JsonQueryData : ISetSource
             },
             TestEnumCollection = new[] { JsonEnum.One, JsonEnum.Three, (JsonEnum)(-7) },
             TestEnumWithIntConverterCollection = new[] { JsonEnum.One, JsonEnum.Three, (JsonEnum)(-7) },
-            TestNullableEnumCollection = new List<JsonEnum?>
+            TestNullableEnumCollection = new ObservableCollection<JsonEnum?>
             {
                 JsonEnum.One,
                 null,
                 JsonEnum.Three,
                 (JsonEnum)(-7)
             },
-            TestNullableEnumWithIntConverterCollection = new List<JsonEnum?>
+            TestNullableEnumWithIntConverterCollection = new ObservableCollection<JsonEnum?>
             {
                 JsonEnum.One,
                 null,
@@ -953,10 +1020,16 @@ public class JsonQueryData : ISetSource
                 "S3"
             },
             TestBooleanCollection = new[] { true, false },
-            TestCharacterCollection = new[] { 'A', 'B', '\"' },
+            TestCharacterCollection = new ObservableCollection<char>
+            {
+                'A',
+                'B',
+                '\"'
+            },
             TestDateTimeCollection = new List<DateTime> { DateTime.Parse("01/01/2000 12:34:56"), DateTime.Parse("01/01/3000 12:34:56") },
             TestDateTimeOffsetCollection = new[] { new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)) },
             TestDoubleCollection = new[] { -1.23456789, 1.23456789, 0.0 },
+            TestDecimalCollection = new[] { -1234567890.01M },
             TestGuidCollection = new List<Guid> { new("12345678-1234-4321-7777-987654321000") },
             TestInt16Collection = new[] { short.MinValue, (short)0, short.MaxValue },
             TestInt32Collection = new[] { int.MinValue, 0, int.MaxValue },
@@ -976,13 +1049,13 @@ public class JsonQueryData : ISetSource
             TestTimeSpanCollection = new[] { new TimeSpan(0, 10, 9, 8, 7), new TimeSpan(0, -10, 9, 8, 7) },
             TestUnsignedInt16Collection = new[] { ushort.MinValue, (ushort)0, ushort.MaxValue },
             TestUnsignedInt32Collection = new[] { uint.MinValue, (uint)0, uint.MaxValue },
-            TestUnsignedInt64Collection = new List<ulong>
+            TestUnsignedInt64Collection = new ObservableCollection<ulong>
             {
                 ulong.MinValue,
                 0,
                 ulong.MaxValue
             },
-            TestNullableInt32Collection = new List<int?>
+            TestNullableInt32Collection = new ObservableCollection<int?>
             {
                 null,
                 int.MinValue,
@@ -993,14 +1066,14 @@ public class JsonQueryData : ISetSource
             },
             TestEnumCollection = new[] { JsonEnum.One, JsonEnum.Three, (JsonEnum)(-7) },
             TestEnumWithIntConverterCollection = new[] { JsonEnum.One, JsonEnum.Three, (JsonEnum)(-7) },
-            TestNullableEnumCollection = new List<JsonEnum?>
+            TestNullableEnumCollection = new ObservableCollection<JsonEnum?>
             {
                 JsonEnum.One,
                 null,
                 JsonEnum.Three,
                 (JsonEnum)(-7)
             },
-            TestNullableEnumWithIntConverterCollection = new List<JsonEnum?>
+            TestNullableEnumWithIntConverterCollection = new ObservableCollection<JsonEnum?>
             {
                 JsonEnum.One,
                 null,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
@@ -21,7 +20,7 @@ public class JsonQuerySqlServerTest : JsonQueryTestBase<JsonQuerySqlServerFixtur
         await base.Basic_json_projection_owner_entity(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -32,7 +31,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_owner_entity_NoTracking(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -43,7 +42,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_owner_entity_duplicated(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -54,7 +53,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_owner_entity_duplicated_NoTracking(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Name], [j].[OwnedCollection], [j].[OwnedCollection]
 FROM [JsonEntitiesSingleOwned] AS [j]
 """);
@@ -65,7 +64,7 @@ FROM [JsonEntitiesSingleOwned] AS [j]
         await base.Basic_json_projection_owned_reference_root(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[OwnedReferenceRoot], [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -76,7 +75,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_owned_reference_duplicated2(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf')
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
@@ -88,7 +87,7 @@ ORDER BY [j].[Id]
         await base.Basic_json_projection_owned_reference_duplicated(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch')
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
@@ -100,7 +99,7 @@ ORDER BY [j].[Id]
         await base.Basic_json_projection_owned_collection_root(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[OwnedCollectionRoot], [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -111,7 +110,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_owned_reference_branch(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -122,7 +121,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_owned_collection_branch(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -133,7 +132,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_owned_reference_leaf(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -144,7 +143,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_owned_collection_leaf(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -155,7 +154,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Basic_json_projection_scalar(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_VALUE([j].[OwnedReferenceRoot], '$.Name')
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -166,7 +165,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_scalar_length(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Name]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE CAST(LEN(JSON_VALUE([j].[OwnedReferenceRoot], '$.Name')) AS int) > 2
@@ -178,7 +177,7 @@ WHERE CAST(LEN(JSON_VALUE([j].[OwnedReferenceRoot], '$.Name')) AS int) > 2
         await base.Basic_json_projection_enum_inside_json_entity(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Enum') AS [Enum]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -189,7 +188,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_projection_enum_with_custom_conversion(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomEnum') AS int) AS [Enum]
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
@@ -200,7 +199,7 @@ FROM [JsonEntitiesCustomNaming] AS [j]
         await base.Json_projection_with_deduplication(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething')
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -211,7 +210,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_projection_with_deduplication_reverse_order(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id], [j].[OwnedReferenceRoot], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -222,7 +221,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_property_in_predicate(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Fraction') AS decimal(18,2)) < 20.5
@@ -234,7 +233,7 @@ WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Fraction
         await base.Json_subquery_property_pushdown_length(async);
 
         AssertSql(
-"""
+            """
 @__p_0='3'
 
 SELECT CAST(LEN([t0].[c]) AS int)
@@ -254,7 +253,7 @@ FROM (
         await base.Json_subquery_reference_pushdown_reference(async);
 
         AssertSql(
-"""
+            """
 @__p_0='10'
 
 SELECT JSON_QUERY([t0].[c], '$.OwnedReferenceBranch'), [t0].[Id]
@@ -274,7 +273,7 @@ FROM (
         await base.Json_subquery_reference_pushdown_reference_anonymous_projection(async);
 
         AssertSql(
-"""
+            """
 @__p_0='10'
 
 SELECT JSON_QUERY([t0].[c], '$.OwnedReferenceSharedBranch'), [t0].[Id], CAST(LEN([t0].[c0]) AS int)
@@ -294,7 +293,7 @@ FROM (
         await base.Json_subquery_reference_pushdown_reference_pushdown_anonymous_projection(async);
 
         AssertSql(
-"""
+            """
 @__p_0='10'
 
 SELECT JSON_QUERY([t2].[c],'$.OwnedReferenceSharedLeaf'), [t2].[Id], JSON_QUERY([t2].[c], '$.OwnedCollectionSharedLeaf'), [t2].[Length]
@@ -321,7 +320,7 @@ FROM (
         await base.Json_subquery_reference_pushdown_reference_pushdown_reference(async);
 
         AssertSql(
-"""
+            """
 @__p_0='10'
 
 SELECT JSON_QUERY([t2].[c], '$.OwnedReferenceLeaf'), [t2].[Id]
@@ -348,7 +347,7 @@ FROM (
         await base.Json_subquery_reference_pushdown_reference_pushdown_collection(async);
 
         AssertSql(
-"""
+            """
 @__p_0='10'
 
 SELECT JSON_QUERY([t2].[c], '$.OwnedCollectionLeaf'), [t2].[Id]
@@ -375,7 +374,7 @@ FROM (
         await base.Json_subquery_reference_pushdown_property(async);
 
         AssertSql(
-"""
+            """
 @__p_0='10'
 
 SELECT JSON_VALUE([t0].[c], '$.SomethingSomething')
@@ -395,7 +394,7 @@ FROM (
         await base.Custom_naming_projection_owner_entity(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Title], [j].[json_collection_custom_naming], [j].[json_reference_custom_naming]
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
@@ -406,7 +405,7 @@ FROM [JsonEntitiesCustomNaming] AS [j]
         await base.Custom_naming_projection_owned_reference(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch'), [j].[Id]
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
@@ -417,7 +416,7 @@ FROM [JsonEntitiesCustomNaming] AS [j]
         await base.Custom_naming_projection_owned_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[json_collection_custom_naming], [j].[Id]
 FROM [JsonEntitiesCustomNaming] AS [j]
 ORDER BY [j].[Id]
@@ -429,7 +428,7 @@ ORDER BY [j].[Id]
         await base.Custom_naming_projection_owned_scalar(async);
 
         AssertSql(
-"""
+            """
 SELECT CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch.CustomFraction') AS float)
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
@@ -440,7 +439,7 @@ FROM [JsonEntitiesCustomNaming] AS [j]
         await base.Custom_naming_projection_everything(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Title], [j].[json_collection_custom_naming], [j].[json_reference_custom_naming], [j].[json_reference_custom_naming], JSON_QUERY([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch'), [j].[json_collection_custom_naming], JSON_QUERY([j].[json_reference_custom_naming], '$.CustomOwnedCollectionBranch'), JSON_VALUE([j].[json_reference_custom_naming], '$.CustomName'), CAST(JSON_VALUE([j].[json_reference_custom_naming], '$.CustomOwnedReferenceBranch.CustomFraction') AS float)
 FROM [JsonEntitiesCustomNaming] AS [j]
 """);
@@ -451,7 +450,7 @@ FROM [JsonEntitiesCustomNaming] AS [j]
         await base.Project_entity_with_single_owned(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Name], [j].[OwnedCollection]
 FROM [JsonEntitiesSingleOwned] AS [j]
 """);
@@ -462,7 +461,7 @@ FROM [JsonEntitiesSingleOwned] AS [j]
         await base.Left_join_json_entities(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Name], [j].[OwnedCollection], [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot], [j0].[OwnedReferenceRoot]
 FROM [JsonEntitiesSingleOwned] AS [j]
 LEFT JOIN [JsonEntitiesBasic] AS [j0] ON [j].[Id] = [j0].[Id]
@@ -474,7 +473,7 @@ LEFT JOIN [JsonEntitiesBasic] AS [j0] ON [j].[Id] = [j0].[Id]
         await base.Left_join_json_entities_complex_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j0].[Id], [j0].[EntityBasicId], [j0].[Name], [j0].[OwnedCollectionRoot], [j0].[OwnedReferenceRoot], [j0].[OwnedReferenceRoot], JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf')
 FROM [JsonEntitiesSingleOwned] AS [j]
 LEFT JOIN [JsonEntitiesBasic] AS [j0] ON [j].[Id] = [j0].[Id]
@@ -486,7 +485,7 @@ LEFT JOIN [JsonEntitiesBasic] AS [j0] ON [j].[Id] = [j0].[Id]
         await base.Left_join_json_entities_json_being_inner(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j0].[Id], [j0].[Name], [j0].[OwnedCollection]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
@@ -498,7 +497,7 @@ LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
         await base.Left_join_json_entities_complex_projection_json_being_inner(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j0].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), [j0].[Name], [j0].[OwnedCollection]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
@@ -510,7 +509,7 @@ LEFT JOIN [JsonEntitiesSingleOwned] AS [j0] ON [j].[Id] = [j0].[Id]
         await base.Project_json_entity_FirstOrDefault_subquery(async);
 
         AssertSql(
-"""
+            """
 SELECT [t].[c], [t].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 OUTER APPLY (
@@ -527,7 +526,7 @@ ORDER BY [j].[Id]
         await base.Project_json_entity_FirstOrDefault_subquery_with_binding_on_top(async);
 
         AssertSql(
-"""
+            """
 SELECT (
     SELECT TOP(1) CAST(JSON_VALUE([j0].[OwnedReferenceRoot], '$.OwnedReferenceBranch.Date') AS datetime2)
     FROM [JsonEntitiesBasic] AS [j0]
@@ -550,7 +549,7 @@ ORDER BY [j].[Id]
         await base.Project_json_entity_FirstOrDefault_subquery_deduplication(async);
 
         AssertSql(
-"""
+            """
 SELECT [t].[c], [t].[Id], [t].[c0], [t].[Id0], [t].[c1], [t].[c2], [t].[c3], [t].[c4]
 FROM [JsonEntitiesBasic] AS [j]
 OUTER APPLY (
@@ -567,7 +566,7 @@ ORDER BY [j].[Id]
         await base.Project_json_entity_FirstOrDefault_subquery_deduplication_and_outer_reference(async);
 
         AssertSql(
-"""
+            """
 SELECT [t].[c], [t].[Id], [t].[c0], [t].[Id0], [t].[c1], [t].[c2], [t].[c3], [t].[c4]
 FROM [JsonEntitiesBasic] AS [j]
 OUTER APPLY (
@@ -584,7 +583,7 @@ ORDER BY [j].[Id]
         await base.Project_json_entity_FirstOrDefault_subquery_deduplication_outer_reference_and_pruning(async);
 
         AssertSql(
-"""
+            """
 SELECT [t].[c], [t].[Id], [t].[c0]
 FROM [JsonEntitiesBasic] AS [j]
 OUTER APPLY (
@@ -601,7 +600,7 @@ ORDER BY [j].[Id]
         await base.Json_entity_with_inheritance_basic_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Discriminator], [j].[Name], [j].[Fraction], [j].[CollectionOnBase], [j].[ReferenceOnBase], [j].[CollectionOnDerived], [j].[ReferenceOnDerived]
 FROM [JsonEntitiesInheritance] AS [j]
 """);
@@ -612,7 +611,7 @@ FROM [JsonEntitiesInheritance] AS [j]
         await base.Json_entity_with_inheritance_project_derived(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Discriminator], [j].[Name], [j].[Fraction], [j].[CollectionOnBase], [j].[ReferenceOnBase], [j].[CollectionOnDerived], [j].[ReferenceOnDerived]
 FROM [JsonEntitiesInheritance] AS [j]
 WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
@@ -624,7 +623,7 @@ WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
         await base.Json_entity_with_inheritance_project_navigations(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[ReferenceOnBase], [j].[CollectionOnBase]
 FROM [JsonEntitiesInheritance] AS [j]
 """);
@@ -635,7 +634,7 @@ FROM [JsonEntitiesInheritance] AS [j]
         await base.Json_entity_with_inheritance_project_navigations_on_derived(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Discriminator], [j].[Name], [j].[Fraction], [j].[CollectionOnBase], [j].[ReferenceOnBase], [j].[CollectionOnDerived], [j].[ReferenceOnDerived], [j].[ReferenceOnBase], [j].[ReferenceOnDerived], [j].[CollectionOnBase], [j].[CollectionOnDerived]
 FROM [JsonEntitiesInheritance] AS [j]
 WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
@@ -655,7 +654,7 @@ WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
         await base.Json_collection_element_access_in_projection_basic(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -666,7 +665,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_using_ElementAt(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -677,7 +676,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_using_ElementAtOrDefault(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -688,7 +687,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_project_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -699,7 +698,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_using_ElementAt_project_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -710,7 +709,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_using_ElementAtOrDefault_project_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -722,7 +721,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_using_parameter(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='0'
 
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
@@ -736,7 +735,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_using_column(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + ']'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -761,7 +760,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_outside_bounds(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[25]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -772,7 +771,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_outside_bounds2(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[25]'), [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -783,7 +782,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_outside_bounds_with_property_access(async);
 
         AssertSql(
-"""
+            """
 SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[25].Number') AS int)
 FROM [JsonEntitiesBasic] AS [j]
 ORDER BY [j].[Id]
@@ -796,7 +795,7 @@ ORDER BY [j].[Id]
         await base.Json_collection_element_access_in_projection_nested(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0
@@ -810,7 +809,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_nested_project_scalar(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].Date') AS datetime2)
@@ -824,7 +823,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_nested_project_reference(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceLeaf'), [j].[Id], @__prm_0
@@ -838,7 +837,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_nested_project_collection(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), [j].[Id], @__prm_0
@@ -853,7 +852,7 @@ ORDER BY [j].[Id]
         await base.Json_collection_element_access_in_projection_nested_project_collection_anonymous_projection(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionLeaf'), @__prm_0
@@ -866,7 +865,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_predicate_using_constant(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') <> N'Foo' OR JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') IS NULL
@@ -879,7 +878,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') <> N'Foo' OR JSON_VALUE
         await base.Json_collection_element_access_in_predicate_using_variable(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT [j].[Id]
@@ -894,7 +893,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max
         await base.Json_collection_element_access_in_predicate_using_column(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].Name') = N'e1_c2'
@@ -907,7 +906,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max
         await base.Json_collection_element_access_in_predicate_using_complex_expression1(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST(CASE
@@ -923,7 +922,7 @@ END AS nvarchar(max)) + '].Name') = N'e1_c1'
         await base.Json_collection_element_access_in_predicate_using_complex_expression2(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST((
@@ -937,7 +936,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[' + CAST((
         await base.Json_collection_element_access_in_predicate_using_ElementAt(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].Name') <> N'Foo' OR JSON_VALUE([j].[OwnedCollectionRoot], '$[1].Name') IS NULL
@@ -950,7 +949,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].Name') <> N'Foo' OR JSON_VALUE
         await base.Json_collection_element_access_in_predicate_nested_mix(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='0'
 
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
@@ -964,7 +963,7 @@ WHERE JSON_VALUE([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST
         await base.Json_collection_element_access_manual_Element_at_and_pushdown(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], CAST(JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Number') AS int) AS [CollectionElement]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -1017,7 +1016,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_projection_deduplication_with_collection_indexer_in_original(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[0]'), JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedReferenceBranch.OwnedCollectionLeaf')
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -1029,7 +1028,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_projection_deduplication_with_collection_indexer_in_target(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT [j].[Id], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[1]'), [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
@@ -1043,7 +1042,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_projection_deduplication_with_collection_in_original_and_collection_indexer_in_target(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0].OwnedCollectionLeaf[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), [j].[Id], @__prm_0, JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch[0]')
@@ -1056,7 +1055,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_using_constant_when_owner_is_present(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[1]')
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -1068,7 +1067,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_using_parameter_when_owner_is_present(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
@@ -1076,24 +1075,26 @@ FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
-    public override async Task Json_collection_after_collection_element_access_in_projection_using_constant_when_owner_is_present(bool async)
+    public override async Task Json_collection_after_collection_element_access_in_projection_using_constant_when_owner_is_present(
+        bool async)
     {
         await base.Json_collection_after_collection_element_access_in_projection_using_constant_when_owner_is_present(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch')
 FROM [JsonEntitiesBasic] AS [j]
 """);
     }
 
     [SqlServerCondition(SqlServerCondition.SupportsJsonPathExpressions)]
-    public override async Task Json_collection_after_collection_element_access_in_projection_using_parameter_when_owner_is_present(bool async)
+    public override async Task Json_collection_after_collection_element_access_in_projection_using_parameter_when_owner_is_present(
+        bool async)
     {
         await base.Json_collection_after_collection_element_access_in_projection_using_parameter_when_owner_is_present(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch'), @__prm_0
@@ -1107,7 +1108,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_when_owner_is_present_misc1(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[' + CAST(@__prm_0 AS nvarchar(max)) + ']'), @__prm_0
@@ -1120,7 +1121,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_when_owner_is_present_misc2(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[1]')
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -1132,7 +1133,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_collection_element_access_in_projection_when_owner_is_present_multiple(async);
 
         AssertSql(
-"""
+            """
 @__prm_0='1'
 
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[1]'), @__prm_0, JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST(@__prm_0 AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[1].OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[' + CAST([j].[Id] AS nvarchar(max)) + '].OwnedCollectionBranch[' + CAST([j].[Id] AS nvarchar(max)) + ']')
@@ -1145,7 +1146,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_scalar_required_null_semantics(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Name]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.Number') AS int) <> CAST(LEN(JSON_VALUE([j].[OwnedReferenceRoot], '$.Name')) AS int) OR JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') IS NULL
@@ -1157,7 +1158,7 @@ WHERE CAST(JSON_VALUE([j].[OwnedReferenceRoot], '$.Number') AS int) <> CAST(LEN(
         await base.Json_scalar_optional_null_semantics(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Name]
 FROM [JsonEntitiesBasic] AS [j]
 WHERE JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') = JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') OR (JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') IS NULL AND JSON_VALUE([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething') IS NULL)
@@ -1169,7 +1170,7 @@ WHERE JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') = JSON_VALUE([j].[OwnedRefe
         await base.Group_by_on_json_scalar(async);
 
         AssertSql(
-"""
+            """
 SELECT [t].[Key], COUNT(*) AS [Count]
 FROM (
     SELECT JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') AS [Key]
@@ -1184,7 +1185,7 @@ GROUP BY [t].[Key]
         await base.Group_by_on_json_scalar_using_collection_indexer(async);
 
         AssertSql(
-"""
+            """
 SELECT [t].[Key], COUNT(*) AS [Count]
 FROM (
     SELECT JSON_VALUE([j].[OwnedCollectionRoot], '$[0].Name') AS [Key]
@@ -1199,7 +1200,7 @@ GROUP BY [t].[Key]
         await base.Group_by_First_on_json_scalar(async);
 
         AssertSql(
-"""
+            """
 SELECT [t1].[Id], [t1].[EntityBasicId], [t1].[Name], [t1].[c], [t1].[c0]
 FROM (
     SELECT [t].[Key]
@@ -1228,7 +1229,7 @@ LEFT JOIN (
         await base.Group_by_FirstOrDefault_on_json_scalar(async);
 
         AssertSql(
-"""
+            """
 SELECT [t1].[Id], [t1].[EntityBasicId], [t1].[Name], [t1].[c], [t1].[c0]
 FROM (
     SELECT [t].[Key]
@@ -1257,7 +1258,7 @@ LEFT JOIN (
         await base.Group_by_Skip_Take_on_json_scalar(async);
 
         AssertSql(
-"""
+            """
 SELECT [t0].[Key], [t1].[Id], [t1].[EntityBasicId], [t1].[Name], [t1].[c], [t1].[c0]
 FROM (
     SELECT [t].[Key]
@@ -1295,7 +1296,7 @@ ORDER BY [t0].[Key], [t1].[Key], [t1].[Id]
         await base.Group_by_json_scalar_Skip_First_project_json_scalar(async);
 
         AssertSql(
-"""
+            """
 SELECT (
     SELECT TOP(1) JSON_VALUE([t0].[c0], '$.OwnedReferenceBranch.Enum')
     FROM (
@@ -1316,7 +1317,7 @@ GROUP BY [t].[Key]
         await base.Json_with_include_on_json_entity(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [JsonEntitiesBasic] AS [j]
 """);
@@ -1327,7 +1328,7 @@ FROM [JsonEntitiesBasic] AS [j]
         await base.Json_with_include_on_entity_reference(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j0].[Id], [j0].[Name], [j0].[ParentId]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForReference] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1339,7 +1340,7 @@ LEFT JOIN [JsonEntitiesBasicForReference] AS [j0] ON [j].[Id] = [j0].[ParentId]
         await base.Json_with_include_on_entity_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j0].[Id], [j0].[Name], [j0].[ParentId]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1352,7 +1353,7 @@ ORDER BY [j].[Id]
         await base.Entity_including_collection_with_json(async);
 
         AssertSql(
-"""
+            """
 SELECT [e].[Id], [e].[Name], [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
 FROM [EntitiesBasic] AS [e]
 LEFT JOIN [JsonEntitiesBasic] AS [j] ON [e].[Id] = [j].[EntityBasicId]
@@ -1365,7 +1366,7 @@ ORDER BY [e].[Id]
         await base.Json_with_include_on_entity_collection_and_reference(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot], [j0].[Id], [j0].[Name], [j0].[ParentId], [j1].[Id], [j1].[Name], [j1].[ParentId]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForReference] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1379,7 +1380,7 @@ ORDER BY [j].[Id], [j0].[Id]
         await base.Json_with_projection_of_json_reference_leaf_and_entity_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j].[Id], [j0].[Id], [j0].[Name], [j0].[ParentId]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1392,7 +1393,7 @@ ORDER BY [j].[Id]
         await base.Json_with_projection_of_json_reference_and_entity_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[OwnedReferenceRoot], [j].[Id], [j0].[Id], [j0].[Name], [j0].[ParentId]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1405,7 +1406,7 @@ ORDER BY [j].[Id]
         await base.Json_with_projection_of_multiple_json_references_and_entity_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[OwnedReferenceRoot], [j].[Id], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedReferenceBranch'), [j0].[Id], [j0].[Name], [j0].[ParentId], JSON_QUERY([j].[OwnedCollectionRoot], '$[1].OwnedReferenceBranch.OwnedReferenceLeaf'), JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch[0].OwnedReferenceLeaf')
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1418,7 +1419,7 @@ ORDER BY [j].[Id]
         await base.Json_with_projection_of_json_collection_leaf_and_entity_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), [j].[Id], [j0].[Id], [j0].[Name], [j0].[ParentId]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1431,7 +1432,7 @@ ORDER BY [j].[Id]
         await base.Json_with_projection_of_json_collection_and_entity_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[OwnedCollectionRoot], [j].[Id], [j0].[Id], [j0].[Name], [j0].[ParentId]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1444,7 +1445,7 @@ ORDER BY [j].[Id]
         await base.Json_with_projection_of_json_collection_element_and_entity_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedCollectionRoot], '$[0]'), [j].[Id], [j0].[Id], [j0].[Name], [j0].[ParentId], [j1].[Id], [j1].[Name], [j1].[ParentId]
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForReference] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1458,7 +1459,7 @@ ORDER BY [j].[Id], [j0].[Id]
         await base.Json_with_projection_of_mix_of_json_collections_json_references_and_entity_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf'), [j].[Id], [j0].[Id], [j0].[Name], [j0].[ParentId], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedReferenceLeaf'), [j1].[Id], [j1].[Name], [j1].[ParentId], JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedReferenceBranch.OwnedCollectionLeaf[0]'), JSON_QUERY([j].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [j].[OwnedCollectionRoot], JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedReferenceBranch'), JSON_QUERY([j].[OwnedCollectionRoot], '$[0].OwnedCollectionBranch')
 FROM [JsonEntitiesBasic] AS [j]
 LEFT JOIN [JsonEntitiesBasicForReference] AS [j0] ON [j].[Id] = [j0].[ParentId]
@@ -1481,7 +1482,7 @@ ORDER BY [j].[Id], [j0].[Id]
         await base.Json_all_types_entity_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 """);
@@ -1492,7 +1493,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
         await base.Json_all_types_projection_from_owned_entity_reference(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Reference], [j].[Id]
 FROM [JsonEntitiesAllTypes] AS [j]
 """);
@@ -1503,7 +1504,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
         await base.Json_all_types_projection_individual_properties(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_VALUE([j].[Reference], '$.TestDefaultString') AS [TestDefaultString], JSON_VALUE([j].[Reference], '$.TestMaxLengthString') AS [TestMaxLengthString], CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) AS [TestBoolean], CAST(JSON_VALUE([j].[Reference], '$.TestByte') AS tinyint) AS [TestByte], JSON_VALUE([j].[Reference], '$.TestCharacter') AS [TestCharacter], CAST(JSON_VALUE([j].[Reference], '$.TestDateTime') AS datetime2) AS [TestDateTime], CAST(JSON_VALUE([j].[Reference], '$.TestDateTimeOffset') AS datetimeoffset) AS [TestDateTimeOffset], CAST(JSON_VALUE([j].[Reference], '$.TestDecimal') AS decimal(18,3)) AS [TestDecimal], CAST(JSON_VALUE([j].[Reference], '$.TestDouble') AS float) AS [TestDouble], CAST(JSON_VALUE([j].[Reference], '$.TestGuid') AS uniqueidentifier) AS [TestGuid], CAST(JSON_VALUE([j].[Reference], '$.TestInt16') AS smallint) AS [TestInt16], CAST(JSON_VALUE([j].[Reference], '$.TestInt32') AS int) AS [TestInt32], CAST(JSON_VALUE([j].[Reference], '$.TestInt64') AS bigint) AS [TestInt64], CAST(JSON_VALUE([j].[Reference], '$.TestSignedByte') AS smallint) AS [TestSignedByte], CAST(JSON_VALUE([j].[Reference], '$.TestSingle') AS real) AS [TestSingle], CAST(JSON_VALUE([j].[Reference], '$.TestTimeSpan') AS time) AS [TestTimeSpan], CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt16') AS int) AS [TestUnsignedInt16], CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt32') AS bigint) AS [TestUnsignedInt32], CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt64') AS decimal(20,0)) AS [TestUnsignedInt64], JSON_VALUE([j].[Reference], '$.TestEnum') AS [TestEnum], CAST(JSON_VALUE([j].[Reference], '$.TestEnumWithIntConverter') AS int) AS [TestEnumWithIntConverter], JSON_VALUE([j].[Reference], '$.TestNullableEnum') AS [TestNullableEnum], CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS int) AS [TestNullableEnumWithIntConverter], JSON_VALUE([j].[Reference], '$.TestNullableEnumWithConverterThatHandlesNulls') AS [TestNullableEnumWithConverterThatHandlesNulls]
 FROM [JsonEntitiesAllTypes] AS [j]
 """);
@@ -1514,7 +1515,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
         await base.Json_boolean_predicate(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(1 AS bit)
@@ -1526,7 +1527,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(1 AS bit)
         await base.Json_boolean_predicate_negated(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(0 AS bit)
@@ -1538,7 +1539,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(0 AS bit)
         await base.Json_boolean_projection(async);
 
         AssertSql(
-"""
+            """
 SELECT CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit)
 FROM [JsonEntitiesAllTypes] AS [j]
 """);
@@ -1549,7 +1550,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
         await base.Json_boolean_projection_negated(async);
 
         AssertSql(
-"""
+            """
 SELECT CASE
     WHEN CAST(JSON_VALUE([j].[Reference], '$.TestBoolean') AS bit) = CAST(0 AS bit) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
@@ -1563,7 +1564,7 @@ FROM [JsonEntitiesAllTypes] AS [j]
         await base.Json_predicate_on_default_string(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.TestDefaultString') <> N'MyDefaultStringInReference1' OR JSON_VALUE([j].[Reference], '$.TestDefaultString') IS NULL
@@ -1575,7 +1576,7 @@ WHERE JSON_VALUE([j].[Reference], '$.TestDefaultString') <> N'MyDefaultStringInR
         await base.Json_predicate_on_max_length_string(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.TestMaxLengthString') <> N'Foo' OR JSON_VALUE([j].[Reference], '$.TestMaxLengthString') IS NULL
@@ -1587,7 +1588,7 @@ WHERE JSON_VALUE([j].[Reference], '$.TestMaxLengthString') <> N'Foo' OR JSON_VAL
         await base.Json_predicate_on_string_condition(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CASE
@@ -1602,7 +1603,7 @@ END = N'MyDefaultStringInReference1'
         await base.Json_predicate_on_byte(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestByte') AS tinyint) <> CAST(3 AS tinyint) OR CAST(JSON_VALUE([j].[Reference], '$.TestByte') AS tinyint) IS NULL
@@ -1614,7 +1615,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestByte') AS tinyint) <> CAST(3 AS ti
         await base.Json_predicate_on_character(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.TestCharacter') <> N'z' OR JSON_VALUE([j].[Reference], '$.TestCharacter') IS NULL
@@ -1626,7 +1627,7 @@ WHERE JSON_VALUE([j].[Reference], '$.TestCharacter') <> N'z' OR JSON_VALUE([j].[
         await base.Json_predicate_on_datetime(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDateTime') AS datetime2) <> '2000-01-03T00:00:00.0000000' OR CAST(JSON_VALUE([j].[Reference], '$.TestDateTime') AS datetime2) IS NULL
@@ -1638,7 +1639,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDateTime') AS datetime2) <> '2000-
         await base.Json_predicate_on_datetimeoffset(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDateTimeOffset') AS datetimeoffset) <> '2000-01-04T00:00:00.0000000+03:02' OR CAST(JSON_VALUE([j].[Reference], '$.TestDateTimeOffset') AS datetimeoffset) IS NULL
@@ -1650,7 +1651,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDateTimeOffset') AS datetimeoffset
         await base.Json_predicate_on_decimal(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDecimal') AS decimal(18,3)) <> 1.35 OR CAST(JSON_VALUE([j].[Reference], '$.TestDecimal') AS decimal(18,3)) IS NULL
@@ -1662,7 +1663,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDecimal') AS decimal(18,3)) <> 1.3
         await base.Json_predicate_on_double(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDouble') AS float) <> 33.25E0 OR CAST(JSON_VALUE([j].[Reference], '$.TestDouble') AS float) IS NULL
@@ -1674,7 +1675,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestDouble') AS float) <> 33.25E0 OR C
         await base.Json_predicate_on_enum(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.TestEnum') <> N'Two' OR JSON_VALUE([j].[Reference], '$.TestEnum') IS NULL
@@ -1686,7 +1687,7 @@ WHERE JSON_VALUE([j].[Reference], '$.TestEnum') <> N'Two' OR JSON_VALUE([j].[Ref
         await base.Json_predicate_on_enumwithintconverter(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestEnumWithIntConverter') AS int) <> 2 OR CAST(JSON_VALUE([j].[Reference], '$.TestEnumWithIntConverter') AS int) IS NULL
@@ -1698,7 +1699,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestEnumWithIntConverter') AS int) <> 
         await base.Json_predicate_on_guid(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestGuid') AS uniqueidentifier) <> '00000000-0000-0000-0000-000000000000' OR CAST(JSON_VALUE([j].[Reference], '$.TestGuid') AS uniqueidentifier) IS NULL
@@ -1710,7 +1711,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestGuid') AS uniqueidentifier) <> '00
         await base.Json_predicate_on_int16(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt16') AS smallint) <> CAST(3 AS smallint) OR CAST(JSON_VALUE([j].[Reference], '$.TestInt16') AS smallint) IS NULL
@@ -1722,7 +1723,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt16') AS smallint) <> CAST(3 AS 
         await base.Json_predicate_on_int32(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt32') AS int) <> 33 OR CAST(JSON_VALUE([j].[Reference], '$.TestInt32') AS int) IS NULL
@@ -1734,7 +1735,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt32') AS int) <> 33 OR CAST(JSON
         await base.Json_predicate_on_int64(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt64') AS bigint) <> CAST(333 AS bigint) OR CAST(JSON_VALUE([j].[Reference], '$.TestInt64') AS bigint) IS NULL
@@ -1746,7 +1747,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestInt64') AS bigint) <> CAST(333 AS 
         await base.Json_predicate_on_nullableenum1(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnum') <> N'One' OR JSON_VALUE([j].[Reference], '$.TestNullableEnum') IS NULL
@@ -1758,7 +1759,7 @@ WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnum') <> N'One' OR JSON_VALUE(
         await base.Json_predicate_on_nullableenum2(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnum') IS NOT NULL
@@ -1770,7 +1771,7 @@ WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnum') IS NOT NULL
         await base.Json_predicate_on_nullableenumwithconverter1(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS int) <> 1 OR CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS int) IS NULL
@@ -1782,7 +1783,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS 
         await base.Json_predicate_on_nullableenumwithconverter2(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS int) IS NOT NULL
@@ -1794,7 +1795,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableEnumWithIntConverter') AS 
         await base.Json_predicate_on_nullableenumwithconverterthathandlesnulls1(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnumWithConverterThatHandlesNulls') <> N'One' OR JSON_VALUE([j].[Reference], '$.TestNullableEnumWithConverterThatHandlesNulls') IS NULL
@@ -1806,7 +1807,7 @@ WHERE JSON_VALUE([j].[Reference], '$.TestNullableEnumWithConverterThatHandlesNul
         await base.Json_predicate_on_nullableenumwithconverterthathandlesnulls2(async);
 
         AssertSql(
-"""
+            """
 x
 """);
     }
@@ -1816,7 +1817,7 @@ x
         await base.Json_predicate_on_nullableint321(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableInt32') AS int) <> 100 OR CAST(JSON_VALUE([j].[Reference], '$.TestNullableInt32') AS int) IS NULL
@@ -1828,7 +1829,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableInt32') AS int) <> 100 OR 
         await base.Json_predicate_on_nullableint322(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableInt32') AS int) IS NOT NULL
@@ -1840,7 +1841,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestNullableInt32') AS int) IS NOT NUL
         await base.Json_predicate_on_signedbyte(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestSignedByte') AS smallint) <> CAST(100 AS smallint) OR CAST(JSON_VALUE([j].[Reference], '$.TestSignedByte') AS smallint) IS NULL
@@ -1852,7 +1853,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestSignedByte') AS smallint) <> CAST(
         await base.Json_predicate_on_single(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestSingle') AS real) <> CAST(10.4 AS real) OR CAST(JSON_VALUE([j].[Reference], '$.TestSingle') AS real) IS NULL
@@ -1864,7 +1865,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestSingle') AS real) <> CAST(10.4 AS 
         await base.Json_predicate_on_timespan(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestTimeSpan') AS time) <> '03:02:00' OR CAST(JSON_VALUE([j].[Reference], '$.TestTimeSpan') AS time) IS NULL
@@ -1876,7 +1877,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestTimeSpan') AS time) <> '03:02:00' 
         await base.Json_predicate_on_unisgnedint16(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt16') AS int) <> 100 OR CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt16') AS int) IS NULL
@@ -1888,7 +1889,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt16') AS int) <> 100 OR 
         await base.Json_predicate_on_unsignedint32(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt32') AS bigint) <> CAST(1000 AS bigint) OR CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt32') AS bigint) IS NULL
@@ -1900,7 +1901,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt32') AS bigint) <> CAST
         await base.Json_predicate_on_unsignedint64(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Collection], [j].[Reference]
 FROM [JsonEntitiesAllTypes] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt64') AS decimal(20,0)) <> 10000.0 OR CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt64') AS decimal(20,0)) IS NULL
@@ -1912,7 +1913,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.TestUnsignedInt64') AS decimal(20,0)) 
         await base.Json_predicate_on_bool_converted_to_int_zero_one(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Reference]
 FROM [JsonEntitiesConverters] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.BoolConvertedToIntZeroOne') AS int) = 1
@@ -1924,7 +1925,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.BoolConvertedToIntZeroOne') AS int) = 
         await base.Json_predicate_on_bool_converted_to_string_True_False(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Reference]
 FROM [JsonEntitiesConverters] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.BoolConvertedToStringTrueFalse') = N'True'
@@ -1936,7 +1937,7 @@ WHERE JSON_VALUE([j].[Reference], '$.BoolConvertedToStringTrueFalse') = N'True'
         await base.Json_predicate_on_bool_converted_to_string_Y_N(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Reference]
 FROM [JsonEntitiesConverters] AS [j]
 WHERE JSON_VALUE([j].[Reference], '$.BoolConvertedToStringYN') = N'Y'
@@ -1948,7 +1949,7 @@ WHERE JSON_VALUE([j].[Reference], '$.BoolConvertedToStringYN') = N'Y'
         await base.Json_predicate_on_int_zero_one_converted_to_bool(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Reference]
 FROM [JsonEntitiesConverters] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.IntZeroOneConvertedToBool') AS bit) = CAST(1 AS bit)
@@ -1960,7 +1961,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.IntZeroOneConvertedToBool') AS bit) = 
         await base.Json_predicate_on_string_True_False_converted_to_bool(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Reference]
 FROM [JsonEntitiesConverters] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.StringTrueFalseConvertedToBool') AS bit) = CAST(0 AS bit)
@@ -1972,7 +1973,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.StringTrueFalseConvertedToBool') AS bi
         await base.Json_predicate_on_string_Y_N_converted_to_bool(async);
 
         AssertSql(
-"""
+            """
 SELECT [j].[Id], [j].[Reference]
 FROM [JsonEntitiesConverters] AS [j]
 WHERE CAST(JSON_VALUE([j].[Reference], '$.StringYNConvertedToBool') AS bit) = CAST(0 AS bit)
@@ -1986,7 +1987,7 @@ WHERE CAST(JSON_VALUE([j].[Reference], '$.StringYNConvertedToBool') AS bit) = CA
         await base.FromSql_on_entity_with_json_basic(async);
 
         AssertSql(
-"""
+            """
 SELECT [m].[Id], [m].[EntityBasicId], [m].[Name], [m].[OwnedCollectionRoot], [m].[OwnedReferenceRoot]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j
@@ -2002,12 +2003,13 @@ FROM (
         await AssertQuery(
             async,
             ss => ((DbSet<JsonEntityBasic>)ss.Set<JsonEntityBasic>()).FromSql(
-                Fixture.TestStore.NormalizeDelimitersInInterpolatedString($"SELECT * FROM [JsonEntitiesBasic] AS j WHERE [j].[Id] = {parameter}")),
+                Fixture.TestStore.NormalizeDelimitersInInterpolatedString(
+                    $"SELECT * FROM [JsonEntitiesBasic] AS j WHERE [j].[Id] = {parameter}")),
             ss => ss.Set<JsonEntityBasic>(),
             entryCount: 40);
 
         AssertSql(
-"""
+            """
 prm='1'
 
 SELECT [m].[Id], [m].[EntityBasicId], [m].[Name], [m].[OwnedCollectionRoot], [m].[OwnedReferenceRoot]
@@ -2024,7 +2026,7 @@ FROM (
         await base.FromSql_on_entity_with_json_project_json_reference(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([m].[OwnedReferenceRoot], '$.OwnedReferenceBranch'), [m].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j
@@ -2039,7 +2041,7 @@ FROM (
         await base.FromSql_on_entity_with_json_project_json_collection(async);
 
         AssertSql(
-"""
+            """
 SELECT JSON_QUERY([m].[OwnedReferenceRoot], '$.OwnedCollectionBranch'), [m].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesBasic" AS j
@@ -2054,7 +2056,7 @@ FROM (
         await base.FromSql_on_entity_with_json_inheritance_on_base(async);
 
         AssertSql(
-"""
+            """
 SELECT [m].[Id], [m].[Discriminator], [m].[Name], [m].[Fraction], [m].[CollectionOnBase], [m].[ReferenceOnBase], [m].[CollectionOnDerived], [m].[ReferenceOnDerived]
 FROM (
     SELECT * FROM "JsonEntitiesInheritance" AS j
@@ -2069,7 +2071,7 @@ FROM (
         await base.FromSql_on_entity_with_json_inheritance_on_derived(async);
 
         AssertSql(
-"""
+            """
 SELECT [m].[Id], [m].[Discriminator], [m].[Name], [m].[Fraction], [m].[CollectionOnBase], [m].[ReferenceOnBase], [m].[CollectionOnDerived], [m].[ReferenceOnDerived]
 FROM (
     SELECT * FROM "JsonEntitiesInheritance" AS j
@@ -2085,7 +2087,7 @@ WHERE [m].[Discriminator] = N'JsonEntityInheritanceDerived'
         await base.FromSql_on_entity_with_json_inheritance_project_reference_on_base(async);
 
         AssertSql(
-"""
+            """
 SELECT [m].[ReferenceOnBase], [m].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesInheritance" AS j
@@ -2101,7 +2103,7 @@ ORDER BY [m].[Id]
         await base.FromSql_on_entity_with_json_inheritance_project_reference_on_derived(async);
 
         AssertSql(
-"""
+            """
 SELECT [m].[CollectionOnDerived], [m].[Id]
 FROM (
     SELECT * FROM "JsonEntitiesInheritance" AS j

--- a/test/EFCore.SqlServer.FunctionalTests/Update/JsonUpdateSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Update/JsonUpdateSqlServerTest.cs
@@ -17,7 +17,7 @@ public class JsonUpdateSqlServerTest : JsonUpdateTestBase<JsonUpdateSqlServerFix
 
         AssertSql(
             """
-@p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":10.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 684)
+@p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":10.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":10.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 808)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -61,7 +61,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='[{"Date":"2221-01-01T00:00:00","Enum":"Two","Fraction":221.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2222-01-01T00:00:00","Enum":"Three","Fraction":222.1,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 668)
+@p0='[{"Date":"2221-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":221.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2222-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":222.1,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 792)
 @p1='2'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -84,7 +84,7 @@ WHERE [j].[Discriminator] = N'JsonEntityInheritanceDerived'
 
         AssertSql(
             """
-@p0='[{"Name":"e1_c1","Number":11,"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Fraction":11.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Number":12,"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Fraction":12.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Fraction":12.2,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Fraction":12.0,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Number":142,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}]' (Nullable = false) (Size = 1867)
+@p0='[{"Name":"e1_c1","Names":["e1_c11","e1_c12"],"Number":11,"Numbers":[-1000,0,1000],"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":11.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":11.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":11.0,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Names":["e1_c21","e1_c22"],"Number":12,"Numbers":[-1001,0,1001],"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":12.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":12.2,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":12.0,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Names":null,"Number":142,"Numbers":null,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}]' (Nullable = false) (Size = 2305)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -106,7 +106,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='[{"Name":"e1_c1","Number":11,"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Fraction":11.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Number":12,"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Fraction":12.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Fraction":12.2,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Fraction":12.0,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Number":142,"OwnedCollectionBranch":null,"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":null,"OwnedReferenceLeaf":null}}]' (Nullable = false) (Size = 1790)
+@p0='[{"Name":"e1_c1","Names":["e1_c11","e1_c12"],"Number":11,"Numbers":[-1000,0,1000],"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":11.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":11.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":11.0,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Names":["e1_c21","e1_c22"],"Number":12,"Numbers":[-1001,0,1001],"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":12.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":12.2,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":12.0,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Names":null,"Number":142,"Numbers":null,"OwnedCollectionBranch":null,"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":null,"OwnedReferenceLeaf":null}}]' (Nullable = false) (Size = 2228)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -128,7 +128,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='{"Name":"RootName","Number":42,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 296)
+@p0='{"Name":"RootName","Names":null,"Number":42,"Numbers":null,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 358)
 @p1='2'
 @p2=NULL (DbType = Int32)
 @p3='NewEntity' (Size = 4000)
@@ -151,7 +151,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='{"Name":"RootName","Number":42,"OwnedCollectionBranch":null,"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":null}}' (Nullable = false) (Size = 274)
+@p0='{"Name":"RootName","Names":null,"Number":42,"Numbers":null,"OwnedCollectionBranch":null,"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":null}}' (Nullable = false) (Size = 336)
 @p1='2'
 @p2=NULL (DbType = Int32)
 @p3='NewEntity' (Size = 4000)
@@ -196,7 +196,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='{"Name":"RootName","Number":42,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 296)
+@p0='{"Name":"RootName","Names":null,"Number":42,"Numbers":null,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 358)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -393,8 +393,8 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"...and another"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"yet another change"},{"SomethingSomething":"and another"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}]' (Nullable = false) (Size = 485)
-@p1='{"Name":"edit","Number":10,"OwnedCollectionBranch":[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":10.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}}],"OwnedReferenceBranch":{"Date":"2111-11-11T00:00:00","Enum":"One","Fraction":10.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}}' (Nullable = false) (Size = 773)
+@p0='[{"Date":"2111-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":11.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"...and another"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":11.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"yet another change"},{"SomethingSomething":"and another"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}]' (Nullable = false) (Size = 575)
+@p1='{"Name":"edit","Names":["e1_r1","e1_r2"],"Number":10,"Numbers":[-2147483648,-1,0,1,2147483647],"OwnedCollectionBranch":[{"Date":"2101-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":10.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":10.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}}],"OwnedReferenceBranch":{"Date":"2111-11-11T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":10.0,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}}' (Nullable = false) (Size = 976)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -416,7 +416,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":4321.3,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2222-11-11T00:00:00","Enum":"Three","Fraction":45.32,"NullableEnum":null,"OwnedCollectionLeaf":null,"OwnedReferenceLeaf":{"SomethingSomething":"cc"}}]' (Nullable = false) (Size = 630)
+@p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":4321.3,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":10.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2222-11-11T00:00:00","Enum":"Three","Enums":null,"Fraction":45.32,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":null,"OwnedReferenceLeaf":{"SomethingSomething":"cc"}}]' (Nullable = false) (Size = 754)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -460,7 +460,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='[{"Name":"edit1","Number":11,"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Fraction":11.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"edit2","Number":12,"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Fraction":12.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Fraction":12.2,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Fraction":12.0,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}}]' (Nullable = false) (Size = 1569)
+@p0='[{"Name":"edit1","Names":["e1_c11","e1_c12"],"Number":11,"Numbers":[-1000,0,1000],"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":11.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":11.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":11.0,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"edit2","Names":["e1_c21","e1_c22"],"Number":12,"Numbers":[-1001,0,1001],"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":12.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":12.2,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":12.0,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}}]' (Nullable = false) (Size = 1945)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -482,7 +482,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"edit1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit2"}}' (Nullable = false) (Size = 225)
+@p0='{"Date":"2102-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":10.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"edit1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit2"}}' (Nullable = false) (Size = 270)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1197,8 +1197,8 @@ WHERE [j].[Id] = 1
 
         AssertSql(
             """
-@p0='{"TestBoolean":false,"TestBooleanCollection":[true,false],"TestByte":25,"TestByteCollection":null,"TestCharacter":"h","TestCharacterCollection":["A","B","\u0022"],"TestDateTime":"2100-11-11T12:34:56","TestDateTimeCollection":["2000-01-01T12:34:56","3000-01-01T12:34:56"],"TestDateTimeOffset":"2200-11-11T12:34:56-05:00","TestDateTimeOffsetCollection":["2000-01-01T12:34:56-08:00"],"TestDecimal":-123450.01,"TestDecimalCollection":null,"TestDefaultString":"MyDefaultStringInCollection1","TestDefaultStringCollection":["S1","\u0022S2\u0022","S3"],"TestDouble":-1.2345,"TestDoubleCollection":[-1.23456789,1.23456789,0],"TestEnum":"One","TestEnumCollection":[0,2,-7],"TestEnumWithIntConverter":1,"TestEnumWithIntConverterCollection":[0,2,-7],"TestGuid":"00000000-0000-0000-0000-000000000000","TestGuidCollection":["12345678-1234-4321-7777-987654321000"],"TestInt16":-12,"TestInt16Collection":[-32768,0,32767],"TestInt32":32,"TestInt32Collection":[-2147483648,0,2147483647],"TestInt64":64,"TestInt64Collection":[-9223372036854775808,0,9223372036854775807],"TestMaxLengthString":"Baz","TestMaxLengthStringCollection":["S1","S2","S3"],"TestNullableEnum":"One","TestNullableEnumCollection":[0,null,2,-7],"TestNullableEnumWithConverterThatHandlesNulls":"Two","TestNullableEnumWithConverterThatHandlesNullsCollection":[0,null,-7],"TestNullableEnumWithIntConverter":2,"TestNullableEnumWithIntConverterCollection":[0,null,2,-7],"TestNullableInt32":90,"TestNullableInt32Collection":[null,-2147483648,0,null,2147483647,null],"TestSignedByte":-18,"TestSignedByteCollection":[-128,0,127],"TestSingle":-1.4,"TestSingleCollection":[-1.234,0,-1.234],"TestTimeSpan":"6:05:04.003","TestTimeSpanCollection":["10:09:08.007","-9:50:51.993"],"TestUnsignedInt16":12,"TestUnsignedInt16Collection":[0,0,65535],"TestUnsignedInt32":12345,"TestUnsignedInt32Collection":[0,0,4294967295],"TestUnsignedInt64":1234567867,"TestUnsignedInt64Collection":[0,0,18446744073709551615]}' (Nullable = false) (Size = 1943)
-@p1='{"TestBoolean":true,"TestBooleanCollection":[true,false],"TestByte":255,"TestByteCollection":null,"TestCharacter":"a","TestCharacterCollection":["A","B","\u0022"],"TestDateTime":"2000-01-01T12:34:56","TestDateTimeCollection":["2000-01-01T12:34:56","3000-01-01T12:34:56"],"TestDateTimeOffset":"2000-01-01T12:34:56-08:00","TestDateTimeOffsetCollection":["2000-01-01T12:34:56-08:00"],"TestDecimal":-1234567890.01,"TestDecimalCollection":null,"TestDefaultString":"MyDefaultStringInReference1","TestDefaultStringCollection":["S1","\u0022S2\u0022","S3"],"TestDouble":-1.23456789,"TestDoubleCollection":[-1.23456789,1.23456789,0],"TestEnum":"One","TestEnumCollection":[0,2,-7],"TestEnumWithIntConverter":1,"TestEnumWithIntConverterCollection":[0,2,-7],"TestGuid":"12345678-1234-4321-7777-987654321000","TestGuidCollection":["12345678-1234-4321-7777-987654321000"],"TestInt16":-1234,"TestInt16Collection":[-32768,0,32767],"TestInt32":32,"TestInt32Collection":[-2147483648,0,2147483647],"TestInt64":64,"TestInt64Collection":[-9223372036854775808,0,9223372036854775807],"TestMaxLengthString":"Foo","TestMaxLengthStringCollection":["S1","S2","S3"],"TestNullableEnum":"One","TestNullableEnumCollection":[0,null,2,-7],"TestNullableEnumWithConverterThatHandlesNulls":"Three","TestNullableEnumWithConverterThatHandlesNullsCollection":[0,null,-7],"TestNullableEnumWithIntConverter":1,"TestNullableEnumWithIntConverterCollection":[0,null,2,-7],"TestNullableInt32":78,"TestNullableInt32Collection":[null,-2147483648,0,null,2147483647,null],"TestSignedByte":-128,"TestSignedByteCollection":[-128,0,127],"TestSingle":-1.234,"TestSingleCollection":[-1.234,0,-1.234],"TestTimeSpan":"10:09:08.007","TestTimeSpanCollection":["10:09:08.007","-9:50:51.993"],"TestUnsignedInt16":1234,"TestUnsignedInt16Collection":[0,0,65535],"TestUnsignedInt32":1234565789,"TestUnsignedInt32Collection":[0,0,4294967295],"TestUnsignedInt64":1234567890123456789,"TestUnsignedInt64Collection":[0,0,18446744073709551615]}' (Nullable = false) (Size = 1974)
+@p0='{"TestBoolean":false,"TestBooleanCollection":[true,false],"TestByte":25,"TestByteCollection":null,"TestCharacter":"h","TestCharacterCollection":["A","B","\u0022"],"TestDateTime":"2100-11-11T12:34:56","TestDateTimeCollection":["2000-01-01T12:34:56","3000-01-01T12:34:56"],"TestDateTimeOffset":"2200-11-11T12:34:56-05:00","TestDateTimeOffsetCollection":["2000-01-01T12:34:56-08:00"],"TestDecimal":-123450.01,"TestDecimalCollection":[-1234567890.01],"TestDefaultString":"MyDefaultStringInCollection1","TestDefaultStringCollection":["S1","\u0022S2\u0022","S3"],"TestDouble":-1.2345,"TestDoubleCollection":[-1.23456789,1.23456789,0],"TestEnum":"One","TestEnumCollection":[0,2,-7],"TestEnumWithIntConverter":1,"TestEnumWithIntConverterCollection":[0,2,-7],"TestGuid":"00000000-0000-0000-0000-000000000000","TestGuidCollection":["12345678-1234-4321-7777-987654321000"],"TestInt16":-12,"TestInt16Collection":[-32768,0,32767],"TestInt32":32,"TestInt32Collection":[-2147483648,0,2147483647],"TestInt64":64,"TestInt64Collection":[-9223372036854775808,0,9223372036854775807],"TestMaxLengthString":"Baz","TestMaxLengthStringCollection":["S1","S2","S3"],"TestNullableEnum":"One","TestNullableEnumCollection":[0,null,2,-7],"TestNullableEnumWithConverterThatHandlesNulls":"Two","TestNullableEnumWithConverterThatHandlesNullsCollection":[0,null,-7],"TestNullableEnumWithIntConverter":2,"TestNullableEnumWithIntConverterCollection":[0,null,2,-7],"TestNullableInt32":90,"TestNullableInt32Collection":[null,-2147483648,0,null,2147483647,null],"TestSignedByte":-18,"TestSignedByteCollection":[-128,0,127],"TestSingle":-1.4,"TestSingleCollection":[-1.234,0,-1.234],"TestTimeSpan":"6:05:04.003","TestTimeSpanCollection":["10:09:08.007","-9:50:51.993"],"TestUnsignedInt16":12,"TestUnsignedInt16Collection":[0,0,65535],"TestUnsignedInt32":12345,"TestUnsignedInt32Collection":[0,0,4294967295],"TestUnsignedInt64":1234567867,"TestUnsignedInt64Collection":[0,0,18446744073709551615]}' (Nullable = false) (Size = 1955)
+@p1='{"TestBoolean":true,"TestBooleanCollection":[true,false],"TestByte":255,"TestByteCollection":null,"TestCharacter":"a","TestCharacterCollection":["A","B","\u0022"],"TestDateTime":"2000-01-01T12:34:56","TestDateTimeCollection":["2000-01-01T12:34:56","3000-01-01T12:34:56"],"TestDateTimeOffset":"2000-01-01T12:34:56-08:00","TestDateTimeOffsetCollection":["2000-01-01T12:34:56-08:00"],"TestDecimal":-1234567890.01,"TestDecimalCollection":[-1234567890.01],"TestDefaultString":"MyDefaultStringInReference1","TestDefaultStringCollection":["S1","\u0022S2\u0022","S3"],"TestDouble":-1.23456789,"TestDoubleCollection":[-1.23456789,1.23456789,0],"TestEnum":"One","TestEnumCollection":[0,2,-7],"TestEnumWithIntConverter":1,"TestEnumWithIntConverterCollection":[0,2,-7],"TestGuid":"12345678-1234-4321-7777-987654321000","TestGuidCollection":["12345678-1234-4321-7777-987654321000"],"TestInt16":-1234,"TestInt16Collection":[-32768,0,32767],"TestInt32":32,"TestInt32Collection":[-2147483648,0,2147483647],"TestInt64":64,"TestInt64Collection":[-9223372036854775808,0,9223372036854775807],"TestMaxLengthString":"Foo","TestMaxLengthStringCollection":["S1","S2","S3"],"TestNullableEnum":"One","TestNullableEnumCollection":[0,null,2,-7],"TestNullableEnumWithConverterThatHandlesNulls":"Three","TestNullableEnumWithConverterThatHandlesNullsCollection":[0,null,-7],"TestNullableEnumWithIntConverter":1,"TestNullableEnumWithIntConverterCollection":[0,null,2,-7],"TestNullableInt32":78,"TestNullableInt32Collection":[null,-2147483648,0,null,2147483647,null],"TestSignedByte":-128,"TestSignedByteCollection":[-128,0,127],"TestSingle":-1.234,"TestSingleCollection":[-1.234,0,-1.234],"TestTimeSpan":"10:09:08.007","TestTimeSpanCollection":["10:09:08.007","-9:50:51.993"],"TestUnsignedInt16":1234,"TestUnsignedInt16Collection":[0,0,65535],"TestUnsignedInt32":1234565789,"TestUnsignedInt32Collection":[0,0,4294967295],"TestUnsignedInt64":1234567890123456789,"TestUnsignedInt64Collection":[0,0,18446744073709551615]}' (Nullable = false) (Size = 1986)
 @p2='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1221,7 +1221,7 @@ WHERE [j].[Id] = 1
 
         AssertSql(
             """
-@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 227)
+@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":523.532,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 272)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1243,7 +1243,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"edit"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}' (Nullable = false) (Size = 191)
+@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":523.532,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"edit"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}' (Nullable = false) (Size = 236)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1265,7 +1265,7 @@ FROM [JsonEntitiesBasic] AS [j]
 
         AssertSql(
             """
-@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 227)
+@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":523.532,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 272)
 @p1='1'
 
 SET IMPLICIT_TRANSACTIONS OFF;
@@ -1417,6 +1417,677 @@ WHERE [Id] = @p1;
             """
 SELECT TOP(2) [j].[Id], [j].[Reference]
 FROM [JsonEntitiesConverters] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_numeric()
+    {
+        await base.Edit_single_property_collection_of_numeric();
+
+        AssertSql(
+            """
+@p0='[1024,2048]' (Nullable = false) (Size = 4000)
+@p1='[999,997]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesBasic] SET [OwnedCollectionRoot] = JSON_MODIFY([OwnedCollectionRoot], 'strict $[1].Numbers', JSON_QUERY(@p0)), [OwnedReferenceRoot] = JSON_MODIFY([OwnedReferenceRoot], 'strict $.Numbers', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[EntityBasicId], [j].[Name], [j].[OwnedCollectionRoot], [j].[OwnedReferenceRoot]
+FROM [JsonEntitiesBasic] AS [j]
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_bool()
+    {
+        await base.Edit_single_property_collection_of_bool();
+
+        AssertSql(
+            """
+@p0='[true,true,true,false]' (Nullable = false) (Size = 4000)
+@p1='[true,true,false]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestBooleanCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestBooleanCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_byte()
+    {
+        await base.Edit_single_property_collection_of_byte();
+
+        AssertSql(
+            """
+@p0='Dg==' (Nullable = false) (Size = 4)
+@p1='GRo=' (Nullable = false) (Size = 4)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestByteCollection', @p0), [Reference] = JSON_MODIFY([Reference], 'strict $.TestByteCollection', @p1)
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_char()
+    {
+        await base.Edit_single_property_collection_of_char();
+
+        AssertSql(
+            """
+@p0='["A","B","\u0022","\u0000"]' (Nullable = false) (Size = 4000)
+@p1='["E","F","C","\u00F6","r","E","\u0022","\\"]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestCharacterCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestCharacterCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_datetime()
+    {
+        await base.Edit_single_property_collection_of_datetime();
+
+        AssertSql(
+            """
+@p0='["2000-01-01T12:34:56","3000-01-01T12:34:56","3000-01-01T12:34:56"]' (Nullable = false) (Size = 4000)
+@p1='["2000-01-01T12:34:56","3000-01-01T12:34:56","3000-01-01T12:34:56"]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDateTimeCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDateTimeCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_datetimeoffset()
+    {
+        await base.Edit_single_property_collection_of_datetimeoffset();
+
+        AssertSql(
+            """
+@p0='["3000-01-01T12:34:56-04:00"]' (Nullable = false) (Size = 4000)
+@p1='["3000-01-01T12:34:56-04:00"]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDateTimeOffsetCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDateTimeOffsetCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_decimal()
+    {
+        await base.Edit_single_property_collection_of_decimal();
+
+        AssertSql(
+            """
+@p0='[-13579.01]' (Nullable = false) (Size = 4000)
+@p1='[-13579.01]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDecimalCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDecimalCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_double()
+    {
+        await base.Edit_single_property_collection_of_double();
+
+        AssertSql(
+            """
+@p0='[-1.23456789,1.23456789,0,-1.23579]' (Nullable = false) (Size = 4000)
+@p1='[-1.23456789,1.23456789,0,-1.23579]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestDoubleCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestDoubleCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_guid()
+    {
+        await base.Edit_single_property_collection_of_guid();
+
+        AssertSql(
+            """
+@p0='["12345678-1234-4321-5555-987654321000"]' (Nullable = false) (Size = 4000)
+@p1='["12345678-1234-4321-5555-987654321000"]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestGuidCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestGuidCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_int16()
+    {
+        await base.Edit_single_property_collection_of_int16();
+
+        AssertSql(
+            """
+@p0='[-3234]' (Nullable = false) (Size = 4000)
+@p1='[-3234]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt16Collection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt16Collection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_int32()
+    {
+        await base.Edit_single_property_collection_of_int32();
+
+        AssertSql(
+            """
+@p0='[-3234]' (Nullable = false) (Size = 4000)
+@p1='[-3234]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt32Collection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt32Collection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_int64()
+    {
+        await base.Edit_single_property_collection_of_int64();
+
+        AssertSql(
+            """
+@p0='[]' (Nullable = false) (Size = 4000)
+@p1='[]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestInt64Collection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestInt64Collection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_signed_byte()
+    {
+        await base.Edit_single_property_collection_of_signed_byte();
+
+        AssertSql(
+            """
+@p0='[-108]' (Nullable = false) (Size = 4000)
+@p1='[-108]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestSignedByteCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestSignedByteCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_single()
+    {
+        await base.Edit_single_property_collection_of_single();
+
+        AssertSql(
+            """
+@p0='[-1.234,-1.234]' (Nullable = false) (Size = 4000)
+@p1='[0,-1.234]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestSingleCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestSingleCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_timespan()
+    {
+        await base.Edit_single_property_collection_of_timespan();
+
+        AssertSql(
+            """
+@p0='["10:09:08.007","10:01:01.007"]' (Nullable = false) (Size = 4000)
+@p1='["10:01:01.007","-9:50:51.993"]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestTimeSpanCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestTimeSpanCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_uint16()
+    {
+        await base.Edit_single_property_collection_of_uint16();
+
+        AssertSql(
+            """
+@p0='[1534]' (Nullable = false) (Size = 4000)
+@p1='[1534]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt16Collection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt16Collection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_uint32()
+    {
+        await base.Edit_single_property_collection_of_uint32();
+
+        AssertSql(
+            """
+@p0='[1237775789]' (Nullable = false) (Size = 4000)
+@p1='[1237775789]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt32Collection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt32Collection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_uint64()
+    {
+        await base.Edit_single_property_collection_of_uint64();
+
+        AssertSql(
+            """
+@p0='[1234555555123456789]' (Nullable = false) (Size = 4000)
+@p1='[1234555555123456789]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestUnsignedInt64Collection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestUnsignedInt64Collection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_int32()
+    {
+        await base.Edit_single_property_collection_of_nullable_int32();
+
+        AssertSql(
+            """
+@p0='[null,77]' (Nullable = false) (Size = 4000)
+@p1='[null,-2147483648,0,null,2147483647,null,77,null]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableInt32Collection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableInt32Collection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_int32_set_to_null()
+    {
+        await base.Edit_single_property_collection_of_nullable_int32_set_to_null();
+
+        AssertSql(
+            """
+@p0=NULL (Nullable = false) (Size = 4000)
+@p1=NULL (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableInt32Collection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableInt32Collection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_enum()
+    {
+        await base.Edit_single_property_collection_of_enum();
+
+        AssertSql(
+            """
+@p0='[2]' (Nullable = false) (Size = 4000)
+@p1='[2]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestEnumCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestEnumCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_enum_with_int_converter()
+    {
+        await base.Edit_single_property_collection_of_enum_with_int_converter();
+
+        AssertSql(
+            """
+@p0='[2]' (Nullable = false) (Size = 4000)
+@p1='[2]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestEnumWithIntConverterCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestEnumWithIntConverterCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum();
+
+        AssertSql(
+            """
+@p0='[2]' (Nullable = false) (Size = 4000)
+@p1='[2]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestEnumCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestEnumCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_set_to_null()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_set_to_null();
+
+        AssertSql(
+            """
+@p0=NULL (Nullable = false) (Size = 4000)
+@p1=NULL (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_with_int_converter()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_with_int_converter();
+
+        AssertSql(
+            """
+@p0='[0,null,-7,1]' (Nullable = false) (Size = 4000)
+@p1='[0,2,-7,1]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithIntConverterCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithIntConverterCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_with_int_converter_set_to_null()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_with_int_converter_set_to_null();
+
+        AssertSql(
+            """
+@p0=NULL (Nullable = false) (Size = 4000)
+@p1=NULL (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithIntConverterCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithIntConverterCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_with_converter_that_handles_nulls()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_with_converter_that_handles_nulls();
+
+        AssertSql(
+            """
+@p0='[2]' (Nullable = false) (Size = 4000)
+@p1='[0]' (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithConverterThatHandlesNullsCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithConverterThatHandlesNullsCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
+WHERE [j].[Id] = 1
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_with_converter_that_handles_nulls_set_to_null()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_with_converter_that_handles_nulls_set_to_null();
+
+        AssertSql(
+            """
+@p0=NULL (Nullable = false) (Size = 4000)
+@p1=NULL (Nullable = false) (Size = 4000)
+@p2='1'
+
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+UPDATE [JsonEntitiesAllTypes] SET [Collection] = JSON_MODIFY([Collection], 'strict $[0].TestNullableEnumWithConverterThatHandlesNullsCollection', JSON_QUERY(@p0)), [Reference] = JSON_MODIFY([Reference], 'strict $.TestNullableEnumWithConverterThatHandlesNullsCollection', JSON_QUERY(@p1))
+OUTPUT 1
+WHERE [Id] = @p2;
+""",
+            //
+            """
+SELECT TOP(2) [j].[Id], [j].[Collection], [j].[Reference]
+FROM [JsonEntitiesAllTypes] AS [j]
 WHERE [j].[Id] = 1
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Update/JsonUpdateSqliteTest.cs
@@ -16,8 +16,8 @@ public class JsonUpdateSqliteTest : JsonUpdateTestBase<JsonUpdateSqliteFixture>
         await base.Add_element_to_json_collection_branch();
 
         AssertSql(
-"""
-@p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":10.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 684)
+            """
+@p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":10.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":10.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 808)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch', json(@p0))
@@ -25,7 +25,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -37,7 +37,7 @@ LIMIT 2
         await base.Add_element_to_json_collection_leaf();
 
         AssertSql(
-"""
+            """
 @p0='[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"},{"SomethingSomething":"ss1"}]' (Nullable = false) (Size = 100)
 @p1='1'
 
@@ -46,7 +46,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -58,8 +58,8 @@ LIMIT 2
         await base.Add_element_to_json_collection_on_derived();
 
         AssertSql(
-"""
-@p0='[{"Date":"2221-01-01T00:00:00","Enum":"Two","Fraction":221.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2222-01-01T00:00:00","Enum":"Three","Fraction":222.1,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 668)
+            """
+@p0='[{"Date":"2221-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":221.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2222-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":222.1,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"d2_r_c1"},{"SomethingSomething":"d2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"d2_r_r"}},{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}]' (Nullable = false) (Size = 792)
 @p1='2'
 
 UPDATE "JsonEntitiesInheritance" SET "CollectionOnDerived" = @p0
@@ -67,7 +67,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Discriminator", "j"."Name", "j"."Fraction", "j"."CollectionOnBase", "j"."ReferenceOnBase", "j"."CollectionOnDerived", "j"."ReferenceOnDerived"
 FROM "JsonEntitiesInheritance" AS "j"
 WHERE "j"."Discriminator" = 'JsonEntityInheritanceDerived'
@@ -80,8 +80,8 @@ LIMIT 2
         await base.Add_element_to_json_collection_root();
 
         AssertSql(
-"""
-@p0='[{"Name":"e1_c1","Number":11,"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Fraction":11.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Number":12,"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Fraction":12.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Fraction":12.2,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Fraction":12.0,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Number":142,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}]' (Nullable = false) (Size = 1867)
+            """
+@p0='[{"Name":"e1_c1","Names":["e1_c11","e1_c12"],"Number":11,"Numbers":[-1000,0,1000],"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":11.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":11.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":11.0,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Names":["e1_c21","e1_c22"],"Number":12,"Numbers":[-1001,0,1001],"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":12.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":12.2,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":12.0,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Names":null,"Number":142,"Numbers":null,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}]' (Nullable = false) (Size = 2305)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = @p0
@@ -89,7 +89,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -101,16 +101,16 @@ LIMIT 2
         await base.Add_element_to_json_collection_root_null_navigations();
 
         AssertSql(
-"""
-@p0='[{"Name":"e1_c1","Number":11,"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Fraction":11.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Number":12,"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Fraction":12.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Fraction":12.2,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Fraction":12.0,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Number":142,"OwnedCollectionBranch":null,"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":null,"OwnedReferenceLeaf":null}}]' (Nullable = false) (Size = 1790)
+            """
+@p0='[{"Name":"e1_c1","Names":["e1_c11","e1_c12"],"Number":11,"Numbers":[-1000,0,1000],"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":11.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":11.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":11.0,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"e1_c2","Names":["e1_c21","e1_c22"],"Number":12,"Numbers":[-1001,0,1001],"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":12.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":12.2,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":12.0,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}},{"Name":"new Name","Names":null,"Number":142,"Numbers":null,"OwnedCollectionBranch":null,"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":null,"OwnedReferenceLeaf":null}}]' (Nullable = false) (Size = 2228)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = @p0
 WHERE "Id" = @p1
 RETURNING 1;
 """,
-                //
-                """
+            //
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -122,8 +122,8 @@ LIMIT 2
         await base.Add_entity_with_json();
 
         AssertSql(
-"""
-@p0='{"Name":"RootName","Number":42,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 296)
+            """
+@p0='{"Name":"RootName","Names":null,"Number":42,"Numbers":null,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 358)
 @p1='2'
 @p2=NULL (DbType = Int32)
 @p3='NewEntity' (Size = 9)
@@ -132,7 +132,7 @@ INSERT INTO "JsonEntitiesBasic" ("OwnedReferenceRoot", "Id", "EntityBasicId", "N
 VALUES (@p0, @p1, @p2, @p3);
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 """);
@@ -143,8 +143,8 @@ FROM "JsonEntitiesBasic" AS "j"
         await base.Add_entity_with_json_null_navigations();
 
         AssertSql(
-"""
-@p0='{"Name":"RootName","Number":42,"OwnedCollectionBranch":null,"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":null}}' (Nullable = false) (Size = 274)
+            """
+@p0='{"Name":"RootName","Names":null,"Number":42,"Numbers":null,"OwnedCollectionBranch":null,"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":null}}' (Nullable = false) (Size = 336)
 @p1='2'
 @p2=NULL (DbType = Int32)
 @p3='NewEntity' (Size = 9)
@@ -153,7 +153,7 @@ INSERT INTO "JsonEntitiesBasic" ("OwnedReferenceRoot", "Id", "EntityBasicId", "N
 VALUES (@p0, @p1, @p2, @p3);
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 """);
@@ -164,7 +164,7 @@ FROM "JsonEntitiesBasic" AS "j"
         await base.Add_json_reference_leaf();
 
         AssertSql(
-"""
+            """
 @p0='{"SomethingSomething":"ss3"}' (Nullable = false) (Size = 28)
 @p1='1'
 
@@ -173,7 +173,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -185,8 +185,8 @@ LIMIT 2
         await base.Add_json_reference_root();
 
         AssertSql(
-"""
-@p0='{"Name":"RootName","Number":42,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Fraction":42.42,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 296)
+            """
+@p0='{"Name":"RootName","Names":null,"Number":42,"Numbers":null,"OwnedCollectionBranch":[],"OwnedReferenceBranch":{"Date":"2010-10-10T00:00:00","Enum":"Three","Enums":null,"Fraction":42.42,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":[{"SomethingSomething":"ss1"},{"SomethingSomething":"ss2"}],"OwnedReferenceLeaf":{"SomethingSomething":"ss3"}}}' (Nullable = false) (Size = 358)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = @p0
@@ -194,7 +194,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -206,7 +206,7 @@ LIMIT 2
         await base.Delete_entity_with_json();
 
         AssertSql(
-"""
+            """
 @p0='1'
 
 DELETE FROM "JsonEntitiesBasic"
@@ -214,7 +214,7 @@ WHERE "Id" = @p0
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT COUNT(*)
 FROM "JsonEntitiesBasic" AS "j"
 """);
@@ -225,7 +225,7 @@ FROM "JsonEntitiesBasic" AS "j"
         await base.Delete_json_collection_branch();
 
         AssertSql(
-"""
+            """
 @p0=NULL (Nullable = false)
 @p1='1'
 
@@ -234,7 +234,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -246,7 +246,7 @@ LIMIT 2
         await base.Delete_json_collection_root();
 
         AssertSql(
-"""
+            """
 @p0=NULL (Nullable = false)
 @p1='1'
 
@@ -255,7 +255,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -267,7 +267,7 @@ LIMIT 2
         await base.Delete_json_reference_leaf();
 
         AssertSql(
-"""
+            """
 @p0=NULL (Nullable = false)
 @p1='1'
 
@@ -276,7 +276,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -288,7 +288,7 @@ LIMIT 2
         await base.Delete_json_reference_root();
 
         AssertSql(
-"""
+            """
 @p0=NULL (Nullable = false)
 @p1='1'
 
@@ -297,7 +297,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -309,7 +309,7 @@ LIMIT 2
         await base.Edit_element_in_json_collection_branch();
 
         AssertSql(
-"""
+            """
 @p0='2111-11-11T00:00:00' (Nullable = false) (Size = 19)
 @p1='1'
 
@@ -318,7 +318,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -330,7 +330,7 @@ LIMIT 2
         await base.Edit_element_in_json_collection_root1();
 
         AssertSql(
-"""
+            """
 @p0='Modified' (Nullable = false) (Size = 8)
 @p1='1'
 
@@ -339,7 +339,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -351,7 +351,7 @@ LIMIT 2
         await base.Edit_element_in_json_collection_root2();
 
         AssertSql(
-"""
+            """
 @p0='Modified' (Nullable = false) (Size = 8)
 @p1='1'
 
@@ -360,7 +360,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -372,9 +372,9 @@ LIMIT 2
         await base.Edit_element_in_json_multiple_levels_partial_update();
 
         AssertSql(
-"""
-@p0='[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"...and another"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"yet another change"},{"SomethingSomething":"and another"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}]' (Nullable = false) (Size = 485)
-@p1='{"Name":"edit","Number":10,"OwnedCollectionBranch":[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":10.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}}],"OwnedReferenceBranch":{"Date":"2111-11-11T00:00:00","Enum":"One","Fraction":10.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}}' (Nullable = false) (Size = 773)
+            """
+@p0='[{"Date":"2111-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":11.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"...and another"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":11.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"yet another change"},{"SomethingSomething":"and another"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}]' (Nullable = false) (Size = 575)
+@p1='{"Name":"edit","Names":["e1_r1","e1_r2"],"Number":10,"Numbers":[-2147483648,-1,0,1,2147483647],"OwnedCollectionBranch":[{"Date":"2101-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":10.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":10.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}}],"OwnedReferenceBranch":{"Date":"2111-11-11T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":10.0,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}}' (Nullable = false) (Size = 976)
 @p2='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[0].OwnedCollectionBranch', json(@p0)), "OwnedReferenceRoot" = @p1
@@ -382,7 +382,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -394,8 +394,8 @@ LIMIT 2
         await base.Edit_element_in_json_branch_collection_and_add_element_to_the_same_collection();
 
         AssertSql(
-"""
-@p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Fraction":4321.3,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2222-11-11T00:00:00","Enum":"Three","Fraction":45.32,"NullableEnum":null,"OwnedCollectionLeaf":null,"OwnedReferenceLeaf":{"SomethingSomething":"cc"}}]' (Nullable = false) (Size = 630)
+            """
+@p0='[{"Date":"2101-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":4321.3,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c1_c1"},{"SomethingSomething":"e1_r_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c1_r"}},{"Date":"2102-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":10.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_c2_c1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_c2_r"}},{"Date":"2222-11-11T00:00:00","Enum":"Three","Enums":null,"Fraction":45.32,"NullableEnum":null,"NullableEnums":null,"OwnedCollectionLeaf":null,"OwnedReferenceLeaf":{"SomethingSomething":"cc"}}]' (Nullable = false) (Size = 754)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch', json(@p0))
@@ -403,7 +403,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -415,7 +415,7 @@ LIMIT 2
         await base.Edit_two_elements_in_the_same_json_collection();
 
         AssertSql(
-"""
+            """
 @p0='[{"SomethingSomething":"edit1"},{"SomethingSomething":"edit2"}]' (Nullable = false) (Size = 63)
 @p1='1'
 
@@ -424,7 +424,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -436,8 +436,8 @@ LIMIT 2
         await base.Edit_two_elements_in_the_same_json_collection_at_the_root();
 
         AssertSql(
-"""
-@p0='[{"Name":"edit1","Number":11,"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Fraction":11.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Fraction":11.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Fraction":11.0,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"edit2","Number":12,"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Fraction":12.1,"NullableEnum":"One","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Fraction":12.2,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Fraction":12.0,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}}]' (Nullable = false) (Size = 1569)
+            """
+@p0='[{"Name":"edit1","Names":["e1_c11","e1_c12"],"Number":11,"Numbers":[-1000,0,1000],"OwnedCollectionBranch":[{"Date":"2111-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":11.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c1_c1"},{"SomethingSomething":"e1_c1_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c1_r"}},{"Date":"2112-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":11.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_c2_c1"},{"SomethingSomething":"e1_c1_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_c2_r"}}],"OwnedReferenceBranch":{"Date":"2110-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":11.0,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c1_r_c1"},{"SomethingSomething":"e1_c1_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c1_r_r"}}},{"Name":"edit2","Names":["e1_c21","e1_c22"],"Number":12,"Numbers":[-1001,0,1001],"OwnedCollectionBranch":[{"Date":"2121-01-01T00:00:00","Enum":"Two","Enums":[0,-1,1],"Fraction":12.1,"NullableEnum":"One","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c1_c1"},{"SomethingSomething":"e1_c2_c1_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c1_r"}},{"Date":"2122-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":12.2,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_c2_c1"},{"SomethingSomething":"e1_c2_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_c2_r"}}],"OwnedReferenceBranch":{"Date":"2120-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":12.0,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_c2_r_c1"},{"SomethingSomething":"e1_c2_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_c2_r_r"}}}]' (Nullable = false) (Size = 1945)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = @p0
@@ -445,7 +445,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -457,8 +457,8 @@ LIMIT 2
         await base.Edit_collection_element_and_reference_at_once();
 
         AssertSql(
-"""
-@p0='{"Date":"2102-01-01T00:00:00","Enum":"Three","Fraction":10.2,"NullableEnum":"Two","OwnedCollectionLeaf":[{"SomethingSomething":"edit1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit2"}}' (Nullable = false) (Size = 225)
+            """
+@p0='{"Date":"2102-01-01T00:00:00","Enum":"Three","Enums":[0,-1,1],"Fraction":10.2,"NullableEnum":"Two","NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"edit1"},{"SomethingSomething":"e1_r_c2_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit2"}}' (Nullable = false) (Size = 270)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedCollectionBranch[1]', json(@p0))
@@ -466,7 +466,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -478,7 +478,7 @@ LIMIT 2
         await base.Edit_single_enum_property();
 
         AssertSql(
-"""
+            """
 @p0='Two' (Nullable = false) (Size = 3)
 @p1='Two' (Nullable = false) (Size = 3)
 @p2='1'
@@ -488,7 +488,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -500,7 +500,7 @@ LIMIT 2
         await base.Edit_single_numeric_property();
 
         AssertSql(
-"""
+            """
 @p0='1024'
 @p1='999'
 @p2='1'
@@ -510,7 +510,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -522,7 +522,7 @@ LIMIT 2
         await base.Edit_single_property_bool();
 
         AssertSql(
-"""
+            """
 @p0='true' (Nullable = false) (Size = 4)
 @p1='false' (Nullable = false) (Size = 5)
 @p2='1'
@@ -532,7 +532,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -545,7 +545,7 @@ LIMIT 2
         await base.Edit_single_property_byte();
 
         AssertSql(
-"""
+            """
 @p0='14'
 @p1='25'
 @p2='1'
@@ -555,7 +555,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -568,7 +568,7 @@ LIMIT 2
         await base.Edit_single_property_char();
 
         AssertSql(
-"""
+            """
 @p0='t' (DbType = String)
 @p1='1'
 
@@ -577,7 +577,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -590,7 +590,7 @@ LIMIT 2
         await base.Edit_single_property_datetime();
 
         AssertSql(
-"""
+            """
 @p0='3000-01-01T12:34:56' (Nullable = false) (Size = 19)
 @p1='3000-01-01T12:34:56' (Nullable = false) (Size = 19)
 @p2='1'
@@ -600,7 +600,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -613,7 +613,7 @@ LIMIT 2
         await base.Edit_single_property_datetimeoffset();
 
         AssertSql(
-"""
+            """
 @p0='3000-01-01T12:34:56-04:00' (Nullable = false) (Size = 25)
 @p1='3000-01-01T12:34:56-04:00' (Nullable = false) (Size = 25)
 @p2='1'
@@ -623,7 +623,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -636,7 +636,7 @@ LIMIT 2
         await base.Edit_single_property_decimal();
 
         AssertSql(
-"""
+            """
 @p0='-13579.01'
 @p1='-13579.01'
 @p2='1'
@@ -646,7 +646,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -659,7 +659,7 @@ LIMIT 2
         await base.Edit_single_property_double();
 
         AssertSql(
-"""
+            """
 @p0='-1.23579'
 @p1='-1.23579'
 @p2='1'
@@ -669,7 +669,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -682,7 +682,7 @@ LIMIT 2
         await base.Edit_single_property_guid();
 
         AssertSql(
-"""
+            """
 @p0='12345678-1234-4321-5555-987654321000' (Nullable = false) (Size = 36)
 @p1='12345678-1234-4321-5555-987654321000' (Nullable = false) (Size = 36)
 @p2='1'
@@ -692,7 +692,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -705,7 +705,7 @@ LIMIT 2
         await base.Edit_single_property_int16();
 
         AssertSql(
-"""
+            """
 @p0='-3234'
 @p1='-3234'
 @p2='1'
@@ -715,7 +715,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -728,7 +728,7 @@ LIMIT 2
         await base.Edit_single_property_int32();
 
         AssertSql(
-"""
+            """
 @p0='-3234'
 @p1='-3234'
 @p2='1'
@@ -738,7 +738,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -751,7 +751,7 @@ LIMIT 2
         await base.Edit_single_property_int64();
 
         AssertSql(
-"""
+            """
 @p0='-3234'
 @p1='-3234'
 @p2='1'
@@ -761,7 +761,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -774,7 +774,7 @@ LIMIT 2
         await base.Edit_single_property_signed_byte();
 
         AssertSql(
-"""
+            """
 @p0='-108'
 @p1='-108'
 @p2='1'
@@ -784,7 +784,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -797,7 +797,7 @@ LIMIT 2
         await base.Edit_single_property_single();
 
         AssertSql(
-"""
+            """
 @p0='-7.234'
 @p1='-7.234'
 @p2='1'
@@ -807,7 +807,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -820,7 +820,7 @@ LIMIT 2
         await base.Edit_single_property_timespan();
 
         AssertSql(
-"""
+            """
 @p0='10:01:01.007' (Nullable = false) (Size = 12)
 @p1='10:01:01.007' (Nullable = false) (Size = 12)
 @p2='1'
@@ -830,7 +830,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -843,7 +843,7 @@ LIMIT 2
         await base.Edit_single_property_uint16();
 
         AssertSql(
-"""
+            """
 @p0='1534'
 @p1='1534'
 @p2='1'
@@ -853,7 +853,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -866,7 +866,7 @@ LIMIT 2
         await base.Edit_single_property_uint32();
 
         AssertSql(
-"""
+            """
 @p0='1237775789'
 @p1='1237775789'
 @p2='1'
@@ -876,7 +876,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -889,7 +889,7 @@ LIMIT 2
         await base.Edit_single_property_uint64();
 
         AssertSql(
-"""
+            """
 @p0='1234555555123456789'
 @p1='1234555555123456789'
 @p2='1'
@@ -899,7 +899,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -912,7 +912,7 @@ LIMIT 2
         await base.Edit_single_property_nullable_int32();
 
         AssertSql(
-"""
+            """
 @p0='122354'
 @p1='64528'
 @p2='1'
@@ -922,7 +922,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -935,7 +935,7 @@ LIMIT 2
         await base.Edit_single_property_nullable_int32_set_to_null();
 
         AssertSql(
-"""
+            """
 @p0=NULL (Nullable = false) (DbType = Int32)
 @p1=NULL (Nullable = false) (DbType = Int32)
 @p2='1'
@@ -945,7 +945,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -958,7 +958,7 @@ LIMIT 2
         await base.Edit_single_property_enum();
 
         AssertSql(
-"""
+            """
 @p0='Three' (Nullable = false) (Size = 5)
 @p1='Three' (Nullable = false) (Size = 5)
 @p2='1'
@@ -968,7 +968,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -981,7 +981,7 @@ LIMIT 2
         await base.Edit_single_property_enum_with_int_converter();
 
         AssertSql(
-"""
+            """
 @p0='2'
 @p1='2'
 @p2='1'
@@ -991,7 +991,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -1004,7 +1004,7 @@ LIMIT 2
         await base.Edit_single_property_nullable_enum();
 
         AssertSql(
-"""
+            """
 @p0='Three' (Nullable = false) (Size = 5)
 @p1='Three' (Nullable = false) (Size = 5)
 @p2='1'
@@ -1014,7 +1014,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -1027,7 +1027,7 @@ LIMIT 2
         await base.Edit_single_property_nullable_enum_set_to_null();
 
         AssertSql(
-"""
+            """
 @p0=NULL (Nullable = false)
 @p1=NULL (Nullable = false)
 @p2='1'
@@ -1037,7 +1037,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -1050,7 +1050,7 @@ LIMIT 2
         await base.Edit_single_property_nullable_enum_with_int_converter();
 
         AssertSql(
-"""
+            """
 @p0='0'
 @p1='2'
 @p2='1'
@@ -1060,7 +1060,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -1073,7 +1073,7 @@ LIMIT 2
         await base.Edit_single_property_nullable_enum_with_int_converter_set_to_null();
 
         AssertSql(
-"""
+            """
 @p0=NULL (Nullable = false) (DbType = Int32)
 @p1=NULL (Nullable = false) (DbType = Int32)
 @p2='1'
@@ -1083,7 +1083,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -1096,7 +1096,7 @@ LIMIT 2
         await base.Edit_single_property_nullable_enum_with_converter_that_handles_nulls();
 
         AssertSql(
-"""
+            """
 @p0='Three' (Nullable = false) (Size = 5)
 @p1='One' (Nullable = false) (Size = 3)
 @p2='1'
@@ -1106,7 +1106,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -1119,7 +1119,7 @@ LIMIT 2
         await base.Edit_single_property_nullable_enum_with_converter_that_handles_nulls_set_to_null();
 
         AssertSql(
-"""
+            """
 @p0='Null' (Nullable = false) (Size = 4)
 @p1='Null' (Nullable = false) (Size = 4)
 @p2='1'
@@ -1129,7 +1129,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -1142,9 +1142,9 @@ LIMIT 2
         await base.Edit_two_properties_on_same_entity_updates_the_entire_entity();
 
         AssertSql(
-"""
-@p0='{"TestBoolean":false,"TestBooleanCollection":[true,false],"TestByte":25,"TestByteCollection":null,"TestCharacter":"h","TestCharacterCollection":["A","B","\u0022"],"TestDateTime":"2100-11-11T12:34:56","TestDateTimeCollection":["2000-01-01T12:34:56","3000-01-01T12:34:56"],"TestDateTimeOffset":"2200-11-11T12:34:56-05:00","TestDateTimeOffsetCollection":["2000-01-01T12:34:56-08:00"],"TestDecimal":-123450.01,"TestDecimalCollection":null,"TestDefaultString":"MyDefaultStringInCollection1","TestDefaultStringCollection":["S1","\u0022S2\u0022","S3"],"TestDouble":-1.2345,"TestDoubleCollection":[-1.23456789,1.23456789,0],"TestEnum":"One","TestEnumCollection":[0,2,-7],"TestEnumWithIntConverter":1,"TestEnumWithIntConverterCollection":[0,2,-7],"TestGuid":"00000000-0000-0000-0000-000000000000","TestGuidCollection":["12345678-1234-4321-7777-987654321000"],"TestInt16":-12,"TestInt16Collection":[-32768,0,32767],"TestInt32":32,"TestInt32Collection":[-2147483648,0,2147483647],"TestInt64":64,"TestInt64Collection":[-9223372036854775808,0,9223372036854775807],"TestMaxLengthString":"Baz","TestMaxLengthStringCollection":["S1","S2","S3"],"TestNullableEnum":"One","TestNullableEnumCollection":[0,null,2,-7],"TestNullableEnumWithConverterThatHandlesNulls":"Two","TestNullableEnumWithConverterThatHandlesNullsCollection":[0,null,-7],"TestNullableEnumWithIntConverter":2,"TestNullableEnumWithIntConverterCollection":[0,null,2,-7],"TestNullableInt32":90,"TestNullableInt32Collection":[null,-2147483648,0,null,2147483647,null],"TestSignedByte":-18,"TestSignedByteCollection":[-128,0,127],"TestSingle":-1.4,"TestSingleCollection":[-1.234,0,-1.234],"TestTimeSpan":"6:05:04.003","TestTimeSpanCollection":["10:09:08.007","-9:50:51.993"],"TestUnsignedInt16":12,"TestUnsignedInt16Collection":[0,0,65535],"TestUnsignedInt32":12345,"TestUnsignedInt32Collection":[0,0,4294967295],"TestUnsignedInt64":1234567867,"TestUnsignedInt64Collection":[0,0,18446744073709551615]}' (Nullable = false) (Size = 1943)
-@p1='{"TestBoolean":true,"TestBooleanCollection":[true,false],"TestByte":255,"TestByteCollection":null,"TestCharacter":"a","TestCharacterCollection":["A","B","\u0022"],"TestDateTime":"2000-01-01T12:34:56","TestDateTimeCollection":["2000-01-01T12:34:56","3000-01-01T12:34:56"],"TestDateTimeOffset":"2000-01-01T12:34:56-08:00","TestDateTimeOffsetCollection":["2000-01-01T12:34:56-08:00"],"TestDecimal":-1234567890.01,"TestDecimalCollection":null,"TestDefaultString":"MyDefaultStringInReference1","TestDefaultStringCollection":["S1","\u0022S2\u0022","S3"],"TestDouble":-1.23456789,"TestDoubleCollection":[-1.23456789,1.23456789,0],"TestEnum":"One","TestEnumCollection":[0,2,-7],"TestEnumWithIntConverter":1,"TestEnumWithIntConverterCollection":[0,2,-7],"TestGuid":"12345678-1234-4321-7777-987654321000","TestGuidCollection":["12345678-1234-4321-7777-987654321000"],"TestInt16":-1234,"TestInt16Collection":[-32768,0,32767],"TestInt32":32,"TestInt32Collection":[-2147483648,0,2147483647],"TestInt64":64,"TestInt64Collection":[-9223372036854775808,0,9223372036854775807],"TestMaxLengthString":"Foo","TestMaxLengthStringCollection":["S1","S2","S3"],"TestNullableEnum":"One","TestNullableEnumCollection":[0,null,2,-7],"TestNullableEnumWithConverterThatHandlesNulls":"Three","TestNullableEnumWithConverterThatHandlesNullsCollection":[0,null,-7],"TestNullableEnumWithIntConverter":1,"TestNullableEnumWithIntConverterCollection":[0,null,2,-7],"TestNullableInt32":78,"TestNullableInt32Collection":[null,-2147483648,0,null,2147483647,null],"TestSignedByte":-128,"TestSignedByteCollection":[-128,0,127],"TestSingle":-1.234,"TestSingleCollection":[-1.234,0,-1.234],"TestTimeSpan":"10:09:08.007","TestTimeSpanCollection":["10:09:08.007","-9:50:51.993"],"TestUnsignedInt16":1234,"TestUnsignedInt16Collection":[0,0,65535],"TestUnsignedInt32":1234565789,"TestUnsignedInt32Collection":[0,0,4294967295],"TestUnsignedInt64":1234567890123456789,"TestUnsignedInt64Collection":[0,0,18446744073709551615]}' (Nullable = false) (Size = 1974)
+            """
+@p0='{"TestBoolean":false,"TestBooleanCollection":[true,false],"TestByte":25,"TestByteCollection":null,"TestCharacter":"h","TestCharacterCollection":["A","B","\u0022"],"TestDateTime":"2100-11-11T12:34:56","TestDateTimeCollection":["2000-01-01T12:34:56","3000-01-01T12:34:56"],"TestDateTimeOffset":"2200-11-11T12:34:56-05:00","TestDateTimeOffsetCollection":["2000-01-01T12:34:56-08:00"],"TestDecimal":-123450.01,"TestDecimalCollection":[-1234567890.01],"TestDefaultString":"MyDefaultStringInCollection1","TestDefaultStringCollection":["S1","\u0022S2\u0022","S3"],"TestDouble":-1.2345,"TestDoubleCollection":[-1.23456789,1.23456789,0],"TestEnum":"One","TestEnumCollection":[0,2,-7],"TestEnumWithIntConverter":1,"TestEnumWithIntConverterCollection":[0,2,-7],"TestGuid":"00000000-0000-0000-0000-000000000000","TestGuidCollection":["12345678-1234-4321-7777-987654321000"],"TestInt16":-12,"TestInt16Collection":[-32768,0,32767],"TestInt32":32,"TestInt32Collection":[-2147483648,0,2147483647],"TestInt64":64,"TestInt64Collection":[-9223372036854775808,0,9223372036854775807],"TestMaxLengthString":"Baz","TestMaxLengthStringCollection":["S1","S2","S3"],"TestNullableEnum":"One","TestNullableEnumCollection":[0,null,2,-7],"TestNullableEnumWithConverterThatHandlesNulls":"Two","TestNullableEnumWithConverterThatHandlesNullsCollection":[0,null,-7],"TestNullableEnumWithIntConverter":2,"TestNullableEnumWithIntConverterCollection":[0,null,2,-7],"TestNullableInt32":90,"TestNullableInt32Collection":[null,-2147483648,0,null,2147483647,null],"TestSignedByte":-18,"TestSignedByteCollection":[-128,0,127],"TestSingle":-1.4,"TestSingleCollection":[-1.234,0,-1.234],"TestTimeSpan":"6:05:04.003","TestTimeSpanCollection":["10:09:08.007","-9:50:51.993"],"TestUnsignedInt16":12,"TestUnsignedInt16Collection":[0,0,65535],"TestUnsignedInt32":12345,"TestUnsignedInt32Collection":[0,0,4294967295],"TestUnsignedInt64":1234567867,"TestUnsignedInt64Collection":[0,0,18446744073709551615]}' (Nullable = false) (Size = 1955)
+@p1='{"TestBoolean":true,"TestBooleanCollection":[true,false],"TestByte":255,"TestByteCollection":null,"TestCharacter":"a","TestCharacterCollection":["A","B","\u0022"],"TestDateTime":"2000-01-01T12:34:56","TestDateTimeCollection":["2000-01-01T12:34:56","3000-01-01T12:34:56"],"TestDateTimeOffset":"2000-01-01T12:34:56-08:00","TestDateTimeOffsetCollection":["2000-01-01T12:34:56-08:00"],"TestDecimal":-1234567890.01,"TestDecimalCollection":[-1234567890.01],"TestDefaultString":"MyDefaultStringInReference1","TestDefaultStringCollection":["S1","\u0022S2\u0022","S3"],"TestDouble":-1.23456789,"TestDoubleCollection":[-1.23456789,1.23456789,0],"TestEnum":"One","TestEnumCollection":[0,2,-7],"TestEnumWithIntConverter":1,"TestEnumWithIntConverterCollection":[0,2,-7],"TestGuid":"12345678-1234-4321-7777-987654321000","TestGuidCollection":["12345678-1234-4321-7777-987654321000"],"TestInt16":-1234,"TestInt16Collection":[-32768,0,32767],"TestInt32":32,"TestInt32Collection":[-2147483648,0,2147483647],"TestInt64":64,"TestInt64Collection":[-9223372036854775808,0,9223372036854775807],"TestMaxLengthString":"Foo","TestMaxLengthStringCollection":["S1","S2","S3"],"TestNullableEnum":"One","TestNullableEnumCollection":[0,null,2,-7],"TestNullableEnumWithConverterThatHandlesNulls":"Three","TestNullableEnumWithConverterThatHandlesNullsCollection":[0,null,-7],"TestNullableEnumWithIntConverter":1,"TestNullableEnumWithIntConverterCollection":[0,null,2,-7],"TestNullableInt32":78,"TestNullableInt32Collection":[null,-2147483648,0,null,2147483647,null],"TestSignedByte":-128,"TestSignedByteCollection":[-128,0,127],"TestSingle":-1.234,"TestSingleCollection":[-1.234,0,-1.234],"TestTimeSpan":"10:09:08.007","TestTimeSpanCollection":["10:09:08.007","-9:50:51.993"],"TestUnsignedInt16":1234,"TestUnsignedInt16Collection":[0,0,65535],"TestUnsignedInt32":1234565789,"TestUnsignedInt32Collection":[0,0,4294967295],"TestUnsignedInt64":1234567890123456789,"TestUnsignedInt64Collection":[0,0,18446744073709551615]}' (Nullable = false) (Size = 1986)
 @p2='1'
 
 UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0]', json(@p0)), "Reference" = @p1
@@ -1152,7 +1152,7 @@ WHERE "Id" = @p2
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Collection", "j"."Reference"
 FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
@@ -1165,8 +1165,8 @@ LIMIT 2
         await base.Edit_a_scalar_property_and_reference_navigation_on_the_same_entity();
 
         AssertSql(
-"""
-@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 227)
+            """
+@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":523.532,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 272)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch', json(@p0))
@@ -1174,7 +1174,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -1186,8 +1186,8 @@ LIMIT 2
         await base.Edit_a_scalar_property_and_collection_navigation_on_the_same_entity();
 
         AssertSql(
-"""
-@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"edit"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}' (Nullable = false) (Size = 191)
+            """
+@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":523.532,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"edit"}],"OwnedReferenceLeaf":{"SomethingSomething":"e1_r_r_r"}}' (Nullable = false) (Size = 236)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch', json(@p0))
@@ -1195,7 +1195,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -1207,8 +1207,8 @@ LIMIT 2
         await base.Edit_a_scalar_property_and_another_property_behind_reference_navigation_on_the_same_entity();
 
         AssertSql(
-"""
-@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Fraction":523.532,"NullableEnum":null,"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 227)
+            """
+@p0='{"Date":"2100-01-01T00:00:00","Enum":"One","Enums":[0,-1,1],"Fraction":523.532,"NullableEnum":null,"NullableEnums":[null,-1,1],"OwnedCollectionLeaf":[{"SomethingSomething":"e1_r_r_c1"},{"SomethingSomething":"e1_r_r_c2"}],"OwnedReferenceLeaf":{"SomethingSomething":"edit"}}' (Nullable = false) (Size = 272)
 @p1='1'
 
 UPDATE "JsonEntitiesBasic" SET "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.OwnedReferenceBranch', json(@p0))
@@ -1216,7 +1216,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
 FROM "JsonEntitiesBasic" AS "j"
 LIMIT 2
@@ -1228,7 +1228,7 @@ LIMIT 2
         await base.Edit_single_property_with_converter_bool_to_int_zero_one();
 
         AssertSql(
-"""
+            """
 @p0='0'
 @p1='1'
 
@@ -1237,7 +1237,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Reference"
 FROM "JsonEntitiesConverters" AS "j"
 WHERE "j"."Id" = 1
@@ -1250,7 +1250,7 @@ LIMIT 2
         await base.Edit_single_property_with_converter_bool_to_string_True_False();
 
         AssertSql(
-"""
+            """
 @p0='True' (Nullable = false) (Size = 4)
 @p1='1'
 
@@ -1259,7 +1259,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Reference"
 FROM "JsonEntitiesConverters" AS "j"
 WHERE "j"."Id" = 1
@@ -1272,7 +1272,7 @@ LIMIT 2
         await base.Edit_single_property_with_converter_bool_to_string_Y_N();
 
         AssertSql(
-"""
+            """
 @p0='N' (Nullable = false) (Size = 1)
 @p1='1'
 
@@ -1281,7 +1281,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Reference"
 FROM "JsonEntitiesConverters" AS "j"
 WHERE "j"."Id" = 1
@@ -1294,7 +1294,7 @@ LIMIT 2
         await base.Edit_single_property_with_converter_int_zero_one_to_bool();
 
         AssertSql(
-"""
+            """
 @p0='true' (Nullable = false) (Size = 4)
 @p1='1'
 
@@ -1303,7 +1303,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Reference"
 FROM "JsonEntitiesConverters" AS "j"
 WHERE "j"."Id" = 1
@@ -1316,7 +1316,7 @@ LIMIT 2
         await base.Edit_single_property_with_converter_string_True_False_to_bool();
 
         AssertSql(
-"""
+            """
 @p0='false' (Nullable = false) (Size = 5)
 @p1='1'
 
@@ -1325,7 +1325,7 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Reference"
 FROM "JsonEntitiesConverters" AS "j"
 WHERE "j"."Id" = 1
@@ -1338,7 +1338,7 @@ LIMIT 2
         await base.Edit_single_property_with_converter_string_Y_N_to_bool();
 
         AssertSql(
-"""
+            """
 @p0='true' (Nullable = false) (Size = 4)
 @p1='1'
 
@@ -1347,9 +1347,646 @@ WHERE "Id" = @p1
 RETURNING 1;
 """,
             //
-"""
+            """
 SELECT "j"."Id", "j"."Reference"
 FROM "JsonEntitiesConverters" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_numeric()
+    {
+        await base.Edit_single_property_collection_of_numeric();
+
+        AssertSql(
+            """
+@p0='[1024,2048]' (Nullable = false) (Size = 11)
+@p1='[999,997]' (Nullable = false) (Size = 9)
+@p2='1'
+
+UPDATE "JsonEntitiesBasic" SET "OwnedCollectionRoot" = json_set("OwnedCollectionRoot", '$[1].Numbers', json(@p0)), "OwnedReferenceRoot" = json_set("OwnedReferenceRoot", '$.Numbers', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."EntityBasicId", "j"."Name", "j"."OwnedCollectionRoot", "j"."OwnedReferenceRoot"
+FROM "JsonEntitiesBasic" AS "j"
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_bool()
+    {
+        await base.Edit_single_property_collection_of_bool();
+
+        AssertSql(
+            """
+@p0='[true,true,true,false]' (Nullable = false) (Size = 22)
+@p1='[true,true,false]' (Nullable = false) (Size = 17)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestBooleanCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestBooleanCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_byte()
+    {
+        await base.Edit_single_property_collection_of_byte();
+
+        AssertSql(
+            """
+@p0='Dg==' (Nullable = false) (Size = 4)
+@p1='GRo=' (Nullable = false) (Size = 4)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestByteCollection', @p0), "Reference" = json_set("Reference", '$.TestByteCollection', @p1)
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_char()
+    {
+        await base.Edit_single_property_collection_of_char();
+
+        AssertSql(
+            """
+@p0='["A","B","\u0022","\u0000"]' (Nullable = false) (Size = 27)
+@p1='["E","F","C","\u00F6","r","E","\u0022","\\"]' (Nullable = false) (Size = 44)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestCharacterCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestCharacterCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_datetime()
+    {
+        await base.Edit_single_property_collection_of_datetime();
+
+        AssertSql(
+            """
+@p0='["2000-01-01T12:34:56","3000-01-01T12:34:56","3000-01-01T12:34:56"]' (Nullable = false) (Size = 67)
+@p1='["2000-01-01T12:34:56","3000-01-01T12:34:56","3000-01-01T12:34:56"]' (Nullable = false) (Size = 67)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDateTimeCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestDateTimeCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_datetimeoffset()
+    {
+        await base.Edit_single_property_collection_of_datetimeoffset();
+
+        AssertSql(
+            """
+@p0='["3000-01-01T12:34:56-04:00"]' (Nullable = false) (Size = 29)
+@p1='["3000-01-01T12:34:56-04:00"]' (Nullable = false) (Size = 29)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDateTimeOffsetCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestDateTimeOffsetCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_decimal()
+    {
+        await base.Edit_single_property_collection_of_decimal();
+        AssertSql(
+            """
+@p0='[-13579.01]' (Nullable = false) (Size = 11)
+@p1='[-13579.01]' (Nullable = false) (Size = 11)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDecimalCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestDecimalCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_double()
+    {
+        await base.Edit_single_property_collection_of_double();
+
+        AssertSql(
+            """
+@p0='[-1.23456789,1.23456789,0,-1.23579]' (Nullable = false) (Size = 35)
+@p1='[-1.23456789,1.23456789,0,-1.23579]' (Nullable = false) (Size = 35)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestDoubleCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestDoubleCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_guid()
+    {
+        await base.Edit_single_property_collection_of_guid();
+        AssertSql(
+            """
+@p0='["12345678-1234-4321-5555-987654321000"]' (Nullable = false) (Size = 40)
+@p1='["12345678-1234-4321-5555-987654321000"]' (Nullable = false) (Size = 40)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestGuidCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestGuidCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_int16()
+    {
+        await base.Edit_single_property_collection_of_int16();
+        AssertSql(
+            """
+@p0='[-3234]' (Nullable = false) (Size = 7)
+@p1='[-3234]' (Nullable = false) (Size = 7)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt16Collection', json(@p0)), "Reference" = json_set("Reference", '$.TestInt16Collection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_int32()
+    {
+        await base.Edit_single_property_collection_of_int32();
+        AssertSql(
+            """
+@p0='[-3234]' (Nullable = false) (Size = 7)
+@p1='[-3234]' (Nullable = false) (Size = 7)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt32Collection', json(@p0)), "Reference" = json_set("Reference", '$.TestInt32Collection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_int64()
+    {
+        await base.Edit_single_property_collection_of_int64();
+
+        AssertSql(
+            """
+@p0='[]' (Nullable = false) (Size = 2)
+@p1='[]' (Nullable = false) (Size = 2)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestInt64Collection', json(@p0)), "Reference" = json_set("Reference", '$.TestInt64Collection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_signed_byte()
+    {
+        await base.Edit_single_property_collection_of_signed_byte();
+
+        AssertSql(
+            """
+@p0='[-108]' (Nullable = false) (Size = 6)
+@p1='[-108]' (Nullable = false) (Size = 6)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestSignedByteCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestSignedByteCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_single()
+    {
+        await base.Edit_single_property_collection_of_single();
+
+        AssertSql(
+            """
+@p0='[-1.234,-1.234]' (Nullable = false) (Size = 15)
+@p1='[0,-1.234]' (Nullable = false) (Size = 10)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestSingleCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestSingleCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_timespan()
+    {
+        await base.Edit_single_property_collection_of_timespan();
+        AssertSql(
+            """
+@p0='["10:09:08.007","10:01:01.007"]' (Nullable = false) (Size = 31)
+@p1='["10:01:01.007","-9:50:51.993"]' (Nullable = false) (Size = 31)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestTimeSpanCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestTimeSpanCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_uint16()
+    {
+        await base.Edit_single_property_collection_of_uint16();
+
+        AssertSql(
+            """
+@p0='[1534]' (Nullable = false) (Size = 6)
+@p1='[1534]' (Nullable = false) (Size = 6)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt16Collection', json(@p0)), "Reference" = json_set("Reference", '$.TestUnsignedInt16Collection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_uint32()
+    {
+        await base.Edit_single_property_collection_of_uint32();
+
+        AssertSql(
+            """
+@p0='[1237775789]' (Nullable = false) (Size = 12)
+@p1='[1237775789]' (Nullable = false) (Size = 12)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt32Collection', json(@p0)), "Reference" = json_set("Reference", '$.TestUnsignedInt32Collection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_uint64()
+    {
+        await base.Edit_single_property_collection_of_uint64();
+
+        AssertSql(
+            """
+@p0='[1234555555123456789]' (Nullable = false) (Size = 21)
+@p1='[1234555555123456789]' (Nullable = false) (Size = 21)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestUnsignedInt64Collection', json(@p0)), "Reference" = json_set("Reference", '$.TestUnsignedInt64Collection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_int32()
+    {
+        await base.Edit_single_property_collection_of_nullable_int32();
+
+        AssertSql(
+            """
+@p0='[null,77]' (Nullable = false) (Size = 9)
+@p1='[null,-2147483648,0,null,2147483647,null,77,null]' (Nullable = false) (Size = 49)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableInt32Collection', json(@p0)), "Reference" = json_set("Reference", '$.TestNullableInt32Collection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_int32_set_to_null()
+    {
+        await base.Edit_single_property_collection_of_nullable_int32_set_to_null();
+
+        AssertSql(
+            """
+@p0=NULL (Nullable = false)
+@p1=NULL (Nullable = false)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableInt32Collection', json(@p0)), "Reference" = json_set("Reference", '$.TestNullableInt32Collection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_enum()
+    {
+        await base.Edit_single_property_collection_of_enum();
+
+        AssertSql(
+            """
+@p0='[2]' (Nullable = false) (Size = 3)
+@p1='[2]' (Nullable = false) (Size = 3)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestEnumCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestEnumCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_enum_with_int_converter()
+    {
+        await base.Edit_single_property_collection_of_enum_with_int_converter();
+
+        AssertSql(
+            """
+@p0='[2]' (Nullable = false) (Size = 3)
+@p1='[2]' (Nullable = false) (Size = 3)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestEnumWithIntConverterCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestEnumWithIntConverterCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum();
+
+        AssertSql(
+            """
+@p0='[2]' (Nullable = false) (Size = 3)
+@p1='[2]' (Nullable = false) (Size = 3)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestEnumCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestEnumCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_set_to_null()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_set_to_null();
+
+        AssertSql(
+            """
+@p0=NULL (Nullable = false)
+@p1=NULL (Nullable = false)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestNullableEnumCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_with_int_converter()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_with_int_converter();
+
+        AssertSql(
+            """
+@p0='[0,null,-7,1]' (Nullable = false) (Size = 13)
+@p1='[0,2,-7,1]' (Nullable = false) (Size = 10)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithIntConverterCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestNullableEnumWithIntConverterCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_with_int_converter_set_to_null()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_with_int_converter_set_to_null();
+
+        AssertSql(
+            """
+@p0=NULL (Nullable = false)
+@p1=NULL (Nullable = false)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithIntConverterCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestNullableEnumWithIntConverterCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_with_converter_that_handles_nulls()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_with_converter_that_handles_nulls();
+
+        AssertSql(
+            """
+@p0='[2]' (Nullable = false) (Size = 3)
+@p1='[0]' (Nullable = false) (Size = 3)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithConverterThatHandlesNullsCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestNullableEnumWithConverterThatHandlesNullsCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
+WHERE "j"."Id" = 1
+LIMIT 2
+""");
+    }
+
+    public override async Task Edit_single_property_collection_of_nullable_enum_with_converter_that_handles_nulls_set_to_null()
+    {
+        await base.Edit_single_property_collection_of_nullable_enum_with_converter_that_handles_nulls_set_to_null();
+        AssertSql(
+            """
+@p0=NULL (Nullable = false)
+@p1=NULL (Nullable = false)
+@p2='1'
+
+UPDATE "JsonEntitiesAllTypes" SET "Collection" = json_set("Collection", '$[0].TestNullableEnumWithConverterThatHandlesNullsCollection', json(@p0)), "Reference" = json_set("Reference", '$.TestNullableEnumWithConverterThatHandlesNullsCollection', json(@p1))
+WHERE "Id" = @p2
+RETURNING 1;
+""",
+            //
+            """
+SELECT "j"."Id", "j"."Collection", "j"."Reference"
+FROM "JsonEntitiesAllTypes" AS "j"
 WHERE "j"."Id" = 1
 LIMIT 2
 """);


### PR DESCRIPTION
Part of #30677

Builds on https://github.com/dotnet/efcore/pull/31272

This is the case where the CLR types contains, for example, an `ObservableCollection<int>`. In this case, we populate this existing collection, rather than creating a new instance.

Same still needs to be done for relational materialization of primitive collections.