### PR TITLE
Fixes and improvements to StartsWith/EndsWith/Contains

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -736,6 +736,7 @@ public class QuerySqlGenerator : SqlExpressionVisitor
         }
 
         _relationalCommandBuilder.Append(" LIKE ");
+
         Visit(likeExpression.Pattern);
 
         if (likeExpression.EscapeChar != null)

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1029,7 +1029,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
     /// <inheritdoc />
     protected override Expression VisitParameter(ParameterExpression parameterExpression)
         => parameterExpression.Name?.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal) == true
-            ? new SqlParameterExpression(parameterExpression, null)
+            ? new SqlParameterExpression(parameterExpression.Name, parameterExpression.Type, null)
             : throw new InvalidOperationException(CoreStrings.TranslationFailed(parameterExpression.Print()));
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
@@ -6,32 +6,30 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 /// <summary>
 ///     An expression that represents a parameter in a SQL tree.
 /// </summary>
-/// <remarks>
-///     This is a simple wrapper around a <see cref="ParameterExpression" /> in the SQL tree.
-///     Instances of this type cannot be constructed by application or database provider code. If this is a problem for your
-///     application or provider, then please file an issue at
-///     <see href="https://github.com/dotnet/efcore">github.com/dotnet/efcore</see>.
-/// </remarks>
 public sealed class SqlParameterExpression : SqlExpression
 {
-    private readonly ParameterExpression _parameterExpression;
-    private readonly string _name;
-
-    internal SqlParameterExpression(ParameterExpression parameterExpression, RelationalTypeMapping? typeMapping)
-        : base(parameterExpression.Type.UnwrapNullableType(), typeMapping)
+    /// <summary>
+    ///     Creates a new instance of the <see cref="SqlParameterExpression" /> class.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="type">The <see cref="Type" /> of the expression.</param>
+    /// <param name="typeMapping">The <see cref="RelationalTypeMapping" /> associated with the expression.</param>
+    public SqlParameterExpression(string name, Type type, RelationalTypeMapping? typeMapping)
+        : this(name, type.UnwrapNullableType(), type.IsNullableType(), typeMapping)
     {
-        Check.DebugAssert(parameterExpression.Name != null, "Parameter must have name.");
+    }
 
-        _parameterExpression = parameterExpression;
-        _name = parameterExpression.Name;
-        IsNullable = parameterExpression.Type.IsNullableType();
+    private SqlParameterExpression(string name, Type type, bool nullable, RelationalTypeMapping? typeMapping)
+        : base(type, typeMapping)
+    {
+        Name = name;
+        IsNullable = nullable;
     }
 
     /// <summary>
     ///     The name of the parameter.
     /// </summary>
-    public string Name
-        => _name;
+    public string Name { get; }
 
     /// <summary>
     ///     The bool value indicating if this parameter can have null values.
@@ -44,7 +42,7 @@ public sealed class SqlParameterExpression : SqlExpression
     /// <param name="typeMapping">A relational type mapping to apply.</param>
     /// <returns>A new expression which has supplied type mapping.</returns>
     public SqlExpression ApplyTypeMapping(RelationalTypeMapping? typeMapping)
-        => new SqlParameterExpression(_parameterExpression, typeMapping);
+        => new SqlParameterExpression(Name, Type, IsNullable, typeMapping);
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -52,7 +50,7 @@ public sealed class SqlParameterExpression : SqlExpression
 
     /// <inheritdoc />
     protected override void Print(ExpressionPrinter expressionPrinter)
-        => expressionPrinter.Append("@" + _parameterExpression.Name);
+        => expressionPrinter.Append("@" + Name);
 
     /// <inheritdoc />
     public override bool Equals(object? obj)

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using ExpressionExtensions = Microsoft.EntityFrameworkCore.Query.ExpressionExtensions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 
@@ -13,6 +16,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExpressionVisitor
 {
+    private readonly QueryCompilationContext _queryCompilationContext;
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
     private static readonly HashSet<string> DateTimeDataTypes
         = new()
         {
@@ -43,6 +49,21 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
             ExpressionType.Modulo
         };
 
+    private static readonly MethodInfo StringStartsWithMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo StringEndsWithMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo StringContainsMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.Contains), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo EscapeLikePatternParameterMethod =
+        typeof(SqlServerSqlTranslatingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ConstructLikePatternParameter))!;
+
+    private const char LikeEscapeChar = '\\';
+    private const string LikeEscapeString = "\\";
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -55,6 +76,8 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
         QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
         : base(dependencies, queryCompilationContext, queryableMethodTranslatingExpressionVisitor)
     {
+        _queryCompilationContext = queryCompilationContext;
+        _sqlExpressionFactory = dependencies.SqlExpressionFactory;
     }
 
     /// <summary>
@@ -142,17 +165,264 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
     /// </summary>
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
-        if (methodCallExpression is { Method: { IsGenericMethod: true } } genericMethodCall
-            && genericMethodCall.Method.GetGenericMethodDefinition() == EnumerableMethods.ElementAt
-            && genericMethodCall.Arguments[0].Type == typeof(byte[]))
+        var method = methodCallExpression.Method;
+
+        if (method.IsGenericMethod
+            && method.GetGenericMethodDefinition() == EnumerableMethods.ElementAt
+            && methodCallExpression.Arguments[0].Type == typeof(byte[]))
         {
             return TranslateByteArrayElementAccess(
-                genericMethodCall.Arguments[0],
-                genericMethodCall.Arguments[1],
+                methodCallExpression.Arguments[0],
+                methodCallExpression.Arguments[1],
                 methodCallExpression.Type);
         }
 
+        if (method == StringStartsWithMethodInfo
+            && TryTranslateStartsEndsWithContains(
+                methodCallExpression.Object!, methodCallExpression.Arguments[0], StartsEndsWithContains.StartsWith, out var translation1))
+        {
+            return translation1;
+        }
+
+        if (method == StringEndsWithMethodInfo
+            && TryTranslateStartsEndsWithContains(
+                methodCallExpression.Object!, methodCallExpression.Arguments[0], StartsEndsWithContains.EndsWith, out var translation2))
+        {
+            return translation2;
+        }
+
+        if (method == StringContainsMethodInfo
+            && TryTranslateStartsEndsWithContains(
+                methodCallExpression.Object!, methodCallExpression.Arguments[0], StartsEndsWithContains.Contains, out var translation3))
+        {
+            return translation3;
+        }
+
         return base.VisitMethodCall(methodCallExpression);
+
+        bool TryTranslateStartsEndsWithContains(
+            Expression instance, Expression pattern, StartsEndsWithContains methodType, [NotNullWhen(true)] out SqlExpression? translation)
+        {
+            if (Visit(instance) is not SqlExpression translatedInstance
+                || Visit(pattern) is not SqlExpression translatedPattern)
+            {
+                translation = null;
+                return false;
+            }
+
+            var stringTypeMapping = ExpressionExtensions.InferTypeMapping(translatedInstance, translatedPattern);
+
+            translatedInstance = _sqlExpressionFactory.ApplyTypeMapping(translatedInstance, stringTypeMapping);
+            translatedPattern = _sqlExpressionFactory.ApplyTypeMapping(translatedPattern, stringTypeMapping);
+
+            switch (translatedPattern)
+            {
+                case SqlConstantExpression patternConstant:
+                {
+                    // The pattern is constant. Aside from null and empty string, we escape all special characters (%, _, \) and send a
+                    // simple LIKE
+                    translation = patternConstant.Value switch
+                    {
+                        null => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant(null, stringTypeMapping)),
+
+                        // In .NET, all strings start with/end with/contain the empty string, but SQL LIKE return false for empty patterns.
+                        // Return % which always matches instead.
+                        // Note that we don't just return a true constant, since null strings shouldn't match even an empty string
+                        // (but SqlNullabilityProcess will convert this to a true constant if the instance is non-nullable)
+                        "" => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant("%")),
+
+                        string s => s.Any(IsLikeWildChar)
+                            ? _sqlExpressionFactory.Like(
+                                translatedInstance,
+                                _sqlExpressionFactory.Constant(
+                                    methodType switch
+                                    {
+                                        StartsEndsWithContains.StartsWith => EscapeLikePattern(s) + '%',
+                                        StartsEndsWithContains.EndsWith => '%' + EscapeLikePattern(s),
+                                        StartsEndsWithContains.Contains => $"%{EscapeLikePattern(s)}%",
+
+                                        _ => throw new ArgumentOutOfRangeException(nameof(methodType), methodType, null)
+                                    }),
+                                _sqlExpressionFactory.Constant(LikeEscapeString))
+                            : _sqlExpressionFactory.Like(
+                                translatedInstance,
+                                _sqlExpressionFactory.Constant(
+                                    methodType switch
+                                    {
+                                        StartsEndsWithContains.StartsWith => s + '%',
+                                        StartsEndsWithContains.EndsWith => '%' + s,
+                                        StartsEndsWithContains.Contains => $"%{s}%",
+
+                                        _ => throw new ArgumentOutOfRangeException(nameof(methodType), methodType, null)
+                                    })),
+
+                        _ => throw new UnreachableException()
+                    };
+
+                    return true;
+                }
+
+                case SqlParameterExpression patternParameter
+                    when patternParameter.Name.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal):
+                {
+                    // The pattern is a parameter, register a runtime parameter that will contain the rewritten LIKE pattern, where
+                    // all special characters have been escaped.
+                    var lambda = Expression.Lambda(
+                        Expression.Call(
+                            EscapeLikePatternParameterMethod,
+                            QueryCompilationContext.QueryContextParameter,
+                            Expression.Constant(patternParameter.Name),
+                            Expression.Constant(methodType)),
+                        QueryCompilationContext.QueryContextParameter);
+
+                    var escapedPatternParameter =
+                        _queryCompilationContext.RegisterRuntimeParameter(patternParameter.Name + "_rewritten", lambda);
+
+                    translation = _sqlExpressionFactory.Like(
+                        translatedInstance,
+                        new SqlParameterExpression(escapedPatternParameter.Name!, escapedPatternParameter.Type, stringTypeMapping),
+                        _sqlExpressionFactory.Constant(LikeEscapeString));
+
+                    return true;
+                }
+
+                default:
+                    // The pattern is a column or a complex expression; the possible special characters in the pattern cannot be escaped,
+                    // preventing us from translating to LIKE.
+                    translation = methodType switch
+                    {
+                        // For StartsWith/EndsWith, use LEFT or RIGHT instead to extract substring and compare:
+                        // WHERE instance IS NOT NULL AND pattern IS NOT NULL AND LEFT(instance, LEN(pattern)) = pattern
+                        // This is less efficient than LIKE (i.e. StartsWith does an index scan instead of seek), but we have no choice.
+                        // Note that we compensate for the case where both the instance and the pattern are null (null.StartsWith(null)); a
+                        // simple equality would yield true in that case, but we want false. We technically
+                        StartsEndsWithContains.StartsWith or StartsEndsWithContains.EndsWith
+                            => _sqlExpressionFactory.AndAlso(
+                                _sqlExpressionFactory.IsNotNull(translatedInstance),
+                                _sqlExpressionFactory.AndAlso(
+                                    _sqlExpressionFactory.IsNotNull(translatedPattern),
+                                    _sqlExpressionFactory.Equal(
+                                        _sqlExpressionFactory.Function(
+                                            methodType is StartsEndsWithContains.StartsWith ? "LEFT" : "RIGHT",
+                                            new[]
+                                            {
+                                                translatedInstance,
+                                                _sqlExpressionFactory.Function(
+                                                    "LEN",
+                                                    new[] { translatedPattern },
+                                                    nullable: true,
+                                                    argumentsPropagateNullability: new[] { true },
+                                                    typeof(int))
+                                            },
+                                            nullable: true,
+                                            argumentsPropagateNullability: new[] { true, true },
+                                            typeof(string),
+                                            stringTypeMapping),
+                                        translatedPattern))),
+
+                        // For Contains, just use CHARINDEX and check if the result is greater than 0.
+                        // Add a check to return null when the pattern is an empty string (and the string isn't null)
+                        StartsEndsWithContains.Contains
+                            => _sqlExpressionFactory.AndAlso(
+                                _sqlExpressionFactory.IsNotNull(translatedInstance),
+                                _sqlExpressionFactory.AndAlso(
+                                    _sqlExpressionFactory.IsNotNull(translatedPattern),
+                                    _sqlExpressionFactory.OrElse(
+                                        _sqlExpressionFactory.GreaterThan(
+                                            _sqlExpressionFactory.Function(
+                                                "CHARINDEX",
+                                                new[] { translatedPattern, translatedInstance },
+                                                nullable: true,
+                                                argumentsPropagateNullability: new[] { true, true },
+                                                typeof(int)),
+                                            _sqlExpressionFactory.Constant(0)),
+                                        _sqlExpressionFactory.Like(
+                                            translatedPattern,
+                                            _sqlExpressionFactory.Constant(string.Empty, stringTypeMapping))))),
+
+                        _ => throw new UnreachableException()
+                    };
+
+                    return true;
+            }
+        }
+    }
+
+    private static string? ConstructLikePatternParameter(
+        QueryContext queryContext, string baseParameterName, StartsEndsWithContains methodType)
+        => queryContext.ParameterValues[baseParameterName] switch
+        {
+            null => null,
+
+            // In .NET, all strings start/end with the empty string, but SQL LIKE return false for empty patterns.
+            // Return % which always matches instead.
+            "" => "%",
+
+            string s => methodType switch
+            {
+                StartsEndsWithContains.StartsWith => EscapeLikePattern(s) + '%',
+                StartsEndsWithContains.EndsWith => '%' + EscapeLikePattern(s),
+                StartsEndsWithContains.Contains => $"%{EscapeLikePattern(s)}%",
+                _ => throw new ArgumentOutOfRangeException(nameof(methodType), methodType, null)
+            },
+
+            _ => throw new UnreachableException()
+        };
+
+    private enum StartsEndsWithContains
+    {
+        StartsWith,
+        EndsWith,
+        Contains
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    private static bool IsLikeWildChar(char c)
+        => c is '%' or '_' or '['; // See https://docs.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    private static string EscapeLikePattern(string pattern)
+    {
+        int i;
+        for (i = 0; i < pattern.Length; i++)
+        {
+            var c = pattern[i];
+            if (IsLikeWildChar(c) || c == LikeEscapeChar)
+            {
+                break;
+            }
+        }
+
+        if (i == pattern.Length) // No special characters were detected, just return the original pattern string
+        {
+            return pattern;
+        }
+
+        var builder = new StringBuilder(pattern, 0, i, pattern.Length + 10);
+
+        for (; i < pattern.Length; i++)
+        {
+            var c = pattern[i];
+            if (IsLikeWildChar(c)
+                || c == LikeEscapeChar)
+            {
+                builder.Append(LikeEscapeChar);
+            }
+
+            builder.Append(c);
+        }
+
+        return builder.ToString();
     }
 
     private Expression TranslateByteArrayElementAccess(Expression array, Expression index, Type resultType)

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using ExpressionExtensions = Microsoft.EntityFrameworkCore.Query.ExpressionExtensions;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 
@@ -14,6 +16,21 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 /// </summary>
 public class SqliteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExpressionVisitor
 {
+    private readonly QueryCompilationContext _queryCompilationContext;
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    private static readonly MethodInfo StringStartsWithMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo StringEndsWithMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo EscapeLikePatternParameterMethod =
+        typeof(SqliteSqlTranslatingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ConstructLikePatternParameter))!;
+
+    private const char LikeEscapeChar = '\\';
+    private const string LikeEscapeString = "\\";
+
     private static readonly IReadOnlyDictionary<ExpressionType, IReadOnlyCollection<Type>> RestrictedBinaryExpressions
         = new Dictionary<ExpressionType, IReadOnlyCollection<Type>>
         {
@@ -91,6 +108,8 @@ public class SqliteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
         QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
         : base(dependencies, queryCompilationContext, queryableMethodTranslatingExpressionVisitor)
     {
+        _queryCompilationContext = queryCompilationContext;
+        _sqlExpressionFactory = dependencies.SqlExpressionFactory;
     }
 
     /// <summary>
@@ -224,6 +243,213 @@ public class SqliteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
         }
 
         return visitedExpression;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        var method = methodCallExpression.Method;
+
+        if (method == StringStartsWithMethodInfo
+            && TryTranslateStartsEndsWith(
+                methodCallExpression.Object!, methodCallExpression.Arguments[0], startsWith: true, out var translation1))
+        {
+            return translation1;
+        }
+
+        if (method == StringEndsWithMethodInfo
+            && TryTranslateStartsEndsWith(
+                methodCallExpression.Object!, methodCallExpression.Arguments[0], startsWith: false, out var translation2))
+        {
+            return translation2;
+        }
+
+        return base.VisitMethodCall(methodCallExpression);
+
+        bool TryTranslateStartsEndsWith(
+            Expression instance,
+            Expression pattern,
+            bool startsWith,
+            [NotNullWhen(true)] out SqlExpression? translation)
+        {
+            if (Visit(instance) is not SqlExpression translatedInstance
+                || Visit(pattern) is not SqlExpression translatedPattern)
+            {
+                translation = null;
+                return false;
+            }
+
+            var stringTypeMapping = ExpressionExtensions.InferTypeMapping(translatedInstance, translatedPattern);
+
+            translatedInstance = _sqlExpressionFactory.ApplyTypeMapping(translatedInstance, stringTypeMapping);
+            translatedPattern = _sqlExpressionFactory.ApplyTypeMapping(translatedPattern, stringTypeMapping);
+
+            switch (translatedPattern)
+            {
+                case SqlConstantExpression patternConstant:
+                {
+                    // The pattern is constant. Aside from null and empty string, we escape all special characters (%, _, \) and send a
+                    // simple LIKE
+                    translation = patternConstant.Value switch
+                    {
+                        null => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant(null, stringTypeMapping)),
+
+                        // In .NET, all strings start with/end with/contain the empty string, but SQL LIKE return false for empty patterns.
+                        // Return % which always matches instead.
+                        // Note that we don't just return a true constant, since null strings shouldn't match even an empty string
+                        // (but SqlNullabilityProcess will convert this to a true constant if the instance is non-nullable)
+                        "" => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant("%")),
+
+                        string s => s.Any(IsLikeWildChar)
+                            ? _sqlExpressionFactory.Like(
+                                translatedInstance,
+                                _sqlExpressionFactory.Constant(startsWith ? EscapeLikePattern(s) + '%' : '%' + EscapeLikePattern(s)),
+                                _sqlExpressionFactory.Constant(LikeEscapeString))
+                            : _sqlExpressionFactory.Like(
+                                translatedInstance,
+                                _sqlExpressionFactory.Constant(startsWith ? s + '%' : '%' + s)),
+
+                        _ => throw new UnreachableException()
+                    };
+
+                    return true;
+                }
+
+                case SqlParameterExpression patternParameter
+                    when patternParameter.Name.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal):
+                {
+                    // The pattern is a parameter, register a runtime parameter that will contain the rewritten LIKE pattern, where
+                    // all special characters have been escaped.
+                    var lambda = Expression.Lambda(
+                        Expression.Call(
+                            EscapeLikePatternParameterMethod,
+                            QueryCompilationContext.QueryContextParameter,
+                            Expression.Constant(patternParameter.Name),
+                            Expression.Constant(startsWith)),
+                        QueryCompilationContext.QueryContextParameter);
+
+                    var escapedPatternParameter =
+                        _queryCompilationContext.RegisterRuntimeParameter(patternParameter.Name + "_rewritten", lambda);
+
+                    translation = _sqlExpressionFactory.Like(
+                        translatedInstance,
+                        new SqlParameterExpression(escapedPatternParameter.Name!, escapedPatternParameter.Type, stringTypeMapping),
+                        _sqlExpressionFactory.Constant(LikeEscapeString));
+
+                    return true;
+                }
+
+                default:
+                    // The pattern is a column or a complex expression; the possible special characters in the pattern cannot be escaped,
+                    // preventing us from translating to LIKE.
+                    if (startsWith)
+                    {
+                        // Generate: WHERE instance IS NOT NULL AND pattern IS NOT NULL AND (substr(instance, 1, length(pattern)) = pattern OR pattern = '')
+                        // Note that the empty string pattern needs special handling, since in .NET it returns true for all non-null
+                        // instances, but substr(instance, 0) returns the entire string in SQLite.
+                        // Note that we compensate for the case where both the instance and the pattern are null (null.StartsWith(null)); a
+                        // simple equality would yield true in that case, but we want false. We technically
+                        translation = _sqlExpressionFactory.AndAlso(
+                            _sqlExpressionFactory.IsNotNull(translatedInstance),
+                            _sqlExpressionFactory.AndAlso(
+                                _sqlExpressionFactory.IsNotNull(translatedPattern),
+                                _sqlExpressionFactory.OrElse(
+                                    _sqlExpressionFactory.Equal(
+                                        _sqlExpressionFactory.Function(
+                                            "substr",
+                                            new[]
+                                            {
+                                                translatedInstance,
+                                                _sqlExpressionFactory.Constant(1),
+                                                _sqlExpressionFactory.Function(
+                                                    "length",
+                                                    new[] { translatedPattern },
+                                                    nullable: true,
+                                                    argumentsPropagateNullability: new[] { true },
+                                                    typeof(int))
+                                            },
+                                            nullable: true,
+                                            argumentsPropagateNullability: new[] { true, false, true },
+                                            typeof(string),
+                                            stringTypeMapping),
+                                        translatedPattern),
+                                    _sqlExpressionFactory.Equal(translatedPattern, _sqlExpressionFactory.Constant(string.Empty)))));
+                    }
+                    else
+                    {
+                        // Generate: WHERE instance IS NOT NULL AND pattern IS NOT NULL AND (substr(instance, -length(pattern)) = pattern OR pattern = '')
+                        // Note that the empty string pattern needs special handling, since in .NET it returns true for all non-null
+                        // instances, but substr(instance, 0) returns the entire string in SQLite.
+                        // Note that we compensate for the case where both the instance and the pattern are null (null.StartsWith(null)); a
+                        // simple equality would yield true in that case, but we want false. We technically
+                        translation =
+                            _sqlExpressionFactory.AndAlso(
+                                _sqlExpressionFactory.IsNotNull(translatedInstance),
+                                _sqlExpressionFactory.AndAlso(
+                                    _sqlExpressionFactory.IsNotNull(translatedPattern),
+                                    _sqlExpressionFactory.OrElse(
+                                        _sqlExpressionFactory.Equal(
+                                            _sqlExpressionFactory.Function(
+                                                "substr",
+                                                new[]
+                                                {
+                                                    translatedInstance,
+                                                    _sqlExpressionFactory.Negate(
+                                                        _sqlExpressionFactory.Function(
+                                                            "length",
+                                                            new[] { translatedPattern },
+                                                            nullable: true,
+                                                            argumentsPropagateNullability: new[] { true },
+                                                            typeof(int)))
+                                                },
+                                                nullable: true,
+                                                argumentsPropagateNullability: new[] { true, true },
+                                                typeof(string),
+                                                stringTypeMapping),
+                                            translatedPattern),
+                                        _sqlExpressionFactory.Equal(translatedPattern, _sqlExpressionFactory.Constant(string.Empty)))));
+                    }
+
+                    return true;
+            }
+        }
+    }
+
+    private static string? ConstructLikePatternParameter(
+        QueryContext queryContext, string baseParameterName, bool startsWith)
+        => queryContext.ParameterValues[baseParameterName] switch
+        {
+            null => null,
+
+            // In .NET, all strings start/end with the empty string, but SQL LIKE return false for empty patterns.
+            // Return % which always matches instead.
+            "" => "%",
+
+            string s => startsWith ? EscapeLikePattern(s) + '%' : '%' + EscapeLikePattern(s),
+
+            _ => throw new UnreachableException()
+        };
+
+    // See https://www.sqlite.org/lang_expr.html
+    private static bool IsLikeWildChar(char c)
+        => c is '%' or '_';
+
+    private static string EscapeLikePattern(string pattern)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < pattern.Length; i++)
+        {
+            var c = pattern[i];
+            if (IsLikeWildChar(c)
+                || c == LikeEscapeChar)
+            {
+                builder.Append(LikeEscapeChar);
+            }
+
+            builder.Append(c);
+        }
+
+        return builder.ToString();
     }
 
     [return: NotNullIfNotNull(nameof(expression))]

--- a/src/EFCore/DbFunctionsExtensions.cs
+++ b/src/EFCore/DbFunctionsExtensions.cs
@@ -31,10 +31,7 @@ public static class DbFunctionsExtensions
     /// <param name="matchExpression">The string that is to be matched.</param>
     /// <param name="pattern">The pattern which may involve wildcards <c>%,_,[,],^</c>.</param>
     /// <returns><see langword="true" /> if there is a match.</returns>
-    public static bool Like(
-        this DbFunctions _,
-        string matchExpression,
-        string pattern)
+    public static bool Like(this DbFunctions _, string? matchExpression, string? pattern)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Like)));
 
     /// <summary>
@@ -59,11 +56,7 @@ public static class DbFunctionsExtensions
     ///     if they are not used as wildcards.
     /// </param>
     /// <returns><see langword="true" /> if there is a match.</returns>
-    public static bool Like(
-        this DbFunctions _,
-        string matchExpression,
-        string pattern,
-        string escapeCharacter)
+    public static bool Like(this DbFunctions _, string? matchExpression, string? pattern, string? escapeCharacter)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Like)));
 
     /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -30,7 +30,21 @@ public class NorthwindFunctionsQueryCosmosTest : NorthwindFunctionsQueryTestBase
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] != null) AND (("M" != null) AND STARTSWITH(c["ContactName"], "M"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
+""");
+    }
+
+    public override async Task String_StartsWith_Parameter(bool async)
+    {
+        await base.String_StartsWith_Parameter(async);
+
+        AssertSql(
+"""
+@__pattern_0='M'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], @__pattern_0))
 """);
     }
 
@@ -42,8 +56,9 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] != null) AND (("
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] = "") OR ((c["ContactName"] != null) AND ((c["ContactName"] != null) AND STARTSWITH(c["ContactName"], c["ContactName"])))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], c["ContactName"]))
 """);
+
     }
 
     public override async Task String_StartsWith_Column(bool async)
@@ -54,7 +69,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] = "") OR ((c["Co
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] = "") OR ((c["ContactName"] != null) AND ((c["ContactName"] != null) AND STARTSWITH(c["ContactName"], c["ContactName"])))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], c["ContactName"]))
 """);
     }
 
@@ -66,7 +81,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] = "") OR ((c["Co
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] != null) AND (("M" != null) AND STARTSWITH(c["ContactName"], "M"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["ContactName"], "M"))
 """);
     }
 
@@ -78,7 +93,21 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] != null) AND (("
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] != null) AND (("b" != null) AND ENDSWITH(c["ContactName"], "b"))))
+WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "b"))
+""");
+    }
+
+    public override async Task String_EndsWith_Parameter(bool async)
+    {
+        await base.String_EndsWith_Parameter(async);
+
+        AssertSql(
+"""
+@__pattern_0='b'
+
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], @__pattern_0))
 """);
     }
 
@@ -90,7 +119,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] != null) AND (("
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] = "") OR ((c["ContactName"] != null) AND ((c["ContactName"] != null) AND ENDSWITH(c["ContactName"], c["ContactName"])))))
+WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], c["ContactName"]))
 """);
     }
 
@@ -102,7 +131,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] = "") OR ((c["Co
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] = "") OR ((c["ContactName"] != null) AND ((c["ContactName"] != null) AND ENDSWITH(c["ContactName"], c["ContactName"])))))
+WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], c["ContactName"]))
 """);
     }
 
@@ -114,7 +143,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] = "") OR ((c["Co
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["ContactName"] != null) AND (("m" != null) AND ENDSWITH(c["ContactName"], "m"))))
+WHERE ((c["Discriminator"] = "Customer") AND ENDSWITH(c["ContactName"], "m"))
 """);
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -1429,7 +1429,7 @@ ORDER BY c["Title"], c["EmployeeID"]
 """
 SELECT c["City"]
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["Country"], c["City"]
 """);
     }
@@ -2966,7 +2966,7 @@ WHERE ((c["Discriminator"] = "Order") AND (c["OrderID"] = 10300))
 
 SELECT c["CustomerID"]
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((@__prefix_0 = "") OR ((c["CustomerID"] != null) AND ((@__prefix_0 != null) AND STARTSWITH(c["CustomerID"], @__prefix_0)))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], @__prefix_0))
 """);
     }
 
@@ -2994,7 +2994,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((@__prefix_0 = "") OR ((c["Custome
 """
 SELECT c["CustomerID"]
 FROM root c
-WHERE (((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A")))) AND NOT((c["CustomerID"] = null)))
+WHERE (((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A")) AND NOT((c["CustomerID"] = null)))
 ORDER BY c["CustomerID"]
 """);
     }
@@ -3059,7 +3059,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
 """
 SELECT c["CustomerID"]
 FROM root c
-WHERE (((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A")))) AND (c["CustomerID"] = c["CustomerID"]))
+WHERE (((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A")) AND (c["CustomerID"] = c["CustomerID"]))
 """);
     }
 
@@ -3095,7 +3095,7 @@ WHERE (((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("
 """
 SELECT c["CustomerID"]
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
 """);
     }
@@ -3108,7 +3108,7 @@ ORDER BY c["CustomerID"]
 """
 SELECT c["CustomerID"]
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"] DESC
 """);
     }
@@ -4238,7 +4238,7 @@ ORDER BY c["CustomerID"]
 """
 SELECT c["CustomerID"]
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -119,7 +119,7 @@ WHERE ((c["Discriminator"] = "Employee") AND (c["EmployeeID"] = 1))
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
 """);
     }
@@ -426,7 +426,7 @@ WHERE ((c["Discriminator"] = "Customer") AND (c["City"] = "London"))
 """
 SELECT 1
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
     }
 
@@ -903,7 +903,7 @@ WHERE (c["Discriminator"] = "Order")
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
     }
 
@@ -915,7 +915,7 @@ WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 """);
     }
 
@@ -1292,7 +1292,7 @@ ORDER BY c["CustomerID"]
 
 SELECT VALUE {"Aggregate" : ((c["CustomerID"] || " ") || c["City"])}
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "A"))
 ORDER BY c["CustomerID"]
 OFFSET 0 LIMIT @__p_0
 """);
@@ -1632,7 +1632,7 @@ ORDER BY c["EmployeeID"]
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Order") AND ((c["CustomerID"] != null) AND (("A" != null) AND STARTSWITH(c["CustomerID"], "A"))))
+WHERE ((c["Discriminator"] = "Order") AND STARTSWITH(c["CustomerID"], "A"))
 """);
     }
 
@@ -1824,7 +1824,7 @@ WHERE (c["Discriminator"] = "Customer")
 """
 SELECT c["CustomerID"]
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND ((c["CustomerID"] != null) AND (("F" != null) AND STARTSWITH(c["CustomerID"], "F"))))
+WHERE ((c["Discriminator"] = "Customer") AND STARTSWITH(c["CustomerID"], "F"))
 """);
     }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -1667,7 +1667,7 @@ WHERE ((c["Discriminator"] = "Product") AND (c["UnitsInStock"] > 10))
 """
 SELECT c
 FROM root c
-WHERE ((c["Discriminator"] = "Customer") AND (((c["CustomerID"] != null) AND (("KI" != null) AND ENDSWITH(c["CustomerID"], "KI"))) = true))
+WHERE ((c["Discriminator"] = "Customer") AND (ENDSWITH(c["CustomerID"], "KI") = true))
 """);
     }
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -29,6 +29,30 @@ public class GearsOfWarQueryInMemoryTest : GearsOfWarQueryTestBase<GearsOfWarQue
                     .Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(
                         async))).Message);
 
+    public override async Task Group_by_on_StartsWith_with_null_parameter_as_argument(bool async)
+        => Assert.Equal(
+            "Value cannot be null. (Parameter 'value')",
+            (await Assert.ThrowsAsync<ArgumentNullException>(
+                () => base.Group_by_on_StartsWith_with_null_parameter_as_argument(async))).Message);
+
+    public override async Task Group_by_with_having_StartsWith_with_null_parameter_as_argument(bool async)
+        => Assert.Equal(
+            "Value cannot be null. (Parameter 'value')",
+            (await Assert.ThrowsAsync<ArgumentNullException>(
+                () => base.Group_by_with_having_StartsWith_with_null_parameter_as_argument(async))).Message);
+
+    public override async Task OrderBy_StartsWith_with_null_parameter_as_argument(bool async)
+        => Assert.Equal(
+            "Value cannot be null. (Parameter 'value')",
+            (await Assert.ThrowsAsync<ArgumentNullException>(
+                () => base.OrderBy_StartsWith_with_null_parameter_as_argument(async))).Message);
+
+    public override async Task Select_StartsWith_with_null_parameter_as_argument(bool async)
+        => Assert.Equal(
+            "Value cannot be null. (Parameter 'value')",
+            (await Assert.ThrowsAsync<ArgumentNullException>(
+                () => base.Select_StartsWith_with_null_parameter_as_argument(async))).Message);
+
     public override async Task Projecting_entity_as_well_as_correlated_collection_followed_by_Distinct(bool async)
         // Distinct. Issue #24325.
         => Assert.Equal(

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindFunctionsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindFunctionsQueryRelationalTestBase.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class NorthwindFunctionsQueryRelationalTestBase<TFixture> : NorthwindFunctionsQueryTestBase<TFixture>

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -310,6 +310,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture> : QueryTestBase<
             async,
             ss => from e1 in ss.Set<Level1>()
                   where e1.OneToOne_Optional_FK1.Name.StartsWith(e1.OneToOne_Optional_FK1.Name)
+                  select e1,
+            ss => from e1 in ss.Set<Level1>()
+                  where e1.OneToOne_Optional_FK1.Name.MaybeScalar(x => x.StartsWith(e1.OneToOne_Optional_FK1.Name)) == true
                   select e1);
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
@@ -23,11 +23,13 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
     {
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("%B")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("%B")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("%B")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("a_")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("a_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("a_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
@@ -37,28 +39,28 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("_Ba_")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("_Ba_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("_Ba_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains("%B%a%r")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.Contains("%B%a%r")) == true)
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("%B%a%r")) != true)
                 .Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains("")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.Contains("")) == true)
-                .Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(null)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
     [ConditionalTheory]
@@ -68,12 +70,14 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         var prm1 = "%B";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm1)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm1)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm1)) == true).Select(c => c.FirstName));
 
         var prm2 = "a_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm2)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm2)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm2)) == true).Select(c => c.FirstName));
 
         var prm3 = (string)null;
         await AssertQuery(
@@ -85,31 +89,32 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm4)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         var prm5 = "_Ba_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm5)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm5)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm5)) == true).Select(c => c.FirstName));
 
         var prm6 = "%B%a%r";
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(prm6)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.Contains(prm6)) == true)
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm6)) != true)
                 .Select(c => c.FirstName));
 
         var prm7 = "";
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(prm7)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null).Select(c => c.FirstName));
 
         var prm8 = (string)null;
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(prm8)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
     [ConditionalTheory]
@@ -122,7 +127,7 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Where(r => r.fn.Contains(r.ln)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.ln == "" || r.fn.Contains(r.ln)),
+                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) == true),
             elementSorter: e => (e.fn, e.ln),
             elementAsserter: (e, a) =>
             {
@@ -140,7 +145,8 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Where(r => !r.fn.Contains(r.ln)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) == true));
+                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) != true));
+                // .Where(r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) == true));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -148,11 +154,13 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
     {
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("%B")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("a_")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("a_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("a_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
@@ -162,28 +170,29 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("_Ba_")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("_Ba_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("_Ba_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith("%B%a%r")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.StartsWith("%B%a%r")) == true)
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("%B%a%r")) != true)
                 .Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith("")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.StartsWith("")) == true)
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null)
                 .Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(null)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
     [ConditionalTheory]
@@ -193,12 +202,14 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         var prm1 = "%B";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm1)) == true).Select(c => c.FirstName));
 
         var prm2 = "a_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm2)) == true).Select(c => c.FirstName));
 
         var prm3 = (string)null;
         await AssertQuery(
@@ -210,31 +221,32 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm4)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         var prm5 = "_Ba_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm5)) == true).Select(c => c.FirstName));
 
         var prm6 = "%B%a%r";
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(prm6)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.StartsWith(prm6)) == true)
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm6)) != true)
                 .Select(c => c.FirstName));
 
         var prm7 = "";
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(prm7)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null).Select(c => c.FirstName));
 
         var prm8 = (string)null;
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(prm8)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
     [ConditionalTheory]
@@ -243,34 +255,41 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
     {
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("[")));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("[")),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("[")) == true));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[")));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[")),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("B[")) == true));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[[a^")));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[[a^")),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("B[[a^")) == true));
 
         var prm1 = "[";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm1)) == true));
 
         var prm2 = "B[";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm2)) == true));
 
         var prm3 = "B[[a^";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm3)));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm3)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm3)) == true));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(c.LastName)));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(c.LastName)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => c.LastName.MaybeScalar(xx => x.StartsWith(xx))) == true));
     }
 
     [ConditionalTheory]
@@ -283,7 +302,7 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Where(r => r.fn.StartsWith(r.ln)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.ln == "" || r.fn.StartsWith(r.ln)),
+                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.StartsWith(xx))) == true),
             elementSorter: e => (e.fn, e.ln),
             elementAsserter: (e, a) =>
             {
@@ -301,7 +320,7 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Where(r => !r.fn.StartsWith(r.ln)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.StartsWith(xx))) == true));
+                .Where(r => !(r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.StartsWith(xx))) == true)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -309,11 +328,13 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
     {
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("%B")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("%B")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("%B")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("a_")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("a_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("a_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
@@ -323,27 +344,27 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("_Ba_")).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("_Ba_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("_Ba_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith("%B%a%r")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.EndsWith("%B%a%r")) == true)
-                .Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("%B%a%r")) != true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith("")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.EndsWith("")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("")) != true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(null)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
     [ConditionalTheory]
@@ -353,12 +374,14 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         var prm1 = "%B";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm1)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm1)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm1)) == true).Select(c => c.FirstName));
 
         var prm2 = "a_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm2)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm2)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm2)) == true).Select(c => c.FirstName));
 
         var prm3 = (string)null;
         await AssertQuery(
@@ -370,30 +393,31 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm4)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm4)) == true).Select(c => c.FirstName));
 
         var prm5 = "_Ba_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm5)).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm5)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm5)) == true).Select(c => c.FirstName));
 
         var prm6 = "%B%a%r";
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(prm6)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.EndsWith(prm6)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm6)) != true).Select(c => c.FirstName));
 
         var prm7 = "";
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(prm7)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null).Select(c => c.FirstName));
 
         var prm8 = (string)null;
         await AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(prm8)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
     [ConditionalTheory]
@@ -406,7 +430,7 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Where(r => r.fn.EndsWith(r.ln)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.ln == "" || r.fn.EndsWith(r.ln)),
+                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true),
             elementSorter: e => (e.fn, e.ln),
             elementAsserter: (e, a) =>
             {
@@ -424,7 +448,7 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Where(r => !r.fn.EndsWith(r.ln)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true));
+                .Where(r => !(r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -436,7 +460,7 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Where(r => r.fn.EndsWith(r.ln) ? true : false),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.ln == "" || r.fn.EndsWith(r.ln) ? true : false),
+                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true),
             elementSorter: e => (e.fn, e.ln),
             elementAsserter: (e, a) =>
             {
@@ -455,7 +479,7 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
                 .Where(
-                    r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true
+                    r => !(r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true)
                         ? true
                         : false));
 
@@ -466,6 +490,8 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
             async,
             ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
                 .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) == r.c1.NullableBool.Value),
+            ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
+                .Where(r => (r.c1.FirstName != null && r.c2.LastName != null && r.c1.FirstName.EndsWith(r.c2.LastName)) == r.c1.NullableBool),
             elementSorter: e => (e.c1.Id, e.c2.Id),
             elementAsserter: (e, a) =>
             {
@@ -480,6 +506,8 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
             async,
             ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
                 .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) != r.c1.NullableBool.Value),
+            ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
+                .Where(r => (r.c1.FirstName != null && r.c2.LastName != null && r.c1.FirstName.EndsWith(r.c2.LastName)) != r.c1.NullableBool),
             elementSorter: e => (e.c1.Id, e.c2.Id),
             elementAsserter: (e, a) =>
             {

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -42,6 +42,18 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_StartsWith_Parameter(bool async)
+    {
+        var pattern = "M";
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ContactName.StartsWith(pattern)),
+            entryCount: 12);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task String_StartsWith_Identity(bool async)
         => AssertQuery(
             async,
@@ -71,6 +83,18 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
             async,
             ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith("b")),
             entryCount: 1);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_EndsWith_Parameter(bool async)
+    {
+        var pattern = "b";
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith(pattern)),
+            entryCount: 1);
+    }
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqlServerTest.cs
@@ -116,7 +116,7 @@ LEFT JOIN [Context30572_Dependent] AS [c0] ON [c].[DependentId] = [c0].[Id]
 DELETE FROM [p]
 FROM [Posts] AS [p]
 LEFT JOIN [Blogs] AS [b] ON [p].[BlogId] = [b].[Id]
-WHERE [b].[Title] IS NOT NULL AND [b].[Title] LIKE N'Arthur%'
+WHERE [b].[Title] LIKE N'Arthur%'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqlServerTest.cs
@@ -357,7 +357,7 @@ DELETE FROM [o]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-WHERE [c].[CustomerID] IS NOT NULL AND [c].[CustomerID] LIKE N'F%'
+WHERE [c].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -503,7 +503,7 @@ DELETE FROM [o]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-WHERE [c].[City] IS NOT NULL AND [c].[City] LIKE N'Se%'
+WHERE [c].[City] LIKE N'Se%'
 """);
     }
 
@@ -1324,7 +1324,7 @@ FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
-    WHERE [c0].[City] IS NOT NULL AND [c0].[City] LIKE N'S%'
+    WHERE [c0].[City] LIKE N'S%'
 ) AS [t]
 LEFT JOIN (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
@@ -1347,7 +1347,7 @@ FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
-    WHERE [c0].[City] IS NOT NULL AND [c0].[City] LIKE N'S%'
+    WHERE [c0].[City] LIKE N'S%'
 ) AS [t]
 CROSS APPLY (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
@@ -1370,7 +1370,7 @@ FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
     FROM [Customers] AS [c0]
-    WHERE [c0].[City] IS NOT NULL AND [c0].[City] LIKE N'S%'
+    WHERE [c0].[City] LIKE N'S%'
 ) AS [t]
 OUTER APPLY (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -153,7 +153,7 @@ SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND [l].[Name] LIKE N'%03' THEN 1
+    WHEN [l].[Name] LIKE N'%03' THEN 1
     ELSE 2
 END, [l].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -479,7 +479,7 @@ LEFT JOIN (
     WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND [l].[Name] LIKE N'%03' THEN 1
+    WHEN [l].[Name] LIKE N'%03' THEN 1
     ELSE 2
 END, [l].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
@@ -1900,7 +1900,7 @@ ORDER BY [l].[Id]
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND [l].[Name] LIKE N'%03' THEN 1
+    WHEN [l].[Name] LIKE N'%03' THEN 1
     ELSE 2
 END, [l].[Id]
 """,
@@ -1910,7 +1910,7 @@ SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND [l].[Name] LIKE N'%03' THEN 1
+    WHEN [l].[Name] LIKE N'%03' THEN 1
     ELSE 2
 END, [l].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -270,7 +270,7 @@ WHERE [l0].[Id] > 5
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
-WHERE [l0].[Name] IS NOT NULL AND [l0].[Name] LIKE N'L%'
+WHERE [l0].[Name] LIKE N'L%'
 """);
     }
 
@@ -283,7 +283,7 @@ WHERE [l0].[Name] IS NOT NULL AND [l0].[Name] LIKE N'L%'
 SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse3Id], [l].[OneToMany_Optional_Self_Inverse3Id], [l].[OneToMany_Required_Inverse3Id], [l].[OneToMany_Required_Self_Inverse3Id], [l].[OneToOne_Optional_PK_Inverse3Id], [l].[OneToOne_Optional_Self3Id]
 FROM [LevelThree] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Level2_Required_Id] = [l0].[Id]
-WHERE [l0].[Name] IS NOT NULL AND [l0].[Name] LIKE N'L%'
+WHERE [l0].[Name] LIKE N'L%'
 """);
     }
 
@@ -296,7 +296,7 @@ WHERE [l0].[Name] IS NOT NULL AND [l0].[Name] LIKE N'L%'
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE [l0].[Name] IS NOT NULL AND [l0].[Name] LIKE N'L%'
+WHERE [l0].[Name] LIKE N'L%'
 """);
     }
 
@@ -322,7 +322,7 @@ WHERE [l0].[Name] = N'L2 01'
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE [l0].[Name] IS NOT NULL AND UPPER([l0].[Name]) LIKE N'L%'
+WHERE UPPER([l0].[Name]) LIKE N'L%'
 """);
     }
 
@@ -335,7 +335,7 @@ WHERE [l0].[Name] IS NOT NULL AND UPPER([l0].[Name]) LIKE N'L%'
 SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE [l0].[Name] = N'' OR ([l0].[Name] IS NOT NULL AND LEFT([l0].[Name], LEN([l0].[Name])) = [l0].[Name])
+WHERE [l0].[Name] IS NOT NULL AND LEFT([l0].[Name], LEN([l0].[Name])) = [l0].[Name]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -3127,7 +3127,7 @@ LEFT JOIN (
     FROM [Level1] AS [l0]
     WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t] ON [l].[Id] = [t].[Level1_Optional_Id]
-WHERE [t].[Level2_Name] IS NOT NULL AND [t].[Level2_Name] LIKE N'L%'
+WHERE [t].[Level2_Name] LIKE N'L%'
 """);
     }
 
@@ -4103,7 +4103,7 @@ LEFT JOIN (
     FROM [Level1] AS [l0]
     WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t] ON [l].[Id] = [t].[Level1_Optional_Id]
-WHERE [t].[Level2_Name] = N'' OR ([t].[Level2_Name] IS NOT NULL AND LEFT([t].[Level2_Name], LEN([t].[Level2_Name])) = [t].[Level2_Name])
+WHERE [t].[Level2_Name] IS NOT NULL AND LEFT([t].[Level2_Name], LEN([t].[Level2_Name])) = [t].[Level2_Name]
 """);
     }
 
@@ -4417,7 +4417,7 @@ LEFT JOIN (
     FROM [Level1] AS [l0]
     WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t] ON [l].[Id] = [t].[Level1_Optional_Id]
-WHERE [t].[Level2_Name] IS NOT NULL AND UPPER([t].[Level2_Name]) LIKE N'L%'
+WHERE UPPER([t].[Level2_Name]) LIKE N'L%'
 """);
     }
 
@@ -4457,7 +4457,7 @@ LEFT JOIN (
     FROM [Level1] AS [l0]
     WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t] ON [l].[Id] = [t].[Level1_Required_Id]
-WHERE [t].[Level2_Name] IS NOT NULL AND [t].[Level2_Name] LIKE N'L%'
+WHERE [t].[Level2_Name] LIKE N'L%'
 """);
     }
 
@@ -6531,7 +6531,7 @@ LEFT JOIN (
 ) AS [t1] ON [t0].[Level2_Required_Id] = CASE
     WHEN [t1].[OneToOne_Required_PK_Date] IS NOT NULL AND [t1].[Level1_Required_Id] IS NOT NULL AND [t1].[OneToMany_Required_Inverse2Id] IS NOT NULL THEN [t1].[Id]
 END
-WHERE [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [t0].[Level2_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [t1].[Level2_Name] IS NOT NULL AND [t1].[Level2_Name] LIKE N'L%'
+WHERE [t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL AND [t0].[Level2_Required_Id] IS NOT NULL AND [t0].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [t1].[Level2_Name] LIKE N'L%'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -39,12 +39,13 @@ WHERE [f].[FirstName] LIKE N'%a\_%' ESCAPE N'\'
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE NULL
+WHERE 0 = 1
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
+WHERE [f].[FirstName] IS NOT NULL
 """,
             //
 """
@@ -56,19 +57,18 @@ WHERE [f].[FirstName] LIKE N'%\_Ba\_%' ESCAPE N'\'
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE N'%\%B\%a\%r%' ESCAPE N'\'
+WHERE [f].[FirstName] NOT LIKE N'%\%B\%a\%r%' ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE 0 = 1
+WHERE [f].[FirstName] IS NULL
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE NULL
 """);
     }
 
@@ -78,63 +78,62 @@ WHERE [f].[FirstName] NOT LIKE NULL
 
         AssertSql(
 """
-@__prm1_0='%B' (Size = 4000)
+@__prm1_0_rewritten='%\%B%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm1_0 LIKE N'' OR CHARINDEX(@__prm1_0, [f].[FirstName]) > 0
+WHERE [f].[FirstName] LIKE @__prm1_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm2_0='a_' (Size = 4000)
+@__prm2_0_rewritten='%a\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm2_0 LIKE N'' OR CHARINDEX(@__prm2_0, [f].[FirstName]) > 0
+WHERE [f].[FirstName] LIKE @__prm2_0_rewritten ESCAPE N'\'
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NULL LIKE N'' OR CHARINDEX(NULL, [f].[FirstName]) > 0
+WHERE 0 = 1
 """,
             //
 """
-@__prm4_0='' (Size = 4000)
+@__prm4_0_rewritten='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm4_0 LIKE N'' OR CHARINDEX(@__prm4_0, [f].[FirstName]) > 0
+WHERE [f].[FirstName] LIKE @__prm4_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm5_0='_Ba_' (Size = 4000)
+@__prm5_0_rewritten='%\_Ba\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm5_0 LIKE N'' OR CHARINDEX(@__prm5_0, [f].[FirstName]) > 0
+WHERE [f].[FirstName] LIKE @__prm5_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm6_0='%B%a%r' (Size = 4000)
+@__prm6_0_rewritten='%\%B\%a\%r%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NOT (@__prm6_0 LIKE N'' OR CHARINDEX(@__prm6_0, [f].[FirstName]) > 0)
+WHERE [f].[FirstName] NOT LIKE @__prm6_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
 """
-@__prm7_0='' (Size = 4000)
+@__prm7_0_rewritten='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NOT (@__prm7_0 LIKE N'' OR CHARINDEX(@__prm7_0, [f].[FirstName]) > 0)
+WHERE [f].[FirstName] NOT LIKE @__prm7_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NOT (NULL LIKE N'' OR CHARINDEX(NULL, [f].[FirstName]) > 0)
 """);
     }
 
@@ -143,11 +142,11 @@ WHERE NOT (NULL LIKE N'' OR CHARINDEX(NULL, [f].[FirstName]) > 0)
         await base.String_contains_on_argument_with_wildcard_column(async);
 
         AssertSql(
-"""
+            """
 SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE [f0].[LastName] LIKE N'' OR CHARINDEX([f0].[LastName], [f].[FirstName]) > 0
+WHERE [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND (CHARINDEX([f0].[LastName], [f].[FirstName]) > 0 OR [f0].[LastName] LIKE N'')
 """);
     }
 
@@ -160,7 +159,7 @@ WHERE [f0].[LastName] LIKE N'' OR CHARINDEX([f0].[LastName], [f].[FirstName]) > 
 SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE NOT ([f0].[LastName] LIKE N'' OR CHARINDEX([f0].[LastName], [f].[FirstName]) > 0)
+WHERE NOT ([f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND (CHARINDEX([f0].[LastName], [f].[FirstName]) > 0 OR [f0].[LastName] LIKE N''))
 """);
     }
 
@@ -172,36 +171,13 @@ WHERE NOT ([f0].[LastName] LIKE N'' OR CHARINDEX([f0].[LastName], [f].[FirstName
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'\%B%' ESCAPE N'\'
+WHERE [f].[FirstName] LIKE N'\%B%' ESCAPE N'\'
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'a\_%' ESCAPE N'\'
-""",
-            //
-"""
-SELECT [f].[FirstName]
-FROM [FunkyCustomers] AS [f]
-WHERE 0 = 1
-""",
-            //
-"""
-SELECT [f].[FirstName]
-FROM [FunkyCustomers] AS [f]
-""",
-            //
-"""
-SELECT [f].[FirstName]
-FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'\_Ba\_%' ESCAPE N'\'
-""",
-            //
-"""
-SELECT [f].[FirstName]
-FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] NOT LIKE N'\%B\%a\%r%' ESCAPE N'\'
+WHERE [f].[FirstName] LIKE N'a\_%' ESCAPE N'\'
 """,
             //
 """
@@ -213,7 +189,30 @@ WHERE 0 = 1
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE 0 = 1
+WHERE [f].[FirstName] IS NOT NULL
+""",
+            //
+"""
+SELECT [f].[FirstName]
+FROM [FunkyCustomers] AS [f]
+WHERE [f].[FirstName] LIKE N'\_Ba\_%' ESCAPE N'\'
+""",
+            //
+"""
+SELECT [f].[FirstName]
+FROM [FunkyCustomers] AS [f]
+WHERE [f].[FirstName] NOT LIKE N'\%B\%a\%r%' ESCAPE N'\' OR [f].[FirstName] IS NULL
+""",
+            //
+"""
+SELECT [f].[FirstName]
+FROM [FunkyCustomers] AS [f]
+WHERE [f].[FirstName] IS NULL
+""",
+            //
+"""
+SELECT [f].[FirstName]
+FROM [FunkyCustomers] AS [f]
 """);
     }
 
@@ -223,19 +222,19 @@ WHERE 0 = 1
 
         AssertSql(
 """
-@__prm1_0='%B' (Size = 4000)
+@__prm1_0_rewritten='\%B%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm1_0 = N'' OR ([f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0)
+WHERE [f].[FirstName] LIKE @__prm1_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm2_0='a_' (Size = 4000)
+@__prm2_0_rewritten='a\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm2_0 = N'' OR ([f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0)
+WHERE [f].[FirstName] LIKE @__prm2_0_rewritten ESCAPE N'\'
 """,
             //
 """
@@ -245,41 +244,40 @@ WHERE 0 = 1
 """,
             //
 """
-@__prm4_0='' (Size = 4000)
+@__prm4_0_rewritten='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm4_0 = N'' OR ([f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0)
+WHERE [f].[FirstName] LIKE @__prm4_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm5_0='_Ba_' (Size = 4000)
+@__prm5_0_rewritten='\_Ba\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm5_0 = N'' OR ([f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0)
+WHERE [f].[FirstName] LIKE @__prm5_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm6_0='%B%a%r' (Size = 4000)
+@__prm6_0_rewritten='\%B\%a\%r%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm6_0 <> N'' AND [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0
+WHERE [f].[FirstName] NOT LIKE @__prm6_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
 """
-@__prm7_0='' (Size = 4000)
+@__prm7_0_rewritten='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm7_0 <> N'' AND [f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0
+WHERE [f].[FirstName] NOT LIKE @__prm7_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE 0 = 1
 """);
     }
 
@@ -291,49 +289,49 @@ WHERE 0 = 1
 """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'\[%' ESCAPE N'\'
+WHERE [f].[FirstName] LIKE N'\[%' ESCAPE N'\'
 """,
             //
 """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'B\[%' ESCAPE N'\'
+WHERE [f].[FirstName] LIKE N'B\[%' ESCAPE N'\'
 """,
             //
 """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'B\[\[a^%' ESCAPE N'\'
+WHERE [f].[FirstName] LIKE N'B\[\[a^%' ESCAPE N'\'
 """,
             //
 """
-@__prm1_0='[' (Size = 4000)
+@__prm1_0_rewritten='\[%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm1_0 = N'' OR ([f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0)
+WHERE [f].[FirstName] LIKE @__prm1_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm2_0='B[' (Size = 4000)
+@__prm2_0_rewritten='B\[%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm2_0 = N'' OR ([f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0)
+WHERE [f].[FirstName] LIKE @__prm2_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm3_0='B[[a^' (Size = 4000)
+@__prm3_0_rewritten='B\[\[a^%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm3_0 = N'' OR ([f].[FirstName] IS NOT NULL AND LEFT([f].[FirstName], LEN(@__prm3_0)) = @__prm3_0)
+WHERE [f].[FirstName] LIKE @__prm3_0_rewritten ESCAPE N'\'
 """,
             //
 """
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[LastName] = N'' OR ([f].[FirstName] IS NOT NULL AND [f].[LastName] IS NOT NULL AND LEFT([f].[FirstName], LEN([f].[LastName])) = [f].[LastName])
+WHERE [f].[FirstName] IS NOT NULL AND [f].[LastName] IS NOT NULL AND LEFT([f].[FirstName], LEN([f].[LastName])) = [f].[LastName]
 """);
     }
 
@@ -346,7 +344,7 @@ WHERE [f].[LastName] = N'' OR ([f].[FirstName] IS NOT NULL AND [f].[LastName] IS
 SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE [f0].[LastName] = N'' OR ([f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND LEFT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName])
+WHERE [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND LEFT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]
 """);
     }
 
@@ -359,7 +357,7 @@ WHERE [f0].[LastName] = N'' OR ([f].[FirstName] IS NOT NULL AND [f0].[LastName] 
 SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE ([f0].[LastName] <> N'' OR [f0].[LastName] IS NULL) AND [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND LEFT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]
+WHERE [f].[FirstName] IS NULL OR [f0].[LastName] IS NULL OR LEFT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]
 """);
     }
 
@@ -371,36 +369,13 @@ WHERE ([f0].[LastName] <> N'' OR [f0].[LastName] IS NULL) AND [f].[FirstName] IS
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'%\%B' ESCAPE N'\'
+WHERE [f].[FirstName] LIKE N'%\%B' ESCAPE N'\'
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'%a\_' ESCAPE N'\'
-""",
-            //
-"""
-SELECT [f].[FirstName]
-FROM [FunkyCustomers] AS [f]
-WHERE 0 = 1
-""",
-            //
-"""
-SELECT [f].[FirstName]
-FROM [FunkyCustomers] AS [f]
-""",
-            //
-"""
-SELECT [f].[FirstName]
-FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] LIKE N'%\_Ba\_' ESCAPE N'\'
-""",
-            //
-"""
-SELECT [f].[FirstName]
-FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] IS NOT NULL AND [f].[FirstName] NOT LIKE N'%\%B\%a\%r' ESCAPE N'\'
+WHERE [f].[FirstName] LIKE N'%a\_' ESCAPE N'\'
 """,
             //
 """
@@ -412,7 +387,30 @@ WHERE 0 = 1
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE 0 = 1
+WHERE [f].[FirstName] IS NOT NULL
+""",
+            //
+"""
+SELECT [f].[FirstName]
+FROM [FunkyCustomers] AS [f]
+WHERE [f].[FirstName] LIKE N'%\_Ba\_' ESCAPE N'\'
+""",
+            //
+"""
+SELECT [f].[FirstName]
+FROM [FunkyCustomers] AS [f]
+WHERE [f].[FirstName] NOT LIKE N'%\%B\%a\%r' ESCAPE N'\' OR [f].[FirstName] IS NULL
+""",
+            //
+"""
+SELECT [f].[FirstName]
+FROM [FunkyCustomers] AS [f]
+WHERE [f].[FirstName] IS NULL
+""",
+            //
+"""
+SELECT [f].[FirstName]
+FROM [FunkyCustomers] AS [f]
 """);
     }
 
@@ -422,19 +420,19 @@ WHERE 0 = 1
 
         AssertSql(
 """
-@__prm1_0='%B' (Size = 4000)
+@__prm1_0_rewritten='%\%B' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm1_0 = N'' OR ([f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm1_0)) = @__prm1_0)
+WHERE [f].[FirstName] LIKE @__prm1_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm2_0='a_' (Size = 4000)
+@__prm2_0_rewritten='%a\_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm2_0 = N'' OR ([f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm2_0)) = @__prm2_0)
+WHERE [f].[FirstName] LIKE @__prm2_0_rewritten ESCAPE N'\'
 """,
             //
 """
@@ -444,41 +442,40 @@ WHERE 0 = 1
 """,
             //
 """
-@__prm4_0='' (Size = 4000)
+@__prm4_0_rewritten='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm4_0 = N'' OR ([f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm4_0)) = @__prm4_0)
+WHERE [f].[FirstName] LIKE @__prm4_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm5_0='_Ba_' (Size = 4000)
+@__prm5_0_rewritten='%\_Ba\_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm5_0 = N'' OR ([f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm5_0)) = @__prm5_0)
+WHERE [f].[FirstName] LIKE @__prm5_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__prm6_0='%B%a%r' (Size = 4000)
+@__prm6_0_rewritten='%\%B\%a\%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm6_0 <> N'' AND [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0
+WHERE [f].[FirstName] NOT LIKE @__prm6_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
 """
-@__prm7_0='' (Size = 4000)
+@__prm7_0_rewritten='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE @__prm7_0 <> N'' AND [f].[FirstName] IS NOT NULL AND RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0
+WHERE [f].[FirstName] NOT LIKE @__prm7_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
 """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE 0 = 1
 """);
     }
 
@@ -491,7 +488,7 @@ WHERE 0 = 1
 SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE [f0].[LastName] = N'' OR ([f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName])
+WHERE [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]
 """);
     }
 
@@ -504,7 +501,7 @@ WHERE [f0].[LastName] = N'' OR ([f].[FirstName] IS NOT NULL AND [f0].[LastName] 
 SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE ([f0].[LastName] <> N'' OR [f0].[LastName] IS NULL) AND [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]
+WHERE [f].[FirstName] IS NULL OR [f0].[LastName] IS NULL OR RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]
 """);
     }
 
@@ -518,7 +515,7 @@ SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN [f0].[LastName] = N'' OR ([f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]) THEN CAST(1 AS bit)
+    WHEN [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName] THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -534,7 +531,7 @@ SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN ([f0].[LastName] <> N'' OR [f0].[LastName] IS NULL) AND [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName] THEN CAST(1 AS bit)
+    WHEN [f].[FirstName] IS NULL OR [f0].[LastName] IS NULL OR RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName] THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)
 """);
@@ -550,7 +547,7 @@ SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool], [f0].[Id],
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN ([f0].[LastName] = N'' AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]) THEN CAST(1 AS bit)
+    WHEN [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName] THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = [f].[NullableBool]
 """);
@@ -566,7 +563,7 @@ SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool], [f0].[Id],
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN ([f0].[LastName] = N'' AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]) THEN CAST(1 AS bit)
+    WHEN [f].[FirstName] IS NOT NULL AND [f0].[LastName] IS NOT NULL AND RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName] THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> [f].[NullableBool] OR [f].[NullableBool] IS NULL
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -962,7 +962,7 @@ FROM [Gears] AS [g]
 WHERE CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CASE
-        WHEN [g].[LeaderNickname] IS NOT NULL AND [g].[LeaderNickname] LIKE N'%us' THEN CAST(1 AS bit)
+        WHEN [g].[LeaderNickname] LIKE N'%us' AND [g].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)
@@ -2431,7 +2431,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) OR [t].[Note] LIKE N'%Cole%'
         AssertSql(
 """
 SELECT CASE
-    WHEN [g].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' THEN CAST(1 AS bit)
+    WHEN [g].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' AND [t].[Note] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Tags] AS [t]
@@ -5952,7 +5952,7 @@ SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN [w0].[Name] LIKE N'%Lancer' THEN CAST(1 AS bit)
+    WHEN [w0].[Name] LIKE N'%Lancer' AND [w0].[Name] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
@@ -28,7 +28,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Name] NOT LIKE N'%B%')
+    WHERE [e].[Id] = [j].[OneId] AND ([e0].[Name] NOT LIKE N'%B%' OR [e0].[Name] IS NULL))
 """);
     }
 
@@ -112,7 +112,7 @@ ORDER BY (
         FROM [EntityRoots] AS [e0]
         WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [e].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -144,7 +144,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] IS NOT NULL AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
+    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -27,7 +27,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Name] NOT LIKE N'%B%')
+    WHERE [e].[Id] = [j].[OneId] AND ([e0].[Name] NOT LIKE N'%B%' OR [e0].[Name] IS NULL))
 """);
     }
 
@@ -111,7 +111,7 @@ ORDER BY (
         FROM [EntityRoots] AS [e0]
         WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [e].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -143,7 +143,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] IS NOT NULL AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
+    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -1973,7 +1973,7 @@ ORDER BY [o].[OrderID]
 """
 SELECT AVG(CAST(CAST([o].[OrderID] AS bigint) AS float))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
+WHERE [o].[CustomerID] LIKE N'A%'
 """);
     }
 
@@ -1985,7 +1985,7 @@ WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
 """
 SELECT MAX(CAST([o].[OrderID] AS bigint))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
+WHERE [o].[CustomerID] LIKE N'A%'
 """);
     }
 
@@ -1997,7 +1997,7 @@ WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
 """
 SELECT MIN(CAST([o].[OrderID] AS bigint))
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
+WHERE [o].[CustomerID] LIKE N'A%'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindEFPropertyIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindEFPropertyIncludeQuerySqlServerTest.cs
@@ -135,7 +135,7 @@ ORDER BY [t].[c] DESC, [t].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Orders] AS [o]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [o0].[OrderID]
 """);
     }
@@ -234,7 +234,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }
@@ -1136,7 +1136,7 @@ ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -1520,7 +1520,7 @@ ORDER BY [t1].[CustomerID], [t1].[CustomerID0], [o].[OrderID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -1750,7 +1750,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -1891,7 +1891,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -1962,7 +1962,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -86,7 +86,21 @@ WHERE [o].[OrderDate] <= @__myDatetime_0
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] IS NOT NULL AND [c].[ContactName] LIKE N'M%'
+WHERE [c].[ContactName] LIKE N'M%'
+""");
+    }
+
+    public override async Task String_StartsWith_Parameter(bool async)
+    {
+        await base.String_StartsWith_Parameter(async);
+
+        AssertSql(
+"""
+@__pattern_0_rewritten='M%' (Size = 30)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE @__pattern_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -98,7 +112,7 @@ WHERE [c].[ContactName] IS NOT NULL AND [c].[ContactName] LIKE N'M%'
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] = N'' OR ([c].[ContactName] IS NOT NULL AND LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName])
+WHERE [c].[ContactName] IS NOT NULL AND LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]
 """);
     }
 
@@ -110,7 +124,7 @@ WHERE [c].[ContactName] = N'' OR ([c].[ContactName] IS NOT NULL AND LEFT([c].[Co
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] = N'' OR ([c].[ContactName] IS NOT NULL AND LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName])
+WHERE [c].[ContactName] IS NOT NULL AND LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]
 """);
     }
 
@@ -122,7 +136,7 @@ WHERE [c].[ContactName] = N'' OR ([c].[ContactName] IS NOT NULL AND LEFT([c].[Co
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] IS NOT NULL AND [c].[ContactName] LIKE N'M%'
+WHERE [c].[ContactName] LIKE N'M%'
 """);
     }
 
@@ -134,7 +148,21 @@ WHERE [c].[ContactName] IS NOT NULL AND [c].[ContactName] LIKE N'M%'
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] IS NOT NULL AND [c].[ContactName] LIKE N'%b'
+WHERE [c].[ContactName] LIKE N'%b'
+""");
+    }
+
+    public override async Task String_EndsWith_Parameter(bool async)
+    {
+        await base.String_EndsWith_Parameter(async);
+
+        AssertSql(
+"""
+@__pattern_0_rewritten='%b' (Size = 30)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE @__pattern_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -146,7 +174,7 @@ WHERE [c].[ContactName] IS NOT NULL AND [c].[ContactName] LIKE N'%b'
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] = N'' OR ([c].[ContactName] IS NOT NULL AND RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName])
+WHERE [c].[ContactName] IS NOT NULL AND RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]
 """);
     }
 
@@ -158,7 +186,7 @@ WHERE [c].[ContactName] = N'' OR ([c].[ContactName] IS NOT NULL AND RIGHT([c].[C
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] = N'' OR ([c].[ContactName] IS NOT NULL AND RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName])
+WHERE [c].[ContactName] IS NOT NULL AND RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]
 """);
     }
 
@@ -170,7 +198,7 @@ WHERE [c].[ContactName] = N'' OR ([c].[ContactName] IS NOT NULL AND RIGHT([c].[C
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] IS NOT NULL AND [c].[ContactName] LIKE N'%m'
+WHERE [c].[ContactName] LIKE N'%m'
 """);
     }
 
@@ -198,7 +226,7 @@ WHERE [c].[ContactName] LIKE N'%M%'
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'' OR CHARINDEX([c].[ContactName], [c].[ContactName]) > 0
+WHERE [c].[ContactName] IS NOT NULL AND (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0 OR [c].[ContactName] LIKE N'')
 """);
     }
 
@@ -210,7 +238,7 @@ WHERE [c].[ContactName] LIKE N'' OR CHARINDEX([c].[ContactName], [c].[ContactNam
 """
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'' OR CHARINDEX([c].[ContactName], [c].[ContactName]) > 0
+WHERE [c].[ContactName] IS NOT NULL AND (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0 OR [c].[ContactName] LIKE N'')
 """);
     }
 
@@ -232,11 +260,11 @@ WHERE [c].[ContactName] LIKE N'%     %'
 
         AssertSql(
 """
-@__pattern_0='     ' (Size = 30)
+@__pattern_0_rewritten='%     %' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__pattern_0 LIKE N'' OR CHARINDEX(@__pattern_0, [c].[ContactName]) > 0
+WHERE [c].[ContactName] LIKE @__pattern_0_rewritten ESCAPE N'\'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2035,7 +2035,7 @@ OUTER APPLY (
     FROM [Products] AS [p0]
     GROUP BY [p0].[ProductID]
 ) AS [t0]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
+WHERE [o].[CustomerID] LIKE N'A%'
 ORDER BY [o].[OrderID], [t].[ProductID]
 """);
     }
@@ -3179,7 +3179,7 @@ ORDER BY [t].[CustomerID]
 SELECT [t].[Key], COUNT(*) AS [Count]
 FROM (
     SELECT CASE
-        WHEN [o].[CustomerID] LIKE N'A%' THEN CAST(1 AS bit)
+        WHEN [o].[CustomerID] LIKE N'A%' AND [o].[CustomerID] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END AS [Key]
     FROM [Orders] AS [o]
@@ -3294,7 +3294,7 @@ END), 0) AS [Sum1], COALESCE(SUM(CASE
     ELSE 0
 END), 0) AS [Sum2]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
+WHERE [o].[CustomerID] LIKE N'A%'
 GROUP BY [o].[CustomerID]
 """);
     }
@@ -3478,7 +3478,7 @@ FROM (
     SELECT DISTINCT [c].[City]
     FROM [Orders] AS [o]
     LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
+    WHERE [o].[CustomerID] LIKE N'A%'
 ) AS [t]
 OUTER APPLY (
     SELECT [p].[ProductID]
@@ -3523,7 +3523,7 @@ FROM (
     SELECT [o].[CustomerID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
-    HAVING [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+    HAVING [o].[CustomerID] LIKE N'F%'
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
 ORDER BY [t].[CustomerID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqlServerTest.cs
@@ -139,7 +139,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -206,7 +206,7 @@ ORDER BY [t].[c], [t].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Orders] AS [o]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [o0].[OrderID]
 """);
     }
@@ -309,7 +309,7 @@ ORDER BY [c].[CustomerID], [t].[OrderID], [t].[OrderID0]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -1499,7 +1499,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -1566,7 +1566,7 @@ ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
@@ -51,7 +51,7 @@ ORDER BY [p].[ProductID], [t].[OrderID], [t].[ProductID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -170,7 +170,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -301,7 +301,7 @@ ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[ProductID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Orders] AS [o]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [o0].[OrderID]
 """);
     }
@@ -2022,7 +2022,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }
@@ -2075,7 +2075,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }
@@ -2090,7 +2090,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -2186,7 +2186,7 @@ ORDER BY [t].[OrderID], [t].[CustomerID0]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -232,7 +232,7 @@ INNER JOIN [Customers] AS [c1] ON [c].[CustomerID] = [c1].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -402,7 +402,7 @@ FROM [Employees] AS [e]
 LEFT JOIN (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+    WHERE [o].[CustomerID] LIKE N'F%'
 ) AS [t] ON [e].[EmployeeID] = [t].[EmployeeID]
 """);
     }
@@ -575,7 +575,7 @@ INNER JOIN (
         FROM [Orders] AS [o]
         ORDER BY [o].[OrderID]
     ) AS [t]
-    WHERE [t].[CustomerID] IS NOT NULL AND [t].[CustomerID] LIKE N'A%'
+    WHERE [t].[CustomerID] LIKE N'A%'
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1488,7 +1488,7 @@ SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE [c].[ContactName] IS NOT NULL AND [c].[ContactName] LIKE N'A%') THEN CAST(1 AS bit)
+        WHERE [c].[ContactName] LIKE N'A%') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -1505,7 +1505,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%')
+    WHERE [o].[CustomerID] LIKE N'A%')
 """);
     }
 
@@ -1520,7 +1520,7 @@ FROM [Customers] AS [c]
 WHERE ([c].[City] <> N'London' OR [c].[City] IS NULL) AND NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%')
+    WHERE [o].[CustomerID] LIKE N'A%')
 """);
     }
 
@@ -1535,7 +1535,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%') AND ([c].[City] <> N'London' OR [c].[City] IS NULL)
+    WHERE [o].[CustomerID] LIKE N'A%') AND ([c].[City] <> N'London' OR [c].[City] IS NULL)
 """);
     }
 
@@ -1550,7 +1550,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%')
+    WHERE [o].[CustomerID] LIKE N'A%')
 """);
     }
 
@@ -1565,7 +1565,7 @@ FROM [Customers] AS [c]
 WHERE ([c].[City] <> N'London' OR [c].[City] IS NULL) AND EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%')
+    WHERE [o].[CustomerID] LIKE N'A%')
 """);
     }
 
@@ -1580,7 +1580,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%') AND ([c].[City] <> N'London' OR [c].[City] IS NULL)
+    WHERE [o].[CustomerID] LIKE N'A%') AND ([c].[City] <> N'London' OR [c].[City] IS NULL)
 """);
     }
 
@@ -1609,7 +1609,7 @@ SELECT CASE
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE [c].[ContactName] IS NULL OR [c].[ContactName] NOT LIKE N'A%') THEN CAST(1 AS bit)
+        WHERE [c].[ContactName] NOT LIKE N'A%' OR [c].[ContactName] IS NULL) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -1625,7 +1625,7 @@ SELECT CASE
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE ([c].[ContactName] <> N'' OR [c].[ContactName] IS NULL) AND ([c].[ContactName] IS NULL OR LEFT([c].[ContactName], LEN([c].[ContactName])) <> [c].[ContactName])) THEN CAST(1 AS bit)
+        WHERE [c].[ContactName] IS NULL OR LEFT([c].[ContactName], LEN([c].[ContactName])) <> [c].[ContactName]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -3041,12 +3041,12 @@ WHERE [o].[OrderDate] > @__p_0
 
         AssertSql(
 """
-@__NewLine_0='
-' (Size = 5)
+@__NewLine_0_rewritten='%
+%' (Size = 5)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__NewLine_0 LIKE N'' OR CHARINDEX(@__NewLine_0, [c].[CustomerID]) > 0
+WHERE [c].[CustomerID] LIKE @__NewLine_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -4786,12 +4786,11 @@ FROM (
 
         AssertSql(
 """
-@__prefix_0='A' (Size = 4000)
-@__prefix_0_1='A' (Size = 5)
+@__prefix_0_rewritten='A%' (Size = 5)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__prefix_0 = N'' OR LEFT([c].[CustomerID], LEN(@__prefix_0_1)) = @__prefix_0_1
+WHERE [c].[CustomerID] LIKE @__prefix_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -4846,7 +4845,7 @@ FROM [Orders] AS [o]
 CROSS JOIN [Orders] AS [o0]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%' AND ([c].[CustomerID] = [c0].[CustomerID] OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))
+WHERE [o].[CustomerID] LIKE N'A%' AND ([c].[CustomerID] = [c0].[CustomerID] OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))
 ORDER BY [o].[OrderID], [o0].[OrderID]
 """);
     }
@@ -4862,7 +4861,7 @@ FROM [Orders] AS [o]
 CROSS JOIN [Orders] AS [o0]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%' AND ([c].[CustomerID] = [c0].[CustomerID] OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))
+WHERE [o].[CustomerID] LIKE N'A%' AND ([c].[CustomerID] = [c0].[CustomerID] OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))
 ORDER BY [o].[OrderID], [o0].[OrderID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
@@ -384,7 +384,7 @@ FROM [Orders] AS [o]
 CROSS JOIN [Orders] AS [o0]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%' AND [o0].[CustomerID] IS NOT NULL AND [o0].[CustomerID] LIKE N'A%' AND ([c].[CustomerID] = [c0].[CustomerID] OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))
+WHERE [o].[CustomerID] LIKE N'A%' AND [o0].[CustomerID] LIKE N'A%' AND ([c].[CustomerID] = [c0].[CustomerID] OR ([c].[CustomerID] IS NULL AND [c0].[CustomerID] IS NULL))
 """);
     }
 
@@ -701,7 +701,7 @@ END AS [all], (
     FROM [Order Details] AS [o3]
     WHERE [o].[OrderID] = [o3].[OrderID]) AS [collection2]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
+WHERE [o].[CustomerID] LIKE N'A%'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -27,12 +27,11 @@ public class NorthwindQueryFiltersQuerySqlServerTest : NorthwindQueryFiltersQuer
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -42,12 +41,11 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_fi
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -57,13 +55,12 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_fi
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 @__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1) AND [c].[CustomerID] = @__p_0
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' AND [c].[CustomerID] = @__p_0
 """);
     }
 
@@ -73,12 +70,11 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_f
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='F' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='F' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='F%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -88,21 +84,19 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_fi
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 """,
             //
 """
-@__ef_filter__TenantPrefix_0='T' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='T' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='T%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -112,12 +106,11 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_fi
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='F' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='F' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='F%' (Size = 40)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -127,12 +120,11 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_fi
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -142,8 +134,7 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_fi
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0]
 FROM [Customers] AS [c]
@@ -153,11 +144,11 @@ LEFT JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+        WHERE [c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 ORDER BY [c].[CustomerID], [t0].[OrderID]
 """);
     }
@@ -181,15 +172,14 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);
@@ -201,8 +191,7 @@ WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_1='B' (Size = 4000)
-@__ef_filter__TenantPrefix_1_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_1_rewritten='B%' (Size = 40)
 @__ef_filter___quantity_0='50'
 
 SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
@@ -213,7 +202,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c].[CustomerID], [c].[CompanyName]
         FROM [Customers] AS [c]
-        WHERE @__ef_filter__TenantPrefix_1 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_1_1)) = @__ef_filter__TenantPrefix_1_1
+        WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_1_rewritten ESCAPE N'\'
     ) AS [t] ON [o0].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
@@ -227,8 +216,7 @@ WHERE [o].[Quantity] > @__ef_filter___quantity_0
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 @__ef_filter___quantity_1='50'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -239,7 +227,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c0].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+        WHERE [c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
@@ -252,13 +240,13 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [c1].[CustomerID], [c1].[CompanyName]
             FROM [Customers] AS [c1]
-            WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c1].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+            WHERE [c1].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
         ) AS [t3] ON [o1].[CustomerID] = [t3].[CustomerID]
         WHERE [t3].[CustomerID] IS NOT NULL AND [t3].[CompanyName] IS NOT NULL
     ) AS [t2] ON [o0].[OrderID] = [t2].[OrderID]
     WHERE [o0].[Quantity] > @__ef_filter___quantity_1
 ) AS [t1] ON [t0].[OrderID] = [t1].[OrderID]
-WHERE (@__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1) AND [t1].[Discount] < CAST(10 AS real)
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' AND [t1].[Discount] < CAST(10 AS real)
 """);
     }
 
@@ -274,14 +262,13 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_f
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
 FROM (
     select * from Customers
 ) AS [m]
-WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([m].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+WHERE [m].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 """);
     }
 
@@ -297,8 +284,7 @@ WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([m].[CompanyName], LEN(@__ef_fi
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [m].[OrderID], [m].[CustomerID], [m].[EmployeeID], [m].[OrderDate]
 FROM (
@@ -307,7 +293,7 @@ FROM (
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 ) AS [t] ON [m].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);
@@ -319,23 +305,21 @@ WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 @__customerID='BERGS' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1) AND [c].[CustomerID] = @__customerID
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' AND [c].[CustomerID] = @__customerID
 """,
             //
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 @__customerID='BLAUS' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1) AND [c].[CustomerID] = @__customerID
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' AND [c].[CustomerID] = @__customerID
 """);
     }
 
@@ -345,15 +329,14 @@ WHERE (@__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_f
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);
@@ -372,15 +355,14 @@ WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 4000)
-@__ef_filter__TenantPrefix_0_1='B' (Size = 40)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE @__ef_filter__TenantPrefix_0 = N'' OR LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0_1)) = @__ef_filter__TenantPrefix_0_1
+    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -2307,7 +2307,7 @@ SELECT [t].[OrderID], [t].[OrderDate], [t0].[OrderID], [t0].[ProductID], [t0].[D
 FROM (
     SELECT TOP(1) [o].[OrderID], [o].[OrderDate]
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+    WHERE [o].[CustomerID] LIKE N'F%'
 ) AS [t]
 OUTER APPLY (
     SELECT [t1].[OrderID], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock], [t1].[UnitPrice] AS [UnitPrice0], [t1].[ProductID] AS [ProductID0]
@@ -2411,7 +2411,7 @@ ORDER BY [c].[CustomerID]
 """
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'A%'
+WHERE [o].[CustomerID] LIKE N'A%'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
@@ -473,7 +473,7 @@ WHERE [o].[OrderID] % 23 = 13
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """,
             //
@@ -482,7 +482,7 @@ SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }
@@ -1186,7 +1186,7 @@ ORDER BY [t].[CustomerID]
 """
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID]
 """,
             //
@@ -1194,7 +1194,7 @@ ORDER BY [o].[OrderID]
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID]
 FROM [Orders] AS [o]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID]
 """);
     }
@@ -1923,7 +1923,7 @@ ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -2010,7 +2010,7 @@ WHERE [o].[CustomerID] = N'ALFKI'
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -2725,7 +2725,7 @@ ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """,
             //
@@ -2734,7 +2734,7 @@ SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
@@ -56,7 +56,7 @@ ORDER BY [p].[ProductID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -164,7 +164,7 @@ ORDER BY [t].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """,
             //
@@ -173,7 +173,7 @@ SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }
@@ -329,7 +329,7 @@ ORDER BY [t].[OrderID]
 """
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID]
 """,
             //
@@ -337,7 +337,7 @@ ORDER BY [o].[OrderID]
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o].[OrderID]
 FROM [Orders] AS [o]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID]
 """);
     }
@@ -2589,7 +2589,7 @@ ORDER BY [o].[OrderID], [c].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -2786,7 +2786,7 @@ WHERE [e0].[EmployeeID] IS NULL
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """,
             //
@@ -2795,7 +2795,7 @@ SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }
@@ -2861,7 +2861,7 @@ ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """,
             //
@@ -2870,7 +2870,7 @@ SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }
@@ -2957,7 +2957,7 @@ ORDER BY [o].[OrderID], [c].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """,
             //
@@ -2966,7 +2966,7 @@ SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindStringIncludeQuerySqlServerTest.cs
@@ -135,7 +135,7 @@ ORDER BY [t].[c] DESC, [t].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Orders] AS [o]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [o0].[OrderID]
 """);
     }
@@ -234,7 +234,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }
@@ -1136,7 +1136,7 @@ ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -1520,7 +1520,7 @@ ORDER BY [t1].[CustomerID], [t1].[CustomerID0], [o].[OrderID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 """);
     }
 
@@ -1750,7 +1750,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -1891,7 +1891,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]
 """);
     }
@@ -1962,7 +1962,7 @@ SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-WHERE [o].[CustomerID] IS NOT NULL AND [o].[CustomerID] LIKE N'F%'
+WHERE [o].[CustomerID] LIKE N'F%'
 ORDER BY [o].[OrderID], [c].[CustomerID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1182,7 +1182,7 @@ END OR [e].[NullableStringC] IS NULL
 """
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringB] LIKE N'' OR CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0) AND [e].[BoolA] = CAST(1 AS bit)
+WHERE [e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL AND (CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0 OR [e].[NullableStringB] LIKE N'') AND [e].[BoolA] = CAST(1 AS bit)
 """);
     }
 
@@ -3248,6 +3248,95 @@ FROM [Entities1] AS [e]
 SELECT COALESCE([e].[NullableIntA], [e].[NullableIntB], [e0].[NullableIntC], [e0].[NullableIntB], [e].[NullableIntC], [e0].[NullableIntA])
 FROM [Entities1] AS [e]
 INNER JOIN [Entities2] AS [e0] ON [e].[Id] = [e0].[Id]
+""");
+    }
+
+    public override async Task Like(bool async)
+    {
+        await base.Like(async);
+
+        AssertSql(
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[StringA] LIKE [e].[StringB]
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[StringA] LIKE [e].[NullableStringB]
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] LIKE [e].[StringB]
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] LIKE [e].[NullableStringB]
+""");
+    }
+
+    public override async Task Like_negated(bool async)
+    {
+        await base.Like_negated(async);
+
+        AssertSql(
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[StringA] NOT LIKE [e].[StringB]
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[StringA] NOT LIKE [e].[NullableStringB] OR [e].[NullableStringB] IS NULL
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] NOT LIKE [e].[StringB] OR [e].[NullableStringA] IS NULL
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] NOT LIKE [e].[NullableStringB] OR [e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL
+""");
+    }
+
+    public override async Task Like_with_escape_char(bool async)
+    {
+        await base.Like_with_escape_char(async);
+
+        AssertSql(
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[StringA] LIKE [e].[StringB] ESCAPE N'\'
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[StringA] NOT LIKE [e].[StringB] ESCAPE N'\'
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE 0 = 1
+""",
+            //
+"""
+SELECT [e].[Id]
+FROM [Entities1] AS [e]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -116,7 +116,7 @@ WHERE -[o].[Value] = -([o].[Id] + [o0].[Value])
 """
 SELECT [o].[Id]
 FROM [OperatorEntityString] AS [o]
-WHERE [o].[Value] IS NOT NULL AND [o].[Value] NOT LIKE N'A%'
+WHERE [o].[Value] NOT LIKE N'A%' OR [o].[Value] IS NULL
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3139,7 +3139,7 @@ FROM [Factions] AS [f]
 WHERE EXISTS (
     SELECT 1
     FROM [Leaders] AS [l]
-    WHERE [l].[Name] IS NOT NULL AND [l].[Name] LIKE N'Bran%' AND [l].[Name] = N'Crach an Craite')
+    WHERE [l].[Name] LIKE N'Bran%' AND [l].[Name] = N'Crach an Craite')
 """);
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -497,7 +497,7 @@ ORDER BY [t].[ParcelNumber]
 """
 SELECT [a].[Id], [a].[Discriminator], [a].[Species], [a].[Name], [a].[EdcuationLevel], [a].[FavoriteToy]
 FROM [Animals] AS [a]
-WHERE [a].[Discriminator] IN (N'Cat', N'Dog') AND [a].[Species] IS NOT NULL AND [a].[Species] LIKE N'F%'
+WHERE [a].[Discriminator] IN (N'Cat', N'Dog') AND [a].[Species] LIKE N'F%'
 """);
     }
 
@@ -515,7 +515,7 @@ FROM [Animals] AS [a]
 LEFT JOIN [Pets] AS [p] ON [a].[Id] = [p].[Id]
 LEFT JOIN [Cats] AS [c] ON [a].[Id] = [c].[Id]
 LEFT JOIN [Dogs] AS [d] ON [a].[Id] = [d].[Id]
-WHERE ([d].[Id] IS NOT NULL OR [c].[Id] IS NOT NULL) AND [a].[Species] IS NOT NULL AND [a].[Species] LIKE N'F%'
+WHERE ([d].[Id] IS NOT NULL OR [c].[Id] IS NOT NULL) AND [a].[Species] LIKE N'F%'
 """);
     }
 
@@ -533,7 +533,7 @@ FROM (
     SELECT [d].[Id], [d].[Species], [d].[Name], NULL AS [EdcuationLevel], [d].[FavoriteToy], N'Dog' AS [Discriminator]
     FROM [Dogs] AS [d]
 ) AS [t]
-WHERE [t].[Species] IS NOT NULL AND [t].[Species] LIKE N'F%'
+WHERE [t].[Species] LIKE N'F%'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCGearsOfWarQuerySqlServerTest.cs
@@ -1331,7 +1331,7 @@ FROM (
 WHERE CASE
     WHEN [t].[LeaderNickname] IS NULL THEN NULL
     ELSE CASE
-        WHEN [t].[LeaderNickname] IS NOT NULL AND [t].[LeaderNickname] LIKE N'%us' THEN CAST(1 AS bit)
+        WHEN [t].[LeaderNickname] LIKE N'%us' AND [t].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)
@@ -3384,7 +3384,7 @@ WHERE [t0].[HasSoulPatch] = CAST(1 AS bit) OR [t].[Note] LIKE N'%Cole%'
         AssertSql(
 """
 SELECT CASE
-    WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' THEN CAST(1 AS bit)
+    WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' AND [t].[Note] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Tags] AS [t]
@@ -8111,7 +8111,7 @@ SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN [w0].[Name] LIKE N'%Lancer' THEN CAST(1 AS bit)
+    WHEN [w0].[Name] LIKE N'%Lancer' AND [w0].[Name] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyNoTrackingQuerySqlServerTest.cs
@@ -24,14 +24,14 @@ public class TPCManyToManyNoTrackingQuerySqlServerTest : TPCManyToManyNoTracking
         await base.Skip_navigation_all(async);
 
         AssertSql(
-"""
+            """
 SELECT [e].[Id], [e].[Name]
 FROM [EntityOnes] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Name] NOT LIKE N'%B%')
+    WHERE [e].[Id] = [j].[OneId] AND ([e0].[Name] NOT LIKE N'%B%' OR [e0].[Name] IS NULL))
 """);
     }
 
@@ -117,7 +117,7 @@ ORDER BY (
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [e].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -149,7 +149,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] IS NOT NULL AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
+    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
 """);
     }
 
@@ -2135,7 +2135,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [UnidirectionalJoinOneToTwo] AS [u0]
     INNER JOIN [UnidirectionalEntityTwos] AS [u1] ON [u0].[TwoId] = [u1].[Id]
-    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Name] NOT LIKE N'%B%')
+    WHERE [u].[Id] = [u0].[OneId] AND ([u1].[Name] NOT LIKE N'%B%' OR [u1].[Name] IS NULL))
 """);
     }
 
@@ -2205,7 +2205,7 @@ ORDER BY (
         SELECT [u2].[Id], [u2].[Name], [u2].[Number], [u2].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
         FROM [UnidirectionalLeaves] AS [u2]
     ) AS [t] ON [u0].[UnidirectionalEntityBranchId] = [t].[Id]
-    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [u].[Id]
+    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] LIKE N'L%'), [u].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPCManyToManyQuerySqlServerTest.cs
@@ -24,14 +24,14 @@ public class TPCManyToManyQuerySqlServerTest : TPCManyToManyQueryRelationalTestB
         await base.Skip_navigation_all(async);
 
         AssertSql(
-"""
+            """
 SELECT [e].[Id], [e].[Name]
 FROM [EntityOnes] AS [e]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Name] NOT LIKE N'%B%')
+    WHERE [e].[Id] = [j].[OneId] AND ([e0].[Name] NOT LIKE N'%B%' OR [e0].[Name] IS NULL))
 """);
     }
 
@@ -117,7 +117,7 @@ ORDER BY (
         SELECT [l].[Id], [l].[Name], [l].[Number], [l].[IsGreen], N'EntityLeaf' AS [Discriminator]
         FROM [Leaves] AS [l]
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [e].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -149,7 +149,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] IS NOT NULL AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
+    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
 """);
     }
 
@@ -2129,14 +2129,14 @@ ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[
         await base.Skip_navigation_all_unidirectional(async);
 
         AssertSql(
-"""
+            """
 SELECT [u].[Id], [u].[Name]
 FROM [UnidirectionalEntityOnes] AS [u]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [UnidirectionalJoinOneToTwo] AS [u0]
     INNER JOIN [UnidirectionalEntityTwos] AS [u1] ON [u0].[TwoId] = [u1].[Id]
-    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Name] NOT LIKE N'%B%')
+    WHERE [u].[Id] = [u0].[OneId] AND ([u1].[Name] NOT LIKE N'%B%' OR [u1].[Name] IS NULL))
 """);
     }
 
@@ -2206,7 +2206,7 @@ ORDER BY (
         SELECT [u2].[Id], [u2].[Name], [u2].[Number], [u2].[IsGreen], N'UnidirectionalEntityLeaf' AS [Discriminator]
         FROM [UnidirectionalLeaves] AS [u2]
     ) AS [t] ON [u0].[UnidirectionalEntityBranchId] = [t].[Id]
-    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [u].[Id]
+    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] LIKE N'L%'), [u].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -1182,7 +1182,7 @@ LEFT JOIN [Officers] AS [o] ON [g].[Nickname] = [o].[Nickname] AND [g].[SquadId]
 WHERE CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CASE
-        WHEN [g].[LeaderNickname] IS NOT NULL AND [g].[LeaderNickname] LIKE N'%us' THEN CAST(1 AS bit)
+        WHEN [g].[LeaderNickname] LIKE N'%us' AND [g].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)
@@ -2896,7 +2896,7 @@ WHERE [t0].[HasSoulPatch] = CAST(1 AS bit) OR [t].[Note] LIKE N'%Cole%'
         AssertSql(
 """
 SELECT CASE
-    WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' THEN CAST(1 AS bit)
+    WHEN [t0].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' AND [t].[Note] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Tags] AS [t]
@@ -6860,7 +6860,7 @@ SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[
 FROM [Weapons] AS [w]
 LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN [w0].[Name] LIKE N'%Lancer' THEN CAST(1 AS bit)
+    WHEN [w0].[Name] LIKE N'%Lancer' AND [w0].[Name] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
@@ -32,7 +32,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Name] NOT LIKE N'%B%')
+    WHERE [e].[Id] = [j].[OneId] AND ([e0].[Name] NOT LIKE N'%B%' OR [e0].[Name] IS NULL))
 """);
     }
 
@@ -119,7 +119,7 @@ ORDER BY (
         INNER JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [e].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -151,7 +151,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] IS NOT NULL AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
+    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
 """);
     }
 
@@ -2087,7 +2087,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [UnidirectionalJoinOneToTwo] AS [u0]
     INNER JOIN [UnidirectionalEntityTwos] AS [u1] ON [u0].[TwoId] = [u1].[Id]
-    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Name] NOT LIKE N'%B%')
+    WHERE [u].[Id] = [u0].[OneId] AND ([u1].[Name] NOT LIKE N'%B%' OR [u1].[Name] IS NULL))
 """);
     }
 
@@ -2158,7 +2158,7 @@ ORDER BY (
         INNER JOIN [UnidirectionalBranches] AS [u2] ON [u1].[Id] = [u2].[Id]
         LEFT JOIN [UnidirectionalLeaves] AS [u3] ON [u1].[Id] = [u3].[Id]
     ) AS [t] ON [u0].[UnidirectionalEntityBranchId] = [t].[Id]
-    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [u].[Id]
+    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] LIKE N'L%'), [u].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
@@ -31,7 +31,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Name] NOT LIKE N'%B%')
+    WHERE [e].[Id] = [j].[OneId] AND ([e0].[Name] NOT LIKE N'%B%' OR [e0].[Name] IS NULL))
 """);
     }
 
@@ -118,7 +118,7 @@ ORDER BY (
         INNER JOIN [Branches] AS [b] ON [r].[Id] = [b].[Id]
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [e].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -150,7 +150,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] AS [e0]
     INNER JOIN [EntityTwos] AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] IS NOT NULL AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
+    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
 """);
     }
 
@@ -2087,7 +2087,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [UnidirectionalJoinOneToTwo] AS [u0]
     INNER JOIN [UnidirectionalEntityTwos] AS [u1] ON [u0].[TwoId] = [u1].[Id]
-    WHERE [u].[Id] = [u0].[OneId] AND [u1].[Name] NOT LIKE N'%B%')
+    WHERE [u].[Id] = [u0].[OneId] AND ([u1].[Name] NOT LIKE N'%B%' OR [u1].[Name] IS NULL))
 """);
     }
 
@@ -2158,7 +2158,7 @@ ORDER BY (
         INNER JOIN [UnidirectionalBranches] AS [u2] ON [u1].[Id] = [u2].[Id]
         LEFT JOIN [UnidirectionalLeaves] AS [u3] ON [u1].[Id] = [u3].[Id]
     ) AS [t] ON [u0].[UnidirectionalEntityBranchId] = [t].[Id]
-    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [u].[Id]
+    WHERE [u].[Id] = [u0].[UnidirectionalEntityOneId] AND [t].[Name] LIKE N'L%'), [u].[Id]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -373,7 +373,7 @@ SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id
 FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
 LEFT JOIN [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND [l].[Name] LIKE N'%03' THEN 1
+    WHEN [l].[Name] LIKE N'%03' THEN 1
     ELSE 2
 END, [l].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -1453,7 +1453,7 @@ LEFT JOIN (
     WHERE [l0].[OneToOne_Required_PK_Date] IS NOT NULL AND [l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 ORDER BY CASE
-    WHEN [l].[Name] IS NOT NULL AND [l].[Name] LIKE N'%03' THEN 1
+    WHEN [l].[Name] LIKE N'%03' THEN 1
     ELSE 2
 END, [l].[Id]
 """);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -966,7 +966,7 @@ SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[
 FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
 LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ORDER BY CASE
-    WHEN [w0].[Name] LIKE N'%Lancer' THEN CAST(1 AS bit)
+    WHEN [w0].[Name] LIKE N'%Lancer' AND [w0].[Name] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 """);
@@ -7673,7 +7673,7 @@ FROM [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g]
 WHERE CASE
     WHEN [g].[LeaderNickname] IS NULL THEN NULL
     ELSE CASE
-        WHEN [g].[LeaderNickname] IS NOT NULL AND [g].[LeaderNickname] LIKE N'%us' THEN CAST(1 AS bit)
+        WHEN [g].[LeaderNickname] LIKE N'%us' AND [g].[LeaderNickname] IS NOT NULL THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
 END = CAST(1 AS bit)
@@ -8975,7 +8975,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit) AND [g].[HasSoulPatch] IN (
         AssertSql(
 """
 SELECT CASE
-    WHEN [g].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' THEN CAST(1 AS bit)
+    WHEN [g].[HasSoulPatch] = CAST(1 AS bit) AND [t].[Note] LIKE N'%Cole%' AND [t].[Note] IS NOT NULL THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Tags] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [t]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerTest.cs
@@ -58,7 +58,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM [JoinOneToTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [j]
     INNER JOIN [EntityTwos] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0] ON [j].[TwoId] = [e0].[Id]
-    WHERE [e].[Id] = [j].[OneId] AND [e0].[Name] NOT LIKE N'%B%')
+    WHERE [e].[Id] = [j].[OneId] AND ([e0].[Name] NOT LIKE N'%B%' OR [e0].[Name] IS NULL))
 """);
     }
 
@@ -142,7 +142,7 @@ ORDER BY (
         FROM [EntityRoots] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0]
         WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
     ) AS [t] ON [j].[EntityBranchId] = [t].[Id]
-    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] IS NOT NULL AND [t].[Name] LIKE N'L%'), [e].[Id]
+    WHERE [e].[Id] = [j].[EntityOneId] AND [t].[Name] LIKE N'L%'), [e].[Id]
 """);
     }
 
@@ -174,7 +174,7 @@ ORDER BY (
     SELECT COUNT_BIG(*)
     FROM [EntityTwoEntityTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0]
     INNER JOIN [EntityTwos] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e1] ON [e0].[SelfSkipSharedLeftId] = [e1].[Id]
-    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] IS NOT NULL AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
+    WHERE [e].[Id] = [e0].[SelfSkipSharedRightId] AND [e1].[Name] LIKE N'L%') DESC, [e].[Id]
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesSqliteTest.cs
@@ -110,7 +110,7 @@ WHERE "p"."Id" IN (
     SELECT "p0"."Id"
     FROM "Posts" AS "p0"
     LEFT JOIN "Blogs" AS "b" ON "p0"."BlogId" = "b"."Id"
-    WHERE "b"."Title" IS NOT NULL AND "b"."Title" LIKE 'Arthur%'
+    WHERE "b"."Title" LIKE 'Arthur%'
 )
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesSqliteTest.cs
@@ -360,7 +360,7 @@ WHERE EXISTS (
     FROM "Order Details" AS "o0"
     INNER JOIN "Orders" AS "o1" ON "o0"."OrderID" = "o1"."OrderID"
     LEFT JOIN "Customers" AS "c" ON "o1"."CustomerID" = "c"."CustomerID"
-    WHERE "c"."CustomerID" IS NOT NULL AND "c"."CustomerID" LIKE 'F%' AND "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
+    WHERE "c"."CustomerID" LIKE 'F%' AND "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
 """);
     }
 
@@ -503,7 +503,7 @@ WHERE EXISTS (
     FROM "Order Details" AS "o0"
     INNER JOIN "Orders" AS "o1" ON "o0"."OrderID" = "o1"."OrderID"
     LEFT JOIN "Customers" AS "c" ON "o1"."CustomerID" = "c"."CustomerID"
-    WHERE "c"."City" IS NOT NULL AND "c"."City" LIKE 'Se%' AND "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
+    WHERE "c"."City" LIKE 'Se%' AND "o0"."OrderID" = "o"."OrderID" AND "o0"."ProductID" = "o"."ProductID")
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
@@ -23,7 +23,7 @@ SELECT "m"."CustomerID", "m"."Address", "m"."City", "m"."CompanyName", "m"."Cont
 FROM (
     SELECT * FROM "Customers"
 ) AS "m"
-WHERE 'z' = '' OR instr("m"."ContactName", 'z') > 0
+WHERE "m"."ContactName" IS NOT NULL AND instr("m"."ContactName", 'z') > 0
 """);
     }
 
@@ -73,7 +73,7 @@ FROM (
     )
     SELECT * FROM "Customers2"
 ) AS "m"
-WHERE 'z' = '' OR instr("m"."ContactName", 'z') > 0
+WHERE "m"."ContactName" IS NOT NULL AND instr("m"."ContactName", 'z') > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -1095,7 +1095,7 @@ SELECT COALESCE((
     FROM (
         SELECT DISTINCT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
         FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName" AND ('Lancer' = '' OR instr("w"."Name", 'Lancer') > 0)
+        WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
     ) AS "t"
     LIMIT 1), 0)
 FROM "Gears" AS "g"
@@ -2259,7 +2259,7 @@ FROM "Gears" AS "g"
 WHERE "g"."HasSoulPatch" AND COALESCE((
     SELECT DISTINCT "w"."IsAutomatic"
     FROM "Weapons" AS "w"
-    WHERE "g"."FullName" = "w"."OwnerFullName" AND ('Lancer' = '' OR instr("w"."Name", 'Lancer') > 0)
+    WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
     LIMIT 1), 0)
 ORDER BY "g"."Nickname"
 """);
@@ -2527,7 +2527,7 @@ SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", 
 FROM "LocustLeaders" AS "l"
 LEFT JOIN "Gears" AS "g" ON "l"."DefeatedByNickname" = "g"."Nickname" AND "l"."DefeatedBySquadId" = "g"."SquadId"
 LEFT JOIN "Weapons" AS "w" ON "g"."FullName" = "w"."OwnerFullName"
-WHERE 'Queen' = '' OR instr("l"."Name", 'Queen') > 0
+WHERE instr("l"."Name", 'Queen') > 0
 ORDER BY "l"."Name", "g"."Nickname", "g"."SquadId"
 """);
     }
@@ -2966,7 +2966,7 @@ WHERE "g"."HasSoulPatch" AND (
     FROM (
         SELECT DISTINCT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
         FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName" AND ('Lancer' = '' OR instr("w"."Name", 'Lancer') > 0)
+        WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
     ) AS "t"
     LIMIT 1)
 ORDER BY "g"."Nickname"
@@ -3169,7 +3169,7 @@ WHERE "g"."HasSoulPatch" AND COALESCE((
     FROM (
         SELECT DISTINCT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
         FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName" AND ('Lancer' = '' OR instr("w"."Name", 'Lancer') > 0)
+        WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
     ) AS "t"
     LIMIT 1), 0)
 ORDER BY "g"."Nickname"
@@ -3283,7 +3283,7 @@ SELECT "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthNa
 FROM "Gears" AS "g"
 WHERE CASE
     WHEN "g"."LeaderNickname" IS NULL THEN NULL
-    ELSE "g"."LeaderNickname" IS NOT NULL AND "g"."LeaderNickname" LIKE '%us'
+    ELSE "g"."LeaderNickname" LIKE '%us' AND "g"."LeaderNickname" IS NOT NULL
 END = 1
 """);
     }
@@ -3697,7 +3697,7 @@ FROM "Weapons" AS "w"
 SELECT "w0"."Id", "w0"."AmmunitionType", "w0"."IsAutomatic", "w0"."Name", "w0"."OwnerFullName", "w0"."SynergyWithId"
 FROM "Weapons" AS "w"
 LEFT JOIN "Weapons" AS "w0" ON "w"."SynergyWithId" = "w0"."Id"
-ORDER BY "w0"."Name" LIKE '%Lancer'
+ORDER BY "w0"."Name" LIKE '%Lancer' AND "w0"."Name" IS NOT NULL
 """);
     }
 
@@ -3781,7 +3781,7 @@ LIMIT 1
 SELECT "l"."Name", "l"."Discriminator", "l"."LocustHordeId", "l"."ThreatLevel", "l"."ThreatLevelByte", "l"."ThreatLevelNullableByte", "l"."DefeatedByNickname", "l"."DefeatedBySquadId", "l"."HighCommandId", "g"."Nickname", "g"."SquadId", "g"."AssignedCityName", "g"."CityOfBirthName", "g"."Discriminator", "g"."FullName", "g"."HasSoulPatch", "g"."LeaderNickname", "g"."LeaderSquadId", "g"."Rank"
 FROM "LocustLeaders" AS "l"
 LEFT JOIN "Gears" AS "g" ON "l"."DefeatedByNickname" = "g"."Nickname" AND "l"."DefeatedBySquadId" = "g"."SquadId"
-WHERE 'Queen' = '' OR instr("l"."Name", 'Queen') > 0
+WHERE instr("l"."Name", 'Queen') > 0
 LIMIT 1
 """);
     }
@@ -3823,7 +3823,7 @@ INNER JOIN "Cities" AS "c" ON "t0"."CityOfBirthName" = "c"."Name"
 """
 SELECT "c"."Name", "c"."Location", "c"."Nation"
 FROM "Cities" AS "c"
-WHERE 'Jacinto' = '' OR instr("c"."Location", 'Jacinto') > 0
+WHERE "c"."Location" IS NOT NULL AND instr("c"."Location", 'Jacinto') > 0
 """);
     }
 
@@ -4738,7 +4738,7 @@ END IS NOT NULL
 SELECT COALESCE((
     SELECT DISTINCT "w"."IsAutomatic"
     FROM "Weapons" AS "w"
-    WHERE "g"."FullName" = "w"."OwnerFullName" AND ('Lancer' = '' OR instr("w"."Name", 'Lancer') > 0)
+    WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
     LIMIT 1), 0)
 FROM "Gears" AS "g"
 WHERE "g"."HasSoulPatch"
@@ -4964,7 +4964,7 @@ WHERE "g"."Rank" & @__parameter_0 = @__parameter_0
 
         AssertSql(
 """
-SELECT "g"."HasSoulPatch" AND ('Cole' = '' OR instr("t"."Note", 'Cole') > 0)
+SELECT "g"."HasSoulPatch" AND "t"."Note" IS NOT NULL AND instr("t"."Note", 'Cole') > 0
 FROM "Tags" AS "t"
 LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname" AND "t"."GearSquadId" = "g"."SquadId"
 """);
@@ -6389,7 +6389,7 @@ ORDER BY "g"."Nickname", "g"."SquadId"
 """
 SELECT "c"."Name", "c"."Location", "c"."Nation"
 FROM "Cities" AS "c"
-WHERE 'Add' = '' OR instr(COALESCE("c"."Location", '') || 'Added', 'Add') > 0
+WHERE instr(COALESCE("c"."Location", '') || 'Added', 'Add') > 0
 """);
     }
 
@@ -7152,7 +7152,7 @@ WHERE "g"."Discriminator" = 'Officer'
 SELECT "t"."Id", "t"."GearNickName", "t"."GearSquadId", "t"."IssueDate", "t"."Note"
 FROM "Tags" AS "t"
 LEFT JOIN "Gears" AS "g" ON "t"."GearNickName" = "g"."Nickname" AND "t"."GearSquadId" = "g"."SquadId"
-WHERE "g"."HasSoulPatch" OR 'Cole' = '' OR instr("t"."Note", 'Cole') > 0
+WHERE "g"."HasSoulPatch" OR ("t"."Note" IS NOT NULL AND instr("t"."Note", 'Cole') > 0)
 """);
     }
 
@@ -7248,7 +7248,7 @@ SELECT (
     FROM (
         SELECT DISTINCT "w"."Id", "w"."AmmunitionType", "w"."IsAutomatic", "w"."Name", "w"."OwnerFullName", "w"."SynergyWithId"
         FROM "Weapons" AS "w"
-        WHERE "g"."FullName" = "w"."OwnerFullName" AND ('Lancer' = '' OR instr("w"."Name", 'Lancer') > 0)
+        WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Lancer') > 0
     ) AS "t"
     LIMIT 1)
 FROM "Gears" AS "g"
@@ -8617,7 +8617,7 @@ LEFT JOIN "Weapons" AS "w0" ON "g"."FullName" = "w0"."OwnerFullName"
 ORDER BY (
     SELECT "w"."Name"
     FROM "Weapons" AS "w"
-    WHERE "g"."FullName" = "w"."OwnerFullName" AND ('Gnasher' = '' OR instr("w"."Name", 'Gnasher') > 0)
+    WHERE "g"."FullName" = "w"."OwnerFullName" AND "w"."Name" IS NOT NULL AND instr("w"."Name", 'Gnasher') > 0
     LIMIT 1), "g"."Nickname", "g"."SquadId"
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -709,7 +709,21 @@ WHERE "o"."OrderID" = 11077 AND radians("o"."Discount") > 0
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" IS NOT NULL AND "c"."ContactName" LIKE 'M%'
+WHERE "c"."ContactName" LIKE 'M%'
+""");
+    }
+
+    public override async Task String_StartsWith_Parameter(bool async)
+    {
+        await base.String_StartsWith_Parameter(async);
+
+        AssertSql(
+"""
+@__pattern_0_rewritten='M%' (Size = 2)
+
+SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
+FROM "Customers" AS "c"
+WHERE "c"."ContactName" LIKE @__pattern_0_rewritten ESCAPE '\'
 """);
     }
 
@@ -721,7 +735,7 @@ WHERE "c"."ContactName" IS NOT NULL AND "c"."ContactName" LIKE 'M%'
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" = '' OR ("c"."ContactName" IS NOT NULL AND (("c"."ContactName" LIKE "c"."ContactName" || '%' AND substr("c"."ContactName", 1, length("c"."ContactName")) = "c"."ContactName") OR "c"."ContactName" = ''))
+WHERE "c"."ContactName" IS NOT NULL AND (substr("c"."ContactName", 1, length("c"."ContactName")) = "c"."ContactName" OR "c"."ContactName" = '')
 """);
     }
 
@@ -733,7 +747,7 @@ WHERE "c"."ContactName" = '' OR ("c"."ContactName" IS NOT NULL AND (("c"."Contac
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" = '' OR ("c"."ContactName" IS NOT NULL AND (("c"."ContactName" LIKE "c"."ContactName" || '%' AND substr("c"."ContactName", 1, length("c"."ContactName")) = "c"."ContactName") OR "c"."ContactName" = ''))
+WHERE "c"."ContactName" IS NOT NULL AND (substr("c"."ContactName", 1, length("c"."ContactName")) = "c"."ContactName" OR "c"."ContactName" = '')
 """);
     }
 
@@ -745,7 +759,7 @@ WHERE "c"."ContactName" = '' OR ("c"."ContactName" IS NOT NULL AND (("c"."Contac
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" IS NOT NULL AND "c"."ContactName" LIKE 'M%'
+WHERE "c"."ContactName" LIKE 'M%'
 """);
     }
 
@@ -757,7 +771,21 @@ WHERE "c"."ContactName" IS NOT NULL AND "c"."ContactName" LIKE 'M%'
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" IS NOT NULL AND "c"."ContactName" LIKE '%b'
+WHERE "c"."ContactName" LIKE '%b'
+""");
+    }
+
+    public override async Task String_EndsWith_Parameter(bool async)
+    {
+        await base.String_EndsWith_Parameter(async);
+
+        AssertSql(
+"""
+@__pattern_0_rewritten='%b' (Size = 2)
+
+SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
+FROM "Customers" AS "c"
+WHERE "c"."ContactName" LIKE @__pattern_0_rewritten ESCAPE '\'
 """);
     }
 
@@ -769,7 +797,7 @@ WHERE "c"."ContactName" IS NOT NULL AND "c"."ContactName" LIKE '%b'
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" = '' OR ("c"."ContactName" IS NOT NULL AND (substr("c"."ContactName", -length("c"."ContactName")) = "c"."ContactName" OR "c"."ContactName" = ''))
+WHERE "c"."ContactName" IS NOT NULL AND (substr("c"."ContactName", -length("c"."ContactName")) = "c"."ContactName" OR "c"."ContactName" = '')
 """);
     }
 
@@ -781,7 +809,7 @@ WHERE "c"."ContactName" = '' OR ("c"."ContactName" IS NOT NULL AND (substr("c"."
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" = '' OR ("c"."ContactName" IS NOT NULL AND (substr("c"."ContactName", -length("c"."ContactName")) = "c"."ContactName" OR "c"."ContactName" = ''))
+WHERE "c"."ContactName" IS NOT NULL AND (substr("c"."ContactName", -length("c"."ContactName")) = "c"."ContactName" OR "c"."ContactName" = '')
 """);
     }
 
@@ -793,7 +821,7 @@ WHERE "c"."ContactName" = '' OR ("c"."ContactName" IS NOT NULL AND (substr("c"."
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" IS NOT NULL AND "c"."ContactName" LIKE '%m'
+WHERE "c"."ContactName" LIKE '%m'
 """);
     }
 
@@ -805,7 +833,7 @@ WHERE "c"."ContactName" IS NOT NULL AND "c"."ContactName" LIKE '%m'
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE 'M' = '' OR instr("c"."ContactName", 'M') > 0
+WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", 'M') > 0
 """);
     }
 
@@ -817,7 +845,7 @@ WHERE 'M' = '' OR instr("c"."ContactName", 'M') > 0
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" = '' OR instr("c"."ContactName", "c"."ContactName") > 0
+WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", "c"."ContactName") > 0
 """);
     }
 
@@ -829,7 +857,7 @@ WHERE "c"."ContactName" = '' OR instr("c"."ContactName", "c"."ContactName") > 0
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" = '' OR instr("c"."ContactName", "c"."ContactName") > 0
+WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", "c"."ContactName") > 0
 """);
     }
 
@@ -863,7 +891,7 @@ WHERE substr("c"."ContactName", length("c"."ContactName"), 1) = 's'
 """
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE 'M' = '' OR instr("c"."ContactName", 'M') > 0
+WHERE "c"."ContactName" IS NOT NULL AND instr("c"."ContactName", 'M') > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -26,7 +26,7 @@ public class NorthwindMiscellaneousQuerySqliteTest : NorthwindMiscellaneousQuery
 """
 SELECT "o"."CustomerID"
 FROM "Orders" AS "o"
-WHERE "o"."OrderDate" IS NOT NULL AND ('10' = '' OR instr(CAST("o"."EmployeeID" AS TEXT), '10') > 0)
+WHERE "o"."OrderDate" IS NOT NULL AND "o"."EmployeeID" IS NOT NULL AND instr(CAST("o"."EmployeeID" AS TEXT), '10') > 0
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQueryFiltersQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQueryFiltersQuerySqliteTest.cs
@@ -21,11 +21,11 @@ public class NorthwindQueryFiltersQuerySqliteTest : NorthwindQueryFiltersQueryTe
 
         AssertSql(
 """
-@__ef_filter__TenantPrefix_0='B' (Size = 1)
+@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 2)
 
 SELECT COUNT(*)
 FROM "Customers" AS "c"
-WHERE @__ef_filter__TenantPrefix_0 = '' OR ("c"."CompanyName" LIKE @__ef_filter__TenantPrefix_0 || '%' AND substr("c"."CompanyName", 1, length(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0) OR @__ef_filter__TenantPrefix_0 = ''
+WHERE "c"."CompanyName" LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE '\'
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OperatorsQuerySqliteTest.cs
@@ -108,7 +108,7 @@ WHERE -"o"."Value" = -("o"."Id" + "o0"."Value")
 """
 SELECT "o"."Id"
 FROM "OperatorEntityString" AS "o"
-WHERE "o"."Value" IS NOT NULL AND "o"."Value" NOT LIKE 'A%'
+WHERE "o"."Value" NOT LIKE 'A%' OR "o"."Value" IS NULL
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SqlQuerySqliteTest.cs
@@ -23,7 +23,7 @@ SELECT "m"."Address", "m"."City", "m"."CompanyName", "m"."ContactName", "m"."Con
 FROM (
     SELECT * FROM "Customers"
 ) AS "m"
-WHERE 'z' = '' OR instr("m"."ContactName", 'z') > 0
+WHERE instr("m"."ContactName", 'z') > 0
 """);
     }
 
@@ -73,7 +73,7 @@ FROM (
     )
     SELECT * FROM "Customers2"
 ) AS "m"
-WHERE 'z' = '' OR instr("m"."ContactName", 'z') > 0
+WHERE instr("m"."ContactName", 'z') > 0
 """);
     }
 


### PR DESCRIPTION
* Implement proper null semantics for LIKE: `x LIKE y` returns true iff x and y are non-null and there's a match; otherwise false (#26735).
* Remove exceptional behavior for StartsWith/EndsWith/Contains, so they now behave like any other function.
	* Switching to regular function null semantics means that these now receive compensation for 2-value logic just like any other function. Following the LIKE changes above, e.g.  `x.EndsWith(y)` now returns true iff x and y are non-null and there's a match; otherwise false. This fixes negation issues such as #30493.
	* In addition, the case of an empty-string pattern - which in .NET returns true for any non-null string - now behaves consistently and returns false instead of true when the string being matched is null (this would throw in .NET).
* Optimize StartsWith/EndsWith/Contains when the pattern is a parameter, by performing escaping on it via our runtime parameter rewriting facility.
	* This required moving translations for these methods out of the method translators and into SqlTranslatingExpressionVisitor (for access to RegisterRuntimeParameter). We should allow translators to access the query compilation context, at which point the code can move back.
	* This means we now do client-side rewriting of both constants and parameters - generating optimal LIKE SQL; the only case where we don't is when the pattern is a column.

@maumar you'll probably want to take a look at this when you're back.