### PR TITLE
Only discover complex types when configured through pre-convention model configuration or annotation

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
@@ -278,9 +278,9 @@ public class SharedTableConvention : IModelFinalizingConvention
             }
         }
 
-        foreach (var complexPropery in type.GetDeclaredComplexProperties())
+        foreach (var complexProperty in type.GetDeclaredComplexProperties())
         {
-            TryUniquifyColumnNames(complexPropery.ComplexType, columns, storeObject, maxLength);
+            TryUniquifyColumnNames(complexProperty.ComplexType, columns, storeObject, maxLength);
         }
     }
 

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -1164,6 +1164,28 @@ public class ModelValidator : IModelValidator
                     }
                 }
 
+                foreach (var complexProperty in entityType.GetComplexProperties())
+                {
+                    if (seedDatum.TryGetValue(complexProperty.Name, out var value)
+                        && ((complexProperty.IsCollection && value is IEnumerable collection && collection.Any())
+                            || (!complexProperty.IsCollection && value != complexProperty.Sentinel)))
+                    {
+                        if (sensitiveDataLogged)
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.SeedDatumComplexPropertySensitive(
+                                    entityType.DisplayName(),
+                                    string.Join(", ", key.Properties.Select((p, i) => p.Name + ":" + keyValues[i])),
+                                    complexProperty.Name));
+                        }
+
+                        throw new InvalidOperationException(
+                            CoreStrings.SeedDatumComplexProperty(
+                                entityType.DisplayName(),
+                                complexProperty.Name));
+                    }
+                }
+
                 if (identityMap == null)
                 {
                     if (!identityMaps.TryGetValue(key, out identityMap))

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -176,6 +176,19 @@ public class ModelValidator : IModelValidator
                         CoreStrings.ComplexPropertyCollection(typeBase.DisplayName(), complexProperty.Name));
                 }
 
+                if (complexProperty.IsNullable)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ComplexPropertyOptional(typeBase.DisplayName(), complexProperty.Name));
+                }
+
+                if (complexProperty.ComplexType.ClrType.IsValueType)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ValueComplexType(
+                            typeBase.DisplayName(), complexProperty.Name, complexProperty.ComplexType.ClrType.ShortDisplayName()));
+                }
+
                 if (complexProperty.ComplexType.GetMembers().Count() == 0)
                 {
                     throw new InvalidOperationException(

--- a/src/EFCore/Metadata/Builders/IConventionModelBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionModelBuilder.cs
@@ -189,7 +189,7 @@ public interface IConventionModelBuilder : IConventionAnnotatableBuilder
     /// <returns>
     ///     An <see cref="IConventionModelBuilder" /> to continue configuration if the annotation was set, <see langword="null" /> otherwise.
     /// </returns>
-    IConventionModelBuilder? Complex(
+    IConventionModelBuilder? ComplexType(
         [DynamicallyAccessedMembers(IEntityType.DynamicallyAccessedMemberTypes)] Type type,
         bool fromDataAnnotation = false);
 

--- a/src/EFCore/Metadata/Conventions/ComplexTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ComplexTypeAttributeConvention.cs
@@ -33,7 +33,7 @@ public class ComplexTypeAttributeConvention : TypeAttributeConventionBase<Comple
         ComplexTypeAttribute attribute,
         IConventionContext<IConventionEntityTypeBuilder> context)
     {
-        entityTypeBuilder.Metadata.Model.Builder.Complex(entityTypeBuilder.Metadata.ClrType);
+        entityTypeBuilder.Metadata.Model.Builder.ComplexType(entityTypeBuilder.Metadata.ClrType);
 
         if (!entityTypeBuilder.Metadata.IsInModel)
         {

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2701,6 +2701,7 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
             propertiesList ??= GetProperties()
                 .Concat<IPropertyBase>(GetNavigations())
                 .Concat(GetSkipNavigations())
+                .Concat(GetComplexProperties())
                 .ToList();
             if (ClrType.IsAssignableFrom(type))
             {

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -937,7 +937,7 @@ public class InternalModelBuilder : AnnotatableBuilder<Model, InternalModelBuild
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
-    IConventionModelBuilder? IConventionModelBuilder.Complex(Type type, bool fromDataAnnotation)
+    IConventionModelBuilder? IConventionModelBuilder.ComplexType(Type type, bool fromDataAnnotation)
         => Complex(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>

--- a/src/EFCore/Metadata/Internal/InternalTypeBaseBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalTypeBaseBuilder.cs
@@ -991,8 +991,6 @@ public abstract class InternalTypeBaseBuilder : AnnotatableBuilder<TypeBase, Int
                 RemoveMembersInHierarchy(propertyName, configurationSource.Value);
             }
 
-            model.Builder.Complex(complexType!, configurationSource.Value);
-
             complexProperty = typeBase.AddComplexProperty(
                 propertyName, propertyType, memberInfo, complexTypeName, complexType!, collection.Value, configurationSource.Value)!;
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -481,6 +481,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type, property);
 
         /// <summary>
+        ///     Configuring the complex property '{type}.{property}' as optional is not supported, call 'IsRequired()'.
+        /// </summary>
+        public static string ComplexPropertyOptional(object? type, object? property)
+            => string.Format(
+                GetString("ComplexPropertyOptional", nameof(type), nameof(property)),
+                type, property);
+
+        /// <summary>
         ///     Configuring the complex property '{type}.{property}' in shadow state isn't supported.
         /// </summary>
         public static string ComplexPropertyShadow(object? type, object? property)
@@ -2970,6 +2978,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("ValueCannotBeNull", "0_property", "1_entityType", nameof(propertyType)),
                 property, entityType, propertyType);
+
+        /// <summary>
+        ///     Adding the complex property '{type}.{property}' isn't supported because it's of a value type '{propertyType}'.
+        /// </summary>
+        public static string ValueComplexType(object? type, object? property, object? propertyType)
+            => string.Format(
+                GetString("ValueComplexType", nameof(type), nameof(property), nameof(propertyType)),
+                type, property, propertyType);
 
         /// <summary>
         ///     Calling '{visitMethodName}' is not allowed. Visit the expression manually for the relevant part in the visitor.

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, type, clrType, targetType);
 
         /// <summary>
-        ///     Adding the collection complex property '{type}.{property}' isn't supported.
+        ///     Adding the collection complex property '{type}.{property}' isn't supported. See https://github.com/dotnet/efcore/issues/31237 for more information.
         /// </summary>
         public static string ComplexPropertyCollection(object? type, object? property)
             => string.Format(
@@ -473,7 +473,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type, property);
 
         /// <summary>
-        ///     Adding the complex property '{type}.{property}' as an indexer property isn't supported.
+        ///     Adding the complex property '{type}.{property}' as an indexer property isn't supported. See https://github.com/dotnet/efcore/issues/31244 for more information.
         /// </summary>
         public static string ComplexPropertyIndexer(object? type, object? property)
             => string.Format(
@@ -481,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type, property);
 
         /// <summary>
-        ///     Configuring the complex property '{type}.{property}' as optional is not supported, call 'IsRequired()'.
+        ///     Configuring the complex property '{type}.{property}' as optional is not supported, call 'IsRequired()'. See https://github.com/dotnet/efcore/issues/31376 for more information.
         /// </summary>
         public static string ComplexPropertyOptional(object? type, object? property)
             => string.Format(
@@ -489,7 +489,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type, property);
 
         /// <summary>
-        ///     Configuring the complex property '{type}.{property}' in shadow state isn't supported.
+        ///     Configuring the complex property '{type}.{property}' in shadow state isn't supported.  See https://github.com/dotnet/efcore/issues/31243 for more information.
         /// </summary>
         public static string ComplexPropertyShadow(object? type, object? property)
             => string.Format(
@@ -2550,6 +2550,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("SavepointsNotSupported");
 
         /// <summary>
+        ///     The seed entity for entity type '{entityType}' cannot be added because it has the complex property '{property}' set. Complex properties are currently not supported in seeding. See https://github.com/dotnet/efcore/issues/31254 for more information. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the involved property values.
+        /// </summary>
+        public static string SeedDatumComplexProperty(object? entityType, object? property)
+            => string.Format(
+                GetString("SeedDatumComplexProperty", nameof(entityType), nameof(property)),
+                entityType, property);
+
+        /// <summary>
+        ///     The seed entity for entity type '{entityType}' with the key value '{keyValue}' cannot be added because it has the complex property '{property}' set. Complex properties are currently not supported in seeding. See https://github.com/dotnet/efcore/issues/31254 for more information.
+        /// </summary>
+        public static string SeedDatumComplexPropertySensitive(object? entityType, object? keyValue, object? property)
+            => string.Format(
+                GetString("SeedDatumComplexPropertySensitive", nameof(entityType), nameof(keyValue), nameof(property)),
+                entityType, keyValue, property);
+
+        /// <summary>
         ///     The seed entity for entity type '{entityType}' cannot be added because a default value was provided for the required property '{property}'. Please provide a value different from '{defaultValue}'.
         /// </summary>
         public static string SeedDatumDefaultValue(object? entityType, object? property, object? defaultValue)
@@ -2980,7 +2996,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, propertyType);
 
         /// <summary>
-        ///     Adding the complex property '{type}.{property}' isn't supported because it's of a value type '{propertyType}'.
+        ///     Adding the complex property '{type}.{property}' isn't supported because it's of a value type '{propertyType}'. See https://github.com/dotnet/efcore/issues/9906 for more information.
         /// </summary>
         public static string ValueComplexType(object? type, object? property, object? propertyType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -288,6 +288,9 @@
   <data name="ComplexPropertyIndexer" xml:space="preserve">
     <value>Adding the complex property '{type}.{property}' as an indexer property isn't supported.</value>
   </data>
+  <data name="ComplexPropertyOptional" xml:space="preserve">
+    <value>Configuring the complex property '{type}.{property}' as optional is not supported, call 'IsRequired()'.</value>
+  </data>
   <data name="ComplexPropertyShadow" xml:space="preserve">
     <value>Configuring the complex property '{type}.{property}' in shadow state isn't supported.</value>
   </data>
@@ -1559,6 +1562,9 @@
   </data>
   <data name="ValueCannotBeNull" xml:space="preserve">
     <value>The value for property '{1_entityType}.{0_property}' cannot be set to null because its type is '{propertyType}' which is not a nullable type.</value>
+  </data>
+  <data name="ValueComplexType" xml:space="preserve">
+    <value>Adding the complex property '{type}.{property}' isn't supported because it's of a value type '{propertyType}'.</value>
   </data>
   <data name="VisitIsNotAllowed" xml:space="preserve">
     <value>Calling '{visitMethodName}' is not allowed. Visit the expression manually for the relevant part in the visitor.</value>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -283,16 +283,16 @@
     <value>The collection complex property '{property}' cannot be added to the type '{type}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection complex property must implement IEnumerable&lt;&gt; of the complex type.</value>
   </data>
   <data name="ComplexPropertyCollection" xml:space="preserve">
-    <value>Adding the collection complex property '{type}.{property}' isn't supported.</value>
+    <value>Adding the collection complex property '{type}.{property}' isn't supported. See https://github.com/dotnet/efcore/issues/31237 for more information.</value>
   </data>
   <data name="ComplexPropertyIndexer" xml:space="preserve">
-    <value>Adding the complex property '{type}.{property}' as an indexer property isn't supported.</value>
+    <value>Adding the complex property '{type}.{property}' as an indexer property isn't supported. See https://github.com/dotnet/efcore/issues/31244 for more information.</value>
   </data>
   <data name="ComplexPropertyOptional" xml:space="preserve">
-    <value>Configuring the complex property '{type}.{property}' as optional is not supported, call 'IsRequired()'.</value>
+    <value>Configuring the complex property '{type}.{property}' as optional is not supported, call 'IsRequired()'. See https://github.com/dotnet/efcore/issues/31376 for more information.</value>
   </data>
   <data name="ComplexPropertyShadow" xml:space="preserve">
-    <value>Configuring the complex property '{type}.{property}' in shadow state isn't supported.</value>
+    <value>Configuring the complex property '{type}.{property}' in shadow state isn't supported.  See https://github.com/dotnet/efcore/issues/31243 for more information.</value>
   </data>
   <data name="ComplexPropertyWrongClrType" xml:space="preserve">
     <value>The complex property '{property}' cannot be added to the type '{type}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.</value>
@@ -1398,6 +1398,12 @@
   <data name="SavepointsNotSupported" xml:space="preserve">
     <value>Savepoints are not supported by the database provider in use.</value>
   </data>
+  <data name="SeedDatumComplexProperty" xml:space="preserve">
+    <value>The seed entity for entity type '{entityType}' cannot be added because it has the complex property '{property}' set. Complex properties are currently not supported in seeding. See https://github.com/dotnet/efcore/issues/31254 for more information. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the involved property values.</value>
+  </data>
+  <data name="SeedDatumComplexPropertySensitive" xml:space="preserve">
+    <value>The seed entity for entity type '{entityType}' with the key value '{keyValue}' cannot be added because it has the complex property '{property}' set. Complex properties are currently not supported in seeding. See https://github.com/dotnet/efcore/issues/31254 for more information.</value>
+  </data>
   <data name="SeedDatumDefaultValue" xml:space="preserve">
     <value>The seed entity for entity type '{entityType}' cannot be added because a default value was provided for the required property '{property}'. Please provide a value different from '{defaultValue}'.</value>
   </data>
@@ -1564,7 +1570,7 @@
     <value>The value for property '{1_entityType}.{0_property}' cannot be set to null because its type is '{propertyType}' which is not a nullable type.</value>
   </data>
   <data name="ValueComplexType" xml:space="preserve">
-    <value>Adding the complex property '{type}.{property}' isn't supported because it's of a value type '{propertyType}'.</value>
+    <value>Adding the complex property '{type}.{property}' isn't supported because it's of a value type '{propertyType}'. See https://github.com/dotnet/efcore/issues/9906 for more information.</value>
   </data>
   <data name="VisitIsNotAllowed" xml:space="preserve">
     <value>Calling '{visitMethodName}' is not allowed. Visit the expression manually for the relevant part in the visitor.</value>

--- a/test/EFCore.Cosmos.FunctionalTests/ConfigPatternsCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ConfigPatternsCosmosTest.cs
@@ -88,7 +88,7 @@ public class ConfigPatternsCosmosTest : IClassFixture<ConfigPatternsCosmosTest.C
             exception.Message);
     }
 
-    [ConditionalFact(Skip = "Issue Azure/azure-cosmos-dotnet-v3#3990")]
+    [ConditionalFact(Skip = "Issue #runtime/issues/89118")]
     public async Task Should_not_throw_if_specified_connection_mode_is_right()
     {
         var connectionMode = ConnectionMode.Direct;

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -5322,8 +5322,7 @@ namespace TestNamespace
                         "Microsoft.EntityFrameworkCore.Scaffolding.Internal.CSharpRuntimeModelCodeGeneratorTest+PrincipalBase.Owned#OwnedType.Principal#PrincipalBase",
                         typeof(CSharpRuntimeModelCodeGeneratorTest.PrincipalBase),
                         propertyInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetProperty("Principal", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
-                        fieldInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetField("<Principal>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
-                        nullable: true);
+                        fieldInfo: typeof(CSharpRuntimeModelCodeGeneratorTest.OwnedType).GetField("<Principal>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly));
 
                     var complexType = complexProperty.ComplexType;
                     var alternateId = complexType.AddProperty(
@@ -5882,8 +5881,7 @@ namespace TestNamespace
                                     .IsRowVersion()
                                     .HasAnnotation("foo", "bar");
                                 eb.Ignore(e => e.Context);
-                                eb.ComplexProperty(o => o.Principal)
-                                    ;
+                                eb.ComplexProperty(o => o.Principal).IsRequired();
                             });
 
                         eb.ToTable("PrincipalBase");

--- a/test/EFCore.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Tests/ApiConsistencyTest.cs
@@ -158,7 +158,7 @@ public class ApiConsistencyTest : ApiConsistencyTestBase<ApiConsistencyTest.ApiC
             typeof(IConventionAnnotatable).GetMethod(nameof(IConventionAnnotatable.SetAnnotation)),
             typeof(IConventionAnnotatable).GetMethod(nameof(IConventionAnnotatable.SetOrRemoveAnnotation)),
             typeof(IConventionModelBuilder).GetMethod(nameof(IConventionModelBuilder.HasNoEntityType)),
-            typeof(IConventionModelBuilder).GetMethod(nameof(IConventionModelBuilder.Complex)),
+            typeof(IConventionModelBuilder).GetMethod(nameof(IConventionModelBuilder.ComplexType)),
             typeof(IReadOnlyEntityType).GetMethod(nameof(IReadOnlyEntityType.GetConcreteDerivedTypesInclusive)),
             typeof(IMutableEntityType).GetMethod(nameof(IMutableEntityType.AddData)),
             typeof(IReadOnlyNavigationBase).GetMethod("get_DeclaringEntityType"),

--- a/test/EFCore.Tests/ModelBuilding/ComplexTypeTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ComplexTypeTestBase.cs
@@ -1518,6 +1518,7 @@ Customer (Customer) Required
                 .Entity<ComplexProperties>()
                 .ComplexProperty(e => e.Customer);
 
+            // TODO: Issue #14661
             //modelBuilder
             //    .Entity<ValueComplexProperties>()
             //    .Ignore(e => e.Tuple)
@@ -1602,6 +1603,7 @@ Customer (Customer) Required
                     Assert.Throws<InvalidOperationException>(modelBuilder.FinalizeModel).Message);
 
             // Uncomment when value types are supported.
+            // TODO: Issue #14661
             //var model = modelBuilder.FinalizeModel();
 
             //var valueType = model.FindEntityType(typeof(ValueComplexProperties));

--- a/test/EFCore.Tests/ModelBuilding/ComplexTypeTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ComplexTypeTestBase.cs
@@ -32,7 +32,7 @@ public abstract partial class ModelBuilderTest
             Assert.Equal("bar2", complexProperty["foo2"]);
             Assert.Equal(typeof(Customer).Name, complexProperty.Name);
             Assert.Equal("""
-Customer (Customer)
+Customer (Customer) Required
   ComplexType: ComplexProperties.Customer#Customer
     Properties: 
       AlternateKey (Guid) Required
@@ -1507,7 +1507,7 @@ Customer (Customer)
         }
 
         [ConditionalFact]
-        public virtual void Complex_properties_discovered_by_convention()
+        public virtual void Complex_properties_not_discovered_by_convention()
         {
             var modelBuilder = CreateModelBuilder();
 
@@ -1518,10 +1518,10 @@ Customer (Customer)
                 .Entity<ComplexProperties>()
                 .ComplexProperty(e => e.Customer);
 
-            modelBuilder
-                .Entity<ValueComplexProperties>()
-                .Ignore(e => e.Tuple)
-                .ComplexProperty(e => e.Label);
+            //modelBuilder
+            //    .Entity<ValueComplexProperties>()
+            //    .Ignore(e => e.Tuple)
+            //    .ComplexProperty(e => e.Label);
 
             var model = modelBuilder.FinalizeModel();
 
@@ -1530,26 +1530,26 @@ Customer (Customer)
             var indexedType = model.FindEntityType(typeof(ComplexProperties))
                 .FindComplexProperty(nameof(ComplexProperties.IndexedClass)).ComplexType;
 
-            var valueType = model.FindEntityType(typeof(ValueComplexProperties));
-            var labelProperty = valueType.FindComplexProperty(nameof(ValueComplexProperties.Label));
-            Assert.False(labelProperty.IsNullable);
-            Assert.Equal(typeof(ProductLabel), labelProperty.ClrType);
-            var labelType = labelProperty.ComplexType;
-            Assert.Equal(typeof(ProductLabel), labelType.ClrType);
+            //var valueType = model.FindEntityType(typeof(ValueComplexProperties));
+            //var labelProperty = valueType.FindComplexProperty(nameof(ValueComplexProperties.Label));
+            //Assert.False(labelProperty.IsNullable);
+            //Assert.Equal(typeof(ProductLabel), labelProperty.ClrType);
+            //var labelType = labelProperty.ComplexType;
+            //Assert.Equal(typeof(ProductLabel), labelType.ClrType);
 
-            var labelCustomerProperty = labelType.FindComplexProperty(nameof(ProductLabel.Customer));
-            Assert.True(labelCustomerProperty.IsNullable);
-            Assert.Equal(typeof(Customer), labelCustomerProperty.ClrType);
+            //var labelCustomerProperty = labelType.FindComplexProperty(nameof(ProductLabel.Customer));
+            //Assert.True(labelCustomerProperty.IsNullable);
+            //Assert.Equal(typeof(Customer), labelCustomerProperty.ClrType);
 
-            var oldLabelProperty = valueType.FindComplexProperty(nameof(ValueComplexProperties.OldLabel));
-            Assert.True(oldLabelProperty.IsNullable);
-            Assert.Equal(typeof(ProductLabel?), oldLabelProperty.ClrType);
-            var oldLabelType = oldLabelProperty.ComplexType;
-            Assert.Equal(typeof(ProductLabel), oldLabelType.ClrType);
+            //var oldLabelProperty = valueType.FindComplexProperty(nameof(ValueComplexProperties.OldLabel));
+            //Assert.True(oldLabelProperty.IsNullable);
+            //Assert.Equal(typeof(ProductLabel?), oldLabelProperty.ClrType);
+            //var oldLabelType = oldLabelProperty.ComplexType;
+            //Assert.Equal(typeof(ProductLabel), oldLabelType.ClrType);
 
-            var oldLabelCustomerProperty = labelType.FindComplexProperty(nameof(ProductLabel.Customer));
-            Assert.True(oldLabelCustomerProperty.IsNullable);
-            Assert.Equal(typeof(Customer), oldLabelCustomerProperty.ClrType);
+            //var oldLabelCustomerProperty = labelType.FindComplexProperty(nameof(ProductLabel.Customer));
+            //Assert.True(oldLabelCustomerProperty.IsNullable);
+            //Assert.Equal(typeof(Customer), oldLabelCustomerProperty.ClrType);
         }
 
         [ConditionalFact]
@@ -1571,7 +1571,22 @@ Customer (Customer)
         }
 
         [ConditionalFact]
-        public virtual void Can_map_tuple()
+        public virtual void Throws_for_optional_complex_property()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder
+                .Entity<ComplexProperties>()
+                .ComplexProperty(e => e.Customer).IsRequired(false);
+
+            Assert.Equal(
+                CoreStrings.ComplexPropertyOptional(
+                    nameof(ComplexProperties), nameof(ComplexProperties.Customer)),
+                    Assert.Throws<InvalidOperationException>(modelBuilder.FinalizeModel).Message);
+        }
+
+        [ConditionalFact]
+        public virtual void Throws_for_tuple()
         {
             var modelBuilder = CreateModelBuilder();
 
@@ -1581,17 +1596,23 @@ Customer (Customer)
                 .Ignore(e => e.OldLabel)
                 .ComplexProperty(e => e.Tuple);
 
-            var model = modelBuilder.FinalizeModel();
+            Assert.Equal(
+                CoreStrings.ValueComplexType(
+                    nameof(ValueComplexProperties), nameof(ValueComplexProperties.Tuple), typeof((string, int)).ShortDisplayName()),
+                    Assert.Throws<InvalidOperationException>(modelBuilder.FinalizeModel).Message);
 
-            var valueType = model.FindEntityType(typeof(ValueComplexProperties));
-            var tupleProperty = valueType.FindComplexProperty(nameof(ValueComplexProperties.Tuple));
-            Assert.False(tupleProperty.IsNullable);
-            Assert.Equal(typeof((string, int)), tupleProperty.ClrType);
-            var tupleType = tupleProperty.ComplexType;
-            Assert.Equal(typeof((string, int)), tupleType.ClrType);
-            Assert.Equal("ValueComplexProperties.Tuple#ValueTuple<string, int>", tupleType.DisplayName());
+            // Uncomment when value types are supported.
+            //var model = modelBuilder.FinalizeModel();
 
-            Assert.Equal(2, tupleType.GetProperties().Count());
+            //var valueType = model.FindEntityType(typeof(ValueComplexProperties));
+            //var tupleProperty = valueType.FindComplexProperty(nameof(ValueComplexProperties.Tuple));
+            //Assert.False(tupleProperty.IsNullable);
+            //Assert.Equal(typeof((string, int)), tupleProperty.ClrType);
+            //var tupleType = tupleProperty.ComplexType;
+            //Assert.Equal(typeof((string, int)), tupleType.ClrType);
+            //Assert.Equal("ValueComplexProperties.Tuple#ValueTuple<string, int>", tupleType.DisplayName());
+
+            //Assert.Equal(2, tupleType.GetProperties().Count());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -165,8 +165,8 @@ public abstract partial class ModelBuilderTest
 
         public int OrderId { get; set; }
         public int ProductId { get; set; }
-        public virtual Order Order { get; set; } = null!;
-        public virtual Product Product { get; set; } = null!;
+        public required virtual Order Order { get; set; }
+        public required virtual Product Product { get; set; }
     }
 
     protected class UniProduct
@@ -239,13 +239,13 @@ public abstract partial class ModelBuilderTest
         public SpecialCustomer? SpecialCustomer { get; set; }
         public BackOrder? BackOrder { get; set; }
         public OrderCombination? SpecialOrderCombination { get; set; }
-        public StreetAddress ShippingAddress { get; set; } = null!;
+        public required StreetAddress ShippingAddress { get; set; }
     }
 
     protected class BackOrder : Order
     {
         public int SpecialOrderId { get; set; }
-        public SpecialOrder SpecialOrder { get; set; } = null!;
+        public required SpecialOrder SpecialOrder { get; set; }
     }
 
     [NotMapped]
@@ -253,10 +253,10 @@ public abstract partial class ModelBuilderTest
     {
         public int Id { get; set; }
         public int OrderId { get; set; }
-        public Order Order { get; set; } = null!;
+        public required Order Order { get; set; }
         public int SpecialOrderId { get; set; }
-        public SpecialOrder SpecialOrder { get; set; } = null!;
-        public DetailsBase Details { get; set; } = null!;
+        public required SpecialOrder SpecialOrder { get; set; }
+        public required DetailsBase Details { get; set; }
     }
 
     protected class OrderDetails : DetailsBase
@@ -363,7 +363,7 @@ public abstract partial class ModelBuilderTest
 
         public string Name { get; set; } = "";
 
-        public User CreatedBy { get; set; } = null!;
+        public required User CreatedBy { get; set; }
 
         public User? UpdatedBy { get; set; }
 
@@ -382,24 +382,24 @@ public abstract partial class ModelBuilderTest
 
         public int Id { get; set; }
 
-        public BookLabel Label { get; set; } = null!;
+        public required BookLabel Label { get; set; }
 
-        public BookLabel AlternateLabel { get; set; } = null!;
+        public required BookLabel AlternateLabel { get; set; }
 
-        public BookDetails Details { get; set; } = null!;
+        public required BookDetails Details { get; set; }
     }
 
     protected abstract class BookDetailsBase : DetailsBase
     {
         public int AnotherBookId { get; set; }
 
-        public Book AnotherBook { get; set; } = null!;
+        public required Book AnotherBook { get; set; }
     }
 
     protected class BookDetails : BookDetailsBase
     {
         [NotMapped]
-        public Book Book { get; set; } = null!;
+        public required Book Book { get; set; }
     }
 
     protected class BookLabel
@@ -407,7 +407,7 @@ public abstract partial class ModelBuilderTest
         public int Id { get; set; }
 
         [InverseProperty("Label")]
-        public Book Book { get; set; } = null!;
+        public required Book Book { get; set; }
 
         public int BookId { get; set; }
 
@@ -448,7 +448,7 @@ public abstract partial class ModelBuilderTest
         [NotMapped]
         public int PrincipalEntityId { get; set; }
 
-        public PrincipalEntity Nav { get; set; } = null!;
+        public required PrincipalEntity Nav { get; set; }
     }
 
     protected class Alpha
@@ -521,10 +521,10 @@ public abstract partial class ModelBuilderTest
         public int CommonFkProperty { get; set; }
 
         [ForeignKey("CommonFkProperty")]
-        public Alpha AlphaOne { get; set; } = null!;
+        public required Alpha AlphaOne { get; set; }
 
         [ForeignKey("CommonFkProperty")]
-        public Alpha AlphaTwo { get; set; } = null!;
+        public required Alpha AlphaTwo { get; set; }
     }
 
     [NotMapped]
@@ -598,7 +598,7 @@ public abstract partial class ModelBuilderTest
         public int OneToOneDependentEntityId { get; set; }
 
         [NotMapped]
-        public OneToOneDependentEntity NavOneToOneDependentEntity { get; set; } = null!;
+        public required OneToOneDependentEntity NavOneToOneDependentEntity { get; set; }
     }
 
     protected class OneToOneDependentEntity
@@ -618,7 +618,7 @@ public abstract partial class ModelBuilderTest
         public int OneToOnePrincipalEntityId { get; set; }
 
         [NotMapped]
-        public OneToOnePrincipalEntity NavOneToOnePrincipalEntity { get; set; } = null!;
+        public required OneToOnePrincipalEntity NavOneToOnePrincipalEntity { get; set; }
     }
 
     protected class OneToOnePrincipalEntityWithAnnotation
@@ -631,7 +631,7 @@ public abstract partial class ModelBuilderTest
 
         [NotMapped]
         [ForeignKey("FkProperty")]
-        public OneToOneDependentEntityWithAnnotation NavOneToOneDependentEntityWithAnnotation { get; set; } = null!;
+        public required OneToOneDependentEntityWithAnnotation NavOneToOneDependentEntityWithAnnotation { get; set; }
     }
 
     protected class OneToOneDependentEntityWithAnnotation
@@ -642,7 +642,7 @@ public abstract partial class ModelBuilderTest
         public int OneToOnePrincipalEntityWithAnnotationId { get; set; }
 
         [NotMapped]
-        public OneToOnePrincipalEntityWithAnnotation NavOneToOnePrincipalEntityWithAnnotation { get; set; } = null!;
+        public required OneToOnePrincipalEntityWithAnnotation NavOneToOnePrincipalEntityWithAnnotation { get; set; }
     }
 
     protected class BaseTypeWithKeyAnnotation
@@ -655,7 +655,7 @@ public abstract partial class ModelBuilderTest
         public int ForeignKeyProperty { get; set; }
 
         [ForeignKey("ForeignKeyProperty")]
-        public PrincipalTypeWithKeyAnnotation Navigation { get; set; } = null!;
+        public required PrincipalTypeWithKeyAnnotation Navigation { get; set; }
     }
 
     protected class DerivedTypeWithKeyAnnotation : BaseTypeWithKeyAnnotation
@@ -674,11 +674,11 @@ public abstract partial class ModelBuilderTest
     {
         public int Id { get; set; }
 
-        public virtual ICollection<CitizenViewModel> People { get; set; } = null!;
+        public virtual required ICollection<CitizenViewModel> People { get; set; }
 
-        public virtual ICollection<PoliceViewModel> Police { get; set; } = null!;
+        public virtual required ICollection<PoliceViewModel> Police { get; set; }
 
-        public virtual ICollection<DoctorViewModel> Medics { get; set; } = null!;
+        public virtual required ICollection<DoctorViewModel> Medics { get; set; }
 
         public Dictionary<string, string>? CustomValues { get; set; } = new();
     }
@@ -689,7 +689,7 @@ public abstract partial class ModelBuilderTest
 
         public int CityVMId { get; set; }
 
-        public virtual CityViewModel CityVM { get; set; } = null!;
+        public virtual required CityViewModel CityVM { get; set; }
     }
 
     protected class CitizenViewModel : PersonBaseViewModel
@@ -722,16 +722,16 @@ public abstract partial class ModelBuilderTest
         public int Id { get; set; }
 
         public int ActionUserId { get; set; }
-        public ApplicationUser ActionUser { get; set; } = null!;
+        public required ApplicationUser ActionUser { get; set; }
 
         public int ApplicationUserId { get; set; }
-        public ApplicationUser ApplicationUser { get; set; } = null!;
+        public required ApplicationUser ApplicationUser { get; set; }
     }
 
     protected class ApplicationUser
     {
         public int Id { get; set; }
-        public IList<Friendship> Friendships { get; set; } = null!;
+        public required IList<Friendship> Friendships { get; set; }
     }
 
     public class EntityWithFields
@@ -750,9 +750,9 @@ public abstract partial class ModelBuilderTest
 
     protected class QueryResult
     {
-        public CustomId Id { get; set; } = null!;
+        public required CustomId Id { get; set; }
         public int ValueFk { get; set; }
-        public Value Value { get; set; } = null!;
+        public required Value Value { get; set; }
     }
 
     [Owned]
@@ -770,26 +770,26 @@ public abstract partial class ModelBuilderTest
 
     protected class ValueCategory
     {
-        public CustomId Id { get; set; } = null!;
+        public required CustomId Id { get; set; }
     }
 
     protected class KeylessEntity
     {
         public int CustomerId { get; set; }
-        public Customer Customer { get; set; } = null!;
+        public required Customer Customer { get; set; }
     }
 
     protected class Parent
     {
         public int Id { get; set; }
-        public List<CompositeChild> Children { get; set; } = null!;
+        public required List<CompositeChild> Children { get; set; }
     }
 
     protected class CompositeChild
     {
         public int Id { get; set; }
         public int Value { get; set; }
-        public Parent Parent { get; set; } = null!;
+        public required Parent Parent { get; set; }
     }
 
     protected class BillingOwner
@@ -815,7 +815,7 @@ public abstract partial class ModelBuilderTest
         public Guid DependentShadowFkId { get; set; }
 
         [ForeignKey("PrincipalShadowFkId")]
-        public PrincipalShadowFk Principal { get; set; } = null!;
+        public required PrincipalShadowFk Principal { get; set; }
     }
 
     protected class PrincipalShadowFk
@@ -827,8 +827,8 @@ public abstract partial class ModelBuilderTest
     protected class BaseOwner
     {
         public int Id { get; set; }
-        public OwnedTypeInheritance1 Owned1 { get; set; } = null!;
-        public OwnedTypeInheritance2 Owned2 { get; set; } = null!;
+        public required OwnedTypeInheritance1 Owned1 { get; set; }
+        public required OwnedTypeInheritance2 Owned2 { get; set; }
     }
 
     protected class DerivedOwner : BaseOwner
@@ -855,19 +855,19 @@ public abstract partial class ModelBuilderTest
     protected class ComplexProperties
     {
         public int Id { get; set; }
-        public Customer Customer { get; set; } = null!;
-        public DoubleProperty DoubleProperty { get; set; } = null!;
-        public IndexedClass IndexedClass { get; set; } = null!;
-        public Quarks Quarks { get; set; } = null!;
+        public required Customer Customer { get; set; }
+        public required DoubleProperty DoubleProperty { get; set; }
+        public required IndexedClass IndexedClass { get; set; } 
+        public required Quarks Quarks { get; set; } 
 
         [NotMapped]
-        public DynamicProperty DynamicProperty { get; set; } = null!;
+        public required DynamicProperty DynamicProperty { get; set; } 
 
         [NotMapped]
-        public EntityWithFields EntityWithFields { get; set; } = null!;
+        public required EntityWithFields EntityWithFields { get; set; } 
 
         [NotMapped]
-        public WrappedStringEntity WrappedStringEntity { get; set; } = null!;
+        public required WrappedStringEntity WrappedStringEntity { get; set; }
     }
 
     protected class ValueComplexProperties
@@ -1005,7 +1005,7 @@ public abstract partial class ModelBuilderTest
         public string? Name { get; set; }
 
         [BackingField("_randomField")]
-        public List<NavDependent> Dependents { get; set; } = null!;
+        public required List<NavDependent> Dependents { get; set; }
     }
 
     protected class NavDependent
@@ -1115,8 +1115,8 @@ public abstract partial class ModelBuilderTest
         public int ManyToManyPrincipalWithFieldId;
         public int DependentWithFieldId;
 
-        public ManyToManyPrincipalWithField ManyToManyPrincipalWithField { get; set; } = null!;
-        public DependentWithField DependentWithField { get; set; } = null!;
+        public required ManyToManyPrincipalWithField ManyToManyPrincipalWithField { get; set; }
+        public required DependentWithField DependentWithField { get; set; }
     }
 
     protected class DependentWithField
@@ -1127,8 +1127,8 @@ public abstract partial class ModelBuilderTest
         public Guid AnotherOneToManyPrincipalId;
         public OneToManyPrincipalWithField? OneToManyPrincipal { get; set; }
         public int OneToOnePrincipalId;
-        public OneToOnePrincipalWithField OneToOnePrincipal { get; set; } = null!;
-        public List<ManyToManyPrincipalWithField> ManyToManyPrincipals { get; set; } = null!;
+        public required OneToOnePrincipalWithField OneToOnePrincipal { get; set; }
+        public required List<ManyToManyPrincipalWithField> ManyToManyPrincipals { get; set; }
     }
 
     protected class OneToManyOwnerWithField
@@ -1294,7 +1294,7 @@ public abstract partial class ModelBuilderTest
     {
         public Guid Id { get; set; }
         public decimal Number { get; set; }
-        public OwnedOtter OwnedEntity { get; set; } = null!;
+        public required OwnedOtter OwnedEntity { get; set; }
     }
 
     protected class OtherOtter

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -855,19 +855,19 @@ public abstract partial class ModelBuilderTest
     protected class ComplexProperties
     {
         public int Id { get; set; }
-        public Customer? Customer { get; set; }
-        public DoubleProperty? DoubleProperty { get; set; }
-        public IndexedClass? IndexedClass { get; set; }
-        public Quarks? Quarks { get; set; }
+        public Customer Customer { get; set; } = null!;
+        public DoubleProperty DoubleProperty { get; set; } = null!;
+        public IndexedClass IndexedClass { get; set; } = null!;
+        public Quarks Quarks { get; set; } = null!;
 
         [NotMapped]
-        public DynamicProperty? DynamicProperty { get; set; }
+        public DynamicProperty DynamicProperty { get; set; } = null!;
 
         [NotMapped]
-        public EntityWithFields? EntityWithFields { get; set; }
+        public EntityWithFields EntityWithFields { get; set; } = null!;
 
         [NotMapped]
-        public WrappedStringEntity? WrappedStringEntity { get; set; }
+        public WrappedStringEntity WrappedStringEntity { get; set; } = null!;
     }
 
     protected class ValueComplexProperties


### PR DESCRIPTION
Throw for complex properties of value types
Throw for optional complex properties

Part of #13947
Fixes #31344
