### PR TITLE
First passing tests

### DIFF
--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingInterceptor.cs
@@ -38,7 +38,7 @@ public class ProxyBindingInterceptor : IInstantiationBindingInterceptor
     /// </summary>
     public virtual InstantiationBinding ModifyBinding(InstantiationBindingInterceptionData interceptionData, InstantiationBinding binding)
     {
-        var entityType = interceptionData.EntityType;
+        var entityType = interceptionData.TypeBase as IEntityType ?? throw new NotImplementedException();
         var proxyType = _proxyFactory.CreateProxyType(entityType);
 
         if ((bool?)entityType.Model[ProxyAnnotationNames.LazyLoading] == true)

--- a/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeExtensions.cs
@@ -68,18 +68,6 @@ public static class RelationalEntityTypeExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static IEnumerable<ITableMappingBase> GetViewOrTableMappings(this IEntityType entityType)
-        => (IEnumerable<ITableMappingBase>?)(entityType.FindRuntimeAnnotationValue(
-                    RelationalAnnotationNames.ViewMappings)
-                ?? entityType.FindRuntimeAnnotationValue(RelationalAnnotationNames.TableMappings))
-            ?? Enumerable.Empty<ITableMappingBase>();
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
     public static List<IProperty> GetNonPrincipalSharedNonPkProperties(this IEntityType entityType, ITableBase table)
     {
         var principalEntityTypes = new HashSet<IEntityType>();

--- a/src/EFCore.Relational/Metadata/Internal/RelationalTypeBaseExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalTypeBaseExtensions.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public static class RelationalTypeBaseExtensions
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static IEnumerable<ITableMappingBase> GetViewOrTableMappings(this ITypeBase typeBase)
+        => (IEnumerable<ITableMappingBase>?)(typeBase.FindRuntimeAnnotationValue(
+                    RelationalAnnotationNames.ViewMappings)
+                ?? typeBase.FindRuntimeAnnotationValue(RelationalAnnotationNames.TableMappings))
+            ?? Enumerable.Empty<ITableMappingBase>();
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -24,7 +24,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
     private SelectExpression _selectExpression;
 
     private bool _indexBasedBinding;
-    private Dictionary<EntityProjectionExpression, ProjectionBindingExpression>? _entityProjectionCache;
+    private Dictionary<StructuralTypeProjectionExpression, ProjectionBindingExpression>? _projectionBindingCache;
     private List<Expression>? _clientProjections;
 
     private readonly Dictionary<ProjectionMember, Expression> _projectionMapping = new();
@@ -64,7 +64,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
         if (result == QueryCompilationContext.NotTranslatedExpression)
         {
             _indexBasedBinding = true;
-            _entityProjectionCache = new Dictionary<EntityProjectionExpression, ProjectionBindingExpression>();
+            _projectionBindingCache = new Dictionary<StructuralTypeProjectionExpression, ProjectionBindingExpression>();
             _projectionMapping.Clear();
             _clientProjections = new List<Expression>();
 
@@ -122,9 +122,9 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
 
                     case ProjectionBindingExpression projectionBindingExpression:
                         var mappedProjection = _selectExpression.GetProjection(projectionBindingExpression);
-                        if (mappedProjection is EntityProjectionExpression entityProjection)
+                        if (mappedProjection is StructuralTypeProjectionExpression structuralTypeProjection)
                         {
-                            return AddClientProjection(entityProjection, typeof(ValueBuffer));
+                            return AddClientProjection(structuralTypeProjection, typeof(ValueBuffer));
                         }
 
                         if (mappedProjection is SqlExpression mappedSqlExpression)
@@ -299,7 +299,7 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
             case EntityShaperExpression entityShaperExpression:
             {
                 // TODO: Make this easier to understand some day.
-                EntityProjectionExpression entityProjectionExpression;
+                StructuralTypeProjectionExpression projectionExpression;
 
                 if (entityShaperExpression.ValueBufferExpression is JsonQueryExpression jsonQueryExpression)
                 {
@@ -344,25 +344,25 @@ public class RelationalProjectionBindingExpressionVisitor : ExpressionVisitor
                             new ProjectionBindingExpression(_selectExpression, _projectionMembers.Peek(), typeof(ValueBuffer)));
                     }
 
-                    entityProjectionExpression = (EntityProjectionExpression)projection;
+                    projectionExpression = (StructuralTypeProjectionExpression)projection;
                 }
                 else
                 {
-                    entityProjectionExpression = (EntityProjectionExpression)entityShaperExpression.ValueBufferExpression;
+                    projectionExpression = (StructuralTypeProjectionExpression)entityShaperExpression.ValueBufferExpression;
                 }
 
                 if (_indexBasedBinding)
                 {
-                    if (!_entityProjectionCache!.TryGetValue(entityProjectionExpression, out var entityProjectionBinding))
+                    if (!_projectionBindingCache!.TryGetValue(projectionExpression, out var entityProjectionBinding))
                     {
-                        entityProjectionBinding = AddClientProjection(entityProjectionExpression, typeof(ValueBuffer));
-                        _entityProjectionCache[entityProjectionExpression] = entityProjectionBinding;
+                        entityProjectionBinding = AddClientProjection(projectionExpression, typeof(ValueBuffer));
+                        _projectionBindingCache[projectionExpression] = entityProjectionBinding;
                     }
 
                     return entityShaperExpression.Update(entityProjectionBinding);
                 }
 
-                _projectionMapping[_projectionMembers.Peek()] = entityProjectionExpression;
+                _projectionMapping[_projectionMembers.Peek()] = projectionExpression;
 
                 return entityShaperExpression.Update(
                     new ProjectionBindingExpression(_selectExpression, _projectionMembers.Peek(), typeof(ValueBuffer)));

--- a/src/EFCore.Relational/Query/Internal/TableReferenceExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/TableReferenceExpression.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public sealed class TableReferenceExpression : Expression
+{
+    private SelectExpression _selectExpression;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public TableReferenceExpression(SelectExpression selectExpression, string alias)
+    {
+        _selectExpression = selectExpression;
+        Alias = alias;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public TableExpressionBase Table
+    {
+        get
+        {
+            var table = _selectExpression.Tables.SingleOrDefault(
+                e => string.Equals((e as JoinExpressionBase)?.Table.Alias ?? e.Alias, Alias, StringComparison.OrdinalIgnoreCase));
+            Check.DebugAssert(
+                table is not null,
+                $"Mismatched {nameof(TableReferenceExpression)}: couldn't find table alias '{Alias}' in referenced select expression's tables: "
+                + Environment.NewLine
+                + Environment.NewLine
+                + ExpressionPrinter.Print(_selectExpression));
+            return table;
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public string Alias { get; internal set; }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Type Type
+        => typeof(object);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+        => this;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public void UpdateTableReference(SelectExpression oldSelect, SelectExpression newSelect)
+    {
+        if (ReferenceEquals(oldSelect, _selectExpression))
+        {
+            _selectExpression = newSelect;
+        }
+    }
+
+    internal void Verify(SelectExpression selectExpression)
+    {
+        if (!ReferenceEquals(selectExpression, _selectExpression))
+        {
+            throw new InvalidOperationException("Dangling TableReferenceExpression.");
+        }
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj != null
+            && (ReferenceEquals(this, obj)
+                || obj is TableReferenceExpression tableReferenceExpression
+                && Equals(tableReferenceExpression));
+
+    // Since table reference is owned by SelectExpression, the select expression should be the same reference if they are matching.
+    // That means we also don't need to compute the hashcode for it.
+    // This allows us to break the cycle in computation when traversing this graph.
+    private bool Equals(TableReferenceExpression tableReferenceExpression)
+        => string.Equals(Alias, tableReferenceExpression.Alias, StringComparison.OrdinalIgnoreCase)
+            && ReferenceEquals(_selectExpression, tableReferenceExpression._selectExpression);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => 0;
+}

--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -20,18 +20,18 @@ public class RelationalEntityShaperExpression : EntityShaperExpression
     /// <summary>
     ///     Creates a new instance of the <see cref="RelationalEntityShaperExpression" /> class.
     /// </summary>
-    /// <param name="entityType">The entity type to shape.</param>
+    /// <param name="structuralType">The entity type to shape.</param>
     /// <param name="valueBufferExpression">An expression of ValueBuffer to get values for properties of the entity.</param>
     /// <param name="nullable">A bool value indicating whether this entity instance can be null.</param>
-    public RelationalEntityShaperExpression(IEntityType entityType, Expression valueBufferExpression, bool nullable)
-        : base(entityType, valueBufferExpression, nullable, null)
+    public RelationalEntityShaperExpression(ITypeBase structuralType, Expression valueBufferExpression, bool nullable)
+        : base(structuralType, valueBufferExpression, nullable, null)
     {
     }
 
     /// <summary>
     ///     Creates a new instance of the <see cref="RelationalEntityShaperExpression" /> class.
     /// </summary>
-    /// <param name="entityType">The entity type to shape.</param>
+    /// <param name="structuralType">The entity type to shape.</param>
     /// <param name="valueBufferExpression">An expression of ValueBuffer to get values for properties of the entity.</param>
     /// <param name="nullable">Whether this entity instance can be null.</param>
     /// <param name="materializationCondition">
@@ -39,17 +39,23 @@ public class RelationalEntityShaperExpression : EntityShaperExpression
     ///     materialize.
     /// </param>
     protected RelationalEntityShaperExpression(
-        IEntityType entityType,
+        ITypeBase structuralType,
         Expression valueBufferExpression,
         bool nullable,
         LambdaExpression? materializationCondition)
-        : base(entityType, valueBufferExpression, nullable, materializationCondition)
+        : base(structuralType, valueBufferExpression, nullable, materializationCondition)
     {
     }
 
     /// <inheritdoc />
-    protected override LambdaExpression GenerateMaterializationCondition(IEntityType entityType, bool nullable)
+    protected override LambdaExpression GenerateMaterializationCondition(ITypeBase structuralType, bool nullable)
     {
+        if (structuralType is IComplexType)
+        {
+            return base.GenerateMaterializationCondition(structuralType, nullable);
+        }
+
+        var entityType = (IEntityType)structuralType;
         LambdaExpression baseCondition;
         // Generate discriminator condition
         var containsDiscriminatorProperty = entityType.FindDiscriminatorProperty() != null;
@@ -152,12 +158,12 @@ public class RelationalEntityShaperExpression : EntityShaperExpression
     public override EntityShaperExpression MakeNullable(bool nullable = true)
         => IsNullable != nullable
             // Marking nullable requires re-computation of Discriminator condition
-            ? new RelationalEntityShaperExpression(EntityType, ValueBufferExpression, true)
+            ? new RelationalEntityShaperExpression(StructuralType, ValueBufferExpression, true)
             : this;
 
     /// <inheritdoc />
     public override EntityShaperExpression Update(Expression valueBufferExpression)
         => valueBufferExpression != ValueBufferExpression
-            ? new RelationalEntityShaperExpression(EntityType, valueBufferExpression, IsNullable, MaterializationCondition)
+            ? new RelationalEntityShaperExpression(StructuralType, valueBufferExpression, IsNullable, MaterializationCondition)
             : this;
 }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -978,7 +978,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             var projectionMember = projectionBindingExpression.ProjectionMember;
             Check.DebugAssert(new ProjectionMember().Equals(projectionMember), "Invalid ProjectionMember when processing OfType");
 
-            var entityProjectionExpression = (EntityProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
+            var entityProjectionExpression = (StructuralTypeProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
             selectExpression.ReplaceProjection(
                 new Dictionary<ProjectionMember, Expression>
                 {
@@ -1693,8 +1693,8 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
     }
 
     /// <summary>
-    ///     Checks weather the current select expression can be used as-is for execute a delete operation,
-    ///     or whether it must be pushed down into a subquery.
+    ///     Checks weather the current select expression can be used as-is for executing a delete operation, or whether it must be pushed
+    ///     down into a subquery.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -1709,7 +1709,9 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
     /// <param name="selectExpression">The select expression to validate.</param>
     /// <param name="entityShaperExpression">The entity shaper expression on which the delete operation is being applied.</param>
     /// <param name="tableExpression">The table expression from which rows are being deleted.</param>
-    /// <returns>Returns <see langword="true" /> if the current select expression can be used for delete as-is, <see langword="false" /> otherwise.</returns>
+    /// <returns>
+    /// Returns <see langword="true" /> if the current select expression can be used for delete as-is, <see langword="false" /> otherwise.
+    /// </returns>
     protected virtual bool IsValidSelectExpressionForExecuteDelete(
         SelectExpression selectExpression,
         EntityShaperExpression entityShaperExpression,
@@ -1776,7 +1778,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             else
             {
                 var projectionBindingExpression = (ProjectionBindingExpression)entityShaperExpression.ValueBufferExpression;
-                var entityProjectionExpression = (EntityProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
+                var entityProjectionExpression = (StructuralTypeProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
                 var column = entityProjectionExpression.BindProperty(entityShaperExpression.EntityType.GetProperties().First());
                 table = column.Table;
                 if (ReferenceEquals(selectExpression.Tables[0], table))
@@ -2111,122 +2113,141 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                 return null;
             }
 
-            var entityType = entityShaperExpression.EntityType;
-            if (convertedType != null)
+            if (entityShaperExpression.StructuralType is IEntityType entityType)
             {
-                entityType = entityType.GetRootType().GetDerivedTypesInclusive()
-                    .FirstOrDefault(et => et.ClrType == convertedType);
-
-                if (entityType == null)
+                if (convertedType != null)
                 {
-                    return null;
+                    var convertedEntityType = entityType.GetRootType().GetDerivedTypesInclusive()
+                        .FirstOrDefault(et => et.ClrType == convertedType);
+
+                    if (convertedEntityType == null)
+                    {
+                        return null;
+                    }
+
+                    entityType = convertedEntityType;
+                }
+
+                var navigation = member.MemberInfo != null
+                    ? entityType.FindNavigation(member.MemberInfo)
+                    : entityType.FindNavigation(member.Name!);
+
+                if (navigation is { TargetEntityType: IEntityType targetEntityType}
+                    && targetEntityType.IsOwned())
+                {
+                    return ExpandOwnedNavigation(navigation);
                 }
             }
-
-            var navigation = member.MemberInfo != null
-                ? entityType.FindNavigation(member.MemberInfo)
-                : entityType.FindNavigation(member.Name!);
-
-            if (navigation == null)
+            else
             {
-                return null;
+                Check.DebugAssert(convertedType is null, "convertedType must be null for complex types, no inheritance support");
             }
 
-            var targetEntityType = navigation.TargetEntityType;
-            if (targetEntityType == null
-                || !targetEntityType.IsOwned())
+            var complexProperty = member.MemberInfo != null
+                ? entityShaperExpression.StructuralType.FindComplexProperty(member.MemberInfo)
+                : entityShaperExpression.StructuralType.FindComplexProperty(member.Name!);
+
+            if (complexProperty is not null)
             {
-                return null;
+                var entityProjectionExpression = GetEntityProjectionExpression(entityShaperExpression);
+                return SelectExpression.GenerateComplexPropertyShaperExpression(entityProjectionExpression, complexProperty);
             }
 
-            if (TryGetJsonQueryExpression(entityShaperExpression, out var jsonQueryExpression))
+            return null;
+
+            Expression ExpandOwnedNavigation(INavigation navigation)
             {
-                var newJsonQueryExpression = jsonQueryExpression.BindNavigation(navigation);
+                var targetEntityType = navigation.TargetEntityType;
 
-                return navigation.IsCollection
-                    ? newJsonQueryExpression
-                    : new RelationalEntityShaperExpression(
-                        navigation.TargetEntityType,
-                        newJsonQueryExpression,
-                        nullable: entityShaperExpression.IsNullable || !navigation.ForeignKey.IsRequired);
-            }
+                if (TryGetJsonQueryExpression(entityShaperExpression, out var jsonQueryExpression))
+                {
+                    var newJsonQueryExpression = jsonQueryExpression.BindNavigation(navigation);
 
-            var entityProjectionExpression = GetEntityProjectionExpression(entityShaperExpression);
-            var foreignKey = navigation.ForeignKey;
+                    return navigation.IsCollection
+                        ? newJsonQueryExpression
+                        : new RelationalEntityShaperExpression(
+                            navigation.TargetEntityType,
+                            newJsonQueryExpression,
+                            nullable: entityShaperExpression.IsNullable || !navigation.ForeignKey.IsRequired);
+                }
 
-            if (targetEntityType.IsMappedToJson())
-            {
-                var innerShaper = entityProjectionExpression.BindNavigation(navigation)!;
+                var entityProjectionExpression = GetEntityProjectionExpression(entityShaperExpression);
+                var foreignKey = navigation.ForeignKey;
 
-                return navigation.IsCollection
-                    ? (JsonQueryExpression)innerShaper.ValueBufferExpression
-                    : innerShaper;
-            }
+                if (targetEntityType.IsMappedToJson())
+                {
+                    var innerShaper = entityProjectionExpression.BindNavigation(navigation)!;
 
-            if (navigation.IsCollection)
-            {
-                // just need any column - we use it only to extract the table it originated from
-                var sourceColumn = entityProjectionExpression
-                    .BindProperty(
+                    return navigation.IsCollection
+                        ? (JsonQueryExpression)innerShaper.ValueBufferExpression
+                        : innerShaper;
+                }
+
+                if (navigation.IsCollection)
+                {
+                    // just need any column - we use it only to extract the table it originated from
+                    var sourceColumn = entityProjectionExpression
+                        .BindProperty(
+                            navigation.IsOnDependent
+                                ? foreignKey.Properties[0]
+                                : foreignKey.PrincipalKey.Properties[0]);
+
+                    var sourceTable = FindRootTableExpressionForColumn(sourceColumn);
+                    var innerSelectExpression = _sqlExpressionFactory.Select(targetEntityType);
+                    innerSelectExpression = (SelectExpression)new AnnotationApplyingExpressionVisitor(sourceTable.GetAnnotations().ToList())
+                        .Visit(innerSelectExpression);
+
+                    var innerShapedQuery = CreateShapedQueryExpression(targetEntityType, innerSelectExpression);
+
+                    var makeNullable = foreignKey.PrincipalKey.Properties
+                        .Concat(foreignKey.Properties)
+                        .Select(p => p.ClrType)
+                        .Any(t => t.IsNullableType());
+
+                    var innerSequenceType = innerShapedQuery.Type.GetSequenceType();
+                    var correlationPredicateParameter = Expression.Parameter(innerSequenceType);
+
+                    var outerKey = entityShaperExpression.CreateKeyValuesExpression(
                         navigation.IsOnDependent
-                            ? foreignKey.Properties[0]
-                            : foreignKey.PrincipalKey.Properties[0]);
+                            ? foreignKey.Properties
+                            : foreignKey.PrincipalKey.Properties,
+                        makeNullable);
+                    var innerKey = correlationPredicateParameter.CreateKeyValuesExpression(
+                        navigation.IsOnDependent
+                            ? foreignKey.PrincipalKey.Properties
+                            : foreignKey.Properties,
+                        makeNullable);
 
-                var sourceTable = FindRootTableExpressionForColumn(sourceColumn);
-                var innerSelectExpression = _sqlExpressionFactory.Select(targetEntityType);
-                innerSelectExpression = (SelectExpression)new AnnotationApplyingExpressionVisitor(sourceTable.GetAnnotations().ToList())
-                    .Visit(innerSelectExpression);
+                    var keyComparison = Infrastructure.ExpressionExtensions.CreateEqualsExpression(outerKey, innerKey);
 
-                var innerShapedQuery = CreateShapedQueryExpression(targetEntityType, innerSelectExpression);
+                    var predicate = makeNullable
+                        ? Expression.AndAlso(
+                            outerKey is NewArrayExpression newArrayExpression
+                                ? newArrayExpression.Expressions
+                                    .Select(
+                                        e =>
+                                        {
+                                            var left = (e as UnaryExpression)?.Operand ?? e;
 
-                var makeNullable = foreignKey.PrincipalKey.Properties
-                    .Concat(foreignKey.Properties)
-                    .Select(p => p.ClrType)
-                    .Any(t => t.IsNullableType());
+                                            return Expression.NotEqual(left, Expression.Constant(null, left.Type));
+                                        })
+                                    .Aggregate(Expression.AndAlso)
+                                : Expression.NotEqual(outerKey, Expression.Constant(null, outerKey.Type)),
+                            keyComparison)
+                        : keyComparison;
 
-                var innerSequenceType = innerShapedQuery.Type.GetSequenceType();
-                var correlationPredicateParameter = Expression.Parameter(innerSequenceType);
+                    var correlationPredicate = Expression.Lambda(predicate, correlationPredicateParameter);
 
-                var outerKey = entityShaperExpression.CreateKeyValuesExpression(
-                    navigation.IsOnDependent
-                        ? foreignKey.Properties
-                        : foreignKey.PrincipalKey.Properties,
-                    makeNullable);
-                var innerKey = correlationPredicateParameter.CreateKeyValuesExpression(
-                    navigation.IsOnDependent
-                        ? foreignKey.PrincipalKey.Properties
-                        : foreignKey.Properties,
-                    makeNullable);
+                    return Expression.Call(
+                        QueryableMethods.Where.MakeGenericMethod(innerSequenceType),
+                        innerShapedQuery,
+                        Expression.Quote(correlationPredicate));
+                }
 
-                var keyComparison = Infrastructure.ExpressionExtensions.CreateEqualsExpression(outerKey, innerKey);
-
-                var predicate = makeNullable
-                    ? Expression.AndAlso(
-                        outerKey is NewArrayExpression newArrayExpression
-                            ? newArrayExpression.Expressions
-                                .Select(
-                                    e =>
-                                    {
-                                        var left = (e as UnaryExpression)?.Operand ?? e;
-
-                                        return Expression.NotEqual(left, Expression.Constant(null, left.Type));
-                                    })
-                                .Aggregate(Expression.AndAlso)
-                            : Expression.NotEqual(outerKey, Expression.Constant(null, outerKey.Type)),
-                        keyComparison)
-                    : keyComparison;
-
-                var correlationPredicate = Expression.Lambda(predicate, correlationPredicateParameter);
-
-                return Expression.Call(
-                    QueryableMethods.Where.MakeGenericMethod(innerSequenceType),
-                    innerShapedQuery,
-                    Expression.Quote(correlationPredicate));
+                return entityProjectionExpression.BindNavigation(navigation)
+                    ?? _selectExpression.GenerateOwnedReferenceEntityProjectionExpression(
+                        entityProjectionExpression, navigation, _sqlExpressionFactory);
             }
-
-            return entityProjectionExpression.BindNavigation(navigation)
-                ?? _selectExpression.GenerateOwnedReferenceEntityProjectionExpression(
-                    entityProjectionExpression, navigation, _sqlExpressionFactory);
 
             static TableExpressionBase FindRootTableExpressionForColumn(ColumnExpression column)
             {
@@ -2298,12 +2319,12 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             }
         }
 
-        private EntityProjectionExpression GetEntityProjectionExpression(EntityShaperExpression entityShaperExpression)
+        private StructuralTypeProjectionExpression GetEntityProjectionExpression(EntityShaperExpression entityShaperExpression)
             => entityShaperExpression.ValueBufferExpression switch
             {
                 ProjectionBindingExpression projectionBindingExpression
-                    => (EntityProjectionExpression)_selectExpression.GetProjection(projectionBindingExpression),
-                EntityProjectionExpression entityProjectionExpression => entityProjectionExpression,
+                    => (StructuralTypeProjectionExpression)_selectExpression.GetProjection(projectionBindingExpression),
+                StructuralTypeProjectionExpression entityProjectionExpression => entityProjectionExpression,
                 _ => throw new InvalidOperationException()
             };
     }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -525,10 +525,10 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         {
                             var entityParameter = Parameter(entityShaperExpression.Type);
                             _variables.Add(entityParameter);
-                            if (entityShaperExpression.EntityType.GetMappingStrategy() == RelationalAnnotationNames.TpcMappingStrategy)
+                            if (entityShaperExpression.StructuralType is IEntityType entityType
+                                && entityType.GetMappingStrategy() == RelationalAnnotationNames.TpcMappingStrategy)
                             {
-                                var concreteTypes = entityShaperExpression.EntityType.GetDerivedTypesInclusive().Where(e => !e.IsAbstract())
-                                    .ToArray();
+                                var concreteTypes = entityType.GetDerivedTypesInclusive().Where(e => !e.IsAbstract()).ToArray();
                                 // Single concrete TPC entity type won't have discriminator column.
                                 // We store the value here and inject it directly rather than reading from server.
                                 if (concreteTypes.Length == 1)

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -427,7 +427,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                         null)
                     ?? QueryCompilationContext.NotTranslatedExpression;
 
-        Expression ProcessGetType(EntityReferenceExpression entityReferenceExpression, Type comparisonType, bool match)
+        Expression ProcessGetType(StructuralTypeReferenceExpression entityReferenceExpression, Type comparisonType, bool match)
         {
             var entityType = entityReferenceExpression.EntityType;
 
@@ -466,7 +466,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                 if (entityReferenceExpression.SubqueryEntity != null)
                 {
                     var entityShaper = (EntityShaperExpression)entityReferenceExpression.SubqueryEntity.ShaperExpression;
-                    var entityProjection = (EntityProjectionExpression)Visit(entityShaper.ValueBufferExpression);
+                    var entityProjection = (StructuralTypeProjectionExpression)Visit(entityShaper.ValueBufferExpression);
                     var subSelectExpression = (SelectExpression)entityReferenceExpression.SubqueryEntity.QueryExpression;
 
                     var predicate = GeneratePredicateTpt(entityProjection);
@@ -485,13 +485,13 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
                 if (entityReferenceExpression.ParameterEntity != null)
                 {
-                    var entityProjection = (EntityProjectionExpression)Visit(
+                    var entityProjection = (StructuralTypeProjectionExpression)Visit(
                         entityReferenceExpression.ParameterEntity.ValueBufferExpression);
 
                     return GeneratePredicateTpt(entityProjection);
                 }
 
-                SqlExpression GeneratePredicateTpt(EntityProjectionExpression entityProjectionExpression)
+                SqlExpression GeneratePredicateTpt(StructuralTypeProjectionExpression entityProjectionExpression)
                 {
                     if (entityProjectionExpression.DiscriminatorExpression is CaseExpression caseExpression)
                     {
@@ -546,7 +546,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             return QueryCompilationContext.NotTranslatedExpression;
         }
 
-        bool IsGetTypeMethodCall(Expression expression, out EntityReferenceExpression? entityReferenceExpression)
+        bool IsGetTypeMethodCall(Expression expression, out StructuralTypeReferenceExpression? entityReferenceExpression)
         {
             entityReferenceExpression = null;
             if (expression is not MethodCallExpression methodCallExpression
@@ -555,7 +555,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                 return false;
             }
 
-            entityReferenceExpression = Visit(methodCallExpression.Object) as EntityReferenceExpression;
+            entityReferenceExpression = Visit(methodCallExpression.Object) as StructuralTypeReferenceExpression;
             return entityReferenceExpression != null;
         }
 
@@ -608,15 +608,15 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
     {
         switch (extensionExpression)
         {
-            case EntityProjectionExpression:
-            case EntityReferenceExpression:
+            case StructuralTypeProjectionExpression:
+            case StructuralTypeReferenceExpression:
             case SqlExpression:
             case EnumerableExpression:
             case JsonQueryExpression:
                 return extensionExpression;
 
             case EntityShaperExpression entityShaperExpression:
-                return new EntityReferenceExpression(entityShaperExpression);
+                return new StructuralTypeReferenceExpression(entityShaperExpression);
 
             case ProjectionBindingExpression projectionBindingExpression:
                 return Visit(
@@ -644,7 +644,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     && (convertedType == null
                         || convertedType.IsAssignableFrom(ese.Type)))
                 {
-                    return new EntityReferenceExpression(shapedQueryExpression.UpdateShaperExpression(innerExpression));
+                    return new StructuralTypeReferenceExpression(shapedQueryExpression.UpdateShaperExpression(innerExpression));
                 }
 
                 if (innerExpression is ProjectionBindingExpression pbe
@@ -1022,7 +1022,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         var innerExpression = Visit(typeBinaryExpression.Expression);
 
         if (typeBinaryExpression.NodeType != ExpressionType.TypeIs
-            || innerExpression is not EntityReferenceExpression entityReferenceExpression)
+            || innerExpression is not StructuralTypeReferenceExpression entityReferenceExpression)
         {
             return QueryCompilationContext.NotTranslatedExpression;
         }
@@ -1052,7 +1052,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             if (entityReferenceExpression.SubqueryEntity != null)
             {
                 var entityShaper = (EntityShaperExpression)entityReferenceExpression.SubqueryEntity.ShaperExpression;
-                var entityProjection = (EntityProjectionExpression)Visit(entityShaper.ValueBufferExpression);
+                var entityProjection = (StructuralTypeProjectionExpression)Visit(entityShaper.ValueBufferExpression);
                 var subSelectExpression = (SelectExpression)entityReferenceExpression.SubqueryEntity.QueryExpression;
 
                 var predicate = GeneratePredicateTpt(entityProjection);
@@ -1071,13 +1071,13 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
             if (entityReferenceExpression.ParameterEntity != null)
             {
-                var entityProjection = (EntityProjectionExpression)Visit(
+                var entityProjection = (StructuralTypeProjectionExpression)Visit(
                     entityReferenceExpression.ParameterEntity.ValueBufferExpression);
 
                 return GeneratePredicateTpt(entityProjection);
             }
 
-            SqlExpression GeneratePredicateTpt(EntityProjectionExpression entityProjectionExpression)
+            SqlExpression GeneratePredicateTpt(StructuralTypeProjectionExpression entityProjectionExpression)
             {
                 if (entityProjectionExpression.DiscriminatorExpression is CaseExpression caseExpression)
                 {
@@ -1136,7 +1136,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
     {
         var operand = Visit(unaryExpression.Operand);
 
-        if (operand is EntityReferenceExpression entityReferenceExpression
+        if (operand is StructuralTypeReferenceExpression entityReferenceExpression
             && unaryExpression.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked or ExpressionType.TypeAs)
         {
             return entityReferenceExpression.Convert(unaryExpression.Type);
@@ -1188,15 +1188,15 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
     private SqlExpression? TryBindMember(Expression? source, MemberIdentity member)
     {
-        if (source is not EntityReferenceExpression entityReferenceExpression)
+        if (source is not StructuralTypeReferenceExpression entityReferenceExpression)
         {
             return null;
         }
 
-        var entityType = entityReferenceExpression.EntityType;
+        var structuralType = entityReferenceExpression.StructuralType;
         var property = member.MemberInfo != null
-            ? entityType.FindProperty(member.MemberInfo)
-            : entityType.FindProperty(member.Name!);
+            ? structuralType.FindProperty(member.MemberInfo)
+            : structuralType.FindProperty(member.Name!);
 
         if (property != null)
         {
@@ -1211,21 +1211,21 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         return null;
     }
 
-    private SqlExpression? BindProperty(EntityReferenceExpression entityReferenceExpression, IProperty property)
+    private SqlExpression? BindProperty(StructuralTypeReferenceExpression structuralTypeReferenceExpression, IProperty property)
     {
-        if (entityReferenceExpression.ParameterEntity != null)
+        if (structuralTypeReferenceExpression.ParameterEntity != null)
         {
-            var valueBufferExpression = Visit(entityReferenceExpression.ParameterEntity.ValueBufferExpression);
+            var valueBufferExpression = Visit(structuralTypeReferenceExpression.ParameterEntity.ValueBufferExpression);
             if (valueBufferExpression is JsonQueryExpression jsonQueryExpression)
             {
                 return jsonQueryExpression.BindProperty(property);
             }
 
-            var entityProjectionExpression = (EntityProjectionExpression)valueBufferExpression;
+            var entityProjectionExpression = (StructuralTypeProjectionExpression)valueBufferExpression;
             var propertyAccess = entityProjectionExpression.BindProperty(property);
 
-            var entityType = entityReferenceExpression.EntityType;
-            if (entityType.FindDiscriminatorProperty() != null
+            if (structuralTypeReferenceExpression.StructuralType is not IEntityType entityType
+                || entityType.FindDiscriminatorProperty() != null
                 || entityType.FindPrimaryKey() == null
                 || entityType.GetRootType() != entityType
                 || entityType.GetMappingStrategy() == RelationalAnnotationNames.TpcMappingStrategy)
@@ -1287,13 +1287,13 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             // single result so either it is regular entity or a collection which always have their own table.
         }
 
-        if (entityReferenceExpression.SubqueryEntity != null)
+        if (structuralTypeReferenceExpression.SubqueryEntity != null)
         {
-            var entityShaper = (EntityShaperExpression)entityReferenceExpression.SubqueryEntity.ShaperExpression;
-            var subSelectExpression = (SelectExpression)entityReferenceExpression.SubqueryEntity.QueryExpression;
+            var entityShaper = (EntityShaperExpression)structuralTypeReferenceExpression.SubqueryEntity.ShaperExpression;
+            var subSelectExpression = (SelectExpression)structuralTypeReferenceExpression.SubqueryEntity.QueryExpression;
 
             var projectionBindingExpression = (ProjectionBindingExpression)entityShaper.ValueBufferExpression;
-            var entityProjectionExpression = (EntityProjectionExpression)subSelectExpression.GetProjection(projectionBindingExpression);
+            var entityProjectionExpression = (StructuralTypeProjectionExpression)subSelectExpression.GetProjection(projectionBindingExpression);
             var innerProjection = entityProjectionExpression.BindProperty(property);
             subSelectExpression.ReplaceProjection(new List<Expression> { innerProjection });
             subSelectExpression.ApplyProjection();
@@ -1587,7 +1587,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
     {
         result = null;
 
-        if (item is not EntityReferenceExpression itemEntityReference)
+        if (item is not StructuralTypeReferenceExpression itemEntityReference)
         {
             return false;
         }
@@ -1662,8 +1662,8 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         bool equalsMethod,
         [NotNullWhen(true)] out Expression? result)
     {
-        var leftEntityReference = left as EntityReferenceExpression;
-        var rightEntityReference = right as EntityReferenceExpression;
+        var leftEntityReference = left as StructuralTypeReferenceExpression;
+        var rightEntityReference = right as StructuralTypeReferenceExpression;
 
         if (leftEntityReference == null
             && rightEntityReference == null)
@@ -1892,33 +1892,40 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         return false;
     }
 
-    private sealed class EntityReferenceExpression : Expression
+    private sealed class StructuralTypeReferenceExpression : Expression
     {
-        public EntityReferenceExpression(EntityShaperExpression parameter)
+        public StructuralTypeReferenceExpression(EntityShaperExpression parameter)
         {
             ParameterEntity = parameter;
-            EntityType = parameter.EntityType;
+            StructuralType = parameter.StructuralType;
         }
 
-        public EntityReferenceExpression(ShapedQueryExpression subquery)
+        public StructuralTypeReferenceExpression(ShapedQueryExpression subquery)
         {
             SubqueryEntity = subquery;
-            EntityType = ((EntityShaperExpression)subquery.ShaperExpression).EntityType;
+            StructuralType = ((EntityShaperExpression)subquery.ShaperExpression).StructuralType;
         }
 
-        private EntityReferenceExpression(EntityReferenceExpression entityReferenceExpression, IEntityType entityType)
+        private StructuralTypeReferenceExpression(
+            StructuralTypeReferenceExpression structuralTypeReferenceExpression, ITypeBase structuralType)
         {
-            ParameterEntity = entityReferenceExpression.ParameterEntity;
-            SubqueryEntity = entityReferenceExpression.SubqueryEntity;
-            EntityType = entityType;
+            ParameterEntity = structuralTypeReferenceExpression.ParameterEntity;
+            SubqueryEntity = structuralTypeReferenceExpression.SubqueryEntity;
+            StructuralType = structuralType;
         }
 
         public EntityShaperExpression? ParameterEntity { get; }
         public ShapedQueryExpression? SubqueryEntity { get; }
-        public IEntityType EntityType { get; }
+
+        // TODO: Temporary, remove
+        public IEntityType EntityType
+            => StructuralType as IEntityType
+                ?? throw new InvalidOperationException("Type isn't an entity type: " + StructuralType.DisplayName());
+
+        public ITypeBase StructuralType { get; }
 
         public override Type Type
-            => EntityType.ClrType;
+            => StructuralType.ClrType;
 
         public override ExpressionType NodeType
             => ExpressionType.Extension;
@@ -1935,7 +1942,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
 
             return derivedEntityType == null
                 ? QueryCompilationContext.NotTranslatedExpression
-                : new EntityReferenceExpression(this, derivedEntityType);
+                : new StructuralTypeReferenceExpression(this, derivedEntityType);
         }
     }
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
@@ -360,9 +361,9 @@ public sealed partial class SelectExpression
         [return: NotNullIfNotNull("expression")]
         public override Expression? Visit(Expression? expression)
         {
-            if (expression is ConcreteColumnExpression columnExpression)
+            if (expression is TableReferenceExpression tableReferenceExpression)
             {
-                columnExpression.UpdateTableReference(_oldSelect, _newSelect);
+                tableReferenceExpression.UpdateTableReference(_oldSelect, _newSelect);
             }
 
             return base.Visit(expression);
@@ -421,63 +422,6 @@ public sealed partial class SelectExpression
 
             return base.Visit(expression);
         }
-    }
-
-    private sealed class TableReferenceExpression : Expression
-    {
-        private SelectExpression _selectExpression;
-
-        public TableReferenceExpression(SelectExpression selectExpression, string alias)
-        {
-            _selectExpression = selectExpression;
-            Alias = alias;
-        }
-
-        public TableExpressionBase Table
-            => _selectExpression.Tables.Single(
-                e => string.Equals((e as JoinExpressionBase)?.Table.Alias ?? e.Alias, Alias, StringComparison.OrdinalIgnoreCase));
-
-        public string Alias { get; internal set; }
-
-        public override Type Type
-            => typeof(object);
-
-        public override ExpressionType NodeType
-            => ExpressionType.Extension;
-
-        public void UpdateTableReference(SelectExpression oldSelect, SelectExpression newSelect)
-        {
-            if (ReferenceEquals(oldSelect, _selectExpression))
-            {
-                _selectExpression = newSelect;
-            }
-        }
-
-        internal void Verify(SelectExpression selectExpression)
-        {
-            if (!ReferenceEquals(selectExpression, _selectExpression))
-            {
-                throw new InvalidOperationException("Dangling TableReferenceExpression.");
-            }
-        }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj)
-            => obj != null
-                && (ReferenceEquals(this, obj)
-                    || obj is TableReferenceExpression tableReferenceExpression
-                    && Equals(tableReferenceExpression));
-
-        // Since table reference is owned by SelectExpression, the select expression should be the same reference if they are matching.
-        // That means we also don't need to compute the hashcode for it.
-        // This allows us to break the cycle in computation when traversing this graph.
-        private bool Equals(TableReferenceExpression tableReferenceExpression)
-            => string.Equals(Alias, tableReferenceExpression.Alias, StringComparison.OrdinalIgnoreCase)
-                && ReferenceEquals(_selectExpression, tableReferenceExpression._selectExpression);
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-            => 0;
     }
 
     private sealed class TpcTablesExpression : TableExpressionBase
@@ -625,16 +569,20 @@ public sealed partial class SelectExpression
 
         /// <inheritdoc />
         protected override Expression VisitChildren(ExpressionVisitor visitor)
-            => this;
+        {
+            // We only need to visit the table reference expression since TableReferenceUpdatingExpressionVisitor may need to modify it; it
+            // mutates TableReferenceExpression (a new TableReferenceExpression is never returned).
+            var newTable = (TableReferenceExpression)visitor.Visit(_table);
+            Check.DebugAssert(newTable == _table, $"New {nameof(TableReferenceExpression)} returned during visitation!");
+
+            return this;
+        }
 
         public override ConcreteColumnExpression MakeNullable()
             => IsNullable ? this : new ConcreteColumnExpression(Name, _table, Type, TypeMapping, true);
 
         public override SqlExpression ApplyTypeMapping(RelationalTypeMapping? typeMapping)
             => new ConcreteColumnExpression(Name, _table, Type, typeMapping, IsNullable);
-
-        public void UpdateTableReference(SelectExpression oldSelect, SelectExpression newSelect)
-            => _table.UpdateTableReference(oldSelect, newSelect);
 
         internal void Verify(IReadOnlyList<TableReferenceExpression> tableReferences)
         {

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -158,14 +158,14 @@ public sealed partial class SelectExpression : TableExpressionBase
             {
                 var keyProperties = entityType.FindPrimaryKey()!.Properties;
                 List<ColumnExpression> joinColumns = default!;
-                var tables = new List<ITableBase>();
+                var tableMap = new Dictionary<ITableBase, TableReferenceExpression>();
                 var columns = new Dictionary<IProperty, ColumnExpression>();
                 foreach (var baseType in entityType.GetAllBaseTypesInclusive())
                 {
-                    var table = GetTableBaseFiltered(baseType, tables);
-                    tables.Add(table);
+                    var table = GetTableBaseFiltered(baseType, tableMap);
                     var tableExpression = new TableExpression(table);
                     var tableReferenceExpression = new TableReferenceExpression(this, tableExpression.Alias);
+                    tableMap.Add(table, tableReferenceExpression);
 
                     foreach (var property in baseType.GetDeclaredProperties())
                     {
@@ -200,10 +200,11 @@ public sealed partial class SelectExpression : TableExpressionBase
                 var caseWhenClauses = new List<CaseWhenClause>();
                 foreach (var derivedType in entityType.GetDerivedTypes())
                 {
-                    var table = GetTableBaseFiltered(derivedType, tables);
-                    tables.Add(table);
+                    var table = GetTableBaseFiltered(derivedType, tableMap);
                     var tableExpression = new TableExpression(table);
                     var tableReferenceExpression = new TableReferenceExpression(this, tableExpression.Alias);
+                    tableMap.Add(table, tableReferenceExpression);
+
                     foreach (var property in derivedType.GetDeclaredProperties())
                     {
                         columns[property] = CreateColumnExpression(property, table, tableReferenceExpression, nullable: true);
@@ -234,8 +235,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                     ? null
                     : sqlExpressionFactory.ApplyDefaultTypeMapping(
                         sqlExpressionFactory.Case(caseWhenClauses, elseResult: null));
-                var entityProjection = new EntityProjectionExpression(entityType, columns, discriminatorExpression);
-                _projectionMapping[new ProjectionMember()] = entityProjection;
+                _projectionMapping[new ProjectionMember()] =
+                    new StructuralTypeProjectionExpression(entityType, columns, tableMap, discriminatorExpression);
             }
 
             break;
@@ -249,8 +250,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                     // For single entity case, we don't need discriminator.
                     var table = entityTypes[0].GetViewOrTableMappings().Single().Table;
                     var tableExpression = new TableExpression(table);
-
                     var tableReferenceExpression = new TableReferenceExpression(this, tableExpression.Alias);
+                    var tableMap = new Dictionary<ITableBase, TableReferenceExpression> { [table] = tableReferenceExpression };
                     AddTable(tableExpression, tableReferenceExpression);
 
                     var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
@@ -259,7 +260,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                         propertyExpressions[property] = CreateColumnExpression(property, table, tableReferenceExpression, nullable: false);
                     }
 
-                    _projectionMapping[new ProjectionMember()] = new EntityProjectionExpression(entityType, propertyExpressions);
+                    _projectionMapping[new ProjectionMember()] = new StructuralTypeProjectionExpression(entityType, propertyExpressions, tableMap);
 
                     var primaryKey = entityType.FindPrimaryKey();
                     if (primaryKey != null)
@@ -367,8 +368,10 @@ public sealed partial class SelectExpression : TableExpressionBase
 
                     var discriminatorColumn = new ConcreteColumnExpression(firstSelectExpression._projection[^1], tpcTableReference);
                     _tpcDiscriminatorValues[tpcTables] = (discriminatorColumn, discriminatorValues);
-                    var entityProjection = new EntityProjectionExpression(entityType, columns, discriminatorColumn);
-                    _projectionMapping[new ProjectionMember()] = entityProjection;
+                    var tableMap = tables.ToDictionary(t => t, _ => tpcTableReference);
+
+                    _projectionMapping[new ProjectionMember()] =
+                        new StructuralTypeProjectionExpression(entityType, columns, tableMap, discriminatorColumn);
                 }
             }
 
@@ -447,8 +450,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                                 property, columnBase, tableReferenceExpressionMap[columnBase.Table], nullable: false);
                         }
 
-                        var entityProjection = new EntityProjectionExpression(entityType, columns);
-                        _projectionMapping[new ProjectionMember()] = entityProjection;
+                        _projectionMapping[new ProjectionMember()] =
+                            new StructuralTypeProjectionExpression(entityType, columns, tableReferenceExpressionMap);
                     }
                 }
             }
@@ -467,9 +470,13 @@ public sealed partial class SelectExpression : TableExpressionBase
                 propertyExpressions[property] = CreateColumnExpression(property, table, tableReferenceExpression, nullable: false);
             }
 
-            var entityProjection = new EntityProjectionExpression(entityType, propertyExpressions);
-            AddJsonNavigationBindings(entityType, entityProjection, propertyExpressions, tableReferenceExpression);
-            _projectionMapping[new ProjectionMember()] = entityProjection;
+            var projectionExpression = new StructuralTypeProjectionExpression(
+                entityType,
+                propertyExpressions,
+                new Dictionary<ITableBase, TableReferenceExpression> { [table] = tableReferenceExpression });
+
+            AddJsonNavigationBindings(entityType, projectionExpression, propertyExpressions, tableReferenceExpression);
+            _projectionMapping[new ProjectionMember()] = projectionExpression;
 
             var primaryKey = entityType.FindPrimaryKey();
             if (primaryKey != null)
@@ -481,8 +488,8 @@ public sealed partial class SelectExpression : TableExpressionBase
             }
         }
 
-        static ITableBase GetTableBaseFiltered(IEntityType entityType, List<ITableBase> existingTables)
-            => entityType.GetViewOrTableMappings().Single(m => !existingTables.Contains(m.Table)).Table;
+        static ITableBase GetTableBaseFiltered(IEntityType entityType, Dictionary<ITableBase, TableReferenceExpression> existingTables)
+            => entityType.GetViewOrTableMappings().Single(m => !existingTables.ContainsKey(m.Table)).Table;
     }
 
     internal SelectExpression(IEntityType entityType, TableExpressionBase tableExpressionBase)
@@ -498,6 +505,7 @@ public sealed partial class SelectExpression : TableExpressionBase
         Check.DebugAssert(table is not null, "SelectExpression with unexpected missing table");
 
         var tableReferenceExpression = new TableReferenceExpression(this, tableExpressionBase.Alias!);
+        var tableMap = new Dictionary<ITableBase, TableReferenceExpression> { [table] = tableReferenceExpression };
         AddTable(tableExpressionBase, tableReferenceExpression);
 
         var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
@@ -506,9 +514,9 @@ public sealed partial class SelectExpression : TableExpressionBase
             propertyExpressions[property] = CreateColumnExpression(property, table, tableReferenceExpression, nullable: false);
         }
 
-        var entityProjection = new EntityProjectionExpression(entityType, propertyExpressions);
-        AddJsonNavigationBindings(entityType, entityProjection, propertyExpressions, tableReferenceExpression);
-        _projectionMapping[new ProjectionMember()] = entityProjection;
+        var projectionExpression = new StructuralTypeProjectionExpression(entityType, propertyExpressions, tableMap);
+        AddJsonNavigationBindings(entityType, projectionExpression, propertyExpressions, tableReferenceExpression);
+        _projectionMapping[new ProjectionMember()] = projectionExpression;
 
         var primaryKey = entityType.FindPrimaryKey();
         if (primaryKey != null)
@@ -522,7 +530,7 @@ public sealed partial class SelectExpression : TableExpressionBase
 
     private void AddJsonNavigationBindings(
         IEntityType entityType,
-        EntityProjectionExpression entityProjection,
+        StructuralTypeProjectionExpression projectionExpression,
         Dictionary<IProperty, ColumnExpression> propertyExpressions,
         TableReferenceExpression tableReferenceExpression)
     {
@@ -570,7 +578,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                     ownedJsonNavigation.IsCollection),
                 !ownedJsonNavigation.ForeignKey.IsRequiredDependent);
 
-            entityProjection.AddNavigationBinding(ownedJsonNavigation, entityShaperExpression);
+            projectionExpression.AddNavigationBinding(ownedJsonNavigation, entityShaperExpression);
         }
     }
 
@@ -664,45 +672,52 @@ public sealed partial class SelectExpression : TableExpressionBase
             var projections = _clientProjections.Count > 0 ? _clientProjections : _projectionMapping.Values.ToList();
             foreach (var projection in projections)
             {
-                if (projection is EntityProjectionExpression entityProjection)
+                switch (projection)
                 {
-                    var primaryKey = entityProjection.EntityType.FindPrimaryKey();
-                    // If there are any existing identifier then all entity projection must have a key
-                    // else keyless entity would have wiped identifier when generating join.
-                    Check.DebugAssert(primaryKey != null, "primary key is null.");
-                    foreach (var property in primaryKey.Properties)
-                    {
-                        entityProjectionIdentifiers.Add(entityProjection.BindProperty(property));
-                        entityProjectionValueComparers.Add(property.GetKeyValueComparer());
-                    }
-                }
-                else if (projection is JsonQueryExpression jsonQueryExpression)
-                {
-                    if (jsonQueryExpression.IsCollection)
-                    {
-                        throw new InvalidOperationException(RelationalStrings.DistinctOnCollectionNotSupported);
-                    }
+                    case StructuralTypeProjectionExpression structuralTypeProjection:
+                        // We know that there are existing identifiers (see condition above); we know we must have a key since a keyless
+                        // entity type would have wiped the identifiers when generating the join.
+                        if (structuralTypeProjection is not { StructuralType: IEntityType entityType }
+                            || entityType.FindPrimaryKey() is not IKey primaryKey)
+                        {
+                            throw new UnreachableException();
+                        }
 
-                    var primaryKeyProperties = jsonQueryExpression.EntityType.FindPrimaryKey()!.Properties;
-                    var primaryKeyPropertiesCount = jsonQueryExpression.IsCollection
-                        ? primaryKeyProperties.Count - 1
-                        : primaryKeyProperties.Count;
+                        foreach (var property in primaryKey.Properties)
+                        {
+                            entityProjectionIdentifiers.Add(structuralTypeProjection.BindProperty(property));
+                            entityProjectionValueComparers.Add(property.GetKeyValueComparer());
+                        }
 
-                    for (var i = 0; i < primaryKeyPropertiesCount; i++)
-                    {
-                        var keyProperty = primaryKeyProperties[i];
-                        entityProjectionIdentifiers.Add((ColumnExpression)jsonQueryExpression.BindProperty(keyProperty));
-                        entityProjectionValueComparers.Add(keyProperty.GetKeyValueComparer());
-                    }
-                }
-                else if (projection is SqlExpression sqlExpression)
-                {
-                    otherExpressions.Add(sqlExpression);
-                }
-                else
-                {
-                    nonProcessableExpressionFound = true;
-                    break;
+                        break;
+
+                    case JsonQueryExpression jsonQueryExpression:
+                        if (jsonQueryExpression.IsCollection)
+                        {
+                            throw new InvalidOperationException(RelationalStrings.DistinctOnCollectionNotSupported);
+                        }
+
+                        var primaryKeyProperties = jsonQueryExpression.EntityType.FindPrimaryKey()!.Properties;
+                        var primaryKeyPropertiesCount = jsonQueryExpression.IsCollection
+                            ? primaryKeyProperties.Count - 1
+                            : primaryKeyProperties.Count;
+
+                        for (var i = 0; i < primaryKeyPropertiesCount; i++)
+                        {
+                            var keyProperty = primaryKeyProperties[i];
+                            entityProjectionIdentifiers.Add((ColumnExpression)jsonQueryExpression.BindProperty(keyProperty));
+                            entityProjectionValueComparers.Add(keyProperty.GetKeyValueComparer());
+                        }
+
+                        break;
+
+                    case SqlExpression sqlExpression:
+                        otherExpressions.Add(sqlExpression);
+                        break;
+
+                    default:
+                        nonProcessableExpressionFound = true;
+                        break;
                 }
             }
 
@@ -751,8 +766,8 @@ public sealed partial class SelectExpression : TableExpressionBase
             {
                 switch (_clientProjections[i])
                 {
-                    case EntityProjectionExpression entityProjectionExpression:
-                        AddEntityProjection(entityProjectionExpression);
+                    case StructuralTypeProjectionExpression structuralTypeProjectionExpression:
+                        AddEntityProjection(structuralTypeProjectionExpression);
                         break;
 
                     case SqlExpression sqlExpression:
@@ -771,9 +786,9 @@ public sealed partial class SelectExpression : TableExpressionBase
         {
             foreach (var (_, expression) in _projectionMapping)
             {
-                if (expression is EntityProjectionExpression entityProjectionExpression)
+                if (expression is StructuralTypeProjectionExpression structuralTypeProjectionExpression)
                 {
-                    AddEntityProjection(entityProjectionExpression);
+                    AddEntityProjection(structuralTypeProjectionExpression);
                 }
                 else
                 {
@@ -784,16 +799,41 @@ public sealed partial class SelectExpression : TableExpressionBase
             _projectionMapping.Clear();
         }
 
-        void AddEntityProjection(EntityProjectionExpression entityProjectionExpression)
+        void AddEntityProjection(StructuralTypeProjectionExpression projectionExpression)
         {
-            foreach (var property in GetAllPropertiesInHierarchy(entityProjectionExpression.EntityType))
+            foreach (var property in GetAllPropertiesInHierarchy(projectionExpression.StructuralType))
             {
-                AddToProjection(entityProjectionExpression.BindProperty(property), null);
+                AddToProjection(projectionExpression.BindProperty(property), null);
             }
 
-            if (entityProjectionExpression.DiscriminatorExpression != null)
+            foreach (var complexProperty in GetAllComplexPropertiesInHierarchy(projectionExpression.StructuralType))
             {
-                AddToProjection(entityProjectionExpression.DiscriminatorExpression, DiscriminatorColumnAlias);
+                // We do not support complex type splitting, so we will only ever have a single table/view mapping to it.
+                var complexTypeTable = complexProperty.ComplexType.GetViewOrTableMappings().Single().Table;
+                var tableReferenceExpression = projectionExpression.TableMap[complexTypeTable];
+
+                ProcessComplexProperties(complexProperty.ComplexType);
+
+                void ProcessComplexProperties(IComplexType complexType)
+                {
+                    foreach (var property in GetAllPropertiesInHierarchy(complexType))
+                    {
+                        // TODO: Nullability
+                        var column = complexTypeTable.FindColumn(property)!;
+                        AddToProjection(
+                            CreateColumnExpression(property, column, tableReferenceExpression, nullable: false));
+                    }
+
+                    foreach (var complexProperty in complexType.GetComplexProperties())
+                    {
+                        ProcessComplexProperties(complexProperty.ComplexType);
+                    }
+                }
+            }
+
+            if (projectionExpression.DiscriminatorExpression != null)
+            {
+                AddToProjection(projectionExpression.DiscriminatorExpression, DiscriminatorColumnAlias);
             }
         }
     }
@@ -980,10 +1020,10 @@ public sealed partial class SelectExpression : TableExpressionBase
 
                         case EntityShaperExpression
                         {
-                            ValueBufferExpression: EntityProjectionExpression entityProjectionExpression
+                            ValueBufferExpression: StructuralTypeProjectionExpression structuralTypeProjectionExpression
                         } entityShaperExpression:
                         {
-                            var clientProjectionToAdd = AddEntityProjection(entityProjectionExpression);
+                            var clientProjectionToAdd = AddEntityProjection(structuralTypeProjectionExpression);
                             var existingIndex = clientProjectionList.FindIndex(
                                 e => ExpressionEqualityComparer.Instance.Equals(e, clientProjectionToAdd));
                             if (existingIndex == -1)
@@ -1088,9 +1128,9 @@ public sealed partial class SelectExpression : TableExpressionBase
                 var value = _clientProjections[i];
                 switch (value)
                 {
-                    case EntityProjectionExpression entityProjection:
+                    case StructuralTypeProjectionExpression structuralTypeProjectionExpression:
                     {
-                        var result = AddEntityProjection(entityProjection);
+                        var result = AddEntityProjection(structuralTypeProjectionExpression);
                         newClientProjections.Add(result);
                         clientProjectionIndexMap.Add(newClientProjections.Count - 1);
 
@@ -1593,7 +1633,7 @@ public sealed partial class SelectExpression : TableExpressionBase
             {
                 result[projectionMember] = expression switch
                 {
-                    EntityProjectionExpression entityProjection => AddEntityProjection(entityProjection),
+                    StructuralTypeProjectionExpression entityProjection => AddEntityProjection(entityProjection),
                     JsonQueryExpression jsonQueryExpression => AddJsonProjection(
                         jsonQueryExpression,
                         new JsonScalarExpression(
@@ -1612,20 +1652,47 @@ public sealed partial class SelectExpression : TableExpressionBase
             return shaperExpression;
         }
 
-        ConstantExpression AddEntityProjection(EntityProjectionExpression entityProjectionExpression)
+        ConstantExpression AddEntityProjection(StructuralTypeProjectionExpression projectionExpression)
         {
-            var dictionary = new Dictionary<IProperty, int>();
-            foreach (var property in GetAllPropertiesInHierarchy(entityProjectionExpression.EntityType))
+            var projections = new Dictionary<IProperty, int>();
+
+            foreach (var property in GetAllPropertiesInHierarchy(projectionExpression.StructuralType))
             {
-                dictionary[property] = AddToProjection(entityProjectionExpression.BindProperty(property), null);
+                projections[property] = AddToProjection(projectionExpression.BindProperty(property), null);
             }
 
-            if (entityProjectionExpression.DiscriminatorExpression != null)
+            foreach (var complexProperty in GetAllComplexPropertiesInHierarchy(projectionExpression.StructuralType))
             {
-                AddToProjection(entityProjectionExpression.DiscriminatorExpression, DiscriminatorColumnAlias);
+                // We do not support complex type splitting, so we will only ever have a single table/view mapping to it.
+                var complexTypeTable = complexProperty.ComplexType.GetViewOrTableMappings().Single().Table;
+                var tableReferenceExpression = projectionExpression.TableMap[complexTypeTable];
+
+                ProcessComplexProperties(complexProperty.ComplexType);
+
+                void ProcessComplexProperties(IComplexType complexType)
+                {
+                    foreach (var property in GetAllPropertiesInHierarchy(complexType))
+                    {
+                        // TODO: Reimplement EntityProjectionExpression via TableMap, and then use that here
+                        // TODO: Nullability
+                        var column = complexTypeTable.FindColumn(property)!;
+                        projections[property] = AddToProjection(
+                            CreateColumnExpression(property, column, tableReferenceExpression, nullable: false));
+                    }
+
+                    foreach (var complexProperty in complexType.GetComplexProperties())
+                    {
+                        ProcessComplexProperties(complexProperty.ComplexType);
+                    }
+                }
             }
 
-            return Constant(dictionary);
+            if (projectionExpression.DiscriminatorExpression is not null)
+            {
+                AddToProjection(projectionExpression.DiscriminatorExpression, DiscriminatorColumnAlias);
+            }
+
+            return Constant(projections);
         }
 
         ConstantExpression AddJsonProjection(JsonQueryExpression jsonQueryExpression, JsonScalarExpression jsonScalarToAdd)
@@ -1693,7 +1760,7 @@ public sealed partial class SelectExpression : TableExpressionBase
         foreach (var (projectionMember, expression) in projectionMapping)
         {
             Check.DebugAssert(
-                expression is SqlExpression or EntityProjectionExpression or JsonQueryExpression,
+                expression is SqlExpression or StructuralTypeProjectionExpression or JsonQueryExpression,
                 "Invalid operation in the projection.");
             _projectionMapping[projectionMember] = expression;
         }
@@ -1711,7 +1778,7 @@ public sealed partial class SelectExpression : TableExpressionBase
         foreach (var expression in clientProjections)
         {
             Check.DebugAssert(
-                expression is SqlExpression or EntityProjectionExpression or ShapedQueryExpression or JsonQueryExpression,
+                expression is SqlExpression or StructuralTypeProjectionExpression or ShapedQueryExpression or JsonQueryExpression,
                 "Invalid operation in the projection.");
             _clientProjections.Add(expression);
             _aliasForClientProjections.Add(null);
@@ -2033,8 +2100,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                 PopulateGroupByTerms(unaryExpression.Operand, groupByTerms, groupByAliases, name);
                 break;
 
-            case EntityShaperExpression { ValueBufferExpression: EntityProjectionExpression entityProjectionExpression }:
-                foreach (var property in GetAllPropertiesInHierarchy(entityProjectionExpression.EntityType))
+            case EntityShaperExpression { ValueBufferExpression: StructuralTypeProjectionExpression entityProjectionExpression }:
+                foreach (var property in GetAllPropertiesInHierarchy(entityProjectionExpression.StructuralType))
                 {
                     PopulateGroupByTerms(entityProjectionExpression.BindProperty(property), groupByTerms, groupByAliases, name: null);
                 }
@@ -2276,8 +2343,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                      kv => kv.Key,
                      (kv1, kv2) => (kv1.Key, Value1: kv1.Value, Value2: kv2.Value)))
         {
-            if (expression1 is EntityProjectionExpression entityProjection1
-                && expression2 is EntityProjectionExpression entityProjection2)
+            if (expression1 is StructuralTypeProjectionExpression entityProjection1
+                && expression2 is StructuralTypeProjectionExpression entityProjection2)
             {
                 HandleEntityProjection(projectionMember, select1, entityProjection1, select2, entityProjection2);
                 continue;
@@ -2391,17 +2458,17 @@ public sealed partial class SelectExpression : TableExpressionBase
         void HandleEntityProjection(
             ProjectionMember projectionMember,
             SelectExpression select1,
-            EntityProjectionExpression projection1,
+            StructuralTypeProjectionExpression projection1,
             SelectExpression select2,
-            EntityProjectionExpression projection2)
+            StructuralTypeProjectionExpression projection2)
         {
-            if (projection1.EntityType != projection2.EntityType)
+            if (projection1.StructuralType != projection2.StructuralType)
             {
                 throw new InvalidOperationException(RelationalStrings.SetOperationsOnDifferentStoreTypes);
             }
 
             var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
-            foreach (var property in GetAllPropertiesInHierarchy(projection1.EntityType))
+            foreach (var property in GetAllPropertiesInHierarchy(projection1.StructuralType))
             {
                 var column1 = projection1.BindProperty(property);
                 var column2 = projection2.BindProperty(property);
@@ -2438,6 +2505,15 @@ public sealed partial class SelectExpression : TableExpressionBase
                 }
             }
 
+            Check.DebugAssert(
+                projection1.TableMap.Count == projection2.TableMap.Count,
+                "Set operation over entity projections with different table map counts");
+            Check.DebugAssert(
+                projection1.TableMap.Keys.All(t => projection2.TableMap.ContainsKey(t)),
+                "Set operation over entity projections with table map discrepancy");
+
+            var tableMap = projection1.TableMap.ToDictionary(kvp => kvp.Key, kvp => tableReferenceExpression);
+
             var discriminatorExpression = projection1.DiscriminatorExpression;
             if (projection1.DiscriminatorExpression != null
                 && projection2.DiscriminatorExpression != null)
@@ -2449,14 +2525,19 @@ public sealed partial class SelectExpression : TableExpressionBase
                 discriminatorExpression = new ConcreteColumnExpression(innerProjection, tableReferenceExpression);
             }
 
-            var entityProjection = new EntityProjectionExpression(projection1.EntityType, propertyExpressions, discriminatorExpression);
+            var entityProjection = new StructuralTypeProjectionExpression(
+                projection1.StructuralType, propertyExpressions, tableMap, discriminatorExpression);
 
             if (outerIdentifiers.Length > 0)
             {
-                var primaryKey = entityProjection.EntityType.FindPrimaryKey();
-                // If there are any existing identifier then all entity projection must have a key
-                // else keyless entity would have wiped identifier when generating join.
-                Check.DebugAssert(primaryKey != null, "primary key is null.");
+                // We know that there are existing identifiers (see condition above); we know we must have a key since a keyless
+                // entity type would have wiped the identifiers when generating the join.
+                if (entityProjection is not { StructuralType: IEntityType entityType }
+                    || entityType.FindPrimaryKey() is not IKey primaryKey)
+                {
+                    throw new UnreachableException();
+                }
+
                 foreach (var property in primaryKey.Properties)
                 {
                     entityProjectionIdentifiers.Add(entityProjection.BindProperty(property));
@@ -2526,7 +2607,7 @@ public sealed partial class SelectExpression : TableExpressionBase
         foreach (var projection in _projectionMapping)
         {
             var projectionToAdd = projection.Value;
-            if (projectionToAdd is EntityProjectionExpression entityProjection)
+            if (projectionToAdd is StructuralTypeProjectionExpression entityProjection)
             {
                 projectionToAdd = entityProjection.MakeNullable();
             }
@@ -2558,7 +2639,7 @@ public sealed partial class SelectExpression : TableExpressionBase
     /// </summary>
     [EntityFrameworkInternal]
     public EntityShaperExpression GenerateOwnedReferenceEntityProjectionExpression(
-        EntityProjectionExpression principalEntityProjection,
+        StructuralTypeProjectionExpression principalEntityProjection,
         INavigation navigation,
         ISqlExpressionFactory sqlExpressionFactory)
     {
@@ -2571,7 +2652,7 @@ public sealed partial class SelectExpression : TableExpressionBase
 
         var entityShaper = new RelationalEntityShaperExpression(
             navigation.TargetEntityType,
-            new EntityProjectionExpression(navigation.TargetEntityType, expressions),
+            new StructuralTypeProjectionExpression(navigation.TargetEntityType, expressions, principalEntityProjection.TableMap),
             identifyingColumn.IsNullable || navigation.DeclaringEntityType.BaseType != null || !navigation.ForeignKey.IsRequiredDependent);
         principalEntityProjection.AddNavigationBinding(navigation, entityShaper);
 
@@ -2825,6 +2906,57 @@ public sealed partial class SelectExpression : TableExpressionBase
 
             return table;
         }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static EntityShaperExpression GenerateComplexPropertyShaperExpression(
+        StructuralTypeProjectionExpression principalProjection,
+        IComplexProperty complexProperty)
+    {
+        // TODO: Make sure nullability is correct in this method
+
+        var propertyExpressionMap = new Dictionary<IProperty, ColumnExpression>();
+
+        // We do not support complex type splitting, so we will only ever have a single table/view mapping to it.
+        var complexTypeTable = complexProperty.ComplexType.GetViewOrTableMappings().Single().Table;
+        var tableReferenceExpression = principalProjection.TableMap[complexTypeTable];
+
+        // TODO: need to find out if the source entity projection is nullable.
+        // For owned entities this is done by binding the identifier column and checking if its nullable, but we can't do that since
+        // the source projection may be itself a complex type
+
+        var isNullable = /* principalEntityProjection.IsNullable ||*/ complexProperty.IsNullable;
+        // identifyingColumn.IsNullable || navigation.DeclaringEntityType.BaseType != null || !navigation.ForeignKey.IsRequiredDependent
+        foreach (var property in complexProperty.ComplexType.GetProperties())
+        {
+            // TODO: Reimplement EntityProjectionExpression via TableMap, and then use that here
+            var column = complexTypeTable.FindColumn(property)!;
+            propertyExpressionMap[property] = CreateColumnExpression(property, column, tableReferenceExpression, isNullable);
+        }
+
+        // The table map of the target complex type should only ever contains a single table (no table splitting).
+        // If the source is itself a complex type (nested complex type), its table map is already suitable and we can just pass it on.
+        var newTableMap = principalProjection.TableMap.Count == 1
+            ? principalProjection.TableMap
+            : new Dictionary<ITableBase, TableReferenceExpression> { [complexTypeTable] = tableReferenceExpression };
+
+        Check.DebugAssert(newTableMap.Single().Key == complexTypeTable, "Bad new table map");
+
+        var entityShaper = new RelationalEntityShaperExpression(
+            complexProperty.ComplexType,
+            new StructuralTypeProjectionExpression(complexProperty.ComplexType, propertyExpressionMap, newTableMap),
+            isNullable);
+
+        // TODO: Caching...
+        // principalEntityProjection.AddNavigationBinding(navigation, entityShaper);
+
+        return entityShaper;
     }
 
     private enum JoinType
@@ -3381,9 +3513,9 @@ public sealed partial class SelectExpression : TableExpressionBase
                 var result = new List<ColumnExpression>();
                 foreach (var (_, expression) in projectionMapping)
                 {
-                    if (expression is EntityProjectionExpression entityProjection)
+                    if (expression is StructuralTypeProjectionExpression entityProjection)
                     {
-                        foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
+                        foreach (var property in GetAllPropertiesInHierarchy(entityProjection.StructuralType))
                         {
                             result.Add(entityProjection.BindProperty(property));
                         }
@@ -3618,9 +3750,9 @@ public sealed partial class SelectExpression : TableExpressionBase
                     break;
                 }
 
-                if (item is EntityProjectionExpression entityProjection)
+                if (item is StructuralTypeProjectionExpression entityProjection)
                 {
-                    _clientProjections[i] = LiftEntityProjectionFromSubquery(entityProjection);
+                    _clientProjections[i] = LiftEntityProjectionFromSubquery(entityProjection, subqueryTableReferenceExpression);
                 }
                 else if (item is JsonQueryExpression jsonQueryExpression)
                 {
@@ -3650,9 +3782,9 @@ public sealed partial class SelectExpression : TableExpressionBase
                     break;
                 }
 
-                if (expression is EntityProjectionExpression entityProjection)
+                if (expression is StructuralTypeProjectionExpression entityProjection)
                 {
-                    _projectionMapping[projectionMember] = LiftEntityProjectionFromSubquery(entityProjection);
+                    _projectionMapping[projectionMember] = LiftEntityProjectionFromSubquery(entityProjection, subqueryTableReferenceExpression);
                 }
                 else if (expression is JsonQueryExpression jsonQueryExpression)
                 {
@@ -3758,15 +3890,45 @@ public sealed partial class SelectExpression : TableExpressionBase
 
         return sqlRemappingVisitor;
 
-        EntityProjectionExpression LiftEntityProjectionFromSubquery(EntityProjectionExpression entityProjection)
+        StructuralTypeProjectionExpression LiftEntityProjectionFromSubquery(
+            StructuralTypeProjectionExpression entityProjection, TableReferenceExpression subqueryTableReference)
         {
             var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
-            foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
+
+            foreach (var property in GetAllPropertiesInHierarchy(entityProjection.StructuralType))
             {
                 var innerColumn = entityProjection.BindProperty(property);
                 var outerColumn = subquery.GenerateOuterColumn(subqueryTableReferenceExpression, innerColumn);
                 projectionMap[innerColumn] = outerColumn;
                 propertyExpressions[property] = outerColumn;
+            }
+
+            foreach (var complexProperty in GetAllComplexPropertiesInHierarchy(entityProjection.StructuralType))
+            {
+                // We do not support complex type splitting, so we will only ever have a single table/view mapping to it.
+                var complexTypeTable = complexProperty.ComplexType.GetViewOrTableMappings().Single().Table;
+                var tableReferenceExpression = entityProjection.TableMap[complexTypeTable];
+
+                ProcessComplexProperties(complexProperty.ComplexType);
+
+                void ProcessComplexProperties(IComplexType complexType)
+                {
+                    foreach (var property in GetAllPropertiesInHierarchy(complexType))
+                    {
+                        // TODO: Nullability
+                        var column = complexTypeTable.FindColumn(property)!;
+
+                        var innerColumn = CreateColumnExpression(property, column, tableReferenceExpression, nullable: false);
+                        var outerColumn = subquery.GenerateOuterColumn(subqueryTableReferenceExpression, innerColumn);
+                        projectionMap[innerColumn] = outerColumn;
+                        propertyExpressions[property] = outerColumn;
+                    }
+
+                    foreach (var complexProperty in complexType.GetComplexProperties())
+                    {
+                        ProcessComplexProperties(complexProperty.ComplexType);
+                    }
+                }
             }
 
             ColumnExpression? discriminatorExpression = null;
@@ -3777,24 +3939,29 @@ public sealed partial class SelectExpression : TableExpressionBase
                 projectionMap[entityProjection.DiscriminatorExpression] = discriminatorExpression;
             }
 
-            var newEntityProjection = new EntityProjectionExpression(
-                entityProjection.EntityType, propertyExpressions, discriminatorExpression);
+            var tableMap = entityProjection.TableMap.ToDictionary(kvp => kvp.Key, _ => subqueryTableReference);
 
-            // Also lift nested entity projections
-            foreach (var navigation in entityProjection.EntityType
-                         .GetAllBaseTypes().Concat(entityProjection.EntityType.GetDerivedTypesInclusive())
-                         .SelectMany(t => t.GetDeclaredNavigations()))
+            var newEntityProjection = new StructuralTypeProjectionExpression(
+                entityProjection.StructuralType, propertyExpressions, tableMap, discriminatorExpression);
+
+            if (entityProjection.StructuralType is IEntityType entityType)
             {
-                var boundEntityShaperExpression = entityProjection.BindNavigation(navigation);
-                if (boundEntityShaperExpression != null)
+                // Also lift nested entity projections
+                foreach (var navigation in entityType
+                             .GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive())
+                             .SelectMany(t => t.GetDeclaredNavigations()))
                 {
-                    var newValueBufferExpression =
-                        boundEntityShaperExpression.ValueBufferExpression is EntityProjectionExpression innerEntityProjection
-                            ? (Expression)LiftEntityProjectionFromSubquery(innerEntityProjection)
-                            : LiftJsonQueryFromSubquery((JsonQueryExpression)boundEntityShaperExpression.ValueBufferExpression);
+                    var boundEntityShaperExpression = entityProjection.BindNavigation(navigation);
+                    if (boundEntityShaperExpression != null)
+                    {
+                        var newValueBufferExpression =
+                            boundEntityShaperExpression.ValueBufferExpression is StructuralTypeProjectionExpression innerEntityProjection
+                                ? (Expression)LiftEntityProjectionFromSubquery(innerEntityProjection, subqueryTableReferenceExpression)
+                                : LiftJsonQueryFromSubquery((JsonQueryExpression)boundEntityShaperExpression.ValueBufferExpression);
 
-                    boundEntityShaperExpression = boundEntityShaperExpression.Update(newValueBufferExpression);
-                    newEntityProjection.AddNavigationBinding(navigation, boundEntityShaperExpression);
+                        boundEntityShaperExpression = boundEntityShaperExpression.Update(newValueBufferExpression);
+                        newEntityProjection.AddNavigationBinding(navigation, boundEntityShaperExpression);
+                    }
                 }
             }
 
@@ -4008,13 +4175,13 @@ public sealed partial class SelectExpression : TableExpressionBase
         bool makeNullable = false)
     {
         var mapping = new Dictionary<ProjectionMember, int>();
-        var entityProjectionCache = new Dictionary<EntityProjectionExpression, int>(ReferenceEqualityComparer.Instance);
+        var entityProjectionCache = new Dictionary<StructuralTypeProjectionExpression, int>(ReferenceEqualityComparer.Instance);
         foreach (var projection in projectionMapping)
         {
             var projectionMember = projection.Key;
             var projectionToAdd = projection.Value;
 
-            if (projectionToAdd is EntityProjectionExpression entityProjection)
+            if (projectionToAdd is StructuralTypeProjectionExpression entityProjection)
             {
                 if (!entityProjectionCache.TryGetValue(entityProjection, out var value))
                 {
@@ -4059,7 +4226,7 @@ public sealed partial class SelectExpression : TableExpressionBase
     {
         if (nullable)
         {
-            if (expression is EntityProjectionExpression entityProjection)
+            if (expression is StructuralTypeProjectionExpression entityProjection)
             {
                 return entityProjection.MakeNullable();
             }
@@ -4085,9 +4252,23 @@ public sealed partial class SelectExpression : TableExpressionBase
     private static TableExpressionBase UnwrapJoinExpression(TableExpressionBase tableExpressionBase)
         => (tableExpressionBase as JoinExpressionBase)?.Table ?? tableExpressionBase;
 
-    private static IEnumerable<IProperty> GetAllPropertiesInHierarchy(IEntityType entityType)
-        => entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive())
-            .SelectMany(t => t.GetDeclaredProperties());
+    private static IEnumerable<IProperty> GetAllPropertiesInHierarchy(ITypeBase structuralType)
+        => structuralType switch
+        {
+            IEntityType entityType => entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive())
+                .SelectMany(t => t.GetDeclaredProperties()),
+            IComplexType complexType => complexType.GetDeclaredProperties(),
+            _ => throw new UnreachableException()
+        };
+
+    private static IEnumerable<IComplexProperty> GetAllComplexPropertiesInHierarchy(ITypeBase structuralType)
+        => structuralType switch
+        {
+            IEntityType entityType => entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive())
+                .SelectMany(t => t.GetDeclaredComplexProperties()),
+            IComplexType complexType => complexType.GetDeclaredComplexProperties(),
+            _ => throw new UnreachableException()
+        };
 
     private static IEnumerable<INavigation> GetAllNavigationsInHierarchy(IEntityType entityType)
         => entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive())

--- a/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/StructuralTypeProjectionExpression.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Microsoft.EntityFrameworkCore.Query;
@@ -14,45 +15,62 @@ namespace Microsoft.EntityFrameworkCore.Query;
 ///         not used in application code.
 ///     </para>
 /// </summary>
-public class EntityProjectionExpression : Expression
+public class StructuralTypeProjectionExpression : Expression
 {
     private readonly IReadOnlyDictionary<IProperty, ColumnExpression> _propertyExpressionMap;
     private readonly Dictionary<INavigation, EntityShaperExpression> _ownedNavigationMap;
 
     /// <summary>
-    ///     Creates a new instance of the <see cref="EntityProjectionExpression" /> class.
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    /// <param name="entityType">An entity type to shape.</param>
-    /// <param name="propertyExpressionMap">A dictionary of column expressions corresponding to properties of the entity type.</param>
-    /// <param name="discriminatorExpression">A <see cref="SqlExpression" /> to generate discriminator for each concrete entity type in hierarchy.</param>
-    public EntityProjectionExpression(
-        IEntityType entityType,
+    [EntityFrameworkInternal]
+    public StructuralTypeProjectionExpression(
+        ITypeBase structuralType,
         IReadOnlyDictionary<IProperty, ColumnExpression> propertyExpressionMap,
+        IReadOnlyDictionary<ITableBase, TableReferenceExpression> tableMap,
         SqlExpression? discriminatorExpression = null)
         : this(
-            entityType,
+            structuralType,
             propertyExpressionMap,
             new Dictionary<INavigation, EntityShaperExpression>(),
+            tableMap,
             discriminatorExpression)
     {
     }
 
-    private EntityProjectionExpression(
-        IEntityType entityType,
+    private StructuralTypeProjectionExpression(
+        ITypeBase structuralType,
         IReadOnlyDictionary<IProperty, ColumnExpression> propertyExpressionMap,
         Dictionary<INavigation, EntityShaperExpression> ownedNavigationMap,
+        IReadOnlyDictionary<ITableBase, TableReferenceExpression> tableMap,
         SqlExpression? discriminatorExpression = null)
     {
-        EntityType = entityType;
+        StructuralType = structuralType;
         _propertyExpressionMap = propertyExpressionMap;
         _ownedNavigationMap = ownedNavigationMap;
+        TableMap = tableMap;
         DiscriminatorExpression = discriminatorExpression;
     }
 
     /// <summary>
-    ///     The entity type being projected out.
+    ///     The base type being projected out (entity or complex type)
     /// </summary>
-    public virtual IEntityType EntityType { get; }
+    public virtual ITypeBase StructuralType { get; }
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    [EntityFrameworkInternal]
+    public virtual IReadOnlyDictionary<ITableBase, TableReferenceExpression> TableMap { get; }
 
     /// <summary>
     ///     A <see cref="SqlExpression" /> to generate discriminator for entity type.
@@ -65,7 +83,7 @@ public class EntityProjectionExpression : Expression
 
     /// <inheritdoc />
     public override Type Type
-        => EntityType.ClrType;
+        => StructuralType.ClrType;
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -80,6 +98,14 @@ public class EntityProjectionExpression : Expression
             propertyExpressionMap[property] = newExpression;
         }
 
+        // We only need to visit the table map since TableReferenceUpdatingExpressionVisitor may need to modify it; it mutates
+        // TableReferenceExpression (a new TableReferenceExpression is never returned), so we never need a new table map.
+        foreach (var (_, tableExpression) in TableMap)
+        {
+            var newTableExpression = (TableReferenceExpression)visitor.Visit(tableExpression);
+            Check.DebugAssert(newTableExpression == tableExpression, $"New {nameof(TableReferenceExpression)} returned during visitation!");
+        }
+
         var discriminatorExpression = (SqlExpression?)visitor.Visit(DiscriminatorExpression);
         changed |= discriminatorExpression != DiscriminatorExpression;
 
@@ -92,7 +118,7 @@ public class EntityProjectionExpression : Expression
         }
 
         return changed
-            ? new EntityProjectionExpression(EntityType, propertyExpressionMap, ownedNavigationMap, discriminatorExpression)
+            ? new StructuralTypeProjectionExpression(StructuralType, propertyExpressionMap, ownedNavigationMap, TableMap, discriminatorExpression)
             : this;
     }
 
@@ -100,7 +126,7 @@ public class EntityProjectionExpression : Expression
     ///     Makes entity instance in projection nullable.
     /// </summary>
     /// <returns>A new entity projection expression which can project nullable entity.</returns>
-    public virtual EntityProjectionExpression MakeNullable()
+    public virtual StructuralTypeProjectionExpression MakeNullable()
     {
         var propertyExpressionMap = new Dictionary<IProperty, ColumnExpression>();
         foreach (var (property, columnExpression) in _propertyExpressionMap)
@@ -130,10 +156,11 @@ public class EntityProjectionExpression : Expression
             }
         }
 
-        return new EntityProjectionExpression(
-            EntityType,
+        return new StructuralTypeProjectionExpression(
+            StructuralType,
             propertyExpressionMap,
             ownedNavigationMap,
+            TableMap,
             discriminatorExpression);
     }
 
@@ -142,13 +169,18 @@ public class EntityProjectionExpression : Expression
     /// </summary>
     /// <param name="derivedType">A derived entity type which should be projected.</param>
     /// <returns>A new entity projection expression which has the derived type being projected.</returns>
-    public virtual EntityProjectionExpression UpdateEntityType(IEntityType derivedType)
+    public virtual StructuralTypeProjectionExpression UpdateEntityType(IEntityType derivedType)
     {
-        if (!derivedType.GetAllBaseTypes().Contains(EntityType))
+        if (StructuralType is not IEntityType entityType)
+        {
+            throw new InvalidOperationException(); // TODO: Message
+        }
+
+        if (!derivedType.GetAllBaseTypes().Contains(entityType))
         {
             throw new InvalidOperationException(
                 RelationalStrings.InvalidDerivedTypeInEntityProjection(
-                    derivedType.DisplayName(), EntityType.DisplayName()));
+                    derivedType.DisplayName(), entityType.DisplayName()));
         }
 
         var propertyExpressionMap = new Dictionary<IProperty, ColumnExpression>();
@@ -171,8 +203,34 @@ public class EntityProjectionExpression : Expression
             }
         }
 
+        // Remove tables from the table map which aren't mapped to the new derived type.
+        Dictionary<ITableBase, TableReferenceExpression>? newTableMap = null;
+        switch (entityType.GetMappingStrategy())
+        {
+            case RelationalAnnotationNames.TphMappingStrategy:
+                // In TPH, changing the entity type has no effect on the tables being mapped; just reuse the existing TableMap.
+                break;
+
+            case RelationalAnnotationNames.TpcMappingStrategy:
+            case RelationalAnnotationNames.TptMappingStrategy:
+                newTableMap = new();
+                foreach (var (table, tableReferenceExpression) in TableMap)
+                {
+                    if (table.EntityTypeMappings.Any(m => m.TypeBase == derivedType))
+                    {
+                        newTableMap.Add(table, tableReferenceExpression);
+                    }
+                }
+                break;
+
+            case null:
+                throw new UnreachableException($"Cannot be in {nameof(UpdateEntityType)} for entity type '{entityType.DisplayName()}' which has no mapping strategy");
+            default:
+                throw new UnreachableException("Unknown mapping strategy: " + entityType.GetMappingStrategy());
+        }
+
         var discriminatorExpression = DiscriminatorExpression;
-        if (DiscriminatorExpression is CaseExpression caseExpression)
+        if (discriminatorExpression is CaseExpression caseExpression)
         {
             var entityTypesToSelect =
                 derivedType.GetConcreteDerivedTypesInclusive().Select(e => (string)e.GetDiscriminatorValue()!).ToList();
@@ -183,7 +241,8 @@ public class EntityProjectionExpression : Expression
             discriminatorExpression = caseExpression.Update(operand: null, whenClauses, elseResult: null);
         }
 
-        return new EntityProjectionExpression(derivedType, propertyExpressionMap, ownedNavigationMap, discriminatorExpression);
+        return new StructuralTypeProjectionExpression(
+            derivedType, propertyExpressionMap, ownedNavigationMap, newTableMap ?? TableMap, discriminatorExpression);
     }
 
     /// <summary>
@@ -193,11 +252,11 @@ public class EntityProjectionExpression : Expression
     /// <returns>A column which is a SQL representation of the property.</returns>
     public virtual ColumnExpression BindProperty(IProperty property)
     {
-        if (!EntityType.IsAssignableFrom(property.DeclaringType)
-            && !property.DeclaringType.IsAssignableFrom(EntityType))
+        if (!StructuralType.IsAssignableFrom(property.DeclaringType)
+            && !property.DeclaringType.IsAssignableFrom(StructuralType))
         {
             throw new InvalidOperationException(
-                RelationalStrings.UnableToBindMemberToEntityProjection("property", property.Name, EntityType.DisplayName()));
+                RelationalStrings.UnableToBindMemberToEntityProjection("property", property.Name, StructuralType.DisplayName()));
         }
 
         return _propertyExpressionMap[property];
@@ -210,11 +269,16 @@ public class EntityProjectionExpression : Expression
     /// <param name="entityShaper">An entity shaper expression for the target type.</param>
     public virtual void AddNavigationBinding(INavigation navigation, EntityShaperExpression entityShaper)
     {
-        if (!EntityType.IsAssignableFrom(navigation.DeclaringEntityType)
-            && !navigation.DeclaringEntityType.IsAssignableFrom(EntityType))
+        if (StructuralType is not IEntityType entityType)
+        {
+            throw new InvalidOperationException(); // TODO: Message
+        }
+
+        if (!entityType.IsAssignableFrom(navigation.DeclaringEntityType)
+            && !navigation.DeclaringEntityType.IsAssignableFrom(entityType))
         {
             throw new InvalidOperationException(
-                RelationalStrings.UnableToBindMemberToEntityProjection("navigation", navigation.Name, EntityType.DisplayName()));
+                RelationalStrings.UnableToBindMemberToEntityProjection("navigation", navigation.Name, entityType.DisplayName()));
         }
 
         _ownedNavigationMap[navigation] = entityShaper;
@@ -228,11 +292,16 @@ public class EntityProjectionExpression : Expression
     /// <returns>An entity shaper expression for the target entity type of the navigation.</returns>
     public virtual EntityShaperExpression? BindNavigation(INavigation navigation)
     {
-        if (!EntityType.IsAssignableFrom(navigation.DeclaringEntityType)
-            && !navigation.DeclaringEntityType.IsAssignableFrom(EntityType))
+        if (StructuralType is not IEntityType entityType)
+        {
+            throw new InvalidOperationException(); // TODO: Message
+        }
+
+        if (!entityType.IsAssignableFrom(navigation.DeclaringEntityType)
+            && !navigation.DeclaringEntityType.IsAssignableFrom(entityType))
         {
             throw new InvalidOperationException(
-                RelationalStrings.UnableToBindMemberToEntityProjection("navigation", navigation.Name, EntityType.DisplayName()));
+                RelationalStrings.UnableToBindMemberToEntityProjection("navigation", navigation.Name, entityType.DisplayName()));
         }
 
         return _ownedNavigationMap.TryGetValue(navigation, out var expression)
@@ -242,5 +311,5 @@ public class EntityProjectionExpression : Expression
 
     /// <inheritdoc />
     public override string ToString()
-        => $"EntityProjectionExpression: {EntityType.ShortName()}";
+        => $"EntityProjectionExpression: {StructuralType.ShortName()}";
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -318,7 +318,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
             else
             {
                 var projectionBindingExpression = (ProjectionBindingExpression)entityShaperExpression.ValueBufferExpression;
-                var entityProjectionExpression = (EntityProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
+                var entityProjectionExpression = (StructuralTypeProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
                 var column = entityProjectionExpression.BindProperty(entityShaperExpression.EntityType.GetProperties().First());
                 table = column.Table;
                 if (table is JoinExpressionBase joinExpressionBase)
@@ -364,7 +364,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
             else
             {
                 var projectionBindingExpression = (ProjectionBindingExpression)entityShaperExpression.ValueBufferExpression;
-                var entityProjectionExpression = (EntityProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
+                var entityProjectionExpression = (StructuralTypeProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
                 var column = entityProjectionExpression.BindProperty(entityShaperExpression.EntityType.GetProperties().First());
                 table = column.Table;
                 if (table is JoinExpressionBase joinExpressionBase)

--- a/src/EFCore/Diagnostics/InstantiationBindingInterceptionData.cs
+++ b/src/EFCore/Diagnostics/InstantiationBindingInterceptionData.cs
@@ -16,16 +16,16 @@ public readonly struct InstantiationBindingInterceptionData
     /// <summary>
     ///     Constructs the parameter object.
     /// </summary>
-    /// <param name="entityType">The entity type for which the binding is being used.</param>
+    /// <param name="typeBase">The entity type for which the binding is being used.</param>
     [EntityFrameworkInternal]
     [UsedImplicitly]
-    public InstantiationBindingInterceptionData(IEntityType entityType)
+    public InstantiationBindingInterceptionData(ITypeBase typeBase)
     {
-        EntityType = entityType;
+        TypeBase = typeBase;
     }
 
     /// <summary>
     ///     The entity type for which the binding is being used.
     /// </summary>
-    public IEntityType EntityType { get; }
+    public ITypeBase TypeBase { get; }
 }

--- a/src/EFCore/Infrastructure/Internal/LazyLoader.cs
+++ b/src/EFCore/Infrastructure/Internal/LazyLoader.cs
@@ -45,7 +45,7 @@ public class LazyLoader : ILazyLoader, IInjectableService
     public virtual void Injected(DbContext context, object entity, ParameterBindingInfo bindingInfo)
     {
         _queryTrackingBehavior = bindingInfo.QueryTrackingBehavior;
-        _entityType = bindingInfo.EntityType;
+        _entityType = bindingInfo.TypeBase as IEntityType ?? throw new NotImplementedException();
     }
 
     /// <summary>

--- a/src/EFCore/Metadata/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/EntityTypeParameterBinding.cs
@@ -33,7 +33,7 @@ public class EntityTypeParameterBinding : ServiceParameterBinding
         Expression bindingInfoExpression)
         => bindingInfoExpression.Type == typeof(IEntityType)
             ? bindingInfoExpression
-            : Expression.Property(bindingInfoExpression, nameof(ParameterBindingInfo.EntityType));
+            : Expression.Property(bindingInfoExpression, nameof(ParameterBindingInfo.TypeBase));
 
     /// <summary>
     ///     Creates a copy that contains the given consumed properties.

--- a/src/EFCore/Metadata/ITypeBase.cs
+++ b/src/EFCore/Metadata/ITypeBase.cs
@@ -36,7 +36,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     /// <param name="memberInfo">The member on the CLR type.</param>
     /// <returns>The property, or <see langword="null" /> if none is found.</returns>
     new IProperty? FindProperty(MemberInfo memberInfo)
-        => (IProperty?)((IReadOnlyEntityType)this).FindProperty(memberInfo);
+        => (IProperty?)((IReadOnlyTypeBase)this).FindProperty(memberInfo);
 
     /// <summary>
     ///     Gets the property with a given name. Returns <see langword="null" /> if no property with the given name is defined.
@@ -58,7 +58,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     /// <returns>The properties, or <see langword="null" /> if any property is not found.</returns>
     new IReadOnlyList<IProperty>? FindProperties(
         IReadOnlyList<string> propertyNames)
-        => (IReadOnlyList<IProperty>?)((IReadOnlyEntityType)this).FindProperties(propertyNames);
+        => (IReadOnlyList<IProperty>?)((IReadOnlyTypeBase)this).FindProperties(propertyNames);
 
     /// <summary>
     ///     Gets a property with the given name.
@@ -69,7 +69,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     /// <param name="name">The property name.</param>
     /// <returns>The property.</returns>
     new IProperty GetProperty(string name)
-        => (IProperty)((IReadOnlyEntityType)this).GetProperty(name);
+        => (IProperty)((IReadOnlyTypeBase)this).GetProperty(name);
 
     /// <summary>
     ///     Finds a property declared on the type with the given name.
@@ -78,7 +78,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     /// <param name="name">The property name.</param>
     /// <returns>The property, or <see langword="null" /> if none is found.</returns>
     new IProperty? FindDeclaredProperty(string name)
-        => (IProperty?)((IReadOnlyEntityType)this).FindDeclaredProperty(name);
+        => (IProperty?)((IReadOnlyTypeBase)this).FindDeclaredProperty(name);
 
     /// <summary>
     ///     Gets all non-navigation properties declared on this type.
@@ -101,7 +101,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     /// </remarks>
     /// <returns>Derived non-navigation properties.</returns>
     new IEnumerable<IProperty> GetDerivedProperties()
-        => ((IReadOnlyEntityType)this).GetDerivedProperties().Cast<IProperty>();
+        => ((IReadOnlyTypeBase)this).GetDerivedProperties().Cast<IProperty>();
 
     /// <summary>
     ///     Gets the properties defined on this type.
@@ -131,7 +131,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     /// <param name="memberInfo">The member on the entity class.</param>
     /// <returns>The property, or <see langword="null" /> if none is found.</returns>
     new IComplexProperty? FindComplexProperty(MemberInfo memberInfo)
-        => (IComplexProperty?)((IReadOnlyEntityType)this).FindComplexProperty(memberInfo);
+        => (IComplexProperty?)((IReadOnlyTypeBase)this).FindComplexProperty(memberInfo);
 
     /// <summary>
     ///     Finds a property declared on the type with the given name.
@@ -143,7 +143,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     /// <param name="name">The property name.</param>
     /// <returns>The property, or <see langword="null" /> if none is found.</returns>
     new IComplexProperty? FindDeclaredComplexProperty(string name)
-        => (IComplexProperty?)((IReadOnlyEntityType)this).FindDeclaredComplexProperty(name);
+        => (IComplexProperty?)((IReadOnlyTypeBase)this).FindDeclaredComplexProperty(name);
 
     /// <summary>
     ///     Gets the complex properties defined on this entity type.
@@ -170,7 +170,7 @@ public interface ITypeBase : IReadOnlyTypeBase, IAnnotatable
     /// </remarks>
     /// <returns>Derived complex properties.</returns>
     new IEnumerable<IComplexProperty> GetDerivedComplexProperties()
-        => ((IReadOnlyEntityType)this).GetDerivedComplexProperties().Cast<IComplexProperty>();
+        => ((IReadOnlyTypeBase)this).GetDerivedComplexProperties().Cast<IComplexProperty>();
 
     /// <summary>
     ///     Gets the members defined on this type and base types.

--- a/src/EFCore/Metadata/ParameterBindingInfo.cs
+++ b/src/EFCore/Metadata/ParameterBindingInfo.cs
@@ -14,16 +14,16 @@ public readonly struct ParameterBindingInfo
     /// <summary>
     ///     Creates a new <see cref="ParameterBindingInfo" /> to define a parameter binding.
     /// </summary>
-    /// <param name="entityType">The entity type for this binding.</param>
+    /// <param name="typeBase">The entity type for this binding.</param>
     /// <param name="materializationContextExpression">The expression tree from which the parameter value will come.</param>
     public ParameterBindingInfo(
-        IEntityType entityType,
+        IEntityType typeBase,
         Expression materializationContextExpression)
     {
-        Check.NotNull(entityType, nameof(entityType));
-        Check.NotNull(entityType, nameof(materializationContextExpression));
+        Check.NotNull(typeBase, nameof(typeBase));
+        Check.NotNull(typeBase, nameof(materializationContextExpression));
 
-        EntityType = entityType;
+        TypeBase = typeBase;
         EntityInstanceName = "instance";
         MaterializationContextExpression = materializationContextExpression;
     }
@@ -37,7 +37,7 @@ public readonly struct ParameterBindingInfo
         EntityMaterializerSourceParameters materializerSourceParameters,
         Expression materializationContextExpression)
     {
-        EntityType = materializerSourceParameters.EntityType;
+        TypeBase = materializerSourceParameters.TypeBase;
         QueryTrackingBehavior = materializerSourceParameters.QueryTrackingBehavior;
         EntityInstanceName = materializerSourceParameters.EntityInstanceName;
         MaterializationContextExpression = materializationContextExpression;
@@ -46,7 +46,7 @@ public readonly struct ParameterBindingInfo
     /// <summary>
     ///     The entity type for this binding.
     /// </summary>
-    public IEntityType EntityType { get; }
+    public ITypeBase TypeBase { get; }
 
     /// <summary>
     ///     The name of the instance being materialized.

--- a/src/EFCore/Query/EntityMaterializerSourceParameters.cs
+++ b/src/EFCore/Query/EntityMaterializerSourceParameters.cs
@@ -6,36 +6,10 @@ namespace Microsoft.EntityFrameworkCore.Query;
 /// <summary>
 ///     Parameter object for <see cref="IEntityMaterializerSource" />.
 /// </summary>
-public readonly record struct EntityMaterializerSourceParameters
-{
-    /// <summary>
-    ///     Creates a new <see cref="EntityMaterializerSourceParameters" />.
-    /// </summary>
-    /// <param name="entityType">The entity type being materialized.</param>
-    /// <param name="entityInstanceName">The name of the instance being materialized.</param>
-    /// <param name="queryTrackingBehavior">The query tracking behavior, or <see langword="null" /> if this materialization is not from a query.</param>
-    public EntityMaterializerSourceParameters(
-        IEntityType entityType,
-        string entityInstanceName,
-        QueryTrackingBehavior? queryTrackingBehavior)
-    {
-        EntityType = entityType;
-        EntityInstanceName = entityInstanceName;
-        QueryTrackingBehavior = queryTrackingBehavior;
-    }
-
-    /// <summary>
-    ///     The entity type being materialized.
-    /// </summary>
-    public IEntityType EntityType { get; }
-
-    /// <summary>
-    ///     The name of the instance being materialized.
-    /// </summary>
-    public string EntityInstanceName { get; }
-
-    /// <summary>
-    ///     The query tracking behavior, or <see langword="null" /> if this materialization is not from a query.
-    /// </summary>
-    public QueryTrackingBehavior? QueryTrackingBehavior { get; }
-}
+/// <param name="TypeBase">The entity type being materialized.</param>
+/// <param name="EntityInstanceName">The name of the instance being materialized.</param>
+/// <param name="QueryTrackingBehavior">
+///     The query tracking behavior, or <see langword="null" /> if this materialization is not from a query.
+/// </param>
+public readonly record struct EntityMaterializerSourceParameters(
+    ITypeBase TypeBase, string EntityInstanceName, QueryTrackingBehavior? QueryTrackingBehavior);

--- a/src/EFCore/Query/EntityShaperExpression.cs
+++ b/src/EFCore/Query/EntityShaperExpression.cs
@@ -30,21 +30,21 @@ public class EntityShaperExpression : Expression, IPrintableExpression
     /// <summary>
     ///     Creates a new instance of the <see cref="EntityShaperExpression" /> class.
     /// </summary>
-    /// <param name="entityType">The entity type to shape.</param>
+    /// <param name="structuralType">The entity or complex type to shape.</param>
     /// <param name="valueBufferExpression">An expression of ValueBuffer to get values for properties of the entity.</param>
     /// <param name="nullable">A bool value indicating whether this entity instance can be null.</param>
     public EntityShaperExpression(
-        IEntityType entityType,
+        ITypeBase structuralType,
         Expression valueBufferExpression,
         bool nullable)
-        : this(entityType, valueBufferExpression, nullable, null)
+        : this(structuralType, valueBufferExpression, nullable, null)
     {
     }
 
     /// <summary>
     ///     Creates a new instance of the <see cref="EntityShaperExpression" /> class.
     /// </summary>
-    /// <param name="entityType">The entity type to shape.</param>
+    /// <param name="structuralType">The entity type to shape.</param>
     /// <param name="valueBufferExpression">An expression of ValueBuffer to get values for properties of the entity.</param>
     /// <param name="nullable">Whether this entity instance can be null.</param>
     /// <param name="materializationCondition">
@@ -52,26 +52,27 @@ public class EntityShaperExpression : Expression, IPrintableExpression
     ///     materialize.
     /// </param>
     protected EntityShaperExpression(
-        IEntityType entityType,
+        ITypeBase structuralType,
         Expression valueBufferExpression,
         bool nullable,
         LambdaExpression? materializationCondition)
     {
         if (materializationCondition == null)
         {
-            materializationCondition = GenerateMaterializationCondition(entityType, nullable);
+            materializationCondition = GenerateMaterializationCondition(structuralType, nullable);
         }
         else if (materializationCondition.Parameters.Count != 1
                  || materializationCondition.Parameters[0].Type != typeof(ValueBuffer)
-                 || materializationCondition.ReturnType != typeof(IEntityType))
+                 || materializationCondition.ReturnType != (structuralType is IEntityType ? typeof(IEntityType) : typeof(IComplexType)))
         {
-            throw new InvalidOperationException(CoreStrings.QueryEntityMaterializationConditionWrongShape(entityType.DisplayName()));
+            throw new InvalidOperationException(CoreStrings.QueryEntityMaterializationConditionWrongShape(structuralType.DisplayName()));
         }
 
-        EntityType = entityType;
+        StructuralType = structuralType;
+
         ValueBufferExpression = valueBufferExpression;
         IsNullable = nullable;
-        MaterializationCondition = materializationCondition;
+        MaterializationCondition = materializationCondition!;
     }
 
     /// <summary>
@@ -93,12 +94,19 @@ public class EntityShaperExpression : Expression, IPrintableExpression
     /// <summary>
     ///     Creates an expression of <see cref="Func{ValueBuffer, IEntityType}" /> to determine which entity type to materialize.
     /// </summary>
-    /// <param name="entityType">The entity type to create materialization condition for.</param>
+    /// <param name="structuralType">The entity type to create materialization condition for.</param>
     /// <param name="nullable">Whether this entity instance can be null.</param>
     /// <returns>An expression of <see cref="Func{ValueBuffer, IEntityType}" /> representing materilization condition for the entity type.</returns>
-    protected virtual LambdaExpression GenerateMaterializationCondition(IEntityType entityType, bool nullable)
+    protected virtual LambdaExpression GenerateMaterializationCondition(ITypeBase structuralType, bool nullable)
     {
         var valueBufferParameter = Parameter(typeof(ValueBuffer));
+
+        if (structuralType is IComplexType complexType)
+        {
+            return Lambda(Constant(complexType, typeof(IComplexType)), valueBufferParameter);
+        }
+
+        var entityType = (IEntityType)structuralType;
         Expression body;
         var concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToArray();
         var discriminatorProperty = entityType.FindDiscriminatorProperty();
@@ -155,6 +163,8 @@ public class EntityShaperExpression : Expression, IPrintableExpression
         if (entityType.FindPrimaryKey() == null
             && nullable)
         {
+            // If there's no nullable key and we're generating a nullable shaper, generate checks for any non-null property; if all are
+            // null, return null for the entity instance.
             body = Condition(
                 entityType.GetProperties()
                     .Select(
@@ -169,10 +179,19 @@ public class EntityShaperExpression : Expression, IPrintableExpression
         return Lambda(body, valueBufferParameter);
     }
 
+    // TODO: Temporary, remove
     /// <summary>
     ///     The entity type being shaped.
     /// </summary>
-    public virtual IEntityType EntityType { get; }
+    public virtual IEntityType EntityType
+        => StructuralType is IEntityType entityType
+            ? entityType
+            : throw new InvalidOperationException("Type isn't an entity type: " + StructuralType.DisplayName());
+
+    /// <summary>
+    ///     The entity or complex type being shaped.
+    /// </summary>
+    public virtual ITypeBase StructuralType { get; }
 
     /// <summary>
     ///     The expression representing a <see cref="ValueBuffer" /> to get values from that are used to create the entity instance.
@@ -231,7 +250,7 @@ public class EntityShaperExpression : Expression, IPrintableExpression
 
     /// <inheritdoc />
     public override Type Type
-        => EntityType.ClrType;
+        => StructuralType.ClrType;
 
     /// <inheritdoc />
     public sealed override ExpressionType NodeType

--- a/src/EFCore/Query/IEntityMaterializerSource.cs
+++ b/src/EFCore/Query/IEntityMaterializerSource.cs
@@ -57,11 +57,13 @@ public interface IEntityMaterializerSource
     /// <param name="parameters">Parameters for the entity being materialized.</param>
     /// <param name="materializationExpression">The materialization expression to build on.</param>
     /// <returns>An expression to read the value.</returns>
+#pragma warning disable CS0618
     Expression CreateMaterializeExpression(
         EntityMaterializerSourceParameters parameters,
         Expression materializationExpression)
-#pragma warning disable CS0618
-        => CreateMaterializeExpression(parameters.EntityType, parameters.EntityInstanceName, materializationExpression);
+        => parameters.TypeBase is IEntityType entityType
+            ? CreateMaterializeExpression(entityType, parameters.EntityInstanceName, materializationExpression)
+            : throw new InvalidOperationException(); // TODO
 #pragma warning restore CS0618
 
     /// <summary>

--- a/src/EFCore/Query/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/EntityMaterializerSource.cs
@@ -59,7 +59,7 @@ public class EntityMaterializerSource : IEntityMaterializerSource
         IEntityType entityType,
         string entityInstanceName,
         Expression materializationContextExpression)
-        => ((IEntityMaterializerSource)this).CreateMaterializeExpression(
+        => CreateMaterializeExpression(
             new EntityMaterializerSourceParameters(entityType, entityInstanceName, null), materializationContextExpression);
 
     /// <summary>
@@ -68,37 +68,41 @@ public class EntityMaterializerSource : IEntityMaterializerSource
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    Expression IEntityMaterializerSource.CreateMaterializeExpression(
+    public Expression CreateMaterializeExpression(
         EntityMaterializerSourceParameters parameters,
         Expression materializationContextExpression)
     {
-        var (entityType, entityInstanceName) = (parameters.EntityType, parameters.EntityInstanceName);
+        var (structuralType, entityInstanceName) = (parameters.TypeBase, parameters.EntityInstanceName);
 
-        if (entityType.IsAbstract())
+        if (structuralType.IsAbstract())
         {
-            throw new InvalidOperationException(CoreStrings.CannotMaterializeAbstractType(entityType.DisplayName()));
+            throw new InvalidOperationException(CoreStrings.CannotMaterializeAbstractType(structuralType.DisplayName()));
         }
 
-        var constructorBinding = ModifyBindings(entityType, entityType.ConstructorBinding!);
+        var constructorBinding = ModifyBindings(structuralType, structuralType.ConstructorBinding!);
         var bindingInfo = new ParameterBindingInfo(parameters, materializationContextExpression);
-        var serviceProperties = entityType.GetServiceProperties().ToList();
         var blockExpressions = new List<Expression>();
 
         var instanceVariable = Expression.Variable(constructorBinding.RuntimeType, entityInstanceName);
         bindingInfo.ServiceInstances.Add(instanceVariable);
 
-        CreateServiceInstances(constructorBinding, bindingInfo, blockExpressions, serviceProperties);
-
+        // TODO: Need to worry about shadow complex property?
         var properties = new HashSet<IPropertyBase>(
-            serviceProperties.Cast<IPropertyBase>()
-                .Concat(
-                    entityType
-                        .GetProperties()
-                        .Where(p => !p.IsShadowProperty())));
+            structuralType.GetProperties().Cast<IPropertyBase>().Where(p => !p.IsShadowProperty())
+                .Concat(structuralType.GetComplexProperties().Where(p => !p.IsShadowProperty())));
 
-        foreach (var consumedProperty in constructorBinding
-                     .ParameterBindings
-                     .SelectMany(p => p.ConsumedProperties))
+        if (structuralType is IEntityType entityType)
+        {
+            var serviceProperties = entityType.GetServiceProperties().ToList();
+            CreateServiceInstances(constructorBinding, bindingInfo, blockExpressions, serviceProperties);
+
+            foreach (var serviceProperty in serviceProperties)
+            {
+                properties.Add(serviceProperty);
+            }
+        }
+
+        foreach (var consumedProperty in constructorBinding.ParameterBindings.SelectMany(p => p.ConsumedProperties))
         {
             properties.Remove(consumedProperty);
         }
@@ -107,16 +111,15 @@ public class EntityMaterializerSource : IEntityMaterializerSource
 
         if (_materializationInterceptor == null)
         {
-            if (properties.Count == 0 && blockExpressions.Count == 0)
-            {
-                return constructorExpression;
-            }
-
-            return CreateMaterializeExpression(blockExpressions, instanceVariable, constructorExpression, properties, bindingInfo);
+            return properties.Count == 0 && blockExpressions.Count == 0
+                ? constructorExpression
+                : CreateMaterializeExpression(blockExpressions, instanceVariable, constructorExpression, properties, bindingInfo);
         }
 
+        // TODO: This currently applies the materialization interceptor only on the root structural type - any contained complex types
+        // don't get intercepted.
         return CreateInterceptionMaterializeExpression(
-            entityType,
+            structuralType,
             properties,
             _materializationInterceptor,
             bindingInfo,
@@ -125,7 +128,7 @@ public class EntityMaterializerSource : IEntityMaterializerSource
             blockExpressions);
     }
 
-    private static void AddInitializeExpressions(
+    private void AddInitializeExpressions(
         HashSet<IPropertyBase> properties,
         ParameterBindingInfo bindingInfo,
         Expression instanceVariable,
@@ -139,14 +142,24 @@ public class EntityMaterializerSource : IEntityMaterializerSource
         {
             var memberInfo = property.GetMemberInfo(forMaterialization: true, forSet: true);
 
-            blockExpressions.Add(
-                CreateMemberAssignment(
-                    instanceVariable, memberInfo, property, property is IServiceProperty serviceProperty
-                        ? serviceProperty.ParameterBinding.BindToParameter(bindingInfo)
-                        : valueBufferExpression.CreateValueBufferReadValueExpression(
-                            memberInfo.GetMemberType(),
-                            property.GetIndex(),
-                            property)));
+            var valueExpression = property switch
+            {
+                IProperty
+                    => valueBufferExpression.CreateValueBufferReadValueExpression(
+                        memberInfo.GetMemberType(), property.GetIndex(), property),
+
+                IServiceProperty serviceProperty
+                    => serviceProperty.ParameterBinding.BindToParameter(bindingInfo),
+
+                // TODO: Better InstanceTypeName? We use "instance" everywhere else apparently?
+                IComplexProperty complexProperty
+                    => CreateMaterializeExpression(
+                        new EntityMaterializerSourceParameters(complexProperty.ComplexType, "complexType", null),
+                        bindingInfo.MaterializationContextExpression),
+                _ => throw new UnreachableException()
+            };
+
+            blockExpressions.Add(CreateMemberAssignment(instanceVariable, memberInfo, property, valueExpression));
         }
 
         static Expression CreateMemberAssignment(Expression parameter, MemberInfo memberInfo, IPropertyBase property, Expression value)
@@ -254,7 +267,7 @@ public class EntityMaterializerSource : IEntityMaterializerSource
         = typeof(ValueTuple<object, Func<MaterializationContext, object?>>).GetConstructor(
             new[] { typeof(object), typeof(Func<MaterializationContext, object?>) })!;
 
-    private static Expression CreateMaterializeExpression(
+    private Expression CreateMaterializeExpression(
         List<Expression> blockExpressions,
         ParameterExpression instanceVariable,
         Expression constructorExpression,
@@ -271,8 +284,8 @@ public class EntityMaterializerSource : IEntityMaterializerSource
         return Expression.Block(bindingInfo.ServiceInstances, blockExpressions);
     }
 
-    private static Expression CreateInterceptionMaterializeExpression(
-        IEntityType entityType,
+    private Expression CreateInterceptionMaterializeExpression(
+        ITypeBase structuralType,
         HashSet<IPropertyBase> properties,
         IMaterializationInterceptor materializationInterceptor,
         ParameterBindingInfo bindingInfo,
@@ -312,7 +325,7 @@ public class EntityMaterializerSource : IEntityMaterializerSource
                 Expression.New(
                     MaterializationInterceptionDataConstructor,
                     bindingInfo.MaterializationContextExpression,
-                    Expression.Constant(entityType),
+                    Expression.Constant(structuralType),
                     Expression.Constant(bindingInfo.QueryTrackingBehavior, typeof(QueryTrackingBehavior?)),
                     accessorDictionaryVariable)));
         blockExpressions.Add(
@@ -392,37 +405,40 @@ public class EntityMaterializerSource : IEntityMaterializerSource
                             .GetConstructor(Type.EmptyTypes)!))
             };
 
-            foreach (var property in entityType.GetServiceProperties().Cast<IPropertyBase>().Concat(entityType.GetProperties()))
+            if (structuralType is IEntityType entityType)
             {
-                snapshotBlockExpressions.Add(
-                    Expression.Call(
-                        dictionaryVariable,
-                        DictionaryAddMethod,
-                        Expression.Constant(property),
-                        Expression.New(
-                            DictionaryConstructor,
-                            Expression.Lambda(
-                                typeof(Func<,>).MakeGenericType(typeof(MaterializationContext), property.ClrType),
-                                CreateAccessorReadExpression(),
-                                (ParameterExpression)bindingInfo.MaterializationContextExpression),
-                            Expression.Lambda<Func<MaterializationContext, object?>>(
-                                Expression.Convert(CreateAccessorReadExpression(), typeof(object)),
-                                (ParameterExpression)bindingInfo.MaterializationContextExpression))));
+                foreach (var property in entityType.GetServiceProperties().Cast<IPropertyBase>().Concat(structuralType.GetProperties()))
+                {
+                    snapshotBlockExpressions.Add(
+                        Expression.Call(
+                            dictionaryVariable,
+                            DictionaryAddMethod,
+                            Expression.Constant(property),
+                            Expression.New(
+                                DictionaryConstructor,
+                                Expression.Lambda(
+                                    typeof(Func<,>).MakeGenericType(typeof(MaterializationContext), property.ClrType),
+                                    CreateAccessorReadExpression(),
+                                    (ParameterExpression)bindingInfo.MaterializationContextExpression),
+                                Expression.Lambda<Func<MaterializationContext, object?>>(
+                                    Expression.Convert(CreateAccessorReadExpression(), typeof(object)),
+                                    (ParameterExpression)bindingInfo.MaterializationContextExpression))));
 
-                Expression CreateAccessorReadExpression()
-                    => property is IServiceProperty serviceProperty
-                        ? serviceProperty.ParameterBinding.BindToParameter(bindingInfo)
-                        : (property as IProperty)?.IsPrimaryKey() == true
-                            ? Expression.Convert(
-                                valueBufferExpression.CreateValueBufferReadValueExpression(
-                                    typeof(object),
+                    Expression CreateAccessorReadExpression()
+                        => property is IServiceProperty serviceProperty
+                            ? serviceProperty.ParameterBinding.BindToParameter(bindingInfo)
+                            : (property as IProperty)?.IsPrimaryKey() == true
+                                ? Expression.Convert(
+                                    valueBufferExpression.CreateValueBufferReadValueExpression(
+                                        typeof(object),
+                                        property.GetIndex(),
+                                        property),
+                                    property.ClrType)
+                                : valueBufferExpression.CreateValueBufferReadValueExpression(
+                                    property.ClrType,
                                     property.GetIndex(),
-                                    property),
-                                property.ClrType)
-                            : valueBufferExpression.CreateValueBufferReadValueExpression(
-                                property.ClrType,
-                                property.GetIndex(),
-                                property);
+                                    property);
+                }
             }
 
             snapshotBlockExpressions.Add(dictionaryVariable);
@@ -522,9 +538,9 @@ public class EntityMaterializerSource : IEntityMaterializerSource
                         self._materializationInterceptor == null
                             ? properties.Count == 0 && blockExpressions.Count == 0
                                 ? constructorExpression
-                                : CreateMaterializeExpression(
+                                : self.CreateMaterializeExpression(
                                     blockExpressions, instanceVariable, constructorExpression, properties, bindingInfo)
-                            : CreateInterceptionMaterializeExpression(
+                            : self.CreateInterceptionMaterializeExpression(
                                 e,
                                 new HashSet<IPropertyBase>(),
                                 self._materializationInterceptor,
@@ -537,9 +553,9 @@ public class EntityMaterializerSource : IEntityMaterializerSource
             },
             this);
 
-    private InstantiationBinding ModifyBindings(IEntityType entityType, InstantiationBinding binding)
+    private InstantiationBinding ModifyBindings(ITypeBase structuralType, InstantiationBinding binding)
     {
-        var interceptionData = new InstantiationBindingInterceptionData(entityType);
+        var interceptionData = new InstantiationBindingInterceptionData(structuralType);
         foreach (var bindingInterceptor in _bindingInterceptors)
         {
             binding = bindingInterceptor.ModifyBinding(interceptionData, binding);

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -314,6 +314,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
         public Expression Inject(Expression expression)
         {
             var result = Visit(expression);
+
             if (_queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
             {
                 foreach (var entityType in _visitedEntityTypes)
@@ -344,7 +345,8 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             var expressions = new List<Expression>();
             var variables = new List<ParameterExpression>();
 
-            var entityType = entityShaperExpression.EntityType;
+            var typeBase = entityShaperExpression.StructuralType;
+            var clrType = typeBase.ClrType;
 
             var materializationContextVariable = Variable(
                 typeof(MaterializationContext),
@@ -360,16 +362,16 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
 
             var valueBufferExpression = Call(materializationContextVariable, MaterializationContext.GetValueBufferMethod);
 
-            var primaryKey = entityType.FindPrimaryKey();
+            var primaryKey = typeBase is IEntityType entityType ? entityType.FindPrimaryKey() : null;
 
             var concreteEntityTypeVariable = Variable(
-                typeof(IEntityType),
+                typeBase is IEntityType ? typeof(IEntityType) : typeof(IComplexType),
                 "entityType" + _currentEntityIndex);
             variables.Add(concreteEntityTypeVariable);
 
-            var instanceVariable = Variable(entityType.ClrType, "instance" + _currentEntityIndex);
+            var instanceVariable = Variable(clrType, "instance" + _currentEntityIndex);
             variables.Add(instanceVariable);
-            expressions.Add(Assign(instanceVariable, Constant(null, entityType.ClrType)));
+            expressions.Add(Assign(instanceVariable, Constant(null, clrType)));
 
             if (_queryStateManager
                 && primaryKey != null)
@@ -407,7 +409,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                                 Assign(
                                     instanceVariable, Convert(
                                         MakeMemberAccess(entryVariable, EntityMemberInfo),
-                                        entityType.ClrType))),
+                                        clrType))),
                             MaterializeEntity(
                                 entityShaperExpression, materializationContextVariable, concreteEntityTypeVariable, instanceVariable,
                                 entryVariable))));
@@ -455,7 +457,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                                                     typeof(object), p.GetIndex(), p)))),
                                     Call(
                                         CreateNullKeyValueInNoTrackingQueryMethod,
-                                        Constant(entityType),
+                                        Constant(typeBase),
                                         Constant(primaryKey.Properties),
                                         keyValuesVariable))));
                     }
@@ -480,7 +482,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             ParameterExpression instanceVariable,
             ParameterExpression? entryVariable)
         {
-            var entityType = entityShaperExpression.EntityType;
+            var typeBase = entityShaperExpression.StructuralType;
 
             var expressions = new List<Expression>();
             var variables = new List<ParameterExpression>();
@@ -494,7 +496,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                     shadowValuesVariable,
                     Constant(ValueBuffer.Empty)));
 
-            var returnType = entityType.ClrType;
+            var returnType = typeBase.ClrType;
             var valueBufferExpression = Call(materializationContextVariable, MaterializationContext.GetValueBufferMethod);
             var expressionContext = (returnType, materializationContextVariable, concreteEntityTypeVariable, shadowValuesVariable);
             expressions.Add(
@@ -505,14 +507,16 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
                         valueBufferExpression,
                         entityShaperExpression.MaterializationCondition.Body)));
 
-            var concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToArray();
+            var (primaryKey, concreteEntityTypes) = typeBase is IEntityType entityType
+                ? (entityType.FindPrimaryKey(), entityType.GetConcreteDerivedTypesInclusive().Cast<ITypeBase>().ToArray())
+                : (null, new[] { typeBase});
 
             var switchCases = new SwitchCase[concreteEntityTypes.Length];
             for (var i = 0; i < concreteEntityTypes.Length; i++)
             {
                 switchCases[i] = SwitchCase(
                     CreateFullMaterializeExpression(concreteEntityTypes[i], expressionContext),
-                    Constant(concreteEntityTypes[i], typeof(IEntityType)));
+                    Constant(concreteEntityTypes[i], typeBase is IEntityType ? typeof(IEntityType) : typeof(IComplexType)));
             }
 
             var materializationExpression = Switch(
@@ -522,12 +526,14 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
 
             expressions.Add(Assign(instanceVariable, materializationExpression));
 
-            if (_queryStateManager
-                && entityType.FindPrimaryKey() != null)
+            if (_queryStateManager && primaryKey is not null)
             {
-                foreach (var et in entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive()))
+                if (typeBase is IEntityType entityType2)
                 {
-                    _visitedEntityTypes.Add(et);
+                    foreach (var et in entityType2.GetAllBaseTypes().Concat(entityType2.GetDerivedTypesInclusive()))
+                    {
+                        _visitedEntityTypes.Add(et);
+                    }
                 }
 
                 expressions.Add(
@@ -553,7 +559,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
         }
 
         private BlockExpression CreateFullMaterializeExpression(
-            IEntityType concreteEntityType,
+            ITypeBase concreteTypeBase,
             (Type ReturnType,
                 ParameterExpression MaterializationContextVariable,
                 ParameterExpression ConcreteEntityTypeVariable,
@@ -569,19 +575,24 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
             var materializer = _entityMaterializerSource
                 .CreateMaterializeExpression(
                     new EntityMaterializerSourceParameters(
-                        concreteEntityType, "instance", _queryTrackingBehavior), materializationContextVariable);
+                        concreteTypeBase, "instance", _queryTrackingBehavior), materializationContextVariable);
 
             if (_queryStateManager
-                && ((IRuntimeEntityType)concreteEntityType).ShadowPropertyCount > 0)
+                && ((IRuntimeTypeBase)concreteTypeBase).ShadowPropertyCount > 0)
             {
                 var valueBufferExpression = Call(
                     materializationContextVariable, MaterializationContext.GetValueBufferMethod);
 
-                var shadowProperties = concreteEntityType.GetProperties()
-                    .Concat<IPropertyBase>(concreteEntityType.GetNavigations())
-                    .Concat(concreteEntityType.GetSkipNavigations())
-                    .Where(n => n.IsShadowProperty())
-                    .OrderBy(e => e.GetShadowIndex());
+                IEnumerable<IPropertyBase> shadowProperties = concreteTypeBase.GetProperties();
+
+                if (concreteTypeBase is IEntityType concreteEntityType)
+                {
+                    shadowProperties = shadowProperties
+                        .Concat(concreteEntityType.GetNavigations())
+                        .Concat(concreteEntityType.GetSkipNavigations());
+                }
+
+                shadowProperties = shadowProperties.Where(n => n.IsShadowProperty()).OrderBy(e => e.GetShadowIndex());
 
                 blockExpressions.Add(
                     Assign(

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexTypeQueryRelationalTestBase.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public abstract class ComplexTypeQueryRelationalTestBase<TFixture> : ComplexTypeQueryTestBase<TFixture>
+    where TFixture : ComplexTypeQueryRelationalTestBase<TFixture>.RelationalComplexTypeQueryFixture, new()
+{
+    protected ComplexTypeQueryRelationalTestBase(TFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    public abstract class RelationalComplexTypeQueryFixture : ComplexTypeQueryFixtureBase
+    {
+        public new RelationalTestStore TestStore
+            => (RelationalTestStore)base.TestStore;
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+    }
+}

--- a/test/EFCore.Specification.Tests/MaterializationInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/MaterializationInterceptionTestBase.cs
@@ -421,7 +421,7 @@ public abstract class MaterializationInterceptionTestBase<TContext> : SingletonI
                 this,
                 typeof(TestBindingInterceptor).GetTypeInfo().GetDeclaredMethod(nameof(BookFactory))!,
                 new List<ParameterBinding>(),
-                interceptionData.EntityType.ClrType);
+                interceptionData.TypeBase.ClrType);
         }
     }
 

--- a/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
@@ -1,0 +1,343 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+#nullable enable
+
+public abstract class ComplexTypeQueryTestBase<TFixture> : QueryTestBase<TFixture>
+    where TFixture : ComplexTypeQueryTestBase<TFixture>.ComplexTypeQueryFixtureBase, new()
+{
+    public ComplexTypeQueryTestBase(TFixture fixture)
+        : base(fixture)
+    {
+        fixture.ListLoggerFactory.Clear();
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ShippingAddress.ZipCode == 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_nested_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ShippingAddress.Country.Code == "DE"));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_complex_type_after_subquery(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>()
+                .OrderBy(c => c.Id)
+                .Skip(1)
+                .Distinct()
+                .Where(c => c.ShippingAddress.ZipCode == 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_nested_complex_type_after_subquery(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>()
+                .OrderBy(c => c.Id)
+                .Skip(1)
+                .Distinct()
+                .Where(c => c.ShippingAddress.Country.Code == "DE"));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Load_complex_type_after_subquery_on_entity_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>()
+                .OrderBy(c => c.Id)
+                .Skip(1)
+                .Distinct());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Select(c => c.ShippingAddress));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_nested_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Select(c => c.ShippingAddress.Country));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_single_property_on_nested_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Select(c => c.ShippingAddress.Country.FullName));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_multiplex_complex_types(bool async)
+        => throw new NotImplementedException();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_same_complex_type_twice(bool async)
+        => throw new NotImplementedException();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Impossible_equality_operator(bool async)
+        => throw new NotImplementedException();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Impossible_equality_method(bool async)
+        => throw new NotImplementedException();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Impossible_object_equality_method(bool async)
+        => throw new NotImplementedException();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Projecting_base_type_loads_all_owned_navs(bool async)
+        => throw new NotImplementedException();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Set_throws_for_owned_type(bool async)
+        => throw new NotImplementedException();
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Entity_splitting_with_complex_property_in_own_table(bool async)
+        => throw new NotImplementedException();
+
+    // TODO: Got to Preserve_includes_when_applying_skip_take_after_anonymous_type_select in OwnedQueryTestBase
+
+    // TODO: Query filter going into complex type
+
+    // TODO: Tracking queries
+
+    // TODO: Exercise all inheritance scenarios, with the complex property being on derived types.
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Projecting_complex_type_in_tracking_query_throws(bool async)
+        => throw new NotImplementedException();
+
+    public abstract class ComplexTypeQueryFixtureBase : SharedStoreFixtureBase<PoolableDbContext>, IQueryFixtureBase
+    {
+        protected override string StoreName
+            => "ComplexTypeQueryTest";
+
+        private ComplexTypeQueryData? _expectedData;
+
+        public override PoolableDbContext CreateContext()
+        {
+            var context = base.CreateContext();
+            context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            return context;
+        }
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder).ConfigureWarnings(wcb => wcb.Throw());
+
+        protected override void Seed(PoolableDbContext context)
+            => ComplexTypeQueryData.Seed(context);
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        {
+            modelBuilder.Entity<Customer>(cb =>
+            {
+                cb.Property(c => c.Id).ValueGeneratedNever();
+
+                cb.ComplexProperty(c => c.ShippingAddress, sab => sab.ComplexProperty(sa => sa.Country));
+            });
+        }
+
+        public Func<DbContext> GetContextCreator()
+            => () => CreateContext();
+
+        public ISetSource GetExpectedData()
+            => _expectedData ??= new ComplexTypeQueryData();
+
+        public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object?>>
+        {
+            { typeof(Customer), e => ((Customer)e).Id },
+
+            // Complex types - still need comparers for cases where they are projected directly
+            { typeof(Address), e => ((Address)e).ZipCode },
+            { typeof(Country), e => ((Country)e).Code }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+        public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+        {
+            {
+                typeof(Customer), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a is not null && e is not null)
+                    {
+                        var ee = (Customer)e;
+                        var aa = (Customer)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Name, aa.Name);
+                        AssertAddress(ee.ShippingAddress, aa.ShippingAddress);
+                    }
+                }
+            },
+            {
+                typeof(Address), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a is not null && e is not null)
+                    {
+                        AssertAddress((Address)e, (Address)e);
+                    }
+                }
+            },
+            {
+                typeof(Country), (e, a) =>
+                {
+                    Assert.Equal(e == null, a == null);
+                    if (a is not null && e is not null)
+                    {
+                        AssertCountry((Country)e, (Country)e);
+                    }
+                }
+            }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
+    }
+
+    private static void AssertAddress(Address? expected, Address? actual)
+    {
+        if (expected is not null && actual is not null)
+        {
+            Assert.Equal(expected.AddressLine1, actual.AddressLine1);
+            Assert.Equal(expected.AddressLine2, actual.AddressLine2);
+            Assert.Equal(expected.ZipCode, actual.ZipCode);
+
+            AssertCountry(expected.Country, actual.Country);
+        }
+        else
+        {
+            Assert.Equal(expected is null, actual is null);
+        }
+    }
+
+    private static void AssertCountry(Country? expected, Country? actual)
+    {
+        if (expected is not null && actual is not null)
+        {
+            Assert.Equal(expected.FullName, actual.FullName);
+            Assert.Equal(expected.Code, actual.Code);
+        }
+        else
+        {
+            Assert.Equal(expected is null, actual is null);
+        }
+    }
+
+    protected class ComplexTypeQueryData : ISetSource
+    {
+        private readonly IReadOnlyList<Customer> _customers;
+
+        public ComplexTypeQueryData()
+        {
+            _customers = CreateCustomers();
+
+            // WireUp(_ownedPeople, _planets, _stars, _moons, _finks, _bartons);
+        }
+
+        public IQueryable<TEntity> Set<TEntity>()
+            where TEntity : class
+        {
+            if (typeof(TEntity) == typeof(Customer))
+            {
+                return (IQueryable<TEntity>)_customers.AsQueryable();
+            }
+
+            throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
+        }
+
+        private static IReadOnlyList<Customer> CreateCustomers()
+        {
+            var customer1 = new Customer
+            {
+                Id = 1,
+                Name = "Mona Cy",
+                ShippingAddress = new Address
+                {
+                    AddressLine1 = "804 S. Lakeshore Road",
+                    ZipCode = 38654,
+                    Country = new Country
+                    {
+                        FullName = "United States",
+                        Code = "US"
+                    }
+                }
+            };
+
+            var customer2 = new Customer
+            {
+                Id = 2,
+                Name = "Antigonus Mitul",
+                ShippingAddress = new Address
+                {
+                    AddressLine1 = "72 Hickory Rd.",
+                    ZipCode = 07728,
+                    Country = new Country
+                    {
+                        FullName = "Germany",
+                        Code = "DE"
+                    }
+                }
+            };
+
+            return new List<Customer> { customer1, customer2 };
+        }
+
+        public static void Seed(PoolableDbContext context)
+        {
+            // TODO: Temporarily seeding via raw SQL as update pipeline support for complex types, see provider-specific implementations
+
+            // context.Set<Customer>().AddRange(CreateCustomers());
+            // context.SaveChanges();
+        }
+    }
+
+    protected class Customer
+    {
+        public int Id { get; set; }
+        public required string Name { get; set; }
+
+        public required Address ShippingAddress { get; set; }
+
+        // public ICollection<Order> Orders { get; set; }
+    }
+
+    protected class Address
+    {
+        public required string AddressLine1 { get; set; }
+        public string? AddressLine2 { get; set; }
+        public int ZipCode { get; set; }
+
+        public required Country Country { get; set; }
+    }
+
+    protected class Country
+    {
+        public required string FullName { get; set; }
+        public required string Code { get; set; }
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -946,14 +946,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             => () => CreateContext();
 
         public virtual ISetSource GetExpectedData()
-        {
-            if (_expectedData == null)
-            {
-                _expectedData = new OwnedQueryData();
-            }
-
-            return _expectedData;
-        }
+            => _expectedData ??= new OwnedQueryData();
 
         public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
         {
@@ -1213,8 +1206,11 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 eb =>
                 {
                     eb.IndexerProperty<string>("Name");
-                    var ownedPerson = new OwnedPerson { Id = 1 };
-                    ownedPerson["Name"] = "Mona Cy";
+                    var ownedPerson = new OwnedPerson
+                    {
+                        Id = 1,
+                        ["Name"] = "Mona Cy"
+                    };
                     eb.HasData(ownedPerson);
 
                     eb.OwnsOne(
@@ -1673,77 +1669,144 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
         private static IReadOnlyList<OwnedPerson> CreateOwnedPeople()
         {
-            var personAddress1 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
-            personAddress1["AddressLine"] = "804 S. Lakeshore Road";
-            personAddress1["ZipCode"] = 38654;
-            var ownedPerson1 = new OwnedPerson { Id = 1, PersonAddress = personAddress1 };
-            ownedPerson1["Name"] = "Mona Cy";
+            var personAddress1 = new OwnedAddress
+            {
+                PlaceType = "Land",
+                Country = new OwnedCountry { Name = "USA", PlanetId = 1 },
+                ["AddressLine"] = "804 S. Lakeshore Road",
+                ["ZipCode"] = 38654
+            };
 
-            var personAddress2 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
-            personAddress2["AddressLine"] = "7 Church Dr.";
-            personAddress2["ZipCode"] = 28655;
-            var branchAddress2 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "Canada", PlanetId = 1 } };
-            branchAddress2["BranchName"] = "BranchA";
+            var ownedPerson1 = new OwnedPerson
+            {
+                Id = 1,
+                PersonAddress = personAddress1,
+                ["Name"] = "Mona Cy"
+            };
+
+            var personAddress2 = new OwnedAddress
+            {
+                PlaceType = "Land",
+                Country = new OwnedCountry { Name = "USA", PlanetId = 1 },
+                ["AddressLine"] = "7 Church Dr.",
+                ["ZipCode"] = 28655
+            };
+
+            var branchAddress2 = new OwnedAddress
+            {
+                PlaceType = "Land",
+                Country = new OwnedCountry { Name = "Canada", PlanetId = 1 },
+                ["BranchName"] = "BranchA"
+            };
 
             var ownedPerson2 = new Branch
             {
                 Id = 2,
                 PersonAddress = personAddress2,
-                BranchAddress = branchAddress2
+                BranchAddress = branchAddress2,
+                ["Name"] = "Antigonus Mitul"
             };
-            ownedPerson2["Name"] = "Antigonus Mitul";
 
-            var personAddress3 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
-            personAddress3["AddressLine"] = "72 Hickory Rd.";
-            personAddress3["ZipCode"] = 07728;
-            var branchAddress3 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "Canada", PlanetId = 1 } };
-            branchAddress3["BranchName"] = "BranchB";
-            var leafAAddress3 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "Mexico", PlanetId = 1 } };
-            leafAAddress3["LeafType"] = 1;
+            var personAddress3 = new OwnedAddress
+            {
+                PlaceType = "Land",
+                Country = new OwnedCountry { Name = "USA", PlanetId = 1 },
+                ["AddressLine"] = "72 Hickory Rd.",
+                ["ZipCode"] = 07728
+            };
+
+            var branchAddress3 = new OwnedAddress
+            {
+                PlaceType = "Land",
+                Country = new OwnedCountry { Name = "Canada", PlanetId = 1 },
+                ["BranchName"] = "BranchB"
+            };
+
+            var leafAAddress3 = new OwnedAddress
+            {
+                PlaceType = "Land",
+                Country = new OwnedCountry { Name = "Mexico", PlanetId = 1 },
+                ["LeafType"] = 1
+            };
+
             var ownedPerson3 = new LeafA
             {
                 Id = 3,
                 PersonAddress = personAddress3,
                 BranchAddress = branchAddress3,
-                LeafAAddress = leafAAddress3
+                LeafAAddress = leafAAddress3,
+                ["Name"] = "Madalena Morana"
             };
-            ownedPerson3["Name"] = "Madalena Morana";
 
-            var personAddress4 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
-            personAddress4["AddressLine"] = "28 Strawberry St.";
-            personAddress4["ZipCode"] = 19053;
-            var leafBAddress4 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "Panama", PlanetId = 1 } };
-            leafBAddress4["LeafBType"] = "Green";
+            var personAddress4 = new OwnedAddress
+            {
+                PlaceType = "Land",
+                Country = new OwnedCountry { Name = "USA", PlanetId = 1 },
+                ["AddressLine"] = "28 Strawberry St.",
+                ["ZipCode"] = 19053
+            };
+
+            var leafBAddress4 = new OwnedAddress
+            {
+                PlaceType = "Land",
+                Country = new OwnedCountry { Name = "Panama", PlanetId = 1 },
+                ["LeafBType"] = "Green"
+            };
+
             var ownedPerson4 = new LeafB
             {
                 Id = 4,
                 PersonAddress = personAddress4,
-                LeafBAddress = leafBAddress4
+                LeafBAddress = leafBAddress4,
+                ["Name"] = "Vanda Waldemar"
             };
-            ownedPerson4["Name"] = "Vanda Waldemar";
 
-            var order1 = new Order { Id = -10, Client = ownedPerson1 };
-            order1["OrderDate"] = Convert.ToDateTime("2018-07-11 10:01:41");
-            order1.Details = new List<OrderDetail> { new() { Detail = "Discounted Order" }, new() { Detail = "Full Price Order" } };
+            var order1 = new Order
+            {
+                Id = -10,
+                Client = ownedPerson1,
+                ["OrderDate"] = Convert.ToDateTime("2018-07-11 10:01:41"),
+                Details = new List<OrderDetail>
+                {
+                    new() { Detail = "Discounted Order" },
+                    new() { Detail = "Full Price Order" }
+                }
+            };
 
-            var order2 = new Order { Id = -11, Client = ownedPerson1 };
-            order2["OrderDate"] = Convert.ToDateTime("2015-03-03 04:37:59");
-            order2.Details = new List<OrderDetail>();
+            var order2 = new Order
+            {
+                Id = -11,
+                Client = ownedPerson1,
+                ["OrderDate"] = Convert.ToDateTime("2015-03-03 04:37:59"),
+                Details = new List<OrderDetail>()
+            };
             ownedPerson1.Orders = new List<Order> { order1, order2 };
 
-            var order3 = new Order { Id = -20, Client = ownedPerson2 };
-            order3["OrderDate"] = Convert.ToDateTime("2015-05-25 20:35:48");
-            order3.Details = new List<OrderDetail> { new() { Detail = "Internal Order" } };
+            var order3 = new Order
+            {
+                Id = -20,
+                Client = ownedPerson2,
+                ["OrderDate"] = Convert.ToDateTime("2015-05-25 20:35:48"),
+                Details = new List<OrderDetail> { new() { Detail = "Internal Order" } }
+            };
             ownedPerson2.Orders = new List<Order> { order3 };
 
-            var order4 = new Order { Id = -30, Client = ownedPerson3 };
-            order4["OrderDate"] = Convert.ToDateTime("2014-11-10 04:32:42");
-            order4.Details = new List<OrderDetail> { new() { Detail = "Bulk Order" } };
+            var order4 = new Order
+            {
+                Id = -30,
+                Client = ownedPerson3,
+                ["OrderDate"] = Convert.ToDateTime("2014-11-10 04:32:42"),
+                Details = new List<OrderDetail> { new() { Detail = "Bulk Order" } }
+            };
             ownedPerson3.Orders = new List<Order> { order4 };
 
-            var order5 = new Order { Id = -40, Client = ownedPerson4 };
-            order5["OrderDate"] = Convert.ToDateTime("2016-04-25 19:23:56");
-            order5.Details = new List<OrderDetail>();
+            var order5 = new Order
+            {
+                Id = -40,
+                Client = ownedPerson4,
+                ["OrderDate"] = Convert.ToDateTime("2016-04-25 19:23:56"),
+                Details = new List<OrderDetail>()
+            };
             ownedPerson4.Orders = new List<Order> { order5 };
 
             return new List<OwnedPerson>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class ComplexTypeQuerySqlServerTest : ComplexTypeQueryRelationalTestBase<
+    ComplexTypeQuerySqlServerTest.ComplexTypeQuerySqlServerFixture>
+{
+    public ComplexTypeQuerySqlServerTest(ComplexTypeQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    public override async Task Filter_on_property_inside_complex_type(bool async)
+    {
+        await base.Filter_on_property_inside_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [c].[Id], [c].[Name], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+FROM [Customer] AS [c]
+WHERE [c].[ShippingAddress_ZipCode] = 7728
+""");
+    }
+
+    public override async Task Filter_on_property_inside_nested_complex_type(bool async)
+    {
+        await base.Filter_on_property_inside_nested_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [c].[Id], [c].[Name], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+FROM [Customer] AS [c]
+WHERE [c].[ShippingAddress_Country_Code] = N'DE'
+""");
+    }
+
+    public override async Task Filter_on_property_inside_complex_type_after_subquery(bool async)
+    {
+        await base.Filter_on_property_inside_complex_type_after_subquery(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT [t].[Id], [t].[Name], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+FROM (
+    SELECT [c].[Id], [c].[Name], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+    FROM [Customer] AS [c]
+    ORDER BY [c].[Id]
+    OFFSET @__p_0 ROWS
+) AS [t]
+WHERE [t].[ShippingAddress_ZipCode] = 7728
+""");
+    }
+
+    public override async Task Filter_on_property_inside_nested_complex_type_after_subquery(bool async)
+    {
+        await base.Filter_on_property_inside_nested_complex_type_after_subquery(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT [t].[Id], [t].[Name], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+FROM (
+    SELECT [c].[Id], [c].[Name], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+    FROM [Customer] AS [c]
+    ORDER BY [c].[Id]
+    OFFSET @__p_0 ROWS
+) AS [t]
+WHERE [t].[ShippingAddress_Country_Code] = N'DE'
+""");
+    }
+
+    public override async Task Load_complex_type_after_subquery_on_entity_type(bool async)
+    {
+        await base.Load_complex_type_after_subquery_on_entity_type(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT [t].[Id], [t].[Name], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+FROM (
+    SELECT [c].[Id], [c].[Name], [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+    FROM [Customer] AS [c]
+    ORDER BY [c].[Id]
+    OFFSET @__p_0 ROWS
+) AS [t]
+""");
+    }
+
+    public override async Task Project_complex_type(bool async)
+    {
+        await base.Project_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [c].[ShippingAddress_AddressLine1], [c].[ShippingAddress_AddressLine2], [c].[ShippingAddress_ZipCode], [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+FROM [Customer] AS [c]
+""");
+    }
+
+    public override async Task Project_nested_complex_type(bool async)
+    {
+        await base.Project_nested_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [c].[ShippingAddress_Country_Code], [c].[ShippingAddress_Country_FullName]
+FROM [Customer] AS [c]
+""");
+    }
+
+    public override async Task Project_single_property_on_nested_complex_type(bool async)
+    {
+        await base.Project_single_property_on_nested_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [c].[ShippingAddress_Country_FullName]
+FROM [Customer] AS [c]
+""");
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    public class ComplexTypeQuerySqlServerFixture : RelationalComplexTypeQueryFixture
+    {
+        protected override ITestStoreFactory TestStoreFactory
+            => SqlServerTestStoreFactory.Instance;
+
+        // TODO: Temporarily seeding via raw SQL as update pipeline support for complex types, see provider-specific implementations
+        protected override void Seed(PoolableDbContext context)
+            => context.Database.ExecuteSqlRaw(
+"""
+INSERT INTO Customer (Id, Name, ShippingAddress_AddressLine1, ShippingAddress_ZipCode, ShippingAddress_Country_FullName, ShippingAddress_Country_Code)
+VALUES
+    (1, 'Mona Cy', '804 S. Lakeshore Road', 38654, 'United States', 'US'),
+    (2, 'Antigonus Mitul', '72 Hickory Rd.', 07728, 'Germany', 'DE')
+""");
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -14,6 +14,16 @@ public class OwnedQuerySqlServerTest : OwnedQueryRelationalTestBase<OwnedQuerySq
     protected override bool CanExecuteQueryString
         => true;
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Foo(bool async)
+        => AssertQuery(async, ss => ss.Set<OwnedPerson>()
+            .OrderBy(o => o.Id)
+            .Skip(1)
+            .Distinct()
+            .Where(p => p.PersonAddress.PlaceType == "sdf"));
+        // => AssertQuery(async, ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress.PlaceType == "sdf"));
+
     public override async Task Query_with_owned_entity_equality_operator(bool async)
     {
         await base.Query_with_owned_entity_equality_operator(async);


### PR DESCRIPTION
@maumar early-stage draft PR which passes basic scenarios (see ComplexTypeQuerySqlServerTest). There's a lot of work left, but I think the basic approach is implemented and should be OK - submitting to get some first feedback.

(it looks big but most of it is renaming from Entity -> StructuralType :rofl:)

The main big thing here is basically moving in the direction of #31309. Here's a huge wall of text dump, mostly for me;but if it's helpful for you even better :rofl::

* When trying binding to a complex expression, I need to produce an EntityProjectionExpression (now StructuralTypeProjectionExpression) for the target complex type. This involves generating all the property expressions for it.
* I could recursively pre-calculate all the properties in the complex graph - and all the StructuralTypeProjectionExpression for nested complex types as well - but this seems like the wrong way to go. The graph could be big, and it's only used when the user binds to something; so any properties not bound are basically thrown away.
* Instead, I went with the same approach used for non-JSON owned entities (this happens in SelectExpression.GenerateOwnedReferenceEntityProjectionExpression). This calculates all the properties and builds the StructuralTypeProjectionExpression on-demand, only as as an owned entity is being navigated into.
* The problem in this approach is how to build the ColumnExpressions needed for the property expression map of the new StructuralTypeProjectionExpression; we need to know which of the SelectExpression's tables is the right one (there may be many because of joins and what-not).
* For regular properties, this problem is "solved" by pre-generating the property map when first creating the SelectExpression and populating them as a map in StructuralTypeProjectionExpression; this way, we just consult the pre-made map when we need to bind a property. This suffers from the same perf problem above: we needlessly pregenerate ColumnExpressions for all properties, although only a few will typically be needed. This is also complex, since we need to lift the mappings up when pushing to a subquery (this happens in LiftEntityProjectionFromSubquery).
* Coming back to non-JSON owned navigations; there's no pre-generated map like for properties, so GenerateOwnedReferenceEntityProjectionExpression employes a hack to create the ColumnExpressions on demand. It gets the TableExpression of the primary key, and assumes that the table of the owned entity placed the same number of tables after that as it is in the relational type mappings (i.e. there's a problematic assumption about table ordering).
* For complex types I can't even use this hack, since unlike with owned entities there's no primary key that's shared between the owned and the owner. So there's no way to find the table in the current SelectExpression that corresponds to the relational table to which the complex type is mapped.

The proposed solution implemented in this PR:

* All this complexity and work is simply because we have no mapping between tables in the relational model and their corresponding table expressions in the SelectExpressions.
* So I just... added that to StructuralTypeProjectionExpression: `Dictionary<ITableBase, TableReferenceExpression> TableMap`. Whenever StructuralTypeProjectionExpression is created, it must be supplied with this mapping just like it's supplied with the property expression map.
* This allows us to very simply look up the complex types table in the relational model, and then use this new mapping to look up the SelectExpression's TableReferenceExpression and construct colunms over that.
* For now, to avoid risk I'm only using this new TableMap in complex property binding. However, in 9.0, we can also remove the pre-generated property map altogether and just bind on-demand via this table mapping. We can also simplify the owned entity binding to remote the table position hack. This should make everything simpler and more efficient, and should also allow us to bind everything directly from RelationalSqlTranslatingEV instead of from the pre-visitation "expansion" pass.
* Note that this makes TableReferenceExpression pubternal (it was a private implementation detail of SelectExpression). This is one step in opening up SelectExpression: we need to be able to reference tables from things, not just from ColumnExpressions as is the case right now.