### PR TITLE
Bring in LinqToCSharpTranslator

### DIFF
--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -59,6 +59,7 @@
 
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <PackageReference Include="Microsoft.Extensions.HostFactoryResolver.Sources" PrivateAssets="All" Version="$(MicrosoftExtensionsHostFactoryResolverSourcesVersion)" />
     <PackageReference Include="Mono.TextTemplating" Version="2.2.1" />

--- a/src/EFCore.Design/Extensions/Internal/TypeExtensions.cs
+++ b/src/EFCore.Design/Extensions/Internal/TypeExtensions.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+internal static class TypeExtensions
+{
+    internal static TypeSyntax GetTypeSyntax(this Type type)
+    {
+        // TODO: Qualification...
+        if (type.IsGenericType)
+        {
+            return GenericName(
+                Identifier(type.Name.Substring(0, type.Name.IndexOf('`'))),
+                TypeArgumentList(SeparatedList(type.GenericTypeArguments.Select(GetTypeSyntax))));
+        }
+
+        if (type == typeof(string))
+        {
+            return PredefinedType(Token(SyntaxKind.StringKeyword));
+        }
+
+        if (type == typeof(bool))
+        {
+            return PredefinedType(Token(SyntaxKind.BoolKeyword));
+        }
+
+        if (type == typeof(byte))
+        {
+            return PredefinedType(Token(SyntaxKind.ByteKeyword));
+        }
+
+        if (type == typeof(sbyte))
+        {
+            return PredefinedType(Token(SyntaxKind.SByteKeyword));
+        }
+
+        if (type == typeof(int))
+        {
+            return PredefinedType(Token(SyntaxKind.IntKeyword));
+        }
+
+        if (type == typeof(uint))
+        {
+            return PredefinedType(Token(SyntaxKind.UIntKeyword));
+        }
+
+        if (type == typeof(short))
+        {
+            return PredefinedType(Token(SyntaxKind.ShortKeyword));
+        }
+
+        if (type == typeof(ushort))
+        {
+            return PredefinedType(Token(SyntaxKind.UShortKeyword));
+        }
+
+        if (type == typeof(long))
+        {
+            return PredefinedType(Token(SyntaxKind.LongKeyword));
+        }
+
+        if (type == typeof(ulong))
+        {
+            return PredefinedType(Token(SyntaxKind.ULongKeyword));
+        }
+
+        if (type == typeof(float))
+        {
+            return PredefinedType(Token(SyntaxKind.FloatKeyword));
+        }
+
+        if (type == typeof(double))
+        {
+            return PredefinedType(Token(SyntaxKind.DoubleKeyword));
+        }
+
+        if (type == typeof(decimal))
+        {
+            return PredefinedType(Token(SyntaxKind.DecimalKeyword));
+        }
+
+        if (type == typeof(char))
+        {
+            return PredefinedType(Token(SyntaxKind.CharKeyword));
+        }
+
+        if (type == typeof(object))
+        {
+            return PredefinedType(Token(SyntaxKind.ObjectKeyword));
+        }
+
+        if (type == typeof(void))
+        {
+            return PredefinedType(Token(SyntaxKind.VoidKeyword));
+        }
+
+        return IdentifierName(type.Name);
+    }
+}

--- a/src/EFCore.Design/Query/Internal/ILinqToCSharpTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/ILinqToCSharpTranslator.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     Translates a LINQ expression tree to a Roslyn syntax tree.
+/// </summary>
+/// <remarks>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </remarks>
+public interface ILinqToCSharpTranslator
+{
+    /// <summary>
+    ///     Translates a node representing a statement into a Roslyn syntax tree.
+    /// </summary>
+    /// <param name="node">The node to be translated.</param>
+    /// <param name="collectedNamespaces">Any namespaces required by the translated code will be added to this set.</param>
+    /// <returns>A Roslyn syntax tree representation of <paramref name="node" />.</returns>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    SyntaxNode TranslateStatement(Expression node, ISet<string> collectedNamespaces);
+
+    /// <summary>
+    ///     Translates a node representing an expression into a Roslyn syntax tree.
+    /// </summary>
+    /// <param name="node">The node to be translated.</param>
+    /// <param name="collectedNamespaces">Any namespaces required by the translated code will be added to this set.</param>
+    /// <returns>A Roslyn syntax tree representation of <paramref name="node" />.</returns>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    SyntaxNode TranslateExpression(Expression node, ISet<string> collectedNamespaces);
+
+    /// <summary>
+    ///     Returns the captured variables detected in the last translation.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    IReadOnlySet<ParameterExpression> CapturedVariables { get; }
+}

--- a/src/EFCore.Design/Query/Internal/LinqToCSharpTranslator.cs
+++ b/src/EFCore.Design/Query/Internal/LinqToCSharpTranslator.cs
@@ -1,0 +1,2197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using E = System.Linq.Expressions.Expression;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class LinqToCSharpTranslator : ExpressionVisitor, ILinqToCSharpTranslator
+{
+    private sealed record StackFrame(
+        Dictionary<ParameterExpression, string> Variables,
+        HashSet<string> VariableNames,
+        Dictionary<LabelTarget, string> Labels,
+        HashSet<string> UnnamedLabelNames);
+
+    private readonly Stack<StackFrame> _stack
+        = new(new[] { new StackFrame(new(), new(), new(), new()) });
+
+    private int _unnamedParameterCounter;
+
+    private sealed record LiftedState(
+        List<StatementSyntax> Statements,
+        Dictionary<ParameterExpression, string> Variables,
+        HashSet<string> VariableNames,
+        List<LocalDeclarationStatementSyntax> UnassignedVariableDeclarations);
+
+    private LiftedState _liftedState = new(new(), new(), new(), new());
+
+    private ExpressionContext _context;
+    private bool _onLastLambdaLine;
+
+    private readonly HashSet<ParameterExpression> _capturedVariables = new();
+    private ISet<string> _collectedNamespaces = null!;
+
+    private static MethodInfo? _activatorCreateInstanceMethod;
+    private static MethodInfo? _typeGetFieldMethod;
+    private static MethodInfo? _fieldGetValueMethod;
+    private static MethodInfo? _mathPowMethod;
+
+    private readonly SideEffectDetectionSyntaxWalker _sideEffectDetector = new();
+    private readonly ConstantDetectionSyntaxWalker _constantDetector = new();
+    private readonly SyntaxGenerator _g;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public LinqToCSharpTranslator(SyntaxGenerator syntaxGenerator)
+        => _g = syntaxGenerator;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public IReadOnlySet<ParameterExpression> CapturedVariables
+        => _capturedVariables.ToHashSet();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual SyntaxNode? Result { get; set; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SyntaxNode TranslateStatement(Expression node, ISet<string> collectedNamespaces)
+        => TranslateCore(node, collectedNamespaces, statementContext: true);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual SyntaxNode TranslateExpression(Expression node, ISet<string> collectedNamespaces)
+        => TranslateCore(node, collectedNamespaces, statementContext: false);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual SyntaxNode TranslateCore(Expression node, ISet<string> collectedNamespaces, bool statementContext = false)
+    {
+        _capturedVariables.Clear();
+        _collectedNamespaces = collectedNamespaces;
+        _unnamedParameterCounter = 0;
+        _context = statementContext ? ExpressionContext.Statement : ExpressionContext.Expression;
+        _onLastLambdaLine = true;
+
+        Visit(node);
+
+        if (_liftedState.Statements.Count > 0)
+        {
+            if (_context == ExpressionContext.Expression)
+            {
+                throw new NotSupportedException("Lifted expressions remaining at top-level in expression context");
+            }
+        }
+
+        Check.DebugAssert(_stack.Count == 1, "_parameterStack.Count == 1");
+        Check.DebugAssert(_stack.Peek().Variables.Count == 0, "_stack.Peek().Parameters.Count == 0");
+        Check.DebugAssert(_stack.Peek().VariableNames.Count == 0, "_stack.Peek().ParameterNames.Count == 0");
+        Check.DebugAssert(_stack.Peek().Labels.Count == 0, "_stack.Peek().Labels.Count == 0");
+        Check.DebugAssert(_stack.Peek().UnnamedLabelNames.Count == 0, "_stack.Peek().UnnamedLabelNames.Count == 0");
+
+        return Result!;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(node))]
+    protected virtual SyntaxNode? Translate(Expression? node)
+    {
+        Visit(node);
+
+        return Result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual T Translate<T>(Expression? node) where T : CSharpSyntaxNode
+    {
+        Visit(node);
+
+        return Result as T
+               ?? throw new InvalidOperationException(
+                   $"Got translated node of type '{Result?.GetType().Name ?? "<null>"}' instead of the expected {typeof(T)}");
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual ExpressionSyntax Translate(Expression expression, IdentifierNameSyntax? lowerableAssignmentVariable)
+    {
+        Check.DebugAssert(
+            _context is ExpressionContext.Expression or ExpressionContext.ExpressionLambda,
+            "Cannot lower in statement context");
+
+        return expression switch
+        {
+            SwitchExpression switchExpression
+                => (ExpressionSyntax)TranslateSwitch(switchExpression, lowerableAssignmentVariable),
+
+            ConditionalExpression conditionalExpression
+                => (ExpressionSyntax)TranslateConditional(conditionalExpression, lowerableAssignmentVariable),
+
+            _ => Translate<ExpressionSyntax>(expression)
+        };
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [return: NotNullIfNotNull("node")]
+    public override Expression? Visit(Expression? node)
+    {
+        if (node is null)
+        {
+            Result = null;
+            return null;
+        }
+
+        return base.Visit(node);
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitBinary(BinaryExpression binary)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        // Handle some special cases
+        switch (binary.NodeType)
+        {
+            case ExpressionType.Assign:
+                return VisitAssignment(binary);
+
+            case ExpressionType.Power when binary.Left.Type == typeof(double) && binary.Right.Type == typeof(double):
+                return Visit(
+                    E.Call(
+                        _mathPowMethod ??= typeof(Math).GetMethod(
+                            nameof(Math.Pow), BindingFlags.Static | BindingFlags.Public, new[] { typeof(double), typeof(double) })!,
+                        binary.Left,
+                        binary.Right));
+
+            case ExpressionType.Power:
+                throw new NotImplementedException("Power over non-double operands");
+
+            case ExpressionType.PowerAssign:
+                return Visit(
+                    E.Assign(
+                        binary.Left,
+                        E.Power(
+                            binary.Left,
+                            binary.Right)));
+        }
+
+        var liftedStatementOrigPosition = _liftedState.Statements.Count;
+        var left = Translate<ExpressionSyntax>(binary.Left);
+        var liftedStatementLeftPosition = _liftedState.Statements.Count;
+        var right = Translate<ExpressionSyntax>(binary.Right);
+
+        // If both sides were lifted, we don't need to do anything special. Same if the left side was lifted.
+        // But if the right side was lifted and the left wasn't, then in order to preserve evaluation order we need to lift the left side
+        // out as well, otherwise the right side gets evaluated before the left.
+        // We refrain from doing this only if the two expressions can't possibly have side effects over each other, for nicer code.
+        if (_liftedState.Statements.Count > liftedStatementLeftPosition
+            && liftedStatementLeftPosition == liftedStatementOrigPosition
+            && !_sideEffectDetector.CanBeReordered(left, right))
+        {
+            var name = UniquifyVariableName("lifted");
+            _liftedState.Statements.Insert(
+                liftedStatementLeftPosition,
+                GenerateVarDeclaration(name, left));
+            _liftedState.VariableNames.Add(name);
+            left = IdentifierName(name);
+        }
+
+        if (binary.NodeType == ExpressionType.ArrayIndex)
+        {
+            Result = ElementAccessExpression(left, BracketedArgumentList(SingletonSeparatedList(Argument(right))));
+            return binary;
+        }
+
+        // TODO: Confirm what to do with the checked expression types
+
+        var syntaxKind = binary.NodeType switch
+        {
+            ExpressionType.Equal => SyntaxKind.EqualsExpression,
+            ExpressionType.NotEqual => SyntaxKind.NotEqualsExpression,
+
+            ExpressionType.Add => SyntaxKind.AddExpression,
+            ExpressionType.AddChecked => SyntaxKind.AddExpression,
+            ExpressionType.Subtract => SyntaxKind.SubtractExpression,
+            ExpressionType.SubtractChecked => SyntaxKind.SubtractExpression,
+            ExpressionType.Multiply => SyntaxKind.MultiplyExpression,
+            ExpressionType.MultiplyChecked => SyntaxKind.MultiplyExpression,
+            ExpressionType.Divide => SyntaxKind.DivideExpression,
+            ExpressionType.Modulo => SyntaxKind.ModuloExpression,
+            ExpressionType.AddAssign => SyntaxKind.AddAssignmentExpression,
+            ExpressionType.AddAssignChecked => SyntaxKind.AddAssignmentExpression,
+            ExpressionType.SubtractAssign => SyntaxKind.SubtractAssignmentExpression,
+            ExpressionType.SubtractAssignChecked => SyntaxKind.SubtractAssignmentExpression,
+            ExpressionType.MultiplyAssign => SyntaxKind.MultiplyAssignmentExpression,
+            ExpressionType.MultiplyAssignChecked => SyntaxKind.MultiplyAssignmentExpression,
+            ExpressionType.DivideAssign => SyntaxKind.DivideAssignmentExpression,
+            ExpressionType.ModuloAssign => SyntaxKind.ModuloAssignmentExpression,
+
+            ExpressionType.GreaterThan => SyntaxKind.GreaterThanExpression,
+            ExpressionType.GreaterThanOrEqual => SyntaxKind.GreaterThanOrEqualExpression,
+            ExpressionType.LessThan => SyntaxKind.LessThanExpression,
+            ExpressionType.LessThanOrEqual => SyntaxKind.LessThanOrEqualExpression,
+
+            ExpressionType.AndAlso => SyntaxKind.LogicalAndExpression,
+            ExpressionType.OrElse => SyntaxKind.LogicalOrExpression,
+            ExpressionType.AndAssign => SyntaxKind.AndAssignmentExpression,
+            ExpressionType.OrAssign => SyntaxKind.OrAssignmentExpression,
+
+            ExpressionType.And => SyntaxKind.BitwiseAndExpression,
+            ExpressionType.Or => SyntaxKind.BitwiseOrExpression,
+            ExpressionType.ExclusiveOr => SyntaxKind.ExclusiveOrExpression,
+            ExpressionType.LeftShift => SyntaxKind.LeftShiftExpression,
+            ExpressionType.RightShift => SyntaxKind.RightShiftExpression,
+            // TODO UnsignedRightShiftExpression
+            ExpressionType.ExclusiveOrAssign => SyntaxKind.ExclusiveOrAssignmentExpression,
+            ExpressionType.LeftShiftAssign => SyntaxKind.LeftShiftAssignmentExpression,
+            ExpressionType.RightShiftAssign => SyntaxKind.RightShiftAssignmentExpression,
+
+            ExpressionType.TypeIs => SyntaxKind.IsExpression,
+            ExpressionType.TypeAs => SyntaxKind.AsExpression,
+            ExpressionType.Coalesce => SyntaxKind.CoalesceExpression,
+
+            _ => throw new ArgumentOutOfRangeException("BinaryExpression with " + binary.NodeType)
+        };
+
+        Result = BinaryExpression(syntaxKind, left, right);
+
+        return binary;
+
+        Expression VisitAssignment(BinaryExpression assignment)
+        {
+            var translatedLeft = Translate<ExpressionSyntax>(assignment.Left);
+
+            ExpressionSyntax translatedRight;
+
+            // LINQ expression trees can directly access private members, but C# code cannot.
+            // If a private member is being set, VisitMember generated a reflection GetValue invocation for it; detect
+            // that here and replace it with SetValue instead.
+            // TODO: Replace this with a more efficient API for .NET 8.0.
+            // TODO: Private property
+            if (translatedLeft is InvocationExpressionSyntax
+                {
+                    Expression: MemberAccessExpressionSyntax
+                    {
+                        Name.Identifier.Text: nameof(FieldInfo.GetValue),
+                        Expression: var fieldInfoExpression
+                    },
+                    ArgumentList.Arguments: [var lValue]
+                })
+            {
+                translatedRight = Translate<ExpressionSyntax>(assignment.Right);
+
+                Result = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        fieldInfoExpression,
+                        IdentifierName(nameof(FieldInfo.SetValue))),
+                    ArgumentList(
+                        SeparatedList(new[] { lValue, Argument(translatedRight) })));
+            }
+            else
+            {
+                // Identify assignment where the RHS supports assignment lowering (switch, conditional). If the e.g. switch expression is
+                // lifted out (because some arm contains a block), this will lower the variable to be assigned inside the resulting switch
+                // statement, rather then adding another useless temporary variable.
+                translatedRight = Translate(
+                    assignment.Right,
+                    lowerableAssignmentVariable: translatedLeft as IdentifierNameSyntax);
+
+                // If the RHS was lifted out and the assignment lowering succeeded, Translate above returns the lowered assignment variable;
+                // this would mean that we return a useless identity assignment (i = i). Instead, just return it.
+                if (translatedRight == translatedLeft)
+                {
+                    Result = translatedRight;
+                }
+                else
+                {
+                    Result = AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, translatedLeft, translatedRight);
+                }
+            }
+
+            return assignment;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitBlock(BlockExpression block)
+    {
+        var blockContext = _context;
+
+        var parentOnLastLambdaLine = _onLastLambdaLine;
+        var parentLiftedState = _liftedState;
+
+        // Expression blocks have no stack of their own, since they're lifted directly to their parent non-expression block.
+        StackFrame? ownStackFrame = null;
+        if (blockContext != ExpressionContext.Expression)
+        {
+            ownStackFrame = PushNewStackFrame();
+            _liftedState = new(new(), new(), new(), new());
+        }
+
+        var stackFrame = _stack.Peek();
+
+        // Do a 1st pass to identify and register any labels, since goto can appear before its label.
+        PreprocessLabels();
+
+        try
+        {
+            // Go over the block's variables, assign names to any unnamed ones and uniquify. Then add them to our stack frame, unless
+            // this is an expression block that will get lifted.
+            foreach (var parameter in block.Variables)
+            {
+                var (variables, variableNames) = (stackFrame.Variables, stackFrame.VariableNames);
+
+                var uniquifiedName = UniquifyVariableName(parameter.Name ?? "unnamed");
+
+                if (blockContext == ExpressionContext.Expression)
+                {
+                    _liftedState.Variables.Add(parameter, uniquifiedName);
+                    _liftedState.VariableNames.Add(uniquifiedName);
+                }
+                else
+                {
+                    variables.Add(parameter, uniquifiedName);
+                    variableNames.Add(uniquifiedName);
+                }
+            }
+
+            var unassignedVariables = block.Variables.ToList();
+
+            var statements = new List<StatementSyntax>();
+            LabeledStatementSyntax? pendingLabeledStatement = null;
+
+            // Now visit the block's expressions
+            for (var i = 0; i < block.Expressions.Count; i++)
+            {
+                var expression = block.Expressions[i];
+                var onLastBlockLine = i == block.Expressions.Count - 1;
+                _onLastLambdaLine = parentOnLastLambdaLine && onLastBlockLine;
+
+                // Any lines before the last are evaluated in statement context (they aren't returned); the last line is evaluated in the
+                // context of the block as a whole. _context now refers to the statement's context, blockContext to the block's.
+                var statementContext = onLastBlockLine ? _context : ExpressionContext.Statement;
+
+                SyntaxNode translated;
+                using (ChangeContext(statementContext))
+                {
+                    translated = Translate(expression);
+                }
+
+                // If we have a labeled statement, unwrap it and keep the label as pending. VisitLabel returns a dummy statement (since
+                // LINQ labels don't have a statement, unlike C#), so we'll skip that statement and add the label to the next real one.
+                if (translated is LabeledStatementSyntax labeledStatement)
+                {
+                    if (pendingLabeledStatement is not null)
+                    {
+                        throw new NotImplementedException("Multiple labels on the same statement");
+                    }
+
+                    pendingLabeledStatement = labeledStatement;
+                    translated = labeledStatement.Statement;
+                }
+
+                // Syntax optimization. This is an assignment of a block variable to some value. Render this as:
+                // var x = <expression>;
+                // ... instead of:
+                // int x;
+                // x = <expression>;
+                // ... except for expression context (i.e. on the last line), where we just return the value if needed.
+                if (expression is BinaryExpression { NodeType: ExpressionType.Assign, Left: ParameterExpression lValue }
+                    && translated is AssignmentExpressionSyntax { Right: var valueSyntax }
+                    && statementContext == ExpressionContext.Statement
+                    && unassignedVariables.Remove(lValue))
+                {
+                    var useExplicitVariableType = valueSyntax.Kind() == SyntaxKind.NullLiteralExpression;
+
+                    translated = useExplicitVariableType
+                        ? _g.LocalDeclarationStatement(lValue.Type.GetTypeSyntax(), LookupVariableName(lValue), valueSyntax)
+                        : _g.LocalDeclarationStatement(LookupVariableName(lValue), valueSyntax);
+                }
+
+                if (statementContext == ExpressionContext.Expression)
+                {
+                    // We're on the last line of a block in expression context - the block is being lifted out.
+                    // All statements before the last line (this one) have already been added to _liftedStatements, just return the last
+                    // expression.
+                    Check.DebugAssert(onLastBlockLine, "onLastBlockLine");
+                    Result = translated;
+                    break;
+                }
+
+                if (blockContext != ExpressionContext.Expression)
+                {
+                    if (_liftedState.Statements.Count > 0)
+                    {
+                        // If any expressions were lifted out of the current expression, flatten them into our own block, just before the
+                        // expression from which they were lifted. Note that we don't do this in Expression context, since our own block is
+                        // lifted out.
+                        statements.AddRange(_liftedState.Statements);
+                        _liftedState.Statements.Clear();
+                    }
+
+                    // Same for any variables being lifted out of the block; we add them to our own stack frame so that we can do proper
+                    // variable name uniquification etc.
+                    if (_liftedState.Variables.Count > 0)
+                    {
+                        foreach (var (parameter, name) in _liftedState.Variables)
+                        {
+                            stackFrame.Variables[parameter] = name;
+                            stackFrame.VariableNames.Add(name);
+                        }
+
+                        _liftedState.Variables.Clear();
+                    }
+                }
+
+                // Skip useless expressions with no side effects in statement context (these can be the result of switch/conditional lifting
+                // with assignment lowering)
+                if (statementContext == ExpressionContext.Statement && !_sideEffectDetector.MayHaveSideEffects(translated))
+                {
+                    continue;
+                }
+
+                var statement = translated switch
+                {
+                    StatementSyntax s => s,
+
+                    // If this is the last line in an expression lambda, wrap it in a return statement.
+                    ExpressionSyntax e when _onLastLambdaLine && statementContext == ExpressionContext.ExpressionLambda
+                        => ReturnStatement(e),
+
+                    // If we're in statement context and we have an expression that can't stand alone (e.g. literal), assign it to discard
+                    ExpressionSyntax e when statementContext == ExpressionContext.Statement && !IsExpressionValidAsStatement(e)
+                        => ExpressionStatement((ExpressionSyntax)_g.AssignmentStatement(_g.IdentifierName("_"), e)),
+
+                    ExpressionSyntax e => ExpressionStatement(e),
+
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+
+                if (blockContext == ExpressionContext.Expression)
+                {
+                    // This block is in expression context, and so will be lifted (we won't be returning a block).
+                    _liftedState.Statements.Add(statement);
+                }
+                else
+                {
+                    if (pendingLabeledStatement is not null)
+                    {
+                        statement = pendingLabeledStatement.WithStatement(statement);
+                        pendingLabeledStatement = null;
+                    }
+
+                    statements.Add(statement);
+                }
+            }
+
+            // If a label existed on the last line of the block, add an empty statement (since C# requires it); for expression blocks we'd
+            // have to lift that, not supported for now.
+            if (pendingLabeledStatement is not null)
+            {
+                if (blockContext == ExpressionContext.Expression)
+                {
+                    throw new NotImplementedException("Label on last expression of an expression block");
+                }
+                else
+                {
+                    statements.Add(pendingLabeledStatement.WithStatement(EmptyStatement()));
+                }
+            }
+
+            // Above we transform top-level assignments (i = 8) to var-declarations with initializers (var i = 8); those variables have
+            // already been taken care of and removed from the list.
+            // But there may still be variables that get assigned inside nested blocks or other situations; prepare declarations for those
+            // and either add them to the block, or lift them if we're an expression block.
+            var unassignedVariableDeclarations =
+                unassignedVariables.Select(
+                    v => (LocalDeclarationStatementSyntax)_g.LocalDeclarationStatement(v.Type.GetTypeSyntax(), LookupVariableName(v)));
+
+            if (blockContext == ExpressionContext.Expression)
+            {
+                _liftedState.UnassignedVariableDeclarations.AddRange(unassignedVariableDeclarations);
+            }
+            else
+            {
+                statements.InsertRange(0, unassignedVariableDeclarations.Concat(_liftedState.UnassignedVariableDeclarations));
+                _liftedState.UnassignedVariableDeclarations.Clear();
+
+                // We're done. If the block is in an expression context, it needs to be lifted out; but not if it's in a lambda (in that
+                // case we just added return above).
+                Result = Block(statements);
+            }
+
+            return block;
+        }
+        finally
+        {
+            _onLastLambdaLine = parentOnLastLambdaLine;
+            _liftedState = parentLiftedState;
+
+            if (ownStackFrame is not null)
+            {
+                var popped = _stack.Pop();
+                Check.DebugAssert(popped.Equals(ownStackFrame), "popped.Equals(ownStackFrame)");
+            }
+        }
+
+        // Returns true for expressions which have side-effects, and can therefore appear alone as a statement
+        static bool IsExpressionValidAsStatement(ExpressionSyntax expression)
+            => expression.Kind() switch
+            {
+                SyntaxKind.InvocationExpression => true,
+
+                SyntaxKind.AddAssignmentExpression => true,
+                SyntaxKind.AndAssignmentExpression => true,
+                SyntaxKind.CoalesceAssignmentExpression => true,
+                SyntaxKind.DivideAssignmentExpression => true,
+                SyntaxKind.ModuloAssignmentExpression => true,
+                SyntaxKind.MultiplyAssignmentExpression => true,
+                SyntaxKind.OrAssignmentExpression => true,
+                SyntaxKind.SimpleAssignmentExpression => true,
+                SyntaxKind.SubtractAssignmentExpression => true,
+                SyntaxKind.ExclusiveOrAssignmentExpression => true,
+                SyntaxKind.LeftShiftAssignmentExpression => true,
+                SyntaxKind.RightShiftAssignmentExpression => true,
+
+                SyntaxKind.PostIncrementExpression => true,
+                SyntaxKind.PostDecrementExpression => true,
+                SyntaxKind.PreIncrementExpression => true,
+                SyntaxKind.PreDecrementExpression => true,
+
+                _ => false
+            };
+
+        void PreprocessLabels()
+        {
+            // LINQ label targets can be unnamed, so we need to generate names for unnamed ones and maintain a target->name mapping.
+            // We need to maintain this as a stack for every block which has labels.
+            // Normal blocks get their own labels stack frame, which gets popped when we leave the block. Expression labels add their
+            // labels to their parent's stack frame (since they get lifted).
+            var stackFrame = _stack.Peek();
+
+            foreach (var label in block.Expressions.OfType<LabelExpression>())
+            {
+                if (stackFrame.Labels.TryGetValue(label.Target, out var identifier))
+                {
+                    continue;
+                }
+
+                var (_, _, labels, unnamedLabelNames) = stackFrame;
+
+                // Generate names for unnamed label targets and uniquify
+                identifier = label.Target.Name ?? "unnamedLabel";
+                var identifierBase = identifier;
+                for (var i = 0; unnamedLabelNames.Contains(identifier); i++)
+                {
+                    identifier = identifierBase + i;
+                }
+
+                if (label.Target.Name is null)
+                {
+                    unnamedLabelNames.Add(identifier);
+                }
+                labels.Add(label.Target, identifier);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override CatchBlock VisitCatchBlock(CatchBlock catchBlock)
+    {
+        Result = TranslateCatchBlock(catchBlock);
+
+        return catchBlock;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual SyntaxNode TranslateCatchBlock(CatchBlock catchBlock, bool noType = false)
+    {
+        var translatedBody = Translate(catchBlock.Body) switch
+        {
+            BlockSyntax b => b,
+            StatementSyntax s => Block(s),
+            ExpressionSyntax e => Block(ExpressionStatement(e)),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        var catchDeclaration = noType
+            ? null
+            : CatchDeclaration(catchBlock.Test.GetTypeSyntax());
+
+        if (catchBlock.Variable is not null)
+        {
+            Check.DebugAssert(catchDeclaration is not null, "catchDeclaration is not null");
+
+            if (catchBlock.Variable.Name is null)
+            {
+                throw new NotSupportedException("TranslateCatchBlock: unnamed parameter as catch variable");
+            }
+
+            catchDeclaration = catchDeclaration.WithIdentifier(Identifier(catchBlock.Variable.Name));
+        }
+
+        return CatchClause(
+            catchDeclaration,
+            catchBlock.Filter is null ? null : CatchFilterClause(Translate<ExpressionSyntax>(catchBlock.Filter)),
+            translatedBody);
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitConditional(ConditionalExpression conditional)
+    {
+        Result = TranslateConditional(conditional, lowerableAssignmentVariable: null);
+
+        return conditional;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual CSharpSyntaxNode TranslateConditional(
+        ConditionalExpression conditional,
+        IdentifierNameSyntax? lowerableAssignmentVariable)
+    {
+        // ConditionalExpression can be an expression or an if/else statement.
+        var test = Translate<ExpressionSyntax>(conditional.Test);
+
+        var isFalseAbsent = conditional.IfFalse is DefaultExpression defaultIfFalse && defaultIfFalse.Type == typeof(void);
+
+        switch (_context)
+        {
+            case ExpressionContext.Statement:
+                return TranslateConditionalStatement(conditional);
+
+            case ExpressionContext.Expression:
+            case ExpressionContext.ExpressionLambda:
+            {
+                if (isFalseAbsent)
+                {
+                    throw new NotSupportedException(
+                        $"Missing {nameof(System.Linq.Expressions.ConditionalExpression.IfFalse)} in {nameof(ConditionalExpression)} in expression context");
+                }
+
+                var parentLiftedState = _liftedState;
+                _liftedState = new(new(), new(), new(), new());
+
+                // If we're in a lambda body, we try to translate as an expression if possible (i.e. no blocks in the true/false arms).
+                using (ChangeContext(ExpressionContext.Expression))
+                {
+                    var ifTrue = Translate(conditional.IfTrue);
+                    var ifFalse = Translate(conditional.IfFalse);
+
+                    if (ifTrue is not ExpressionSyntax ifTrueExpression
+                        || ifFalse is not ExpressionSyntax ifFalseExpression)
+                    {
+                        throw new InvalidOperationException("Trying to evaluate a non-expression condition in expression context");
+                    }
+
+                    // There were no lifted expressions inside either arm - we can translate directly to a C# conditional expression
+                    if (_liftedState.Statements.Count == 0)
+                    {
+                        _liftedState = parentLiftedState;
+                        return ConditionalExpression(test, ifTrueExpression, ifFalseExpression);
+                    }
+                }
+
+                // If we're in a lambda body and couldn't translate as a conditional expression, translate as an if/else statement with
+                // return. Wrap the true/false sides in blocks to have "return" added.
+                if (_context == ExpressionContext.ExpressionLambda)
+                {
+                    _liftedState = parentLiftedState;
+
+                    return Block(TranslateConditionalStatement(conditional.Update(
+                        conditional.Test,
+                        conditional.IfTrue is BlockExpression ? conditional.IfTrue : E.Block(conditional.IfTrue),
+                        conditional.IfFalse is BlockExpression ? conditional.IfFalse : E.Block(conditional.IfFalse))));
+                }
+
+                // We're in regular expression context, and there are lifted expressions inside one of the arms; we translate to an if/else
+                // statement but lowering an assignment into both sides of the condition
+                _liftedState = new(new(), new(), new(), new());
+
+                IdentifierNameSyntax assignmentVariable;
+                TypeSyntax? loweredAssignmentVariableType = null;
+
+                if (lowerableAssignmentVariable is null)
+                {
+                    var name = UniquifyVariableName("liftedConditional");
+                    var parameter = E.Parameter(conditional.Type, name);
+                    assignmentVariable = IdentifierName(name);
+                    loweredAssignmentVariableType = parameter.Type.GetTypeSyntax();
+                }
+                else
+                {
+                    assignmentVariable = lowerableAssignmentVariable;
+                }
+
+                var ifTrueStatement = ProcessArmBody(conditional.IfTrue);
+                var ifFalseStatement = ProcessArmBody(conditional.IfFalse);
+
+                _liftedState = parentLiftedState;
+
+                if (lowerableAssignmentVariable is null)
+                {
+                    _liftedState.Statements.Add(
+                        LocalDeclarationStatement(
+                            VariableDeclaration(loweredAssignmentVariableType!)
+                                .WithVariables(
+                                    SingletonSeparatedList(
+                                        VariableDeclarator(assignmentVariable.Identifier.Text)))));
+                }
+                _liftedState.Statements.Add(IfStatement(test, ifTrueStatement, ElseClause(ifFalseStatement)));
+                return assignmentVariable;
+
+                StatementSyntax ProcessArmBody(Expression body)
+                {
+                    Check.DebugAssert(_liftedState.Statements.Count == 0, "_liftedExpressions.Count == 0");
+
+                    var translatedBody = Translate(body, assignmentVariable);
+
+                    // Usually we add an assignment for the variable.
+                    // The exception is if the body was itself lifted out and the assignment lowering succeeded (nested conditionals) -
+                    // in this case we get back the lowered assignment variable, and don't need the assignment (i = i)
+                    if (translatedBody != assignmentVariable)
+                    {
+                        _liftedState.Statements.Add(ExpressionStatement(
+                            AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                assignmentVariable,
+                                translatedBody)));
+                    }
+
+                    var block = Block(_liftedState.Statements);
+
+                    _liftedState.Statements.Clear();
+                    return block;
+                }
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        IfStatementSyntax TranslateConditionalStatement(ConditionalExpression conditional)
+        {
+            var ifTrue = Translate(conditional.IfTrue);
+            var ifFalse = Translate(conditional.IfFalse);
+
+            var ifTrueStatement = ProcessArmBody(ifTrue, isTrueArm: true);
+
+            if (isFalseAbsent)
+            {
+                return IfStatement(test, ifTrueStatement);
+            }
+
+            var ifFalseStatement = ProcessArmBody(ifFalse, isTrueArm: false);
+
+            return IfStatement(test, ifTrueStatement, ElseClause(ifFalseStatement));
+
+            StatementSyntax ProcessArmBody(SyntaxNode body, bool isTrueArm)
+                => body switch
+                {
+                    BlockSyntax b => b,
+
+                    // We want to specifically exempt IfStatementSyntax under the Else from being wrapped by a block, so as to get nice
+                    // else if syntax
+                    IfStatementSyntax i => isTrueArm ? Block(i) : i,
+
+                    ExpressionSyntax e => Block(ExpressionStatement(e)),
+                    StatementSyntax s => Block(s),
+
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitConstant(ConstantExpression constant)
+    {
+        Result = GenerateValue(constant.Value);
+
+        return constant;
+
+        ExpressionSyntax GenerateValue(object? value)
+            => value switch
+            {
+                int or long or uint or ulong or short or sbyte or ushort or byte or double or float or decimal
+                    => (ExpressionSyntax)_g.LiteralExpression(constant.Value),
+
+                string or bool or null => (ExpressionSyntax)_g.LiteralExpression(constant.Value),
+
+                Type t => TypeOfExpression(t.GetTypeSyntax()),
+                Enum e => HandleEnum(e),
+
+                ITuple tuple
+                    when tuple.GetType() is { IsGenericType: true } tupleType
+                         && tupleType.Name.StartsWith("ValueTuple`", StringComparison.Ordinal)
+                         && tupleType.Namespace == "System"
+                    => HandleValueTuple(tuple),
+
+                _ => throw new NotSupportedException(
+                    $"Encountered a constant of unsupported type '{value.GetType().Name}'. Only primitive constant nodes are supported.")
+            };
+
+        ExpressionSyntax HandleEnum(Enum e)
+        {
+            var enumType = e.GetType();
+
+            var formatted = Enum.Format(enumType, e, "G");
+            if (char.IsDigit(formatted[0]))
+            {
+                // Unknown value, render as a cast of the underlying integral value
+                if (!Enum.IsDefined(e.GetType(), e))
+                {
+                    var underlyingType = enumType.GetEnumUnderlyingType();
+
+                    return CastExpression(
+                        enumType.GetTypeSyntax(),
+                        LiteralExpression(
+                            SyntaxKind.NumericLiteralExpression,
+                            underlyingType == typeof(sbyte)
+                            || underlyingType == typeof(short)
+                            || underlyingType == typeof(int)
+                            || underlyingType == typeof(long)
+                                ? Literal(long.Parse(formatted))
+                                : Literal(ulong.Parse(formatted))));
+                }
+            }
+
+            var components = formatted.Split(", ");
+            Check.DebugAssert(components.Length > 0, "components.Length > 0");
+
+            return components.Aggregate(
+                (ExpressionSyntax?)null,
+                (last, next) => last is null
+                    ? MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName(enumType.Name),
+                        IdentifierName(next))
+                    : BinaryExpression(
+                        SyntaxKind.BitwiseOrExpression, last,
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName(enumType.Name),
+                            IdentifierName(next))))!;
+        }
+
+        ExpressionSyntax HandleValueTuple(ITuple tuple)
+        {
+            var arguments = new ArgumentSyntax[tuple.Length];
+            for (var i = 0; i < tuple.Length; i++)
+            {
+                arguments[i] = Argument(GenerateValue(tuple[i]!));
+            }
+
+            return TupleExpression(SeparatedList(arguments));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitDebugInfo(DebugInfoExpression node)
+        => throw new NotSupportedException("DebugInfo nodes are not supporting when translating expression trees to C#");
+
+    /// <inheritdoc />
+    protected override Expression VisitDefault(DefaultExpression node)
+    {
+        Result = DefaultExpression(node.Type.GetTypeSyntax());
+
+        return node;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitGoto(GotoExpression gotoNode)
+    {
+        Result = GotoStatement(SyntaxKind.GotoStatement, TranslateLabelTarget(gotoNode.Target));
+        return gotoNode;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitInvocation(InvocationExpression invocation)
+    {
+        var lambda = (LambdaExpression)invocation.Expression;
+
+        // We need to inline the lambda invocation into the tree, by replacing parameters in the lambda body with the invocation arguments.
+        // However, if an argument to the invocation can have side effects (e.g. a method call), and it's referenced multiple times from
+        // the body, then that would cause multiple evaluation, which is wrong (same if the arguments are evaluated only once but in reverse
+        // order).
+        // So we have to lift such arguments.
+        var arguments = new Expression[invocation.Arguments.Count];
+
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var argument = invocation.Arguments[i];
+
+            if (argument is ConstantExpression)
+            {
+                // No need to evaluate into a separate variable, just pass directly
+                arguments[i] = argument;
+                continue;
+            }
+
+            // Need to lift
+            var name = UniquifyVariableName(lambda.Parameters[i].Name ?? "lifted");
+            var parameter = E.Parameter(argument.Type, name);
+            _liftedState.Statements.Add(GenerateVarDeclaration(name, Translate<ExpressionSyntax>(argument)));
+            arguments[i] = parameter;
+        }
+
+        var replacedBody = new ReplacingExpressionVisitor(lambda.Parameters, arguments).Visit(lambda.Body);
+        Result = Translate(replacedBody);
+
+        return invocation;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitLabel(LabelExpression label)
+    {
+        // C# labels apply on a statement, but in LINQ they can appear anywhere (i.e. last thing in a block).
+        // So we apply the label to a dummy null literal statement, which we'll filter out of the block in statement context anyway.
+        Result = LabeledStatement(
+            TranslateLabelTarget(label.Target).Identifier.Text,
+            ExpressionStatement(LiteralExpression(SyntaxKind.NullLiteralExpression)));
+        return label;
+    }
+
+    /// <inheritdoc />
+    protected override LabelTarget VisitLabelTarget(LabelTarget? labelTarget)
+    {
+        if (labelTarget is null)
+        {
+            throw new NotImplementedException("Null argument in VisitLabelTarget");
+        }
+
+        Result = TranslateLabelTarget(labelTarget);
+        return labelTarget;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual IdentifierNameSyntax TranslateLabelTarget(LabelTarget labelTarget)
+    {
+        // In LINQ expression trees, label targets can have a return type (they're expressions), which means they return the last evaluated
+        // thing if e.g. they're the last expression in a block. This would require lifting out the last evaluation before the goto/break,
+        // assigning it to a temporary variable, and adding a variable evaluation after the label.
+        if (labelTarget.Type != typeof(void))
+        {
+            throw new NotImplementedException("Non-void label target");
+        }
+
+        // We did a processing pass on the block's labels, so any labels should already be found in our label stack frame
+        return IdentifierName(_stack.Peek().Labels[labelTarget]);
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitLambda<T>(Expression<T> lambda)
+    {
+        using var _ = ChangeContext(
+            lambda.ReturnType == typeof(void) ? ExpressionContext.Statement : ExpressionContext.ExpressionLambda);
+        var parentOnLastLambdaLine = _onLastLambdaLine;
+        _onLastLambdaLine = true;
+
+        var stackFrame = PushNewStackFrame();
+
+        var localUnnamedParameterCounter = 0;
+        foreach (var parameter in lambda.Parameters)
+        {
+            var name = parameter.Name ?? "unnamed" + (++localUnnamedParameterCounter);
+            stackFrame.Variables[parameter] = name;
+            stackFrame.VariableNames.Add(name);
+        }
+
+        var body = (CSharpSyntaxNode)Translate(lambda.Body);
+
+        // If the lambda body was an expression that had lifted statements (e.g. some block in expression context), we need to create
+        // a block to contain these statements
+        if (_liftedState.Statements.Count > 0)
+        {
+            Check.DebugAssert(lambda.ReturnType != typeof(void), "lambda.ReturnType != typeof(void)");
+
+            body = Block(_liftedState.Statements.Append(ReturnStatement((ExpressionSyntax)body)));
+            _liftedState.Statements.Clear();
+        }
+
+        // Note that we always explicitly include the parameters' types.
+        // This is because in some cases, the parameter isn't actually used in the lambda body, and the compiler can't infer its type.
+        // However, we can't do that when the type is anonymous.
+        Result = ParenthesizedLambdaExpression(
+            ParameterList(SeparatedList(lambda.Parameters.Select(p =>
+                Parameter(Identifier(LookupVariableName(p)))
+                    .WithType(p.Type.IsAnonymousType() ? null : p.Type.GetTypeSyntax())))),
+            body);
+
+        var popped = _stack.Pop();
+        Check.DebugAssert(popped.Equals(stackFrame), "popped.Equals(stackFrame)");
+
+        _onLastLambdaLine = parentOnLastLambdaLine;
+
+        return lambda;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitLoop(LoopExpression loop)
+    {
+        if (_context == ExpressionContext.Expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        var rewrittenLoop1 = loop;
+
+        if (loop.ContinueLabel is not null)
+        {
+            var blockBody = loop.Body is BlockExpression b ? b : E.Block(loop.Body);
+            blockBody = blockBody.Update(
+                blockBody.Variables,
+                new[] { E.Label(loop.ContinueLabel) }.Concat(blockBody.Expressions));
+
+            rewrittenLoop1 = loop.Update(
+                loop.BreakLabel,
+                continueLabel: null,
+                blockBody);
+        }
+
+        Expression rewrittenLoop2 = rewrittenLoop1;
+
+        if (loop.BreakLabel is not null)
+        {
+            rewrittenLoop2 =
+                E.Block(
+                    rewrittenLoop1.Update(breakLabel: null, rewrittenLoop1.ContinueLabel, rewrittenLoop1.Body),
+                    E.Label(loop.BreakLabel));
+        }
+
+        if (rewrittenLoop2 != loop)
+        {
+            return Visit(rewrittenLoop2);
+        }
+
+        var translatedBody = Translate(loop.Body) switch
+        {
+            BlockSyntax b => b,
+            StatementSyntax s => Block(s),
+            ExpressionSyntax e => Block(ExpressionStatement(e)),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        StatementSyntax translated = WhileStatement(
+            LiteralExpression(SyntaxKind.TrueLiteralExpression),
+            translatedBody);
+
+        Result = translated;
+
+        return loop;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMember(MemberExpression member)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        // LINQ expression trees can directly access private members, but C# code cannot; render (slow) reflection code that does the same
+        // thing. Note that assignment to private members is handled in VisitBinary.
+        // TODO: Replace this with a more efficient API for .NET 8.0.
+        switch (member.Member)
+        {
+            case FieldInfo { IsPrivate: true } fieldInfo:
+                if (member.Expression is null)
+                {
+                    throw new NotImplementedException("Private static field access");
+                }
+
+                if (member.Member.DeclaringType is null)
+                {
+                    throw new NotSupportedException("Private field without a declaring type: " + member.Member.Name);
+                }
+
+                Result = Translate(
+                    E.Call(
+                        E.Call(
+                            E.Constant(member.Member.DeclaringType),
+                            _typeGetFieldMethod ??= typeof(Type).GetMethod(
+                                nameof(Type.GetField), new[] { typeof(string), typeof(BindingFlags) })!,
+                            E.Constant(fieldInfo.Name),
+                            E.Constant(BindingFlags.NonPublic | BindingFlags.Instance)),
+                        _fieldGetValueMethod ??= typeof(FieldInfo).GetMethod(nameof(FieldInfo.GetValue), new[] { typeof(object) })!,
+                        member.Expression));
+
+                break;
+
+            // TODO: private property
+            // TODO: private event
+
+            default:
+                Result = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    member.Expression is null
+                        ? member.Type.GetTypeSyntax() // static
+                        : Translate<ExpressionSyntax>(member.Expression),
+                    IdentifierName(member.Member.Name));
+                break;
+        }
+
+        return member;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitIndex(IndexExpression index)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        if (index.Arguments.Count > 1)
+        {
+            throw new NotImplementedException("IndexExpression with multiple arguments");
+        }
+
+        Result =
+            ElementAccessExpression(Translate<ExpressionSyntax>(index.Object!))
+                .WithArgumentList(
+                    BracketedArgumentList(
+                        SingletonSeparatedList(
+                            Argument(
+                                Translate<ExpressionSyntax>(index.Arguments.Single())))));
+
+        return index;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMethodCall(MethodCallExpression call)
+    {
+        if (call.Method.DeclaringType is null)
+        {
+            throw new NotSupportedException($"Can't translate method '{call.Method.Name}' which has no declaring type");
+        }
+
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        var arguments = TranslateMethodArguments(call.Method.GetParameters(), call.Arguments);
+
+        // For generic methods, we check whether the generic type arguments are inferrable (e.g. they all appear in the parameters), and
+        // only explicitly specify the arguments if not. Note that this isn't just for prettier code: anonymous types cannot be explicitly
+        // named in code.
+        SimpleNameSyntax methodIdentifier;
+        if (!call.Method.IsGenericMethod || GenericTypeParameterAreInferrable())
+        {
+            methodIdentifier = IdentifierName(call.Method.Name);
+        }
+        else
+        {
+            Check.DebugAssert(
+                call.Method.GetGenericArguments().All(ga => !ga.IsAnonymousType()),
+                "Anonymous type as generic type argument for method whose type arguments aren't inferrable");
+
+            methodIdentifier = GenericName(
+                Identifier(call.Method.Name),
+                TypeArgumentList(
+                    SeparatedList(
+                        call.Method.GetGenericArguments().Select(ga => ga.GetTypeSyntax()))));
+        }
+
+        // Extension syntax
+        if (call.Method.IsDefined(typeof(ExtensionAttribute), inherit: false)
+            && !(arguments[0].Expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.NullLiteralExpression)))
+        {
+            Result = InvocationExpression(
+                MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    arguments[0].Expression,
+                    methodIdentifier),
+                ArgumentList(SeparatedList(arguments[1..])));
+        }
+        else
+        {
+            ExpressionSyntax expression;
+            if (call.Object is null)
+            {
+                // Static method call. Recursively add MemberAccessExpressions for all declaring types (for methods on nested types)
+                expression = GetMemberAccessesForAllDeclaringTypes(call.Method.DeclaringType);
+
+                static ExpressionSyntax GetMemberAccessesForAllDeclaringTypes(Type type)
+                {
+                    return type.DeclaringType is null
+                        ? type.GetTypeSyntax()
+                        : MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            GetMemberAccessesForAllDeclaringTypes(type.DeclaringType),
+                            IdentifierName(type.Name));
+                }
+            }
+            else
+            {
+                expression = Translate<ExpressionSyntax>(call.Object);
+            }
+
+            Result = InvocationExpression(
+                MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    expression,
+                    methodIdentifier),
+                ArgumentList(SeparatedList(arguments)));
+        }
+
+        if (call.Method.DeclaringType.Namespace is { } ns)
+        {
+            _collectedNamespaces.Add(ns);
+        }
+
+        return call;
+
+        bool GenericTypeParameterAreInferrable()
+        {
+            var originalDefinition = call.Method.GetGenericMethodDefinition();
+            var unseenTypeParameters = originalDefinition.GetGenericArguments().ToList();
+
+            foreach (var parameter in originalDefinition.GetParameters())
+            {
+                ProcessType(parameter.ParameterType);
+            }
+
+            return unseenTypeParameters.Count == 0;
+
+            void ProcessType(Type type)
+            {
+                if (type.IsGenericParameter)
+                {
+                    unseenTypeParameters.Remove(type);
+                }
+                else if (type.IsGenericType)
+                {
+                    foreach (var genericArgument in type.GetGenericArguments())
+                    {
+                        ProcessType(genericArgument);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitNewArray(NewArrayExpression newArray)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        var elementType = newArray.Type.GetElementType()!.GetTypeSyntax();
+
+        var expressions = TranslateList(newArray.Expressions);
+
+        if (newArray.NodeType == ExpressionType.NewArrayBounds)
+        {
+            Result =
+                ArrayCreationExpression(
+                    ArrayType(
+                        elementType,
+                        SingletonList(ArrayRankSpecifier(SeparatedList(expressions)))));
+
+            return newArray;
+        }
+
+        Check.DebugAssert(newArray.NodeType == ExpressionType.NewArrayInit, "newArray.NodeType == ExpressionType.NewArrayInit");
+
+        Result = _g.ArrayCreationExpression(elementType, expressions);
+
+        return newArray;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitNew(NewExpression node)
+    {
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        var arguments = node.Constructor is null
+            ? Array.Empty<ArgumentSyntax>()
+            : TranslateMethodArguments(node.Constructor.GetParameters(), node.Arguments);
+
+        if (node.Type.IsAnonymousType())
+        {
+            if (node.Members is null)
+            {
+                throw new NotSupportedException("Anonymous type creation without members");
+            }
+
+            Result = AnonymousObjectCreationExpression(
+                SeparatedList(
+                    arguments.Select(
+                            (arg, i) =>
+                                AnonymousObjectMemberDeclarator(NameEquals(node.Members[i].Name), arg.Expression))
+                        .ToArray()));
+
+            return node;
+        }
+
+        // If the type has any required properties and the constructor doesn't have [SetsRequiredMembers], we can't just generate an
+        // instantiation expression.
+        // TODO: Currently matching attributes by name since we target .NET 6.0. If/when we target .NET 7.0 and above, match the type.
+        if (node.Type.GetCustomAttributes(inherit: true)
+                .Any(a => a.GetType().FullName == "System.Runtime.CompilerServices.RequiredMemberAttribute")
+            && node.Constructor is not null
+            && node.Constructor.GetCustomAttributes()
+                .Any(a => a.GetType().FullName == "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute") != true)
+        {
+            // If the constructor is parameterless, we generate Activator.Create<T>() which is almost as fast (<10ns difference).
+            // For constructors with parameters, we currently throw as not supported (we can pass parameters, but boxing, probably
+            // speed degradation etc.).
+            if (node.Constructor.GetParameters().Length == 0)
+            {
+                Result =
+                    Translate(
+                        E.Call(
+                            (_activatorCreateInstanceMethod ??= typeof(Activator).GetMethod(
+                                nameof(Activator.CreateInstance), Array.Empty<Type>())!)
+                            .MakeGenericMethod(node.Type)));
+            }
+            else
+            {
+                throw new NotImplementedException("Instantiation of type with required properties via constructor that has parameters");
+            }
+        }
+        else
+        {
+            // Normal case with plain old instantiation
+            Result = ObjectCreationExpression(
+                node.Type.GetTypeSyntax(),
+                ArgumentList(SeparatedList(arguments)),
+                initializer: null);
+        }
+
+        if (node.Constructor?.DeclaringType?.Namespace is not null)
+        {
+            _collectedNamespaces.Add(node.Constructor.DeclaringType.Namespace);
+        }
+
+        return node;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitParameter(ParameterExpression parameter)
+    {
+        // Note that the parameter in the lambda declaration is handled separately in VisitLambda
+        if (_stack.Peek().Variables.TryGetValue(parameter, out var name)
+            || _liftedState.Variables.TryGetValue(parameter, out name))
+        {
+            Result = IdentifierName(name);
+
+            return parameter;
+        }
+
+        // This parameter is unknown to us - it's captured from outside the entire expression tree.
+        // Simply return its name without worrying about uniquification, since the variable needs to correspond to the outside in any
+        // case (it's the callers responsibility).
+        _capturedVariables.Add(parameter);
+
+        if (parameter.Name is null)
+        {
+            throw new NotSupportedException("Unnamed captured variable");
+        }
+
+        Result = IdentifierName(parameter.Name);
+        return parameter;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitRuntimeVariables(RuntimeVariablesExpression node)
+        => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    protected override SwitchCase VisitSwitchCase(SwitchCase node)
+        => throw new NotSupportedException("Translation happens as part of VisitSwitch");
+
+    /// <inheritdoc />
+    protected override Expression VisitSwitch(SwitchExpression switchNode)
+    {
+        Result = TranslateSwitch(switchNode, lowerableAssignmentVariable: null);
+
+        return switchNode;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected virtual CSharpSyntaxNode TranslateSwitch(SwitchExpression switchNode, IdentifierNameSyntax? lowerableAssignmentVariable)
+    {
+        if (switchNode.Comparison is not null)
+        {
+            throw new NotImplementedException("Switch with non-null comparison method");
+        }
+
+        var switchValue = Translate<ExpressionSyntax>(switchNode.SwitchValue);
+
+        switch (_context)
+        {
+            case ExpressionContext.Statement:
+            {
+                var parentLiftedState = _liftedState;
+                _liftedState = new(new(), new(), new(), new());
+
+                var cases = List(
+                    switchNode.Cases.Select(
+                        c => SwitchSection(
+                            labels: List<SwitchLabelSyntax>(
+                                c.TestValues.Select(tv => CaseSwitchLabel(Translate<ExpressionSyntax>(tv)))),
+                            statements: ProcessArmBody(c.Body))));
+
+                // LINQ SwitchExpression supports non-literal labels, which C# does not support. This rewrites the switch as a series of
+                // nested ConditionalExpressions.
+                if (cases.Any(c => c.Labels.Any(l => l is CaseSwitchLabelSyntax l2 && !_constantDetector.IsConstant(l2.Value))))
+                {
+                    _liftedState = parentLiftedState;
+                    return TranslateConditional(RewriteSwitchToConditionals(switchNode), lowerableAssignmentVariable);
+                }
+
+                if (switchNode.DefaultBody is not null)
+                {
+                    cases = cases.Add(
+                        SwitchSection(
+                            SingletonList<SwitchLabelSyntax>(DefaultSwitchLabel()),
+                            ProcessArmBody(switchNode.DefaultBody)));
+                }
+
+                return SwitchStatement(switchValue, cases);
+
+                SyntaxList<StatementSyntax> ProcessArmBody(Expression body)
+                {
+                    var translatedBody = Translate(body);
+
+                    var result = translatedBody switch
+                    {
+                        BlockSyntax block => SingletonList<StatementSyntax>(block.WithStatements(block.Statements.Add(BreakStatement()))),
+                        StatementSyntax s => List(new[] { s, BreakStatement() }),
+                        ExpressionSyntax e => List(new StatementSyntax[] { ExpressionStatement(e), BreakStatement() }),
+
+                        _ => throw new ArgumentOutOfRangeException()
+                    };
+
+                    return result;
+                }
+            }
+
+            case ExpressionContext.Expression:
+            case ExpressionContext.ExpressionLambda:
+            {
+                if (switchNode.DefaultBody is null)
+                {
+                    throw new NotSupportedException("Missing default arm for switch expression");
+                }
+
+                var parentLiftedState = _liftedState;
+                _liftedState = new(new(), new(), new(), new());
+
+                // Translate all arms
+                var arms = SeparatedList(
+                    switchNode.Cases.SelectMany(
+                            c => c.TestValues, (c, tv) => SwitchExpressionArm(
+                                ConstantPattern(Translate<ExpressionSyntax>(tv)),
+                                Translate<ExpressionSyntax>(c.Body)))
+                        .Append(SwitchExpressionArm(DiscardPattern(), Translate<ExpressionSyntax>(switchNode.DefaultBody))));
+
+                // LINQ SwitchExpression supports non-literal labels, which C# does not support. This rewrites the switch as a series of
+                // nested ConditionalExpressions.
+                if (arms.Any(a => a.Pattern is ConstantPatternSyntax cp && !_constantDetector.IsConstant(cp.Expression)))
+                {
+                    _liftedState = parentLiftedState;
+                    return TranslateConditional(RewriteSwitchToConditionals(switchNode), lowerableAssignmentVariable);
+                }
+
+                // If there were no lifted expressions inside any arm, we can translate directly to a C# switch expression
+                if (_liftedState.Statements.Count == 0)
+                {
+                    _liftedState = parentLiftedState;
+                    return SwitchExpression(switchValue, arms);
+                }
+
+                // There are lifted expressions inside some of the arms, we must lift the entire switch expression, rewriting it to
+                // a switch statement.
+                _liftedState = new(new(), new(), new(), new());
+
+                IdentifierNameSyntax assignmentVariable;
+                TypeSyntax? loweredAssignmentVariableType = null;
+
+                if (lowerableAssignmentVariable is null)
+                {
+                    var name = UniquifyVariableName("liftedSwitch");
+                    var parameter = E.Parameter(switchNode.Type, name);
+                    assignmentVariable = IdentifierName(name);
+                    loweredAssignmentVariableType = parameter.Type.GetTypeSyntax();
+                }
+                else
+                {
+                    assignmentVariable = lowerableAssignmentVariable;
+                }
+
+                var cases = List(
+                    switchNode.Cases.Select(
+                        c => SwitchSection(
+                            labels: List<SwitchLabelSyntax>(
+                                c.TestValues.Select(tv => CaseSwitchLabel(Translate<LiteralExpressionSyntax>(tv)))),
+                            statements: ProcessArmBody(c.Body)))
+                        .Append(SwitchSection(
+                            SingletonList<SwitchLabelSyntax>(DefaultSwitchLabel()),
+                            ProcessArmBody(switchNode.DefaultBody))));
+
+                _liftedState = parentLiftedState;
+
+                if (lowerableAssignmentVariable is null)
+                {
+                    _liftedState.Statements.Add(
+                        LocalDeclarationStatement(
+                            VariableDeclaration(loweredAssignmentVariableType!)
+                                .WithVariables(
+                                    SingletonSeparatedList(
+                                        VariableDeclarator(assignmentVariable.Identifier.Text)))));
+                }
+
+                _liftedState.Statements.Add(SwitchStatement(switchValue, cases));
+                return assignmentVariable;
+
+                SyntaxList<StatementSyntax> ProcessArmBody(Expression body)
+                {
+                    Check.DebugAssert(_liftedState.Statements.Count == 0, "_liftedExpressions.Count == 0");
+
+                    var translatedBody = Translate(body, assignmentVariable);
+
+                    var assignmentStatement = ExpressionStatement(
+                        AssignmentExpression(
+                            SyntaxKind.SimpleAssignmentExpression,
+                            assignmentVariable,
+                            translatedBody));
+
+                    if (_liftedState.Statements.Count == 0)
+                    {
+                        // Simple expression, can embed directly in the switch case
+                        return List(new StatementSyntax[] { assignmentStatement, BreakStatement() });
+                    }
+
+                    // Usually we add an assignment for the variable.
+                    // The exception is if the body was itself lifted out and the assignment lowering succeeded (nested conditionals) -
+                    // in this case we get back the lowered assignment variable, and don't need the assignment (i = i)
+                    if (translatedBody != assignmentVariable)
+                    {
+                        _liftedState.Statements.Add(ExpressionStatement(
+                            AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                assignmentVariable,
+                                translatedBody)));
+                    }
+
+                    _liftedState.Statements.Add(BreakStatement());
+                    var block = SingletonList<StatementSyntax>(Block(_liftedState.Statements));
+
+                    _liftedState.Statements.Clear();
+                    return block;
+                }
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        static ConditionalExpression RewriteSwitchToConditionals(SwitchExpression node)
+        {
+            if (node.Type == typeof(void))
+            {
+                return (ConditionalExpression)(node.Cases
+                           .SelectMany(c => c.TestValues, (c, tv) => new { c.Body, Label = tv })
+                           .Reverse()
+                           .Aggregate(
+                               node.DefaultBody,
+                               (expression, arm) => expression is null
+                                   ? E.IfThen(E.Equal(node.SwitchValue, arm.Label), arm.Body)
+                                   : E.IfThenElse(E.Equal(node.SwitchValue, arm.Label), arm.Body, expression))
+                       ?? throw new NotImplementedException("Empty switch statement"));
+            }
+
+            Check.DebugAssert(node.DefaultBody is not null, "Switch expression with non-void return type but no default body");
+
+            return (ConditionalExpression)node.Cases
+                .SelectMany(c => c.TestValues, (c, tv) => new { c.Body, Label = tv })
+                .Reverse()
+                .Aggregate(
+                    node.DefaultBody,
+                    (expression, arm) => E.Condition(
+                        E.Equal(node.SwitchValue, arm.Label),
+                        arm.Body,
+                        expression));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitTry(TryExpression tryNode)
+    {
+        var translatedBody = Translate(tryNode.Body) switch
+        {
+            BlockSyntax b => (IEnumerable<SyntaxNode>)b.Statements,
+            var n => new[] { n }
+        };
+
+        var translatedFinally = Translate(tryNode.Finally) switch
+        {
+            BlockSyntax b => (IEnumerable<SyntaxNode>)b.Statements,
+            null => null,
+            var n => new[] { n }
+        };
+
+        switch (_context)
+        {
+            case ExpressionContext.Statement:
+                if (tryNode.Fault is not null)
+                {
+                    Check.DebugAssert(
+                        tryNode.Finally is null && tryNode.Handlers.Count == 0,
+                        "tryNode.Finally is null && tryNode.Handlers.Count == 0");
+
+                    Result = _g.TryCatchStatement(
+                        translatedBody,
+                        catchClauses: new[] { TranslateCatchBlock(E.Catch(typeof(Exception), tryNode.Fault), noType: true) });
+
+                    return tryNode;
+                }
+
+                Result = _g.TryCatchStatement(
+                    translatedBody,
+                    catchClauses: tryNode.Handlers.Select(h => TranslateCatchBlock(h)),
+                    translatedFinally);
+
+                return tryNode;
+
+            case ExpressionContext.Expression:
+            case ExpressionContext.ExpressionLambda:
+                throw new NotImplementedException();
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitTypeBinary(TypeBinaryExpression node)
+    {
+        var visitedExpression = Translate<ExpressionSyntax>(node.Expression);
+
+        Result = node.NodeType switch
+        {
+            ExpressionType.TypeIs
+                => BinaryExpression(SyntaxKind.IsExpression, visitedExpression, node.TypeOperand.GetTypeSyntax()),
+
+            ExpressionType.TypeEqual
+                => BinaryExpression(SyntaxKind.EqualsExpression, visitedExpression, TypeOfExpression(node.TypeOperand.GetTypeSyntax())),
+
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        return node;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitUnary(UnaryExpression unary)
+    {
+        if (unary.Method is not null)
+        {
+            throw new NotImplementedException("Unary node with non-null method");
+        }
+
+        using var _ = ChangeContext(ExpressionContext.Expression);
+
+        var operand = Translate<ExpressionSyntax>(unary.Operand);
+
+        // TODO: Confirm what to do with the checked expression types
+
+        Result = unary.NodeType switch
+        {
+            ExpressionType.Negate => _g.NegateExpression(operand),
+            ExpressionType.NegateChecked => _g.NegateExpression(operand),
+            ExpressionType.Not when unary.Type == typeof(bool) => _g.LogicalNotExpression(operand),
+            ExpressionType.Not => _g.BitwiseNotExpression(operand),
+            ExpressionType.OnesComplement => _g.BitwiseNotExpression(operand),
+            ExpressionType.IsFalse => _g.LogicalNotExpression(operand),
+            ExpressionType.IsTrue => operand,
+            ExpressionType.ArrayLength => _g.MemberAccessExpression(operand, "Length"),
+            ExpressionType.Convert => _g.ConvertExpression(unary.Type.GetTypeSyntax(), operand),
+            ExpressionType.ConvertChecked => _g.ConvertExpression(unary.Type.GetTypeSyntax(), operand),
+            ExpressionType.Throw when unary.Type == (typeof(void)) => _g.ThrowStatement(operand),
+            ExpressionType.Throw => _g.ThrowExpression(operand),
+            ExpressionType.TypeAs => BinaryExpression(SyntaxKind.AsExpression, operand, unary.Type.GetTypeSyntax()),
+            ExpressionType.Quote => operand,
+            ExpressionType.UnaryPlus => PrefixUnaryExpression(SyntaxKind.UnaryPlusExpression, operand),
+            ExpressionType.Unbox => operand,
+            ExpressionType.Increment => Translate(Expression.Add(unary.Operand, Expression.Constant(1))),
+            ExpressionType.Decrement => Translate(Expression.Subtract(unary.Operand, Expression.Constant(1))),
+            ExpressionType.PostIncrementAssign => PostfixUnaryExpression(SyntaxKind.PostIncrementExpression, operand),
+            ExpressionType.PostDecrementAssign => PostfixUnaryExpression(SyntaxKind.PostDecrementExpression, operand),
+            ExpressionType.PreIncrementAssign => PrefixUnaryExpression(SyntaxKind.PreIncrementExpression, operand),
+            ExpressionType.PreDecrementAssign => PrefixUnaryExpression(SyntaxKind.PreDecrementExpression, operand),
+
+            _ => throw new ArgumentOutOfRangeException("Unsupported LINQ unary node: " + unary.NodeType)
+        };
+
+        return unary;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMemberInit(MemberInitExpression memberInit)
+    {
+        var objectCreation = Translate<ObjectCreationExpressionSyntax>(memberInit.NewExpression);
+
+        List<MemberListBinding>? incompatibleListBindings = null;
+
+        var initializerExpressions = new List<AssignmentExpressionSyntax>(memberInit.Bindings.Count);
+
+        foreach (var binding in memberInit.Bindings)
+        {
+            // C# collection initialization syntax only works when Add is called on an IEnumerable, but LINQ supports arbitrary add
+            // methods. Skip these, we'll add them later outside the initializer
+            if (binding is MemberListBinding listBinding
+                && (!listBinding.Member.GetMemberType().IsAssignableTo(typeof(IEnumerable))
+                    || listBinding.Initializers.Any(e => e.AddMethod.Name != "Add" || e.Arguments.Count != 1)))
+            {
+                incompatibleListBindings ??= new();
+                incompatibleListBindings.Add(listBinding);
+                continue;
+            }
+
+            var liftedStatementsPosition = _liftedState.Statements.Count;
+
+            VisitMemberBinding(binding);
+
+            initializerExpressions.Add((AssignmentExpressionSyntax)Result!);
+
+            if (_liftedState.Statements.Count > liftedStatementsPosition)
+            {
+                // TODO: This is tricky because of the recursive nature of MemberMemberBinding
+                throw new NotImplementedException("MemberInit: lifted statements");
+            }
+        }
+
+        if (incompatibleListBindings is not null)
+        {
+            // TODO: Lift the instantiation and add extra statements to add the incompatible bindings after that
+            throw new NotImplementedException("MemberInit: incompatible MemberListBinding");
+        }
+
+        Result = objectCreation.WithInitializer(
+            InitializerExpression(
+                SyntaxKind.ObjectInitializerExpression,
+                SeparatedList<ExpressionSyntax>(initializerExpressions)));
+
+        return memberInit;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitListInit(ListInitExpression listInit)
+    {
+        var objectCreation = Translate<ObjectCreationExpressionSyntax>(listInit.NewExpression);
+
+        List<ElementInit>? incompatibleListBindings = null;
+
+        var initializerExpressions = new List<ExpressionSyntax>(listInit.Initializers.Count);
+
+        foreach (var initializer in listInit.Initializers)
+        {
+            // C# collection initialization syntax only works when Add is called on an IEnumerable, but LINQ supports arbitrary add
+            // methods. Skip these, we'll add them later outside the initializer
+            if (!listInit.NewExpression.Type.IsAssignableTo(typeof(IEnumerable))
+                || listInit.Initializers.Any(e => e.AddMethod.Name != "Add" || e.Arguments.Count != 1))
+            {
+                incompatibleListBindings ??= new();
+                incompatibleListBindings.Add(initializer);
+                continue;
+            }
+
+            var liftedStatementsPosition = _liftedState.Statements.Count;
+
+            VisitElementInit(initializer);
+
+            initializerExpressions.Add((ExpressionSyntax)Result!);
+
+            if (_liftedState.Statements.Count > liftedStatementsPosition)
+            {
+                throw new NotImplementedException("ListInit: lifted statements");
+            }
+        }
+
+        if (incompatibleListBindings is not null)
+        {
+            // TODO: This requires lifting statements to *after* the instantiation - we usually lift to before.
+            // This is problematic: if such an expression is passed as an argument to a method, there's no way to faithfully translate it
+            // while preserving evaluation order.
+            throw new NotImplementedException("ListInit: incompatible ElementInit");
+        }
+
+        Result = objectCreation.WithInitializer(
+            InitializerExpression(
+                SyntaxKind.CollectionInitializerExpression,
+                SeparatedList(initializerExpressions)));
+
+        return listInit;
+    }
+
+    /// <inheritdoc />
+    protected override ElementInit VisitElementInit(ElementInit elementInit)
+    {
+        Check.DebugAssert(elementInit.Arguments.Count == 1, "elementInit.Arguments.Count == 1");
+
+        Visit(elementInit.Arguments.Single());
+
+        return elementInit;
+    }
+
+    /// <inheritdoc />
+    protected override MemberAssignment VisitMemberAssignment(MemberAssignment memberAssignment)
+    {
+        Result = AssignmentExpression(
+            SyntaxKind.SimpleAssignmentExpression,
+            IdentifierName(memberAssignment.Member.Name),
+            Translate<ExpressionSyntax>(memberAssignment.Expression));
+
+        return memberAssignment;
+    }
+
+    /// <inheritdoc />
+    protected override MemberMemberBinding VisitMemberMemberBinding(MemberMemberBinding memberMemberBinding)
+    {
+        Result = AssignmentExpression(
+            SyntaxKind.SimpleAssignmentExpression,
+            IdentifierName(memberMemberBinding.Member.Name),
+            InitializerExpression(
+                SyntaxKind.ObjectInitializerExpression,
+                SeparatedList(
+                    memberMemberBinding.Bindings.Select(
+                        b =>
+                        {
+                            VisitMemberBinding(b);
+                            return (ExpressionSyntax)Result!;
+                        }))));
+
+        return memberMemberBinding;
+    }
+
+    /// <inheritdoc />
+    protected override MemberListBinding VisitMemberListBinding(MemberListBinding memberListBinding)
+    {
+        Result = AssignmentExpression(
+            SyntaxKind.SimpleAssignmentExpression,
+            IdentifierName(memberListBinding.Member.Name),
+            InitializerExpression(
+                SyntaxKind.CollectionInitializerExpression,
+                SeparatedList(
+                    memberListBinding.Initializers.Select(i =>
+                    {
+                        VisitElementInit(i);
+                        return (ExpressionSyntax)Result!;
+                    }))));
+
+        return memberListBinding;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitExtension(Expression node)
+    {
+        // TODO: Remove any EF-specific code from this visitor (extend if needed)
+        // TODO: Hack mode. Visit the expression beforehand to replace EntityQueryRootExpression with context.Set<>(), or receive it in this visitor as a replacement or something.
+        if (node is EntityQueryRootExpression entityQueryRoot)
+        {
+            // TODO: STET
+            Result = ParseExpression($"context.Set<{entityQueryRoot.EntityType.ClrType.Name}>()");
+            return node;
+        }
+
+        throw new NotSupportedException(
+            $"Encountered non-quotable expression of type {node.GetType()} when translating expression tree to C#");
+    }
+
+    private ArgumentSyntax[] TranslateMethodArguments(ParameterInfo[] parameters, IReadOnlyList<Expression> arguments)
+    {
+        var translatedExpressions = TranslateList(arguments);
+        var translatedArguments = new ArgumentSyntax[arguments.Count];
+
+        for (var i = 0; i < translatedExpressions.Length; i++)
+        {
+            var parameter = parameters[i];
+            var argument = Argument(translatedExpressions[i]);
+
+            if (parameter.IsOut)
+            {
+                argument = argument.WithRefKindKeyword(Token(SyntaxKind.OutKeyword));
+            }
+            else if (parameter.IsIn)
+            {
+                argument = argument.WithRefKindKeyword(Token(SyntaxKind.InKeyword));
+            }
+            else if (parameter.ParameterType.IsByRef)
+            {
+                argument = argument.WithRefKindKeyword(Token(SyntaxKind.RefKeyword));
+            }
+
+            translatedArguments[i] = argument;
+        }
+
+        return translatedArguments;
+    }
+
+    private ExpressionSyntax[] TranslateList(IReadOnlyList<Expression> list)
+    {
+        Check.DebugAssert(_context == ExpressionContext.Expression, "_context == ExpressionContext.Expression");
+
+        var translatedList = new ExpressionSyntax[list.Count];
+        var lastLiftedArgumentPosition = 0;
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            var expression = list[i];
+
+            var liftedStatementsPosition = _liftedState.Statements.Count;
+
+            var translated = Translate<ExpressionSyntax>(expression);
+
+            if (_liftedState.Statements.Count > liftedStatementsPosition)
+            {
+                // This argument contained lifted statements. In order to preserve evaluation order, we must also lift out all preceding
+                // arguments to before this argument's lifted statements.
+                for (; lastLiftedArgumentPosition < i; lastLiftedArgumentPosition++)
+                {
+                    var argumentExpression = translatedList[lastLiftedArgumentPosition];
+
+                    if (!_sideEffectDetector.CanBeReordered(argumentExpression, translated))
+                    {
+                        var name = UniquifyVariableName("liftedArg");
+
+                        _liftedState.Statements.Insert(
+                            liftedStatementsPosition++,
+                            GenerateVarDeclaration(name, argumentExpression));
+                        _liftedState.VariableNames.Add(name);
+
+                        translatedList[lastLiftedArgumentPosition] = IdentifierName(name);
+                    }
+                }
+            }
+
+            translatedList[i] = translated;
+        }
+
+        return translatedList;
+    }
+
+    private StackFrame PushNewStackFrame()
+    {
+        var previousFrame = _stack.Peek();
+        var newFrame = new StackFrame(
+            new(previousFrame.Variables),
+            new(previousFrame.VariableNames),
+            new(previousFrame.Labels),
+            new(previousFrame.UnnamedLabelNames));
+
+        _stack.Push(newFrame);
+
+        return newFrame;
+    }
+
+    private string LookupVariableName(ParameterExpression parameter)
+        => _stack.Peek().Variables.TryGetValue(parameter, out var name)
+            ? name
+            : _liftedState.Variables[parameter];
+
+    private string UniquifyVariableName(string? name)
+    {
+        var isUnnamed = name is null;
+        name ??= "unnamed";
+
+        var parameterNames = _stack.Peek().VariableNames;
+
+        if (parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name))
+        {
+            var baseName = name;
+            for (var j = isUnnamed ? _unnamedParameterCounter++ : 0;
+                 parameterNames.Contains(name) || _liftedState.VariableNames.Contains(name);
+                 j++)
+            {
+                name = baseName + j;
+            }
+        }
+
+        return name;
+    }
+
+    private static LocalDeclarationStatementSyntax GenerateVarDeclaration(string variableIdentifier, ExpressionSyntax initializer)
+        => LocalDeclarationStatement(
+            VariableDeclaration(
+                IdentifierName(Identifier(TriviaList(), SyntaxKind.VarKeyword, "var", "var", TriviaList())),
+                SingletonSeparatedList(
+                    VariableDeclarator(Identifier(variableIdentifier))
+                        .WithInitializer(
+                            EqualsValueClause(
+                                initializer)))));
+
+    private ContextChanger ChangeContext(ExpressionContext newContext)
+        => new(this, newContext);
+
+    private readonly struct ContextChanger : IDisposable
+    {
+        private readonly LinqToCSharpTranslator _translator;
+        private readonly ExpressionContext _oldContext;
+
+        public ContextChanger(LinqToCSharpTranslator translator, ExpressionContext newContext)
+        {
+            _translator = translator;
+            _oldContext = translator._context;
+            translator._context = newContext;
+        }
+
+        public void Dispose()
+            => _translator._context = _oldContext;
+    }
+
+    private enum ExpressionContext
+    {
+        Expression,
+        Statement,
+        ExpressionLambda
+    }
+
+    private sealed class ConstantDetectionSyntaxWalker : SyntaxWalker
+    {
+        private bool _isConstant;
+
+        public bool IsConstant(SyntaxNode node)
+        {
+            _isConstant = true;
+
+            Visit(node);
+
+            return _isConstant;
+        }
+
+        public override void Visit(SyntaxNode node)
+        {
+            _isConstant &= IsConstantCore(node);
+
+            base.Visit(node);
+        }
+
+        private static bool IsConstantCore(SyntaxNode node)
+            => node switch
+            {
+                LiteralExpressionSyntax => true,
+
+                // Binary/unary expressions over constants are also constant
+                BinaryExpressionSyntax or PrefixUnaryExpressionSyntax or PostfixUnaryExpressionSyntax => true,
+
+                _ => false
+            };
+    }
+
+    private sealed class SideEffectDetectionSyntaxWalker : SyntaxWalker
+    {
+        private bool _mayHaveSideEffects;
+
+        /// <summary>
+        ///     Returns whether the two provided nodes can be re-ordered without the reversed evaluation order having any effect.
+        ///     For example, two literal expressions can be safely ordered, while two invocations cannot.
+        /// </summary>
+        public bool CanBeReordered(SyntaxNode first, SyntaxNode second)
+            => first is LiteralExpressionSyntax || (!MayHaveSideEffects(first) && !MayHaveSideEffects(second));
+
+        public bool MayHaveSideEffects(SyntaxNode node)
+        {
+            _mayHaveSideEffects = false;
+
+            Visit(node);
+
+            return _mayHaveSideEffects;
+        }
+
+        public override void Visit(SyntaxNode node)
+        {
+            _mayHaveSideEffects |= MayHaveSideEffectsCore(node);
+
+            base.Visit(node);
+        }
+
+        private static bool MayHaveSideEffectsCore(SyntaxNode node)
+            => node switch
+            {
+                IdentifierNameSyntax or LiteralExpressionSyntax => false,
+                ExpressionStatementSyntax e => MayHaveSideEffectsCore(e.Expression),
+                EmptyStatementSyntax => false,
+
+                // TODO: we can exempt most binary and unary expressions as well, e.g. i + 5, but not anything involving assignment
+                _ => true
+            };
+    }
+}

--- a/test/EFCore.Design.Tests/Query/LinqToCSharpTranslatorTest.cs
+++ b/test/EFCore.Design.Tests/Query/LinqToCSharpTranslatorTest.cs
@@ -1,0 +1,2025 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Xunit.Sdk;
+using static System.Linq.Expressions.Expression;
+using Assert = Xunit.Assert;
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class LinqToCSharpTranslatorTest
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public LinqToCSharpTranslatorTest(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+        _outputExpressionTrees = true;
+    }
+
+    [Theory]
+    [InlineData("hello", "\"hello\"")]
+    [InlineData(1, "1")]
+    [InlineData(1L, "1L")]
+    [InlineData((short)1, "1")]
+    [InlineData((sbyte)1, "1")]
+    [InlineData(1U, "1U")]
+    [InlineData(1UL, "1UL")]
+    [InlineData((ushort)1, "1")]
+    [InlineData((byte)1, "1")]
+    [InlineData(1.5, "1.5D")]
+    [InlineData(1.5F, "1.5F")]
+    [InlineData(true, "true")]
+    [InlineData(typeof(string), "typeof(string)")]
+    public void Constant_values(object constantValue, string literalRepresentation)
+        => AssertExpression(
+            Constant(constantValue),
+            literalRepresentation);
+
+    [Fact]
+    public void Constant_decimal()
+        => AssertExpression(Constant(1.5m), "1.5M");
+
+    [Fact]
+    public void Constant_null()
+        => AssertExpression(Constant(null, typeof(string)), "null");
+
+    [Fact]
+    public void Constant_throws_on_unsupported_type()
+        => Assert.Throws<NotSupportedException>(() => AssertExpression(Constant(default(DateTime)), ""));
+
+    [Fact]
+    public void Enum()
+        => AssertExpression(Constant(SomeEnum.One), "SomeEnum.One");
+
+    [Fact]
+    public void Enum_with_multiple_values()
+        => AssertExpression(Constant(SomeEnum.One | SomeEnum.Two), "SomeEnum.One | SomeEnum.Two");
+
+    [Fact]
+    public void Enum_with_unknown_value()
+        => AssertExpression(Constant((SomeEnum)1000), "(SomeEnum)1000L");
+
+    [Theory]
+    [InlineData(ExpressionType.Add, "+")]
+    [InlineData(ExpressionType.Subtract, "-")]
+    // TODO: Complete
+    public void Binary_numeric(ExpressionType expressionType, string op)
+        => AssertExpression(
+            MakeBinary(expressionType, Constant(2), Constant(3)),
+            $"2 {op} 3");
+
+    [Fact]
+    public void Binary_ArrayIndex()
+        => AssertExpression(
+            ArrayIndex(Parameter(typeof(int[]), "i"), Constant(2)),
+            "i[2]");
+
+    [Fact]
+    public void Binary_Power()
+        => AssertExpression(
+            Power(Constant(2.0), Constant(3.0)),
+            "Math.Pow(2D, 3D)");
+
+    [Fact]
+    public void Binary_PowerAssign()
+        => AssertExpression(
+            PowerAssign(Parameter(typeof(double), "d"), Constant(3.0)),
+            "d = Math.Pow(d, 3D)");
+
+    [Theory]
+    [InlineData(ExpressionType.Negate, "-i")]
+    [InlineData(ExpressionType.NegateChecked, "-i")]
+    [InlineData(ExpressionType.Not, "~i")]
+    [InlineData(ExpressionType.OnesComplement, "~i")]
+    [InlineData(ExpressionType.UnaryPlus, "+i")]
+    [InlineData(ExpressionType.Increment, "i + 1")]
+    [InlineData(ExpressionType.Decrement, "i - 1")]
+    public void Unary_expression_int(ExpressionType expressionType, string expected)
+        => AssertExpression(
+            MakeUnary(expressionType, Parameter(typeof(int), "i"), typeof(int)),
+            expected);
+
+    [Theory]
+    [InlineData(ExpressionType.Not, "!b")]
+    [InlineData(ExpressionType.IsFalse, "!b")]
+    [InlineData(ExpressionType.IsTrue, "b")]
+    public void Unary_expression_bool(ExpressionType expressionType, string expected)
+        => AssertExpression(
+            MakeUnary(expressionType, Parameter(typeof(bool), "b"), typeof(bool)),
+            expected);
+
+    [Theory]
+    [InlineData(ExpressionType.PostIncrementAssign, "i++")]
+    [InlineData(ExpressionType.PostDecrementAssign, "i--")]
+    [InlineData(ExpressionType.PreIncrementAssign, "++i")]
+    [InlineData(ExpressionType.PreDecrementAssign, "--i")]
+    public void Unary_statement(ExpressionType expressionType, string expected)
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+            MakeUnary(expressionType, i, typeof(int))),
+$$"""
+{
+    int i;
+    {{expected}};
+}
+""");
+    }
+
+    [Fact]
+    public void Unary_ArrayLength()
+        => AssertExpression(
+            ArrayLength(Parameter(typeof(int[]), "i")),
+            "i.Length");
+
+    [Fact]
+    public void Unary_Convert()
+        => AssertExpression(
+            Convert(
+                Parameter(typeof(object), "i"),
+                typeof(string)),
+            "(string)i");
+
+    [Fact]
+    public void Unary_Throw()
+        => AssertStatement(
+            Throw(New(typeof(Exception))),
+            "throw new Exception();");
+
+    [Fact]
+    public void Unary_Unbox()
+        => AssertExpression(
+            Unbox(Parameter(typeof(object), "i"), typeof(int)),
+            "i");
+
+    [Fact]
+    public void Unary_Quote()
+        => AssertExpression(
+            Quote((Expression<Func<string, int>>)(s => s.Length)),
+            "(string s) => s.Length");
+
+    [Fact]
+    public void Unary_TypeAs()
+        => AssertExpression(
+            TypeAs(Parameter(typeof(object), "i"), typeof(string)),
+            "i as string");
+
+    [Fact]
+    public void Instance_property()
+        => AssertExpression(
+            Property(
+                Constant("hello"),
+                typeof(string).GetProperty(nameof(string.Length))!),
+            "\"hello\".Length");
+
+    [Fact]
+    public void Static_property()
+        => AssertExpression(
+            Property(
+                null,
+                typeof(DateTime).GetProperty(nameof(DateTime.Now))!),
+            "DateTime.Now");
+
+    [Fact]
+    public void Private_instance_field_read()
+        => AssertExpression(
+            Field(Parameter(typeof(Blog), "blog"), "_privateField"),
+            """typeof(Blog).GetField("_privateField", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(blog)""");
+
+    [Fact]
+    public void Private_instance_field_write()
+        => AssertStatement(
+            Assign(
+                Field(Parameter(typeof(Blog), "blog"), "_privateField"),
+                Constant(8)),
+            """typeof(Blog).GetField("_privateField", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(blog, 8)""");
+
+    [Fact]
+    public void Internal_instance_field_read()
+        => AssertExpression(
+            Field(Parameter(typeof(Blog), "blog"), "InternalField"),
+            "blog.InternalField");
+
+    [Fact]
+    public void Not()
+        => AssertExpression(
+            Expression.Not(Constant(true)),
+            "!true");
+
+    [Fact]
+    public void MemberInit_with_MemberAssignment()
+        => AssertExpression(
+            MemberInit(
+                New(
+                    typeof(Blog).GetConstructor(new[] { typeof(string) })!,
+                    Constant("foo")),
+                Bind(typeof(Blog).GetProperty(nameof(Blog.PublicProperty))!, Constant(8)),
+                Bind(typeof(Blog).GetField(nameof(Blog.PublicField))!, Constant(9))),
+"""
+new Blog("foo")
+{
+    PublicProperty = 8,
+    PublicField = 9
+}
+""");
+
+    [Fact]
+    public void MemberInit_with_MemberListBinding()
+        => AssertExpression(
+            MemberInit(
+                New(
+                    typeof(Blog).GetConstructor(new[] { typeof(string) })!,
+                    Constant("foo")),
+                ListBind(typeof(Blog).GetProperty(nameof(Blog.ListOfInts))!,
+                    ElementInit(typeof(List<int>).GetMethod(nameof(List<int>.Add))!, Constant(8)),
+                    ElementInit(typeof(List<int>).GetMethod(nameof(List<int>.Add))!, Constant(9)))),
+"""
+new Blog("foo")
+{
+    ListOfInts =
+    {
+        8,
+        9
+    }
+}
+""");
+
+    [Fact]
+    public void MemberInit_with_MemberMemberBinding()
+        => AssertExpression(
+            MemberInit(
+                New(
+                    typeof(Blog).GetConstructor(new[] { typeof(string) })!,
+                    Constant("foo")),
+                MemberBind(typeof(Blog).GetProperty(nameof(Blog.Details))!,
+                    Bind(typeof(BlogDetails).GetProperty(nameof(BlogDetails.Foo))!, Constant(5)),
+                    ListBind(typeof(BlogDetails).GetProperty(nameof(BlogDetails.ListOfInts))!,
+                        ElementInit(typeof(List<int>).GetMethod(nameof(List<int>.Add))!, Constant(8)),
+                        ElementInit(typeof(List<int>).GetMethod(nameof(List<int>.Add))!, Constant(9))))),
+"""
+new Blog("foo")
+{
+    Details =
+    {
+        Foo = 5,
+        ListOfInts =
+        {
+            8,
+            9
+        }
+    }
+}
+""");
+
+    [Fact]
+    public void Method_call_instance()
+    {
+        var blog = Parameter(typeof(Blog), "blog");
+
+        AssertStatement(
+            Block(
+                variables: new[] { blog },
+                Assign(blog, New(Blog.Constructor)),
+                Call(
+                    blog,
+                    typeof(Blog).GetMethod(nameof(Blog.SomeInstanceMethod))!)),
+"""
+{
+    var blog = new Blog();
+    blog.SomeInstanceMethod();
+}
+""");
+    }
+
+    [Fact]
+    public void Method_call_static()
+        => AssertExpression(
+            Call(ReturnsIntWithParamMethod, Constant(8)),
+            "LinqToCSharpTranslatorTest.ReturnsIntWithParam(8)");
+
+    [Fact]
+    public void Method_call_static_on_nested_type()
+        => AssertExpression(
+            Call(typeof(Blog).GetMethod(nameof(Blog.Static_method_on_nested_type))!),
+            "LinqToCSharpTranslatorTest.Blog.Static_method_on_nested_type()");
+
+    [Fact]
+    public void Method_call_extension()
+    {
+        var blog = Parameter(typeof(LinqExpressionToRoslynTranslatorExtensionType), "someType");
+
+        AssertStatement(
+            Block(
+                variables: new[] { blog },
+                Assign(blog, New(LinqExpressionToRoslynTranslatorExtensionType.Constructor)),
+                Call(LinqExpressionToRoslynTranslatorExtensions.SomeExtensionMethod, blog)),
+"""
+{
+    var someType = new LinqExpressionToRoslynTranslatorExtensionType();
+    someType.SomeExtension();
+}
+""");
+    }
+
+    [Fact]
+    public void Method_call_extension_with_null_this()
+        => AssertExpression(
+            Call(
+                LinqExpressionToRoslynTranslatorExtensions.SomeExtensionMethod,
+                Constant(null, typeof(LinqExpressionToRoslynTranslatorExtensionType))),
+            "LinqExpressionToRoslynTranslatorExtensions.SomeExtension(null)");
+
+    [Fact]
+    public void Method_call_generic()
+    {
+        var blog = Parameter(typeof(Blog), "blog");
+
+        AssertStatement(
+            Block(
+                variables: new[] { blog },
+                Assign(blog, New(Blog.Constructor)),
+                Call(
+                    GenericMethod.MakeGenericMethod(typeof(Blog)),
+                    blog)),
+"""
+{
+    var blog = new Blog();
+    LinqToCSharpTranslatorTest.GenericMethodImplementation(blog);
+}
+""");
+    }
+
+    [Fact]
+    public void Method_call_namespace_is_collected()
+    {
+        var (translator, _) = CreateTranslator();
+        var namespaces = new HashSet<string>();
+        _ = translator.TranslateExpression(Call(FooMethod), namespaces);
+        Assert.Collection(namespaces,
+            ns => Assert.Equal(typeof(LinqToCSharpTranslatorTest).Namespace, ns));
+    }
+
+    [Fact]
+    public void Method_call_with_in_out_ref_parameters()
+    {
+        var inParam = Parameter(typeof(int), "inParam");
+        var outParam = Parameter(typeof(int), "outParam");
+        var refParam = Parameter(typeof(int), "refParam");
+
+        AssertStatement(
+            Block(
+                variables: new[] { inParam, outParam, refParam },
+                Call(WithInOutRefParameterMethod, new[] { inParam, outParam, refParam })),
+"""
+{
+    int inParam;
+    int outParam;
+    int refParam;
+    LinqToCSharpTranslatorTest.WithInOutRefParameter(in inParam, out outParam, ref refParam);
+}
+""");
+    }
+
+    [Fact]
+    public void Instantiation()
+        => AssertExpression(
+            New(
+                typeof(Blog).GetConstructor(new[] { typeof(string) })!,
+                Constant("foo")),
+            """new Blog("foo")""");
+
+    [Fact]
+    public void Instantiation_with_required_properties_and_parameterless_constructor()
+        => AssertExpression(
+            New(
+                typeof(BlogWithRequiredProperties).GetConstructor(Array.Empty<Type>())!),
+"""
+Activator.CreateInstance<BlogWithRequiredProperties>()
+""");
+
+    [Fact]
+    public void Instantiation_with_required_properties_and_non_parameterless_constructor()
+        => Assert.Throws<NotImplementedException>(() => AssertExpression(
+            New(
+                typeof(BlogWithRequiredProperties).GetConstructor(new[] { typeof(string) })!,
+                Constant("foo")), ""));
+
+    [Fact]
+    public void Instantiation_with_required_properties_with_SetsRequiredMembers()
+        => AssertExpression(
+            New(
+                typeof(BlogWithRequiredProperties).GetConstructor(new[] { typeof(string), typeof(int) })!,
+                Constant("foo"), Constant(8)),
+            """new BlogWithRequiredProperties("foo", 8)""");
+
+    [Fact]
+    public void Lambda_with_expression_body()
+        => AssertExpression(
+            Lambda<Func<bool>>(Constant(true)),
+            "() => true");
+
+    [Fact]
+    public void Lambda_with_block_body()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertExpression(
+            Lambda<Func<int>>(
+                Block(
+                    variables: new[] { i },
+                    Assign(i, Constant(8)),
+                    i)),
+"""
+() =>
+{
+    var i = 8;
+    return i;
+}
+""");
+    }
+
+    [Fact]
+    public void Lambda_with_no_parameters()
+        => AssertExpression(
+            Lambda<Func<bool>>(Constant(true)),
+            "() => true");
+
+    [Fact]
+    public void Lambda_with_one_parameter()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertExpression(
+            Lambda<Func<int, bool>>(Constant(true), i),
+            "(int i) => true");
+    }
+
+    [Fact]
+    public void Lambda_with_two_parameters()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+
+        AssertExpression(
+            Lambda<Func<int, int, int>>(Add(i, j), i, j),
+            "(int i, int j) => i + j");
+    }
+
+    [Fact]
+    public void Invocation_with_literal_argument()
+        => AssertExpression(
+            AndAlso(
+                Constant(true),
+                Invoke((Expression<Func<int, bool>>)(f => f > 5), Constant(8))),
+            "true && 8 > 5");
+
+    [Fact]
+    public void Invocation_with_argument_that_has_side_effects()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(
+                    i,
+                    Add(
+                        Constant(5),
+                        Invoke((Expression<Func<int, int>>)(f => f + f), Call(FooMethod))))),
+"""
+{
+    var f = LinqToCSharpTranslatorTest.Foo();
+    var i = 5 + f + f;
+}
+""");
+    }
+
+    [Fact]
+    public void Conditional_expression()
+        => AssertExpression(
+            Condition(Constant(true), Constant(1), Constant(2)),
+            "true ? 1 : 2");
+
+    [Fact]
+    public void Conditional_without_false_value_fails()
+        => Assert.Throws<NotSupportedException>(
+            () => AssertExpression(
+                IfThen(Constant(true), Constant(8)),
+                "true ? 1 : 2"));
+
+    [Fact]
+    public void Conditional_statement()
+        => AssertStatement(
+            Block(
+                Condition(Constant(true), Call(FooMethod), Call(BarMethod)),
+                Constant(8)),
+"""
+{
+    if (true)
+    {
+        LinqToCSharpTranslatorTest.Foo();
+    }
+    else
+    {
+        LinqToCSharpTranslatorTest.Bar();
+    }
+}
+""");
+
+    [Fact]
+    public void IfThen_statement()
+    {
+        var parameter = Parameter(typeof(int), "i");
+        var block = Block(
+            variables: new[] { parameter },
+            expressions: Assign(parameter, Constant(8)));
+
+        AssertStatement(
+            Block(IfThen(Constant(true), block)),
+"""
+{
+    if (true)
+    {
+        var i = 8;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void IfThenElse_statement()
+    {
+        var parameter1 = Parameter(typeof(int), "i");
+        var block1 = Block(
+            variables: new[] { parameter1 },
+            expressions: Assign(parameter1, Constant(8)));
+
+        var parameter2 = Parameter(typeof(int), "j");
+        var block2 = Block(
+            variables: new[] { parameter2 },
+            expressions: Assign(parameter2, Constant(9)));
+
+        AssertStatement(
+            Block(IfThenElse(Constant(true), block1, block2)),
+"""
+{
+    if (true)
+    {
+        var i = 8;
+    }
+    else
+    {
+        var j = 9;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void IfThenElse_nested()
+    {
+        var variable = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { variable },
+                expressions: IfThenElse(
+                    Constant(true),
+                    Block(Assign(variable, Constant(1))),
+                    IfThenElse(
+                        Constant(false),
+                        Block(Assign(variable, Constant(2))),
+                        Block(Assign(variable, Constant(3)))))),
+"""
+{
+    int i;
+    if (true)
+    {
+        i = 1;
+    }
+    else if (false)
+    {
+        i = 2;
+    }
+    else
+    {
+        i = 3;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Conditional_expression_with_block_in_lambda()
+        => AssertExpression(
+            Lambda<Func<int>>(
+                Condition(
+                    Constant(true),
+                    Block(
+                        Call(FooMethod),
+                        Constant(8)),
+                    Constant(9))),
+"""
+() =>
+{
+    if (true)
+    {
+        LinqToCSharpTranslatorTest.Foo();
+        return 8;
+    }
+    else
+    {
+        return 9;
+    }
+}
+""");
+
+    [Fact]
+    public void IfThen_with_block_inside_expression_block_with_lifted_statements()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(
+                    i, Block(
+                        // We're in expression context. Do anything that will get lifted.
+                        Call(FooMethod),
+                        // Statement condition
+                        IfThen(
+                            Constant(true),
+                            Block(
+                                Call(BarMethod),
+                                Call(BazMethod))),
+                        // Last expression (to make the block above evaluate as statement
+                        Constant(8)))),
+"""
+{
+    LinqToCSharpTranslatorTest.Foo();
+    if (true)
+    {
+        LinqToCSharpTranslatorTest.Bar();
+        LinqToCSharpTranslatorTest.Baz();
+    }
+
+    var i = 8;
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_expression()
+        => AssertExpression(
+            Switch(
+                Constant(8),
+                Constant(0),
+                SwitchCase(Constant(-9), Constant(9)),
+                SwitchCase(Constant(-10), Constant(10))),
+"""
+8 switch
+{
+    9 => -9,
+    10 => -10,
+    _ => 0
+}
+""");
+
+    [Fact]
+    public void Switch_expression_nested()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+        var k = Parameter(typeof(int), "k");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i, j, k },
+                Assign(j, Constant(8)),
+                Assign(
+                    i,
+                    Switch(
+                        j,
+                        defaultBody: Constant(0),
+                        SwitchCase(Constant(1), Constant(100)),
+                        SwitchCase(
+                            Switch(
+                                k,
+                                defaultBody: Constant(0),
+                                SwitchCase(Constant(2), Constant(200)),
+                                SwitchCase(Constant(3), Constant(300))),
+                            Constant(200))))),
+"""
+{
+    int k;
+    var j = 8;
+    var i = j switch
+    {
+        100 => 1,
+        200 => k switch
+        {
+            200 => 2,
+            300 => 3,
+            _ => 0
+        },
+        _ => 0
+    };
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_expression_non_constant_arm()
+        => AssertExpression(
+            Switch(
+                Parameter(typeof(Blog), "blog1"),
+                Constant(0),
+                SwitchCase(Constant(2), Parameter(typeof(Blog), "blog2")),
+                SwitchCase(Constant(3), Parameter(typeof(Blog), "blog3"))),
+            "blog1 == blog2 ? 2 : blog1 == blog3 ? 3 : 0");
+
+    [Fact]
+    public void Switch_statement_with_non_constant_label()
+    {
+        AssertStatement(
+            Switch(
+                Parameter(typeof(Blog), "blog1"),
+                Constant(0),
+                SwitchCase(Constant(2), Parameter(typeof(Blog), "blog2")),
+                SwitchCase(Constant(3), Parameter(typeof(Blog), "blog3"))),
+"""
+if (blog1 == blog2)
+{
+    2;
+}
+else if (blog1 == blog3)
+{
+    3;
+}
+else
+{
+    0;
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_statement_without_default()
+    {
+        var parameter = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { parameter },
+                expressions: Switch(
+                    Constant(7),
+                    SwitchCase(Block(typeof(void), Assign(parameter, Constant(9))), Constant(-9)),
+                    SwitchCase(Block(typeof(void), Assign(parameter, Constant(10))), Constant(-10)))),
+"""
+{
+    int i;
+    switch (7)
+    {
+        case -9:
+        {
+            i = 9;
+            break;
+        }
+
+        case -10:
+        {
+            i = 10;
+            break;
+        }
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_statement_with_default()
+    {
+        var parameter = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { parameter },
+                expressions: Switch(
+                    Constant(7),
+                    Assign(parameter, Constant(0)),
+                    SwitchCase(Assign(parameter, Constant(9)), Constant(-9)),
+                    SwitchCase(Assign(parameter, Constant(10)), Constant(-10)))),
+"""
+{
+    int i;
+    switch (7)
+    {
+        case -9:
+            i = 9;
+            break;
+        case -10:
+            i = 10;
+            break;
+        default:
+            i = 0;
+            break;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Switch_statement_with_multiple_labels()
+    {
+        var parameter = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { parameter },
+                expressions: Switch(
+                    Constant(7),
+                    Assign(parameter, Constant(0)),
+                    SwitchCase(Assign(parameter, Constant(9)), Constant(-9), Constant(-8)),
+                    SwitchCase(Assign(parameter, Constant(10)), Constant(-10)))),
+"""
+{
+    int i;
+    switch (7)
+    {
+        case -9:
+        case -8:
+            i = 9;
+            break;
+        case -10:
+            i = 10;
+            break;
+        default:
+            i = 0;
+            break;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Variable_assignment_uses_var()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i, Constant(8))),
+"""
+{
+    var i = 8;
+}
+""");
+    }
+
+    [Fact]
+    public void Variable_assignment_to_null_does_not_use_var()
+    {
+        var s = Parameter(typeof(string), "s");
+
+        AssertStatement(
+            Block(
+                variables: new[] { s },
+                Assign(s, Constant(null, typeof(string)))),
+"""
+{
+    string s = null;
+}
+""");
+    }
+
+    [Fact]
+    public void Variables_with_same_name_in_sibling_blocks_do_not_get_renamed()
+    {
+        var i1 = Parameter(typeof(int), "i");
+        var i2 = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                Block(
+                    variables: new[] { i1 },
+                    Assign(i1, Constant(8)),
+                    Call(ReturnsIntWithParamMethod, i1)),
+                Block(
+                    variables: new[] { i2 },
+                    Assign(i2, Constant(8)),
+                    Call(ReturnsIntWithParamMethod, i2))),
+"""
+{
+    {
+        var i = 8;
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(i);
+    }
+
+    {
+        var i = 8;
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(i);
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Variable_with_same_name_in_child_block_gets_renamed()
+    {
+        var i1 = Parameter(typeof(int), "i");
+        var i2 = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i1 },
+                Assign(i1, Constant(8)),
+                Call(ReturnsIntWithParamMethod, i1),
+                Block(
+                    variables: new[] { i2 },
+                    Assign(i2, Constant(8)),
+                    Call(ReturnsIntWithParamMethod, i2),
+                    Call(ReturnsIntWithParamMethod, i1))),
+"""
+{
+    var i = 8;
+    LinqToCSharpTranslatorTest.ReturnsIntWithParam(i);
+    {
+        var i0 = 8;
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(i0);
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(i);
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Variable_with_same_name_in_lambda_does_not_get_renamed()
+    {
+        var i1 = Parameter(typeof(int), "i");
+        var i2 = Parameter(typeof(int), "i");
+        var f = Parameter(typeof(Func<int, bool>), "f");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i1 },
+                Assign(i1, Constant(8)),
+                Assign(
+                    f, Lambda<Func<int, bool>>(
+                        Equal(i2, Constant(5)),
+                        i2))),
+"""
+{
+    var i = 8;
+    f = (int i) => i == 5;
+}
+""");
+    }
+
+    [Fact]
+    public void Same_parameter_instance_is_used_twice_in_nested_lambdas()
+    {
+        var f1 = Parameter(typeof(Func<int, bool>), "f1");
+        var f2 = Parameter(typeof(Func<int, bool>), "f2");
+        var i = Parameter(typeof(int), "i");
+
+        AssertExpression(
+            Assign(
+                f1,
+                Lambda<Func<int, bool>>(
+                    Block(
+                        Assign(
+                            f2,
+                            Lambda<Func<int, bool>>(
+                                Equal(i, Constant(5)),
+                                i)),
+                        Constant(true)),
+                    i)),
+"""
+f1 = (int i) =>
+{
+    f2 = (int i) => i == 5;
+    return true;
+}
+""");
+    }
+
+    [Fact]
+    public void Block_with_non_standalone_expression_as_statement()
+        => AssertStatement(
+            Block(Add(Constant(1), Constant(2))),
+"""
+{
+    _ = 1 + 2;
+}
+""");
+
+    [Fact]
+    public void Lift_block_in_assignment_context()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i, Block(
+                    variables: new[] { j },
+                    Assign(j, Call(FooMethod)),
+                    Call(ReturnsIntWithParamMethod, j)))),
+"""
+{
+    var j = LinqToCSharpTranslatorTest.Foo();
+    var i = LinqToCSharpTranslatorTest.ReturnsIntWithParam(j);
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_block_in_method_call_context()
+    {
+        AssertStatement(
+            Block(
+                Call(
+                    ReturnsIntWithParamMethod,
+                    Block(
+                        Call(FooMethod),
+                        Call(BarMethod)))),
+"""
+{
+    LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.ReturnsIntWithParam(LinqToCSharpTranslatorTest.Bar());
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_nested_block()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+
+        AssertStatement(
+            Block(variables: new[] { i },
+            Assign(
+                i,
+                Block(
+                    variables: new[] { j },
+                    Assign(j, Call(FooMethod)),
+                    Block(
+                        Call(BarMethod),
+                        Call(ReturnsIntWithParamMethod, j))))),
+"""
+{
+    var j = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Bar();
+    var i = LinqToCSharpTranslatorTest.ReturnsIntWithParam(j);
+}
+""");
+    }
+
+    [Fact]
+    public void Binary_lifts_left_side_if_right_is_lifted()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i,
+                    Add(
+                        Call(FooMethod),
+                        Block(
+                            Call(BarMethod),
+                            Call(BazMethod))))),
+"""
+{
+    var lifted = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Bar();
+    var i = lifted + LinqToCSharpTranslatorTest.Baz();
+}
+""");
+    }
+
+    [Fact]
+    public void Binary_does_not_lift_left_side_if_it_has_no_side_effects()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i,
+                    Add(
+                        Constant(5),
+                        Block(
+                            Call(BarMethod),
+                            Call(BazMethod))))),
+"""
+{
+    LinqToCSharpTranslatorTest.Bar();
+    var i = 5 + LinqToCSharpTranslatorTest.Baz();
+}
+""");
+    }
+
+    [Fact]
+    public void Method_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i,
+                    Call(
+                        typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(MethodWithSixParams))!,
+                        Call(FooMethod),
+                        Constant(5),
+                        Block(Call(BarMethod), Call(BazMethod)),
+                        Call(FooMethod),
+                        Block(Call(BazMethod), Call(BarMethod)),
+                        Call(FooMethod)))),
+"""
+{
+    var liftedArg = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Bar();
+    var liftedArg0 = LinqToCSharpTranslatorTest.Baz();
+    var liftedArg1 = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Baz();
+    var i = LinqToCSharpTranslatorTest.MethodWithSixParams(liftedArg, 5, liftedArg0, liftedArg1, LinqToCSharpTranslatorTest.Bar(), LinqToCSharpTranslatorTest.Foo());
+}
+""");
+    }
+
+    [Fact]
+    public void New_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        var b = Parameter(typeof(Blog), "b");
+
+        AssertStatement(
+            Block(
+                variables: new[] { b },
+                Assign(b,
+                    New(
+                        typeof(Blog).GetConstructor(new[] { typeof(int), typeof(int) })!,
+                        Call(FooMethod),
+                        Block(
+                            Call(BarMethod),
+                            Call(BazMethod))))),
+"""
+{
+    var liftedArg = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Bar();
+    var b = new Blog(liftedArg, LinqToCSharpTranslatorTest.Baz());
+}
+""");
+    }
+
+    [Fact]
+    public void Index_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        // TODO: Implement
+    }
+
+    [Fact]
+    public void New_array()
+        => AssertExpression(
+            NewArrayInit(typeof(int)),
+"""
+new int[]
+{
+}
+""");
+
+    [Fact]
+    public void New_array_with_bounds()
+        => AssertExpression(
+            NewArrayBounds(typeof(int), Constant(3)),
+            "new int[3]");
+
+    [Fact]
+    public void New_array_with_initializers()
+        => AssertExpression(
+            NewArrayInit(typeof(int), Constant(3), Constant(4)),
+"""
+new int[]
+{
+    3,
+    4
+}
+""");
+
+    [Fact]
+    public void New_array_lifts_earlier_args_if_later_arg_is_lifted()
+    {
+        var a = Parameter(typeof(int[]), "a");
+
+        // a = new[] { Foo(), { Bar(); Baz(); } }
+        AssertStatement(
+            Block(
+                variables: new[] { a },
+                Assign(a,
+                    NewArrayInit(
+                        typeof(int),
+                        Call(FooMethod),
+                        Block(
+                            Call(BarMethod),
+                            Call(BazMethod))))),
+"""
+{
+    var liftedArg = LinqToCSharpTranslatorTest.Foo();
+    LinqToCSharpTranslatorTest.Bar();
+    var a = new int[]
+    {
+        liftedArg,
+        LinqToCSharpTranslatorTest.Baz()
+    };
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_variable_in_expression_block()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i, Block(
+                    variables: new[] { j },
+                    Block(
+                        Call(FooMethod),
+                        Assign(j, Constant(8)),
+                        Constant(9))))),
+"""
+{
+    int j;
+    LinqToCSharpTranslatorTest.Foo();
+    j = 8;
+    var i = 9;
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_block_in_lambda_body_expression()
+    {
+        AssertExpression(
+            Lambda<Func<int>>(
+                Call(
+                    ReturnsIntWithParamMethod,
+                    Block(
+                        Call(FooMethod),
+                        Call(BarMethod))),
+                Array.Empty<ParameterExpression>()),
+"""
+() =>
+{
+    LinqToCSharpTranslatorTest.Foo();
+    return LinqToCSharpTranslatorTest.ReturnsIntWithParam(LinqToCSharpTranslatorTest.Bar());
+}
+""");
+    }
+
+    [Fact]
+    public void Do_not_lift_block_in_lambda_body()
+    {
+        AssertExpression(
+            Lambda<Func<int>>(
+                Block(Block(Constant(8))),
+                Array.Empty<ParameterExpression>()),
+"""
+() =>
+{
+    {
+        return 8;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Simplify_block_with_single_expression()
+        => AssertExpression(
+            Assign(Parameter(typeof(int), "i"), Block(Constant(8))),
+            "i = 8");
+
+    [Fact]
+    public void Cannot_lift_out_of_expression_context()
+        => Assert.Throws<NotSupportedException>(
+            () => AssertExpression(
+                Assign(
+                    Parameter(typeof(int), "i"),
+                    Block(
+                        Call(FooMethod),
+                        Constant(8))),
+                ""));
+
+    [Fact]
+    public void Lift_switch_expression()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+        var k = Parameter(typeof(int), "k");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i, j },
+                Assign(j, Constant(8)),
+                Assign(
+                    i,
+                    Switch(
+                        j,
+                        defaultBody: Block(Constant(0)),
+                        SwitchCase(
+                            Block(
+                                Block(
+                                    Assign(k, Call(FooMethod)),
+                                    Call(ReturnsIntWithParamMethod, k))),
+                            Constant(8)),
+                        SwitchCase(Constant(2), Constant(9))))),
+"""
+{
+    int i;
+    var j = 8;
+    switch (j)
+    {
+        case 8:
+        {
+            k = LinqToCSharpTranslatorTest.Foo();
+            i = LinqToCSharpTranslatorTest.ReturnsIntWithParam(k);
+            break;
+        }
+
+        case 9:
+            i = 2;
+            break;
+        default:
+            i = 0;
+            break;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_nested_switch_expression()
+    {
+        var i = Parameter(typeof(int), "i");
+        var j = Parameter(typeof(int), "j");
+        var k = Parameter(typeof(int), "k");
+        var l = Parameter(typeof(int), "l");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i, j, k },
+                Assign(j, Constant(8)),
+                Assign(
+                    i,
+                    Switch(
+                        j,
+                        defaultBody: Constant(0),
+                        SwitchCase(Constant(1), Constant(100)),
+                        SwitchCase(
+                            Switch(
+                                k,
+                                defaultBody: Constant(0),
+                                SwitchCase(
+                                    Block(
+                                        variables: new[] { l },
+                                        Assign(l, Call(FooMethod)),
+                                        Call(ReturnsIntWithParamMethod, l)),
+                                    Constant(200)),
+                                SwitchCase(Constant(3), Constant(300))),
+                            Constant(200))))),
+"""
+{
+    int i;
+    int k;
+    var j = 8;
+    switch (j)
+    {
+        case 100:
+            i = 1;
+            break;
+        case 200:
+        {
+            switch (k)
+            {
+                case 200:
+                {
+                    var l = LinqToCSharpTranslatorTest.Foo();
+                    i = LinqToCSharpTranslatorTest.ReturnsIntWithParam(l);
+                    break;
+                }
+
+                case 300:
+                    i = 3;
+                    break;
+                default:
+                    i = 0;
+                    break;
+            }
+
+            break;
+        }
+
+        default:
+            i = 0;
+            break;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Lift_non_literal_switch_expression()
+    {
+        var i = Parameter(typeof(int), "i");
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(
+                    i,
+                    Switch(
+                        Parameter(typeof(Blog), "blog1"),
+                        defaultBody: Block(Constant(0)),
+                        SwitchCase(
+                            Block(
+                                Call(ReturnsIntWithParamMethod, Constant(8)),
+                                Constant(1)),
+                            Parameter(typeof(Blog), "blog2")),
+                        SwitchCase(
+                            Block(
+                                Call(ReturnsIntWithParamMethod, Constant(9)),
+                                Constant(2)),
+                            Parameter(typeof(Blog), "blog3")),
+                        SwitchCase(Constant(3), Parameter(typeof(Blog), "blog4"))))),
+"""
+{
+    int i;
+    if (blog1 == blog2)
+    {
+        LinqToCSharpTranslatorTest.ReturnsIntWithParam(8);
+        i = 1;
+    }
+    else
+    {
+        if (blog1 == blog3)
+        {
+            LinqToCSharpTranslatorTest.ReturnsIntWithParam(9);
+            i = 2;
+        }
+        else
+        {
+            i = blog1 == blog4 ? 3 : 0;
+        }
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void ListInit_node()
+        => AssertExpression(
+            ListInit(
+                New(typeof(List<int>)),
+                typeof(List<int>).GetMethod(nameof(List<int>.Add))!,
+                Constant(8),
+                Constant(9)),
+"""
+new List<int>()
+{
+    8,
+    9
+}
+""");
+
+    [Fact]
+    public void TypeEqual_node()
+        => AssertExpression(
+            TypeEqual(Parameter(typeof(object), "p"), typeof(int)),
+            "p == typeof(int)");
+
+    [Fact]
+    public void TypeIs_node()
+        => AssertExpression(
+            TypeIs(Parameter(typeof(object), "p"), typeof(int)),
+            "p is int");
+
+    [Fact]
+    public void Goto_with_named_label()
+    {
+        var labelTarget = Label("label1");
+
+        AssertStatement(
+            Block(
+                Goto(labelTarget),
+                Label(labelTarget),
+                Call(FooMethod)),
+"""
+{
+    goto label1;
+    label1:
+        LinqToCSharpTranslatorTest.Foo();
+}
+""");
+    }
+
+    [Fact]
+    public void Goto_with_label_on_last_line()
+    {
+        var labelTarget = Label("label1");
+
+        AssertStatement(
+            Block(
+                Goto(labelTarget),
+                Label(labelTarget)),
+"""
+{
+    goto label1;
+    label1:
+        ;
+}
+""");
+    }
+
+    [Fact]
+    public void Goto_outside_label()
+    {
+        var labelTarget = Label();
+
+        AssertStatement(
+            Block(
+                IfThen(
+                    Constant(true),
+                    Block(
+                        Call(FooMethod),
+                        Goto(labelTarget))),
+                Label(labelTarget)),
+"""
+{
+    if (true)
+    {
+        LinqToCSharpTranslatorTest.Foo();
+        goto unnamedLabel;
+    }
+
+    unnamedLabel:
+        ;
+}
+""");
+    }
+
+    [Fact]
+    public void Goto_with_unnamed_labels_in_sibling_blocks()
+    {
+        var labelTarget1 = Label();
+        var labelTarget2 = Label();
+
+        AssertStatement(
+            Block(
+                Block(
+                    Goto(labelTarget1),
+                    Label(labelTarget1)),
+                Block(
+                    Goto(labelTarget2),
+                    Label(labelTarget2))),
+"""
+{
+    {
+        goto unnamedLabel;
+        unnamedLabel:
+            ;
+    }
+
+    {
+        goto unnamedLabel;
+        unnamedLabel:
+            ;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Loop_statement_infinite()
+        => AssertStatement(
+            Loop(Call(FooMethod)),
+"""
+while (true)
+{
+    LinqToCSharpTranslatorTest.Foo();
+}
+""");
+
+    [Fact]
+    public void Loop_statement_with_break_and_continue()
+    {
+        var i = Parameter(typeof(int), "i");
+        var breakLabel = Label();
+        var continueLabel = Label();
+
+        AssertStatement(
+            Block(
+                variables: new[] { i },
+                Assign(i, Constant(0)),
+                Loop(
+                    Block(
+                        IfThen(
+                            Equal(i, Constant(100)),
+                            Break(breakLabel)),
+                        IfThen(
+                            Equal(Modulo(i, Constant(2)), Constant(0)),
+                            Continue(continueLabel)),
+                        PostIncrementAssign(i)),
+                    breakLabel,
+                    continueLabel)),
+"""
+{
+    var i = 0;
+    {
+        while (true)
+        {
+            unnamedLabel0:
+                if (i == 100)
+                {
+                    goto unnamedLabel;
+                }
+
+            if (i % 2 == 0)
+            {
+                goto unnamedLabel0;
+            }
+
+            i++;
+        }
+
+        unnamedLabel:
+            ;
+    }
+}
+""");
+    }
+
+    [Fact]
+    public void Try_catch_statement()
+    {
+        var e = Parameter(typeof(InvalidOperationException), "e");
+
+        AssertStatement(
+            TryCatch(
+                Call(FooMethod),
+                Catch(e, Call(BarMethod)),
+                Catch(e, Call(BazMethod))),
+"""
+try
+{
+    LinqToCSharpTranslatorTest.Foo();
+}
+catch (InvalidOperationException e)
+{
+    LinqToCSharpTranslatorTest.Bar();
+}
+catch (InvalidOperationException e)
+{
+    LinqToCSharpTranslatorTest.Baz();
+}
+""");
+    }
+
+    [Fact]
+    public void Try_finally_statement()
+        => AssertStatement(
+            TryFinally(
+                Call(FooMethod),
+                Call(BarMethod)),
+"""
+try
+{
+    LinqToCSharpTranslatorTest.Foo();
+}
+finally
+{
+    LinqToCSharpTranslatorTest.Bar();
+}
+""");
+
+    [Fact]
+    public void Try_catch_finally_statement()
+    {
+        var e = Parameter(typeof(InvalidOperationException), "e");
+
+        AssertStatement(
+            TryCatchFinally(
+                Call(FooMethod),
+                Block(
+                    Call(BarMethod),
+                    Call(BazMethod)),
+                Catch(e, Call(BarMethod)),
+                Catch(
+                    e,
+                    Call(BazMethod),
+                    Equal(
+                        Property(e, nameof(Exception.Message)),
+                        Constant("foo")))),
+"""
+try
+{
+    LinqToCSharpTranslatorTest.Foo();
+}
+catch (InvalidOperationException e)
+{
+    LinqToCSharpTranslatorTest.Bar();
+}
+catch (InvalidOperationException e)when (e.Message == "foo")
+{
+    LinqToCSharpTranslatorTest.Baz();
+}
+finally
+{
+    LinqToCSharpTranslatorTest.Bar();
+    LinqToCSharpTranslatorTest.Baz();
+}
+""");
+    }
+
+    [Fact]
+    public void Try_catch_statement_with_filter()
+    {
+        var e = Parameter(typeof(InvalidOperationException), "e");
+
+        AssertStatement(
+            TryCatch(
+                Call(FooMethod),
+                Catch(
+                    e,
+                    Call(BarMethod),
+                    Equal(
+                        Property(e, nameof(Exception.Message)),
+                        Constant("foo")))),
+"""
+try
+{
+    LinqToCSharpTranslatorTest.Foo();
+}
+catch (InvalidOperationException e)when (e.Message == "foo")
+{
+    LinqToCSharpTranslatorTest.Bar();
+}
+""");
+    }
+
+    [Fact]
+    public void Try_catch_statement_without_exception_reference()
+        => AssertStatement(
+            TryCatch(
+                Call(FooMethod),
+                Catch(
+                    typeof(InvalidOperationException),
+                    Call(BarMethod))),
+"""
+try
+{
+    LinqToCSharpTranslatorTest.Foo();
+}
+catch (InvalidOperationException)
+{
+    LinqToCSharpTranslatorTest.Bar();
+}
+""");
+
+    [Fact]
+    public void Try_fault_statement()
+        => AssertStatement(
+            TryFault(
+                Call(FooMethod),
+                Call(BarMethod)),
+"""
+try
+{
+    LinqToCSharpTranslatorTest.Foo();
+}
+catch
+{
+    LinqToCSharpTranslatorTest.Bar();
+}
+""");
+
+    // TODO: try/catch expressions
+
+    private void AssertStatement(Expression expression, string expected)
+        => AssertCore(expression, isStatement: true, expected);
+
+    private void AssertExpression(Expression expression, string expected)
+        => AssertCore(expression, isStatement: false, expected);
+
+    private void AssertCore(Expression expression, bool isStatement, string expected)
+    {
+        var (translator, workspace) = CreateTranslator();
+        var namespaces = new HashSet<string>();
+        var node = isStatement
+            ? translator.TranslateStatement(expression, namespaces)
+            : translator.TranslateExpression(expression, namespaces);
+
+        if (_outputExpressionTrees)
+        {
+            _testOutputHelper.WriteLine("---- Input LINQ expression tree:");
+            _testOutputHelper.WriteLine(_expressionPrinter.PrintExpression(expression));
+        }
+
+        // TODO: Actually compile the output C# code to make sure it's valid.
+        // TODO: For extra credit, execute both code representations and make sure the results are the same
+        // Simplifier.ReduceAsync(expression).Result
+
+        var code = node.NormalizeWhitespace().ToFullString();
+
+        var projectId = ProjectId.CreateNewId();
+        var versionStamp = VersionStamp.Create();
+        var projectInfo = ProjectInfo.Create(projectId, versionStamp, "TestProj", "TestProj", LanguageNames.CSharp);
+        workspace.AddProject(projectInfo);
+        var document = workspace.AddDocument(projectId, "Test.cs", SourceText.From(code));
+
+        var syntaxRootFoo = document.GetSyntaxRootAsync().Result!;
+        var annotatedDocument = document.WithSyntaxRoot(syntaxRootFoo.WithAdditionalAnnotations(Simplifier.Annotation));
+        document = Simplifier.ReduceAsync(annotatedDocument).Result;
+
+        var actual = document.GetTextAsync().Result.ToString();
+
+        try
+        {
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+
+            if (_outputExpressionTrees)
+            {
+                _testOutputHelper.WriteLine("---- Output Roslyn syntax tree:");
+                _testOutputHelper.WriteLine(actual);
+            }
+        }
+        catch (EqualException)
+        {
+            _testOutputHelper.WriteLine("---- Output Roslyn syntax tree:");
+            _testOutputHelper.WriteLine(actual);
+
+            throw;
+        }
+    }
+
+    private (LinqToCSharpTranslator, AdhocWorkspace) CreateTranslator()
+    {
+        var workspace = new AdhocWorkspace();
+        var syntaxGenerator = SyntaxGenerator.GetGenerator(workspace, LanguageNames.CSharp);
+        return (new LinqToCSharpTranslator(syntaxGenerator), workspace);
+    }
+
+    // ReSharper disable UnusedMember.Local
+    // ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
+    // ReSharper disable UnusedParameter.Local
+    // ReSharper disable UnusedAutoPropertyAccessor.Local
+    // ReSharper disable MemberCanBePrivate.Local
+
+    private static readonly MethodInfo ReturnsIntWithParamMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(ReturnsIntWithParam))!;
+
+    public static int ReturnsIntWithParam(int i)
+        => i + 1;
+
+    private static readonly MethodInfo WithInOutRefParameterMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(WithInOutRefParameter))!;
+
+    public static void WithInOutRefParameter(in int inParam, out int outParam, ref int refParam)
+    {
+        outParam = 8;
+    }
+
+    private static readonly MethodInfo GenericMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethods().Single(m => m.Name == nameof(GenericMethodImplementation));
+
+    public static int GenericMethodImplementation<T>(T t)
+        => 0;
+
+    private static readonly MethodInfo FooMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(Foo))!;
+
+    public static int Foo()
+        => 1;
+
+    private static readonly MethodInfo BarMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(Bar))!;
+
+    public static int Bar()
+        => 1;
+
+    private static readonly MethodInfo BazMethod
+        = typeof(LinqToCSharpTranslatorTest).GetMethod(nameof(Baz))!;
+
+    public static int Baz()
+        => 1;
+
+    public static int MethodWithSixParams(int a, int b, int c, int d, int e, int f)
+        => a + b + c + d + e + f;
+
+    private class Blog
+    {
+#pragma warning disable CS0169
+#pragma warning disable CS0649
+        public int PublicField;
+        public int PublicProperty { get; set; }
+        internal int InternalField;
+        internal int InternalProperty { get; set; }
+        private int _privateField;
+        private int PrivateProperty { get; set; }
+
+        public List<int> ListOfInts { get; set; } = new();
+        public BlogDetails Details { get; set; } = new();
+#pragma warning restore CS0649
+#pragma warning restore CS0169
+
+        public Blog() {}
+        public Blog(string name) {}
+        public Blog(int foo, int bar) {}
+
+        public int SomeInstanceMethod()
+            => 3;
+
+        public static readonly ConstructorInfo Constructor
+            = typeof(Blog).GetConstructor(Array.Empty<Type>())!;
+
+        public static int Static_method_on_nested_type()
+            => 3;
+    }
+
+    public class BlogDetails
+    {
+        public int Foo { get; set; }
+        public List<int> ListOfInts { get; set; } = new();
+    }
+
+    private class BlogWithRequiredProperties
+    {
+        public required string Name { get; set; }
+        public required int Rating { get; set; }
+
+        public BlogWithRequiredProperties() {}
+
+        public BlogWithRequiredProperties(string name)
+        {
+            Name = name;
+        }
+
+        [SetsRequiredMembers]
+        public BlogWithRequiredProperties(string name, int rating)
+        {
+            Name = name;
+            Rating = rating;
+        }
+    }
+
+    [Flags]
+    public enum SomeEnum
+    {
+        One = 1,
+        Two = 2
+    }
+
+    // ReSharper restore UnusedMember.Local
+    // ReSharper restore AutoPropertyCanBeMadeGetOnly.Local
+    // ReSharper restore UnusedParameter.Local
+    // ReSharper restore UnusedAutoPropertyAccessor.Local
+    // ReSharper restore MemberCanBePrivate.Local
+
+    private readonly ExpressionPrinter _expressionPrinter = new();
+    private readonly bool _outputExpressionTrees;
+}
+
+internal class LinqExpressionToRoslynTranslatorExtensionType
+{
+    public static readonly ConstructorInfo Constructor
+        = typeof(LinqExpressionToRoslynTranslatorExtensionType).GetConstructor(Array.Empty<Type>())!;
+}
+
+internal static class LinqExpressionToRoslynTranslatorExtensions
+{
+    public static readonly MethodInfo SomeExtensionMethod
+        = typeof(LinqExpressionToRoslynTranslatorExtensions).GetMethod(
+            nameof(SomeExtension), new[] { typeof(LinqExpressionToRoslynTranslatorExtensionType) })!;
+
+    public static int SomeExtension(this LinqExpressionToRoslynTranslatorExtensionType? someType)
+        => 3;
+}


### PR DESCRIPTION
This brings in LinqToCSharpTranslator from #29949 - it's the component that can generate C# code out of arbitrary LINQ expression trees. @AndriySvyryd let me know how it goes; there's decent test coverage but if you run into issues I can always take a look.