### PR TITLE
Fix to #31365 - Query: add support for projecting JSON entities that have been composed on

### DIFF
--- a/src/EFCore.Relational/Query/Internal/QueryableJsonProjectionInfo.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryableJsonProjectionInfo.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public readonly struct QueryableJsonProjectionInfo
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public QueryableJsonProjectionInfo(
+        Dictionary<IProperty, int> propertyIndexMap,
+        List<(JsonProjectionInfo, INavigation)> childrenProjectionInfo)
+    {
+        PropertyIndexMap = propertyIndexMap;
+        ChildrenProjectionInfo = childrenProjectionInfo;
+    }
+
+    /// <summary>
+    ///     Map between entity properties and corresponding column indexes.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public IDictionary<IProperty, int> PropertyIndexMap { get; }
+
+    /// <summary>
+    ///     Information needed to construct each child JSON entity.
+    ///     - JsonProjection info (same one we use for simple JSON projection),
+    ///     - navigation between parent and the child JSON entity.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public IList<(JsonProjectionInfo JsonProjectionInfo, INavigation Navigation)> ChildrenProjectionInfo { get; }
+}

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerJsonPostprocessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerJsonPostprocessor.cs
@@ -236,8 +236,10 @@ public class SqlServerJsonPostprocessor : ExpressionVisitor
                 columnExpression.Table, "value", columnExpression.Type, _nvarcharMaxTypeMapping, columnExpression.IsNullable);
 
             Check.DebugAssert(columnInfo.Path is not null, "Path shouldn't be null in OPENJSON WITH");
-            Check.DebugAssert(!columnInfo.AsJson, "AS JSON signifies an owned sub-entity being projected out of OPENJSON/WITH. "
-                + "Columns referring to that must be wrapped be Json{Scalar,Query}Expression and will have been already dealt with above");
+            //Check.DebugAssert(
+            //    !columnInfo.AsJson || columnInfo.TypeMapping.ElementTypeMapping is not null,
+            //    "AS JSON signifies an owned sub-entity or array of primitives being projected out of OPENJSON/WITH. "
+            //    + "Columns referring to sub-entities must be wrapped in Json{Scalar,Query}Expression and will have been already dealt with above");
 
             if (columnInfo.Path is [])
             {

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -245,7 +245,8 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 {
                     Name = jsonPropertyName,
                     TypeMapping = property.GetRelationalTypeMapping(),
-                    Path = new PathSegment[] { new(jsonPropertyName) }
+                    Path = new PathSegment[] { new(jsonPropertyName) },
+                    AsJson = property.GetRelationalTypeMapping().ElementTypeMapping is not null
                 });
             }
         }

--- a/test/EFCore.Cosmos.FunctionalTests/MaterializationInterceptionCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/MaterializationInterceptionCosmosTest.cs
@@ -11,6 +11,9 @@ public class MaterializationInterceptionCosmosTest : MaterializationInterception
     {
     }
 
+    public override Task Intercept_query_materialization_with_owned_types_projecting_collection(bool async)
+        => Task.CompletedTask;
+
     public class CosmosLibraryContext : LibraryContext
     {
         public CosmosLibraryContext(DbContextOptions options)

--- a/test/EFCore.Sqlite.FunctionalTests/MaterializationInterceptionSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MaterializationInterceptionSqliteTest.cs
@@ -3,6 +3,8 @@
 
 #nullable enable
 
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
 namespace Microsoft.EntityFrameworkCore;
 
 public class MaterializationInterceptionSqliteTest : MaterializationInterceptionTestBase<MaterializationInterceptionSqliteTest.SqliteLibraryContext>,
@@ -12,6 +14,13 @@ public class MaterializationInterceptionSqliteTest : MaterializationInterception
         : base(fixture)
     {
     }
+
+    public override async Task Intercept_query_materialization_with_owned_types_projecting_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Intercept_query_materialization_with_owned_types_projecting_collection(async)))
+            .Message);
 
     public class SqliteLibraryContext : LibraryContext
     {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQuerySqliteTest.cs
@@ -298,6 +298,83 @@ WHERE "j"."Reference" ->> 'BoolConvertedToStringYN' = 'Y'
                 () => base.Json_collection_skip_take_in_projection_with_json_reference_access_as_final_operation(async)))
             .Message);
 
+    public override async Task Json_collection_distinct_in_projection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_collection_distinct_in_projection(async)))
+            .Message);
+
+    public override async Task Json_collection_filter_in_projection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_collection_filter_in_projection(async)))
+            .Message);
+
+    public override async Task Json_collection_leaf_filter_in_projection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_collection_leaf_filter_in_projection(async)))
+            .Message);
+
+    public override async Task Json_branch_collection_distinct_and_other_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_branch_collection_distinct_and_other_collection(async)))
+            .Message);
+
+    public override async Task Json_leaf_collection_distinct_and_other_collection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_leaf_collection_distinct_and_other_collection(async)))
+            .Message);
+
+    public override async Task Json_multiple_collection_projections(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_multiple_collection_projections(async)))
+            .Message);
+
+    public override async Task Json_collection_SelectMany(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_collection_SelectMany(async)))
+            .Message);
+
+    public override async Task Json_collection_skip_take_in_projection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_collection_skip_take_in_projection(async)))
+            .Message);
+
+    public override async Task Json_nested_collection_anonymous_projection_in_projection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_nested_collection_anonymous_projection_in_projection(async)))
+            .Message);
+
+    public override async Task Json_nested_collection_filter_in_projection(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_nested_collection_filter_in_projection(async)))
+            .Message);
+
+    public override async Task Json_nested_collection_SelectMany(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Json_nested_collection_SelectMany(async)))
+            .Message);
+
     public override async Task Json_collection_index_in_projection_using_untranslatable_client_method(bool async)
     {
         var message = (await Assert.ThrowsAsync<InvalidOperationException>(


### PR DESCRIPTION
Adding new materialization path for JSON entities that have been converted to query roots - they look like normal entity, but materialization is somewhat different.
We need to prune synthesized key properties from materializer code (as they are not associated with any column, but rather made up on the fly)
Also added code to include all the child navigations. For normal entities we have IncludeExpressions in the shaper expression, but for JSON we prune all includes and build them in the materializer.

Fix is to recognize the scenario (entity projection but the entity is mapped to JSON) during apply projection phase and generate all the necessary info needed rather than just dictionary of property to index maps like we do for regular entity.
Then when we build materializer we use that info to prune the synthesized properties from key check and re-use existing include JSON entity code to add child navigations.

Fixes #31365
