### PR TITLE
Use IN instead of EXISTS in more places

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -135,6 +135,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_USINGS_STMT/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_RAW_LITERAL_STRING/@EntryValue">DO_NOT_CHANGE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -522,7 +522,23 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             || !TryGetProjection(source, out var projection))
         {
             // If the item can't be translated, we can't translate to an IN expression.
-            // However, attempt to translate as Any since that passes through Where predicate translation, which e.g. does entity equality.
+
+            // We do attempt one thing: if this is a contains over an entity type which has a single key property (non-composite key),
+            // we can project its key property (entity equality/containment) and translate to InExpression over that.
+            if (item is EntityShaperExpression { EntityType: var entityType }
+                && entityType.FindPrimaryKey()?.Properties is [var singleKeyProperty])
+            {
+                var keySelectorParam = Expression.Parameter(source.Type);
+
+                return TranslateContains(
+                    TranslateSelect(
+                        source,
+                        Expression.Lambda(keySelectorParam.CreateEFPropertyExpression(singleKeyProperty), keySelectorParam)),
+                    item.CreateEFPropertyExpression(singleKeyProperty));
+            }
+
+            // Otherwise, attempt to translate as Any since that passes through Where predicate translation. This will e.g. take care of
+            // entity , which e.g. does entity equality/containment for entities with composite keys.
             var anyLambdaParameter = Expression.Parameter(item.Type, "p");
             var anyLambda = Expression.Lambda(
                 Infrastructure.ExpressionExtensions.CreateEqualsExpression(anyLambdaParameter, item),
@@ -1304,6 +1320,9 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             return null;
         }
 
+        // First, check if the provider has a native translation for the delete represented by the select expression.
+        // The default relational implementation handles simple, universally-supported cases (i.e. no operators except for predicate).
+        // Providers may override IsValidSelectExpressionForExecuteDelete to add support for more cases via provider-specific DELETE syntax.
         var selectExpression = (SelectExpression)source.QueryExpression;
         if (IsValidSelectExpressionForExecuteDelete(selectExpression, entityShaperExpression, out var tableExpression))
         {
@@ -1340,7 +1359,9 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             }
         }
 
-        // We need to convert to PK predicate
+        // The provider doesn't natively support the delete.
+        // As a fallback, we place the original query in a Contains subquery, which will get translated via the regular entity equality/
+        // containment mechanism (InExpression for non-composite keys, Any for composite keys)
         var pk = entityType.FindPrimaryKey();
         if (pk == null)
         {
@@ -1353,14 +1374,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
 
         var clrType = entityType.ClrType;
         var entityParameter = Expression.Parameter(clrType);
-        var innerParameter = Expression.Parameter(clrType);
-        var predicateBody = Expression.Call(
-            QueryableMethods.AnyWithPredicate.MakeGenericMethod(clrType),
-            source,
-            Expression.Quote(
-                Expression.Lambda(
-                    Infrastructure.ExpressionExtensions.CreateEqualsExpression(innerParameter, entityParameter),
-                    innerParameter)));
+        var predicateBody = Expression.Call(QueryableMethods.Contains.MakeGenericMethod(clrType), source, entityParameter);
 
         var newSource = Expression.Call(
             QueryableMethods.Where.MakeGenericMethod(clrType),
@@ -1464,6 +1478,9 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             return null;
         }
 
+        // First, check if the provider has a native translation for the update represented by the select expression.
+        // The default relational implementation handles simple, universally-supported cases (i.e. no operators except for predicate).
+        // Providers may override IsValidSelectExpressionForExecuteDelete to add support for more cases via provider-specific UPDATE syntax.
         var selectExpression = (SelectExpression)source.QueryExpression;
         if (IsValidSelectExpressionForExecuteUpdate(selectExpression, entityShaperExpression, out var tableExpression))
         {
@@ -1472,7 +1489,9 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                 propertyValueLambdaExpressions, remappedUnwrappedLeftExpressions);
         }
 
-        // We need to convert to join with original query using PK
+        // The provider doesn't natively support the update.
+        // As a fallback, we place the original query in a Contains subquery, which will get translated via the regular entity equality/
+        // containment mechanism (InExpression for non-composite keys, Any for composite keys)
         var pk = entityType.FindPrimaryKey();
         if (pk == null)
         {
@@ -1483,51 +1502,20 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             return null;
         }
 
-        var outer = (ShapedQueryExpression)Visit(new EntityQueryRootExpression(entityType));
-        var inner = source;
-        var outerParameter = Expression.Parameter(entityType.ClrType);
-        var outerKeySelector = Expression.Lambda(outerParameter.CreateKeyValuesExpression(pk.Properties), outerParameter);
-        var firstPropertyLambdaExpression = propertyValueLambdaExpressions[0].Item1;
-        var entitySource = GetEntitySource(RelationalDependencies.Model, firstPropertyLambdaExpression.Body);
-        var innerKeySelector = Expression.Lambda(
-            entitySource.CreateKeyValuesExpression(pk.Properties), firstPropertyLambdaExpression.Parameters);
+        var clrType = entityType.ClrType;
+        var entityParameter = Expression.Parameter(clrType);
+        var predicateBody = Expression.Call(QueryableMethods.Contains.MakeGenericMethod(clrType), source, entityParameter);
 
-        var joinPredicate = CreateJoinPredicate(outer, outerKeySelector, inner, innerKeySelector);
+        var newSource = (ShapedQueryExpression)Visit(
+            Expression.Call(
+                QueryableMethods.Where.MakeGenericMethod(clrType),
+                new EntityQueryRootExpression(entityType),
+                Expression.Quote(Expression.Lambda(predicateBody, entityParameter))));
 
-        Check.DebugAssert(joinPredicate != null, "Join predicate shouldn't be null");
+        selectExpression = (SelectExpression)newSource.QueryExpression;
+        tableExpression = (TableExpression)selectExpression.Tables[0];
 
-        var outerSelectExpression = (SelectExpression)outer.QueryExpression;
-        var outerShaperExpression = outerSelectExpression.AddInnerJoin(inner, joinPredicate, outer.ShaperExpression);
-        outer = outer.UpdateShaperExpression(outerShaperExpression);
-        var transparentIdentifierType = outer.ShaperExpression.Type;
-        var transparentIdentifierParameter = Expression.Parameter(transparentIdentifierType);
-
-        var propertyReplacement = AccessField(transparentIdentifierType, transparentIdentifierParameter, "Outer");
-        var valueReplacement = AccessField(transparentIdentifierType, transparentIdentifierParameter, "Inner");
-        for (var i = 0; i < propertyValueLambdaExpressions.Count; i++)
-        {
-            var (propertyExpression, valueExpression) = propertyValueLambdaExpressions[i];
-            propertyExpression = Expression.Lambda(
-                ReplacingExpressionVisitor.Replace(
-                    ReplacingExpressionVisitor.Replace(
-                        firstPropertyLambdaExpression.Parameters[0],
-                        propertyExpression.Parameters[0],
-                        entitySource),
-                    propertyReplacement, propertyExpression.Body),
-                transparentIdentifierParameter);
-
-            valueExpression = valueExpression is LambdaExpression lambdaExpression
-                ? Expression.Lambda(
-                    ReplacingExpressionVisitor.Replace(lambdaExpression.Parameters[0], valueReplacement, lambdaExpression.Body),
-                    transparentIdentifierParameter)
-                : valueExpression;
-
-            propertyValueLambdaExpressions[i] = (propertyExpression, valueExpression);
-        }
-
-        tableExpression = (TableExpression)outerSelectExpression.Tables[0];
-
-        return TranslateSetPropertyExpressions(this, outer, outerSelectExpression, tableExpression, propertyValueLambdaExpressions, null);
+        return TranslateSetPropertyExpressions(this, newSource, selectExpression, tableExpression, propertyValueLambdaExpressions, null);
 
         static NonQueryExpression? TranslateSetPropertyExpressions(
             RelationalQueryableMethodTranslatingExpressionVisitor visitor,
@@ -1670,25 +1658,6 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
 
             entityShaperExpression = null;
             return false;
-        }
-
-        static Expression GetEntitySource(IModel model, Expression propertyAccessExpression)
-        {
-            propertyAccessExpression = propertyAccessExpression.UnwrapTypeConversion(out _);
-            if (propertyAccessExpression is MethodCallExpression mce)
-            {
-                if (mce.TryGetEFPropertyArguments(out var source, out _))
-                {
-                    return source;
-                }
-
-                if (mce.TryGetIndexerArguments(model, out var source2, out _))
-                {
-                    return source2;
-                }
-            }
-
-            return ((MemberExpression)propertyAccessExpression).Expression!;
         }
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqlServerTest.cs
@@ -92,15 +92,16 @@ WHERE (
 """
 DELETE FROM [a]
 FROM [Animals] AS [a]
-WHERE [a].[CountryId] = 1 AND EXISTS (
-    SELECT 1
+WHERE [a].[CountryId] = 1 AND [a].[Id] IN (
+    SELECT (
+        SELECT TOP(1) [a1].[Id]
+        FROM [Animals] AS [a1]
+        WHERE [a1].[CountryId] = 1 AND [a0].[CountryId] = [a1].[CountryId])
     FROM [Animals] AS [a0]
     WHERE [a0].[CountryId] = 1
     GROUP BY [a0].[CountryId]
-    HAVING COUNT(*) < 3 AND (
-        SELECT TOP(1) [a1].[Id]
-        FROM [Animals] AS [a1]
-        WHERE [a1].[CountryId] = 1 AND [a0].[CountryId] = [a1].[CountryId]) = [a].[Id])
+    HAVING COUNT(*) < 3
+)
 """);
     }
 
@@ -122,16 +123,13 @@ WHERE [a].[CountryId] = 1 AND EXISTS (
 
 DELETE FROM [a]
 FROM [Animals] AS [a]
-WHERE EXISTS (
-    SELECT 1
-    FROM (
-        SELECT [a0].[Id], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[Species], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
-        FROM [Animals] AS [a0]
-        WHERE [a0].[CountryId] = 1 AND [a0].[Name] = N'Great spotted kiwi'
-        ORDER BY [a0].[Name]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-    ) AS [t]
-    WHERE [t].[Id] = [a].[Id])
+WHERE [a].[Id] IN (
+    SELECT [a0].[Id]
+    FROM [Animals] AS [a0]
+    WHERE [a0].[CountryId] = 1 AND [a0].[Name] = N'Great spotted kiwi'
+    ORDER BY [a0].[Name]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqlServerTest.cs
@@ -95,14 +95,15 @@ WHERE (
 """
 DELETE FROM [a]
 FROM [Animals] AS [a]
-WHERE EXISTS (
-    SELECT 1
-    FROM [Animals] AS [a0]
-    GROUP BY [a0].[CountryId]
-    HAVING COUNT(*) < 3 AND (
+WHERE [a].[Id] IN (
+    SELECT (
         SELECT TOP(1) [a1].[Id]
         FROM [Animals] AS [a1]
-        WHERE [a0].[CountryId] = [a1].[CountryId]) = [a].[Id])
+        WHERE [a0].[CountryId] = [a1].[CountryId])
+    FROM [Animals] AS [a0]
+    GROUP BY [a0].[CountryId]
+    HAVING COUNT(*) < 3
+)
 """);
     }
 
@@ -124,16 +125,13 @@ WHERE EXISTS (
 
 DELETE FROM [a]
 FROM [Animals] AS [a]
-WHERE EXISTS (
-    SELECT 1
-    FROM (
-        SELECT [a0].[Id], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[Species], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
-        FROM [Animals] AS [a0]
-        WHERE [a0].[Name] = N'Great spotted kiwi'
-        ORDER BY [a0].[Name]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-    ) AS [t]
-    WHERE [t].[Id] = [a].[Id])
+WHERE [a].[Id] IN (
+    SELECT [a0].[Id]
+    FROM [Animals] AS [a0]
+    WHERE [a0].[Name] = N'Great spotted kiwi'
+    ORDER BY [a0].[Name]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -742,13 +742,13 @@ WHERE [c].[CustomerID] LIKE N'F%'
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [c0].[CustomerID]
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS
-)
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -779,13 +779,13 @@ WHERE [c].[CustomerID] LIKE N'F%'
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [c0].[CustomerID]
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-)
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -798,11 +798,11 @@ WHERE [c].[CustomerID] IN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [c0].[CustomerID]
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
-)
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -817,13 +817,13 @@ WHERE [c].[CustomerID] IN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [c0].[CustomerID]
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY [c0].[City]
     OFFSET @__p_0 ROWS
-)
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -838,12 +838,12 @@ WHERE [c].[CustomerID] IN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT TOP(@__p_0) [c0].[CustomerID]
+INNER JOIN (
+    SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY [c0].[City]
-)
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -859,13 +859,13 @@ WHERE [c].[CustomerID] IN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [c0].[CustomerID]
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY [c0].[City]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-)
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -881,8 +881,8 @@ WHERE [c].[CustomerID] IN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [t].[CustomerID]
+INNER JOIN (
+    SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
     FROM (
         SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -892,7 +892,7 @@ WHERE [c].[CustomerID] IN (
     ) AS [t]
     ORDER BY [t].[City]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
-)
+) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 """);
     }
 
@@ -1145,18 +1145,15 @@ WHERE [c].[CustomerID] LIKE N'F%'
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [t].[CustomerID]
-    FROM (
-        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-        FROM [Customers] AS [c0]
-        WHERE [c0].[CustomerID] LIKE N'F%'
-        UNION
-        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
-        FROM [Customers] AS [c1]
-        WHERE [c1].[CustomerID] LIKE N'A%'
-    ) AS [t]
-)
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'F%'
+    UNION
+    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    FROM [Customers] AS [c1]
+    WHERE [c1].[CustomerID] LIKE N'A%'
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -1169,18 +1166,15 @@ WHERE [c].[CustomerID] IN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [t].[CustomerID]
-    FROM (
-        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-        FROM [Customers] AS [c0]
-        WHERE [c0].[CustomerID] LIKE N'F%'
-        UNION ALL
-        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
-        FROM [Customers] AS [c1]
-        WHERE [c1].[CustomerID] LIKE N'A%'
-    ) AS [t]
-)
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'F%'
+    UNION ALL
+    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    FROM [Customers] AS [c1]
+    WHERE [c1].[CustomerID] LIKE N'A%'
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -1193,18 +1187,15 @@ WHERE [c].[CustomerID] IN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [t].[CustomerID]
-    FROM (
-        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-        FROM [Customers] AS [c0]
-        WHERE [c0].[CustomerID] LIKE N'F%'
-        EXCEPT
-        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
-        FROM [Customers] AS [c1]
-        WHERE [c1].[CustomerID] LIKE N'A%'
-    ) AS [t]
-)
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'F%'
+    EXCEPT
+    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    FROM [Customers] AS [c1]
+    WHERE [c1].[CustomerID] LIKE N'A%'
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -1217,18 +1208,15 @@ WHERE [c].[CustomerID] IN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (
-    SELECT [t].[CustomerID]
-    FROM (
-        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-        FROM [Customers] AS [c0]
-        WHERE [c0].[CustomerID] LIKE N'F%'
-        INTERSECT
-        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
-        FROM [Customers] AS [c1]
-        WHERE [c1].[CustomerID] LIKE N'A%'
-    ) AS [t]
-)
+INNER JOIN (
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'F%'
+    INTERSECT
+    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+    FROM [Customers] AS [c1]
+    WHERE [c1].[CustomerID] LIKE N'A%'
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 """);
     }
 
@@ -1407,8 +1395,8 @@ WHERE [c].[CustomerID] LIKE N'F%'
 UPDATE [o]
 SET [o].[OrderDate] = NULL
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] IN (
-    SELECT [t].[OrderID]
+INNER JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID] AS [CustomerID0]
     FROM [Customers] AS [c]
     INNER JOIN (
         SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
@@ -1416,7 +1404,7 @@ WHERE [o].[OrderID] IN (
         WHERE DATEPART(year, [o0].[OrderDate]) = 1997
     ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
     WHERE [c].[CustomerID] LIKE N'F%'
-)
+) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -235,14 +235,15 @@ WHERE [o].[OrderID] < (
 DELETE FROM [o]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE EXISTS (
-    SELECT 1
-    FROM [Orders] AS [o1]
-    GROUP BY [o1].[CustomerID]
-    HAVING COUNT(*) > 9 AND (
+WHERE [o0].[OrderID] IN (
+    SELECT (
         SELECT TOP(1) [o2].[OrderID]
         FROM [Orders] AS [o2]
-        WHERE [o1].[CustomerID] = [o2].[CustomerID] OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL)) = [o0].[OrderID])
+        WHERE [o1].[CustomerID] = [o2].[CustomerID] OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))
+    FROM [Orders] AS [o1]
+    GROUP BY [o1].[CustomerID]
+    HAVING COUNT(*) > 9
+)
 """);
     }
 
@@ -741,13 +742,13 @@ WHERE [c].[CustomerID] LIKE N'F%'
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+WHERE [c].[CustomerID] IN (
+    SELECT [c0].[CustomerID]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+)
 """);
     }
 
@@ -778,13 +779,13 @@ WHERE [c].[CustomerID] LIKE N'F%'
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+WHERE [c].[CustomerID] IN (
+    SELECT [c0].[CustomerID]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+)
 """);
     }
 
@@ -797,11 +798,11 @@ INNER JOIN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+WHERE [c].[CustomerID] IN (
+    SELECT [c0].[CustomerID]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+)
 """);
     }
 
@@ -816,13 +817,13 @@ INNER JOIN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+WHERE [c].[CustomerID] IN (
+    SELECT [c0].[CustomerID]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY [c0].[City]
     OFFSET @__p_0 ROWS
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+)
 """);
     }
 
@@ -837,12 +838,12 @@ INNER JOIN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+WHERE [c].[CustomerID] IN (
+    SELECT TOP(@__p_0) [c0].[CustomerID]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY [c0].[City]
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+)
 """);
     }
 
@@ -858,13 +859,13 @@ INNER JOIN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+WHERE [c].[CustomerID] IN (
+    SELECT [c0].[CustomerID]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'F%'
     ORDER BY [c0].[City]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+)
 """);
     }
 
@@ -880,8 +881,8 @@ INNER JOIN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+WHERE [c].[CustomerID] IN (
+    SELECT [t].[CustomerID]
     FROM (
         SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -891,7 +892,7 @@ INNER JOIN (
     ) AS [t]
     ORDER BY [t].[City]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
-) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
+)
 """);
     }
 
@@ -948,15 +949,16 @@ WHERE [c].[CustomerID] = (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-WHERE EXISTS (
-    SELECT 1
-    FROM [Orders] AS [o]
-    GROUP BY [o].[CustomerID]
-    HAVING COUNT(*) > 11 AND (
+WHERE [c].[CustomerID] IN (
+    SELECT (
         SELECT TOP(1) [c0].[CustomerID]
         FROM [Orders] AS [o0]
         LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-        WHERE [o].[CustomerID] = [o0].[CustomerID] OR ([o].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL)) = [c].[CustomerID])
+        WHERE [o].[CustomerID] = [o0].[CustomerID] OR ([o].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    HAVING COUNT(*) > 11
+)
 """);
     }
 
@@ -1143,15 +1145,18 @@ WHERE [c].[CustomerID] LIKE N'F%'
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'F%'
-    UNION
-    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
-    FROM [Customers] AS [c1]
-    WHERE [c1].[CustomerID] LIKE N'A%'
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] IN (
+    SELECT [t].[CustomerID]
+    FROM (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        WHERE [c0].[CustomerID] LIKE N'F%'
+        UNION
+        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+        FROM [Customers] AS [c1]
+        WHERE [c1].[CustomerID] LIKE N'A%'
+    ) AS [t]
+)
 """);
     }
 
@@ -1164,15 +1169,18 @@ INNER JOIN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'F%'
-    UNION ALL
-    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
-    FROM [Customers] AS [c1]
-    WHERE [c1].[CustomerID] LIKE N'A%'
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] IN (
+    SELECT [t].[CustomerID]
+    FROM (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        WHERE [c0].[CustomerID] LIKE N'F%'
+        UNION ALL
+        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+        FROM [Customers] AS [c1]
+        WHERE [c1].[CustomerID] LIKE N'A%'
+    ) AS [t]
+)
 """);
     }
 
@@ -1185,15 +1193,18 @@ INNER JOIN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'F%'
-    EXCEPT
-    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
-    FROM [Customers] AS [c1]
-    WHERE [c1].[CustomerID] LIKE N'A%'
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] IN (
+    SELECT [t].[CustomerID]
+    FROM (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        WHERE [c0].[CustomerID] LIKE N'F%'
+        EXCEPT
+        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+        FROM [Customers] AS [c1]
+        WHERE [c1].[CustomerID] LIKE N'A%'
+    ) AS [t]
+)
 """);
     }
 
@@ -1206,15 +1217,18 @@ INNER JOIN (
 UPDATE [c]
 SET [c].[ContactName] = N'Updated'
 FROM [Customers] AS [c]
-INNER JOIN (
-    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'F%'
-    INTERSECT
-    SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
-    FROM [Customers] AS [c1]
-    WHERE [c1].[CustomerID] LIKE N'A%'
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] IN (
+    SELECT [t].[CustomerID]
+    FROM (
+        SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        WHERE [c0].[CustomerID] LIKE N'F%'
+        INTERSECT
+        SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+        FROM [Customers] AS [c1]
+        WHERE [c1].[CustomerID] LIKE N'A%'
+    ) AS [t]
+)
 """);
     }
 
@@ -1393,8 +1407,8 @@ WHERE [c].[CustomerID] LIKE N'F%'
 UPDATE [o]
 SET [o].[OrderDate] = NULL
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[CustomerID] AS [CustomerID0]
+WHERE [o].[OrderID] IN (
+    SELECT [t].[OrderID]
     FROM [Customers] AS [c]
     INNER JOIN (
         SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
@@ -1402,7 +1416,7 @@ INNER JOIN (
         WHERE DATEPART(year, [o0].[OrderDate]) = 1997
     ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
     WHERE [c].[CustomerID] LIKE N'F%'
-) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
+)
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7125,18 +7125,20 @@ FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
     FROM [Gears] AS [g]
     INNER JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [s].[Id] IN (
+        SELECT [s0].[Id]
         FROM [Squads] AS [s0]
-        WHERE [s0].[Id] = @__squadId_0 AND [s0].[Id] = [s].[Id])
+        WHERE [s0].[Id] = @__squadId_0
+    )
     UNION ALL
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
     FROM [Gears] AS [g0]
     INNER JOIN [Squads] AS [s1] ON [g0].[SquadId] = [s1].[Id]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [s1].[Id] IN (
+        SELECT [s2].[Id]
         FROM [Squads] AS [s2]
-        WHERE [s2].[Id] = @__squadId_0 AND [s2].[Id] = [s1].[Id])
+        WHERE [s2].[Id] = @__squadId_0
+    )
 ) AS [t]
 ORDER BY [t].[FullName]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1940,10 +1940,11 @@ FROM [Orders] AS [o]
 WHERE EXISTS (
     SELECT 1
     FROM [Customers] AS [c]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [o].[OrderID] IN (
+        SELECT [o0].[OrderID]
         FROM [Orders] AS [o0]
-        WHERE [c].[CustomerID] = [o0].[CustomerID] AND [o0].[OrderID] = [o].[OrderID]))
+        WHERE [c].[CustomerID] = [o0].[CustomerID]
+    ))
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -131,15 +131,16 @@ SELECT cast(null as int) AS MyValue
 @__currentUserId_0='1'
 
 SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [u].[Id] IN (
+        SELECT [u0].[Id]
         FROM [Memberships] AS [m]
         INNER JOIN [Users] AS [u0] ON [m].[UserId] = [u0].[Id]
         WHERE [m].[GroupId] IN (
             SELECT [m0].[GroupId]
             FROM [Memberships] AS [m0]
             WHERE [m0].[UserId] = @__currentUserId_0
-        ) AND [u0].[Id] = [u].[Id]) THEN CAST(1 AS bit)
+        )
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [HasAccess]
 FROM [Users] AS [u]
@@ -155,16 +156,18 @@ FROM [Users] AS [u]
 @__currentUserId_0='1'
 
 SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
+    WHEN [u].[Id] IN (
+        SELECT [u0].[Id]
         FROM [Memberships] AS [m]
         INNER JOIN [Groups] AS [g] ON [m].[GroupId] = [g].[Id]
         INNER JOIN [Users] AS [u0] ON [m].[UserId] = [u0].[Id]
-        WHERE EXISTS (
-            SELECT 1
+        WHERE [g].[Id] IN (
+            SELECT [g0].[Id]
             FROM [Memberships] AS [m0]
             INNER JOIN [Groups] AS [g0] ON [m0].[GroupId] = [g0].[Id]
-            WHERE [m0].[UserId] = @__currentUserId_0 AND [g0].[Id] = [g].[Id]) AND [u0].[Id] = [u].[Id]) THEN CAST(1 AS bit)
+            WHERE [m0].[UserId] = @__currentUserId_0
+        )
+    ) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [HasAccess]
 FROM [Users] AS [u]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -9476,10 +9476,11 @@ FROM (
         FROM [Officers] AS [o]
     ) AS [t]
     INNER JOIN [Squads] AS [s] ON [t].[SquadId] = [s].[Id]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [s].[Id] IN (
+        SELECT [s0].[Id]
         FROM [Squads] AS [s0]
-        WHERE [s0].[Id] = @__squadId_0 AND [s0].[Id] = [s].[Id])
+        WHERE [s0].[Id] = @__squadId_0
+    )
     UNION ALL
     SELECT [t1].[Nickname], [t1].[SquadId], [t1].[AssignedCityName], [t1].[CityOfBirthName], [t1].[FullName], [t1].[HasSoulPatch], [t1].[LeaderNickname], [t1].[LeaderSquadId], [t1].[Rank], [t1].[Discriminator]
     FROM (
@@ -9490,10 +9491,11 @@ FROM (
         FROM [Officers] AS [o0]
     ) AS [t1]
     INNER JOIN [Squads] AS [s1] ON [t1].[SquadId] = [s1].[Id]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [s1].[Id] IN (
+        SELECT [s2].[Id]
         FROM [Squads] AS [s2]
-        WHERE [s2].[Id] = @__squadId_0 AND [s2].[Id] = [s1].[Id])
+        WHERE [s2].[Id] = @__squadId_0
+    )
 ) AS [t0]
 ORDER BY [t0].[FullName]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -8160,10 +8160,11 @@ FROM (
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId] = [o].[SquadId]
     INNER JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [s].[Id] IN (
+        SELECT [s0].[Id]
         FROM [Squads] AS [s0]
-        WHERE [s0].[Id] = @__squadId_0 AND [s0].[Id] = [s].[Id])
+        WHERE [s0].[Id] = @__squadId_0
+    )
     UNION ALL
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], CASE
         WHEN [o0].[Nickname] IS NOT NULL THEN N'Officer'
@@ -8171,10 +8172,11 @@ FROM (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON [g0].[Nickname] = [o0].[Nickname] AND [g0].[SquadId] = [o0].[SquadId]
     INNER JOIN [Squads] AS [s1] ON [g0].[SquadId] = [s1].[Id]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [s1].[Id] IN (
+        SELECT [s2].[Id]
         FROM [Squads] AS [s2]
-        WHERE [s2].[Id] = @__squadId_0 AND [s2].[Id] = [s1].[Id])
+        WHERE [s2].[Id] = @__squadId_0
+    )
 ) AS [t]
 ORDER BY [t].[FullName]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -143,18 +143,20 @@ FROM (
     SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[PeriodEnd], [g].[PeriodStart], [g].[Rank]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
     INNER JOIN [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s] ON [g].[SquadId] = [s].[Id]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [s].[Id] IN (
+        SELECT [s0].[Id]
         FROM [Squads] AS [s0]
-        WHERE [s0].[Id] = @__squadId_0 AND [s0].[Id] = [s].[Id])
+        WHERE [s0].[Id] = @__squadId_0
+    )
     UNION ALL
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[PeriodEnd], [g0].[PeriodStart], [g0].[Rank]
     FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g0]
     INNER JOIN [Squads] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s1] ON [g0].[SquadId] = [s1].[Id]
-    WHERE EXISTS (
-        SELECT 1
+    WHERE [s1].[Id] IN (
+        SELECT [s2].[Id]
         FROM [Squads] AS [s2]
-        WHERE [s2].[Id] = @__squadId_0 AND [s2].[Id] = [s1].[Id])
+        WHERE [s2].[Id] = @__squadId_0
+    )
 ) AS [t]
 ORDER BY [t].[FullName]
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesSqliteTest.cs
@@ -36,16 +36,13 @@ WHERE "a"."CountryId" = 1 AND "a"."Name" = 'Great spotted kiwi'
 @__p_0='0'
 
 DELETE FROM "Animals" AS "a"
-WHERE EXISTS (
-    SELECT 1
-    FROM (
-        SELECT "a0"."Id", "a0"."CountryId", "a0"."Discriminator", "a0"."Name", "a0"."Species", "a0"."EagleId", "a0"."IsFlightless", "a0"."Group", "a0"."FoundOn"
-        FROM "Animals" AS "a0"
-        WHERE "a0"."CountryId" = 1 AND "a0"."Name" = 'Great spotted kiwi'
-        ORDER BY "a0"."Name"
-        LIMIT @__p_1 OFFSET @__p_0
-    ) AS "t"
-    WHERE "t"."Id" = "a"."Id")
+WHERE "a"."Id" IN (
+    SELECT "a0"."Id"
+    FROM "Animals" AS "a0"
+    WHERE "a0"."CountryId" = 1 AND "a0"."Name" = 'Great spotted kiwi'
+    ORDER BY "a0"."Name"
+    LIMIT @__p_1 OFFSET @__p_0
+)
 """);
     }
 
@@ -116,16 +113,17 @@ WHERE (
         AssertSql(
 """
 DELETE FROM "Animals" AS "a"
-WHERE "a"."CountryId" = 1 AND EXISTS (
-    SELECT 1
-    FROM "Animals" AS "a0"
-    WHERE "a0"."CountryId" = 1
-    GROUP BY "a0"."CountryId"
-    HAVING COUNT(*) < 3 AND (
+WHERE "a"."CountryId" = 1 AND "a"."Id" IN (
+    SELECT (
         SELECT "a1"."Id"
         FROM "Animals" AS "a1"
         WHERE "a1"."CountryId" = 1 AND "a0"."CountryId" = "a1"."CountryId"
-        LIMIT 1) = "a"."Id")
+        LIMIT 1)
+    FROM "Animals" AS "a0"
+    WHERE "a0"."CountryId" = 1
+    GROUP BY "a0"."CountryId"
+    HAVING COUNT(*) < 3
+)
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesSqliteTest.cs
@@ -39,16 +39,13 @@ WHERE "a"."Name" = 'Great spotted kiwi'
 @__p_0='0'
 
 DELETE FROM "Animals" AS "a"
-WHERE EXISTS (
-    SELECT 1
-    FROM (
-        SELECT "a0"."Id", "a0"."CountryId", "a0"."Discriminator", "a0"."Name", "a0"."Species", "a0"."EagleId", "a0"."IsFlightless", "a0"."Group", "a0"."FoundOn"
-        FROM "Animals" AS "a0"
-        WHERE "a0"."Name" = 'Great spotted kiwi'
-        ORDER BY "a0"."Name"
-        LIMIT @__p_1 OFFSET @__p_0
-    ) AS "t"
-    WHERE "t"."Id" = "a"."Id")
+WHERE "a"."Id" IN (
+    SELECT "a0"."Id"
+    FROM "Animals" AS "a0"
+    WHERE "a0"."Name" = 'Great spotted kiwi'
+    ORDER BY "a0"."Name"
+    LIMIT @__p_1 OFFSET @__p_0
+)
 """);
     }
 
@@ -119,15 +116,16 @@ WHERE (
         AssertSql(
 """
 DELETE FROM "Animals" AS "a"
-WHERE EXISTS (
-    SELECT 1
-    FROM "Animals" AS "a0"
-    GROUP BY "a0"."CountryId"
-    HAVING COUNT(*) < 3 AND (
+WHERE "a"."Id" IN (
+    SELECT (
         SELECT "a1"."Id"
         FROM "Animals" AS "a1"
         WHERE "a0"."CountryId" = "a1"."CountryId"
-        LIMIT 1) = "a"."Id")
+        LIMIT 1)
+    FROM "Animals" AS "a0"
+    GROUP BY "a0"."CountryId"
+    HAVING COUNT(*) < 3
+)
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -71,11 +71,12 @@ SET "Title" = COALESCE("o"."Title", '') || '_Suffix'
         AssertSql(
 """
 DELETE FROM "Posts" AS "p"
-WHERE EXISTS (
-    SELECT 1
+WHERE "p"."Id" IN (
+    SELECT "p0"."Id"
     FROM "Posts" AS "p0"
     LEFT JOIN "Blogs" AS "b" ON "p0"."BlogId" = "b"."Id"
-    WHERE "b"."Title" IS NOT NULL AND "b"."Title" LIKE 'Arthur%' AND "p0"."Id" = "p"."Id")
+    WHERE "b"."Title" IS NOT NULL AND "b"."Title" LIKE 'Arthur%'
+)
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -712,12 +712,13 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "c0"."CustomerID"
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     LIMIT -1 OFFSET @__p_0
-)
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -731,12 +732,13 @@ WHERE "c"."CustomerID" IN (
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "c0"."CustomerID"
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     LIMIT @__p_0
-)
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -751,12 +753,13 @@ WHERE "c"."CustomerID" IN (
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "c0"."CustomerID"
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     LIMIT @__p_1 OFFSET @__p_0
-)
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -768,11 +771,12 @@ WHERE "c"."CustomerID" IN (
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "c0"."CustomerID"
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
-)
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -786,13 +790,14 @@ WHERE "c"."CustomerID" IN (
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "c0"."CustomerID"
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     ORDER BY "c0"."City"
     LIMIT -1 OFFSET @__p_0
-)
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -806,13 +811,14 @@ WHERE "c"."CustomerID" IN (
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "c0"."CustomerID"
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     ORDER BY "c0"."City"
     LIMIT @__p_0
-)
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -827,13 +833,14 @@ WHERE "c"."CustomerID" IN (
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "c0"."CustomerID"
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     ORDER BY "c0"."City"
     LIMIT @__p_1 OFFSET @__p_0
-)
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -848,8 +855,8 @@ WHERE "c"."CustomerID" IN (
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "t"."CustomerID"
+FROM (
+    SELECT "t"."CustomerID", "t"."Address", "t"."City", "t"."CompanyName", "t"."ContactName", "t"."ContactTitle", "t"."Country", "t"."Fax", "t"."Phone", "t"."PostalCode", "t"."Region"
     FROM (
         SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
         FROM "Customers" AS "c0"
@@ -859,7 +866,8 @@ WHERE "c"."CustomerID" IN (
     ) AS "t"
     ORDER BY "t"."City"
     LIMIT @__p_0 OFFSET @__p_0
-)
+) AS "t0"
+WHERE "c"."CustomerID" = "t0"."CustomerID"
 """);
     }
 
@@ -950,12 +958,13 @@ WHERE "c"."CustomerID" LIKE 'F%'
 """
 UPDATE "Orders" AS "o"
 SET "OrderDate" = NULL
-WHERE "o"."OrderID" IN (
-    SELECT "o0"."OrderID"
+FROM (
+    SELECT "o0"."OrderID", "o0"."CustomerID", "o0"."EmployeeID", "o0"."OrderDate", "c"."CustomerID" AS "CustomerID0"
     FROM "Orders" AS "o0"
     LEFT JOIN "Customers" AS "c" ON "o0"."CustomerID" = "c"."CustomerID"
     WHERE "c"."City" = 'Seattle'
-)
+) AS "t"
+WHERE "o"."OrderID" = "t"."OrderID"
 """);
     }
 
@@ -1106,18 +1115,16 @@ WHERE "c"."CustomerID" LIKE 'F%'
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "t"."CustomerID"
-    FROM (
-        SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
-        FROM "Customers" AS "c0"
-        WHERE "c0"."CustomerID" LIKE 'F%'
-        UNION
-        SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
-        FROM "Customers" AS "c1"
-        WHERE "c1"."CustomerID" LIKE 'A%'
-    ) AS "t"
-)
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+    FROM "Customers" AS "c0"
+    WHERE "c0"."CustomerID" LIKE 'F%'
+    UNION
+    SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
+    FROM "Customers" AS "c1"
+    WHERE "c1"."CustomerID" LIKE 'A%'
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -1129,18 +1136,16 @@ WHERE "c"."CustomerID" IN (
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "t"."CustomerID"
-    FROM (
-        SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
-        FROM "Customers" AS "c0"
-        WHERE "c0"."CustomerID" LIKE 'F%'
-        UNION ALL
-        SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
-        FROM "Customers" AS "c1"
-        WHERE "c1"."CustomerID" LIKE 'A%'
-    ) AS "t"
-)
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+    FROM "Customers" AS "c0"
+    WHERE "c0"."CustomerID" LIKE 'F%'
+    UNION ALL
+    SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
+    FROM "Customers" AS "c1"
+    WHERE "c1"."CustomerID" LIKE 'A%'
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -1152,18 +1157,16 @@ WHERE "c"."CustomerID" IN (
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "t"."CustomerID"
-    FROM (
-        SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
-        FROM "Customers" AS "c0"
-        WHERE "c0"."CustomerID" LIKE 'F%'
-        EXCEPT
-        SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
-        FROM "Customers" AS "c1"
-        WHERE "c1"."CustomerID" LIKE 'A%'
-    ) AS "t"
-)
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+    FROM "Customers" AS "c0"
+    WHERE "c0"."CustomerID" LIKE 'F%'
+    EXCEPT
+    SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
+    FROM "Customers" AS "c1"
+    WHERE "c1"."CustomerID" LIKE 'A%'
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -1175,18 +1178,16 @@ WHERE "c"."CustomerID" IN (
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE "c"."CustomerID" IN (
-    SELECT "t"."CustomerID"
-    FROM (
-        SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
-        FROM "Customers" AS "c0"
-        WHERE "c0"."CustomerID" LIKE 'F%'
-        INTERSECT
-        SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
-        FROM "Customers" AS "c1"
-        WHERE "c1"."CustomerID" LIKE 'A%'
-    ) AS "t"
-)
+FROM (
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+    FROM "Customers" AS "c0"
+    WHERE "c0"."CustomerID" LIKE 'F%'
+    INTERSECT
+    SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
+    FROM "Customers" AS "c1"
+    WHERE "c1"."CustomerID" LIKE 'A%'
+) AS "t"
+WHERE "c"."CustomerID" = "t"."CustomerID"
 """);
     }
 
@@ -1306,8 +1307,8 @@ WHERE "c"."CustomerID" LIKE 'F%'
 """
 UPDATE "Orders" AS "o"
 SET "OrderDate" = NULL
-WHERE "o"."OrderID" IN (
-    SELECT "t"."OrderID"
+FROM (
+    SELECT "t"."OrderID", "t"."CustomerID", "t"."EmployeeID", "t"."OrderDate", "c"."CustomerID" AS "CustomerID0"
     FROM "Customers" AS "c"
     INNER JOIN (
         SELECT "o0"."OrderID", "o0"."CustomerID", "o0"."EmployeeID", "o0"."OrderDate"
@@ -1315,7 +1316,8 @@ WHERE "o"."OrderID" IN (
         WHERE CAST(strftime('%Y', "o0"."OrderDate") AS INTEGER) = 1997
     ) AS "t" ON "c"."CustomerID" = "t"."CustomerID"
     WHERE "c"."CustomerID" LIKE 'F%'
-)
+) AS "t0"
+WHERE "o"."OrderID" = "t0"."OrderID"
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -236,15 +236,16 @@ WHERE EXISTS (
     SELECT 1
     FROM "Order Details" AS "o0"
     INNER JOIN "Orders" AS "o1" ON "o0"."OrderID" = "o1"."OrderID"
-    WHERE EXISTS (
-        SELECT 1
-        FROM "Orders" AS "o2"
-        GROUP BY "o2"."CustomerID"
-        HAVING COUNT(*) > 9 AND (
+    WHERE "o1"."OrderID" IN (
+        SELECT (
             SELECT "o3"."OrderID"
             FROM "Orders" AS "o3"
             WHERE "o2"."CustomerID" = "o3"."CustomerID" OR ("o2"."CustomerID" IS NULL AND "o3"."CustomerID" IS NULL)
-            LIMIT 1) = "o1"."OrderID") AND "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
+            LIMIT 1)
+        FROM "Orders" AS "o2"
+        GROUP BY "o2"."CustomerID"
+        HAVING COUNT(*) > 9
+    ) AND "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
 """);
     }
 
@@ -711,13 +712,12 @@ WHERE "c"."CustomerID" LIKE 'F%'
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+WHERE "c"."CustomerID" IN (
+    SELECT "c0"."CustomerID"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     LIMIT -1 OFFSET @__p_0
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+)
 """);
     }
 
@@ -731,13 +731,12 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+WHERE "c"."CustomerID" IN (
+    SELECT "c0"."CustomerID"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     LIMIT @__p_0
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+)
 """);
     }
 
@@ -752,13 +751,12 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+WHERE "c"."CustomerID" IN (
+    SELECT "c0"."CustomerID"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     LIMIT @__p_1 OFFSET @__p_0
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+)
 """);
     }
 
@@ -770,12 +768,11 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+WHERE "c"."CustomerID" IN (
+    SELECT "c0"."CustomerID"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+)
 """);
     }
 
@@ -789,14 +786,13 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+WHERE "c"."CustomerID" IN (
+    SELECT "c0"."CustomerID"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     ORDER BY "c0"."City"
     LIMIT -1 OFFSET @__p_0
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+)
 """);
     }
 
@@ -810,14 +806,13 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+WHERE "c"."CustomerID" IN (
+    SELECT "c0"."CustomerID"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     ORDER BY "c0"."City"
     LIMIT @__p_0
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+)
 """);
     }
 
@@ -832,14 +827,13 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+WHERE "c"."CustomerID" IN (
+    SELECT "c0"."CustomerID"
     FROM "Customers" AS "c0"
     WHERE "c0"."CustomerID" LIKE 'F%'
     ORDER BY "c0"."City"
     LIMIT @__p_1 OFFSET @__p_0
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+)
 """);
     }
 
@@ -854,8 +848,8 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "t"."CustomerID", "t"."Address", "t"."City", "t"."CompanyName", "t"."ContactName", "t"."ContactTitle", "t"."Country", "t"."Fax", "t"."Phone", "t"."PostalCode", "t"."Region"
+WHERE "c"."CustomerID" IN (
+    SELECT "t"."CustomerID"
     FROM (
         SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
         FROM "Customers" AS "c0"
@@ -865,8 +859,7 @@ FROM (
     ) AS "t"
     ORDER BY "t"."City"
     LIMIT @__p_0 OFFSET @__p_0
-) AS "t0"
-WHERE "c"."CustomerID" = "t0"."CustomerID"
+)
 """);
     }
 
@@ -923,16 +916,17 @@ WHERE "c"."CustomerID" = (
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-WHERE EXISTS (
-    SELECT 1
-    FROM "Orders" AS "o"
-    GROUP BY "o"."CustomerID"
-    HAVING COUNT(*) > 11 AND (
+WHERE "c"."CustomerID" IN (
+    SELECT (
         SELECT "c0"."CustomerID"
         FROM "Orders" AS "o0"
         LEFT JOIN "Customers" AS "c0" ON "o0"."CustomerID" = "c0"."CustomerID"
         WHERE "o"."CustomerID" = "o0"."CustomerID" OR ("o"."CustomerID" IS NULL AND "o0"."CustomerID" IS NULL)
-        LIMIT 1) = "c"."CustomerID")
+        LIMIT 1)
+    FROM "Orders" AS "o"
+    GROUP BY "o"."CustomerID"
+    HAVING COUNT(*) > 11
+)
 """);
     }
 
@@ -956,13 +950,12 @@ WHERE "c"."CustomerID" LIKE 'F%'
 """
 UPDATE "Orders" AS "o"
 SET "OrderDate" = NULL
-FROM (
-    SELECT "o0"."OrderID", "o0"."CustomerID", "o0"."EmployeeID", "o0"."OrderDate", "c"."CustomerID" AS "CustomerID0"
+WHERE "o"."OrderID" IN (
+    SELECT "o0"."OrderID"
     FROM "Orders" AS "o0"
     LEFT JOIN "Customers" AS "c" ON "o0"."CustomerID" = "c"."CustomerID"
     WHERE "c"."City" = 'Seattle'
-) AS "t"
-WHERE "o"."OrderID" = "t"."OrderID"
+)
 """);
     }
 
@@ -1113,16 +1106,18 @@ WHERE "c"."CustomerID" LIKE 'F%'
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
-    FROM "Customers" AS "c0"
-    WHERE "c0"."CustomerID" LIKE 'F%'
-    UNION
-    SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
-    FROM "Customers" AS "c1"
-    WHERE "c1"."CustomerID" LIKE 'A%'
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+WHERE "c"."CustomerID" IN (
+    SELECT "t"."CustomerID"
+    FROM (
+        SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+        FROM "Customers" AS "c0"
+        WHERE "c0"."CustomerID" LIKE 'F%'
+        UNION
+        SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
+        FROM "Customers" AS "c1"
+        WHERE "c1"."CustomerID" LIKE 'A%'
+    ) AS "t"
+)
 """);
     }
 
@@ -1134,16 +1129,18 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
-    FROM "Customers" AS "c0"
-    WHERE "c0"."CustomerID" LIKE 'F%'
-    UNION ALL
-    SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
-    FROM "Customers" AS "c1"
-    WHERE "c1"."CustomerID" LIKE 'A%'
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+WHERE "c"."CustomerID" IN (
+    SELECT "t"."CustomerID"
+    FROM (
+        SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+        FROM "Customers" AS "c0"
+        WHERE "c0"."CustomerID" LIKE 'F%'
+        UNION ALL
+        SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
+        FROM "Customers" AS "c1"
+        WHERE "c1"."CustomerID" LIKE 'A%'
+    ) AS "t"
+)
 """);
     }
 
@@ -1155,16 +1152,18 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
-    FROM "Customers" AS "c0"
-    WHERE "c0"."CustomerID" LIKE 'F%'
-    EXCEPT
-    SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
-    FROM "Customers" AS "c1"
-    WHERE "c1"."CustomerID" LIKE 'A%'
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+WHERE "c"."CustomerID" IN (
+    SELECT "t"."CustomerID"
+    FROM (
+        SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+        FROM "Customers" AS "c0"
+        WHERE "c0"."CustomerID" LIKE 'F%'
+        EXCEPT
+        SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
+        FROM "Customers" AS "c1"
+        WHERE "c1"."CustomerID" LIKE 'A%'
+    ) AS "t"
+)
 """);
     }
 
@@ -1176,16 +1175,18 @@ WHERE "c"."CustomerID" = "t"."CustomerID"
 """
 UPDATE "Customers" AS "c"
 SET "ContactName" = 'Updated'
-FROM (
-    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
-    FROM "Customers" AS "c0"
-    WHERE "c0"."CustomerID" LIKE 'F%'
-    INTERSECT
-    SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
-    FROM "Customers" AS "c1"
-    WHERE "c1"."CustomerID" LIKE 'A%'
-) AS "t"
-WHERE "c"."CustomerID" = "t"."CustomerID"
+WHERE "c"."CustomerID" IN (
+    SELECT "t"."CustomerID"
+    FROM (
+        SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+        FROM "Customers" AS "c0"
+        WHERE "c0"."CustomerID" LIKE 'F%'
+        INTERSECT
+        SELECT "c1"."CustomerID", "c1"."Address", "c1"."City", "c1"."CompanyName", "c1"."ContactName", "c1"."ContactTitle", "c1"."Country", "c1"."Fax", "c1"."Phone", "c1"."PostalCode", "c1"."Region"
+        FROM "Customers" AS "c1"
+        WHERE "c1"."CustomerID" LIKE 'A%'
+    ) AS "t"
+)
 """);
     }
 
@@ -1261,19 +1262,21 @@ WHERE "c"."CustomerID" LIKE 'F%'
         await base.Update_with_cross_join_left_join_set_constant(async);
 
         AssertExecuteUpdateSql(
-            @"UPDATE ""Customers"" AS ""c""
-SET ""ContactName"" = 'Updated'
+"""
+UPDATE "Customers" AS "c"
+SET "ContactName" = 'Updated'
 FROM (
-    SELECT ""c0"".""CustomerID"", ""c0"".""Address"", ""c0"".""City"", ""c0"".""CompanyName"", ""c0"".""ContactName"", ""c0"".""ContactTitle"", ""c0"".""Country"", ""c0"".""Fax"", ""c0"".""Phone"", ""c0"".""PostalCode"", ""c0"".""Region""
-    FROM ""Customers"" AS ""c0""
-    WHERE ""c0"".""City"" IS NOT NULL AND (""c0"".""City"" LIKE 'S%')
-) AS ""t""
+    SELECT "c0"."CustomerID", "c0"."Address", "c0"."City", "c0"."CompanyName", "c0"."ContactName", "c0"."ContactTitle", "c0"."Country", "c0"."Fax", "c0"."Phone", "c0"."PostalCode", "c0"."Region"
+    FROM "Customers" AS "c0"
+    WHERE "c0"."City" IS NOT NULL AND ("c0"."City" LIKE 'S%')
+) AS "t"
 LEFT JOIN (
-    SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
-    FROM ""Orders"" AS ""o""
-    WHERE ""o"".""OrderID"" < 10300
-) AS ""t0"" ON ""c"".""CustomerID"" = ""t0"".""CustomerID""
-WHERE ""c"".""CustomerID"" LIKE 'F%'");
+    SELECT "o"."OrderID", "o"."CustomerID", "o"."EmployeeID", "o"."OrderDate"
+    FROM "Orders" AS "o"
+    WHERE "o"."OrderID" < 10300
+) AS "t0" ON "c"."CustomerID" = "t0"."CustomerID"
+WHERE "c"."CustomerID" LIKE 'F%'
+""");
     }
 
     public override async Task Update_with_cross_join_cross_apply_set_constant(bool async)
@@ -1303,8 +1306,8 @@ WHERE ""c"".""CustomerID"" LIKE 'F%'");
 """
 UPDATE "Orders" AS "o"
 SET "OrderDate" = NULL
-FROM (
-    SELECT "t"."OrderID", "t"."CustomerID", "t"."EmployeeID", "t"."OrderDate", "c"."CustomerID" AS "CustomerID0"
+WHERE "o"."OrderID" IN (
+    SELECT "t"."OrderID"
     FROM "Customers" AS "c"
     INNER JOIN (
         SELECT "o0"."OrderID", "o0"."CustomerID", "o0"."EmployeeID", "o0"."OrderDate"
@@ -1312,8 +1315,7 @@ FROM (
         WHERE CAST(strftime('%Y', "o0"."OrderDate") AS INTEGER) = 1997
     ) AS "t" ON "c"."CustomerID" = "t"."CustomerID"
     WHERE "c"."CustomerID" LIKE 'F%'
-) AS "t0"
-WHERE "o"."OrderID" = "t0"."OrderID"
+)
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -7071,18 +7071,20 @@ FROM (
     SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
     FROM "Gears" AS "g"
     INNER JOIN "Squads" AS "s" ON "g"."SquadId" = "s"."Id"
-    WHERE EXISTS (
-        SELECT 1
+    WHERE "s"."Id" IN (
+        SELECT "s0"."Id"
         FROM "Squads" AS "s0"
-        WHERE "s0"."Id" = @__squadId_0 AND "s0"."Id" = "s"."Id")
+        WHERE "s0"."Id" = @__squadId_0
+    )
     UNION ALL
     SELECT "g0"."Nickname", "g0"."SquadId", "g0"."AssignedCityName", "g0"."CityOfBirthName", "g0"."Discriminator", "g0"."FullName", "g0"."HasSoulPatch", "g0"."LeaderNickname", "g0"."LeaderSquadId", "g0"."Rank"
     FROM "Gears" AS "g0"
     INNER JOIN "Squads" AS "s1" ON "g0"."SquadId" = "s1"."Id"
-    WHERE EXISTS (
-        SELECT 1
+    WHERE "s1"."Id" IN (
+        SELECT "s2"."Id"
         FROM "Squads" AS "s2"
-        WHERE "s2"."Id" = @__squadId_0 AND "s2"."Id" = "s1"."Id")
+        WHERE "s2"."Id" = @__squadId_0
+    )
 ) AS "t"
 ORDER BY "t"."FullName"
 """);


### PR DESCRIPTION
* First, this optimizes to use IN syntax instead of EXISTS for entity equality/containment e.g. (`context.Blogs.Where(b => ctx.BlogsDetails.Contains(b.Details))`) - when the entity has a non-composite key (composite keys are still translate via EXISTS). This improves on [#30955](https://github.com/dotnet/efcore/issues/30955), which already switched most queries from IN to EXISTS where possible, but not for entity equality/containment.
* It then leverages this and switches to using Contains in ExecuteDelete. This form comes into use for complex querying which cannot be directly translated to DELETE; we then add a WHERE clause that checks whether the row's PK is in a subquery containing the complex conditions.
* Note that ExecuteUpdate generated an inner join instead of IN/EXISTS. This is because unlike with delete, update supports arbitrary projections (e.g. into anonymous types), and that's tricky to get working with IN/EXISTS. The inner join approach should be just as efficient - if a tad uglier - so I'm leaving as-is for now.
 
Closes #31386
