### PR TITLE
[release/7.0] Bump Microsoft.Data.SqlClient to 5.1.1

### DIFF
--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

Bump Microsoft.Data.SqlClient to 5.1.1, because the current version (5.0.2) has an insecure dependency and has not been patched because it is going out of support. (We should not have taken a dependency on a non-LTS SqlClient even in a non-LTS EF, since their support still ends before ours. Going forward, we will only ever depend on LTS SqlClient.)

### Customer impact

Ensures customers get a secure release of SqlClient by default.

### How found

Security issue in dependency.

### Regression

No.

### Testing

Existing tests

### Risk

The reason this isn’t just a tell-mode update is that we have to jump to a new _minor_ version of SqlClient in a _patch_ release. This has some risk, but the 5.1.1 version has been out for four months now, and looks solid.
