### PR TITLE
Implemented missing methods in the SaveChangesInterceptorAggregator

### DIFF
--- a/src/EFCore/Diagnostics/Internal/SaveChangesInterceptorAggregator.cs
+++ b/src/EFCore/Diagnostics/Internal/SaveChangesInterceptorAggregator.cs
@@ -64,6 +64,18 @@ public class SaveChangesInterceptorAggregator : InterceptorAggregator<ISaveChang
             }
         }
 
+        public InterceptionResult ThrowingConcurrencyException(
+            ConcurrencyExceptionEventData eventData,
+            InterceptionResult result)
+        {
+            for (var i = 0; i < _interceptors.Length; i++)
+            {
+                result = _interceptors[i].ThrowingConcurrencyException(eventData, result);
+            }
+
+            return result;
+        }
+
         public async ValueTask<InterceptionResult<int>> SavingChangesAsync(
             DbContextEventData eventData,
             InterceptionResult<int> result,
@@ -108,6 +120,21 @@ public class SaveChangesInterceptorAggregator : InterceptorAggregator<ISaveChang
             {
                 await _interceptors[i].SaveChangesCanceledAsync(eventData, cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        public async ValueTask<InterceptionResult> ThrowingConcurrencyExceptionAsync(
+            ConcurrencyExceptionEventData eventData,
+            InterceptionResult result,
+            CancellationToken cancellationToken = default)
+        {
+            for (var i = 0; i < _interceptors.Length; i++)
+            {
+                result = await _interceptors[i]
+                    .ThrowingConcurrencyExceptionAsync(eventData, result, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
Closes #31361

## Description

When more then one interceptor is registered for a DBContext, the `AggregateInterceptors` method from the `InterceptorAggregator` class, creates an `InterceptorAggregator` by calling `CreateChain`.

https://github.com/dotnet/efcore/blob/d0e0824f3e7997a80a2f6f3bc13234a0077ffb30/src/EFCore/Diagnostics/InterceptorAggregator.cs#L48-L58

Then when triggering the interceptor, the `SaveChangesInterceptorAggregator` is triggered.

https://github.com/dotnet/efcore/blob/d0e0824f3e7997a80a2f6f3bc13234a0077ffb30/src/EFCore/Diagnostics/CoreLoggerExtensions.cs#L265-L268

Since `SaveChangesInterceptorAggregator` does not implement the methods `ThrowingConcurrencyException` and `ThrowingConcurrencyExceptionAsync` from the `ISaveChangesInterceptor`, therefore no interceptor in the aggregator is notified.