### PR TITLE
Tiny API review renames

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryRootProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryRootProcessor.cs
@@ -36,7 +36,7 @@ public class RelationalQueryRootProcessor : QueryRootProcessor
 
     /// <summary>
     ///     Indicates that a <see cref="ParameterExpression" /> can be converted to a <see cref="ParameterQueryRootExpression" />;
-    ///     the latter will end up in <see cref="RelationalQueryableMethodTranslatingExpressionVisitor.TranslateCollection" /> for
+    ///     the latter will end up in <see cref="RelationalQueryableMethodTranslatingExpressionVisitor.TranslatePrimitiveCollection" /> for
     ///     translation to a provider-specific SQL expansion mechanism, e.g. <c>OPENJSON</c> on SQL Server.
     /// </summary>
     protected override bool ShouldConvertToParameterQueryRoot(ParameterExpression constantExpression)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -217,7 +217,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                 var sqlParameterExpression =
                     _sqlTranslator.Visit(parameterQueryRootExpression.ParameterExpression) as SqlParameterExpression;
                 Check.DebugAssert(sqlParameterExpression is not null, "sqlParameterExpression is not null");
-                return TranslateCollection(
+                return TranslatePrimitiveCollection(
                         sqlParameterExpression,
                         property: null,
                         char.ToLowerInvariant(sqlParameterExpression.Name.First(c => c != '_')).ToString())
@@ -282,7 +282,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                     _ => "j"
                 };
 
-                if (TranslateCollection(sqlExpression, regularProperty, tableAlias) is
+                if (TranslatePrimitiveCollection(sqlExpression, regularProperty, tableAlias) is
                     { } primitiveCollectionTranslation)
                 {
                     return primitiveCollectionTranslation;
@@ -311,8 +311,8 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
     }
 
     /// <summary>
-    ///     Translates a parameter or column collection. Providers can override this to translate e.g. int[] columns/parameters/constants to
-    ///     a queryable table (OPENJSON on SQL Server, unnest on PostgreSQL...). The default implementation always returns
+    ///     Translates a parameter or column collection of primitive values. Providers can override this to translate e.g. int[] columns or
+    ///     parameters to a queryable table (OPENJSON on SQL Server, unnest on PostgreSQL...). The default implementation always returns
     ///     <see langword="null" /> (no translation).
     /// </summary>
     /// <remarks>
@@ -328,7 +328,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
     ///     Provides an alias to be used for the table returned from translation, which will represent the collection.
     /// </param>
     /// <returns>A <see cref="ShapedQueryExpression" /> if the translation was successful, otherwise <see langword="null" />.</returns>
-    protected virtual ShapedQueryExpression? TranslateCollection(SqlExpression sqlExpression, IProperty? property, string tableAlias)
+    protected virtual ShapedQueryExpression? TranslatePrimitiveCollection(SqlExpression sqlExpression, IProperty? property, string tableAlias)
         => null;
 
     /// <summary>

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -728,7 +728,7 @@ public class SqlNullabilityProcessor
 
                     // On SQL Server, EXISTS isn't less efficient than IN, and the additional COALESCE (and CASE/WHEN which it requires)
                     // add unneeded clutter (and possibly hurt perf). So allow providers to prefer EXISTS.
-                    if (PreferExistsToComplexIn)
+                    if (PreferExistsToInWithCoalesce)
                     {
                         goto TransformToExists;
                     }
@@ -1445,7 +1445,7 @@ public class SqlNullabilityProcessor
     ///     Determines whether an <see cref="InExpression" /> will be transformed to an <see cref="ExistsExpression" /> when it would
     ///     otherwise require complex compensation for null semantics.
     /// </summary>
-    protected virtual bool PreferExistsToComplexIn => false;
+    protected virtual bool PreferExistsToInWithCoalesce => false;
 
     // Note that we can check parameter values for null since we cache by the parameter nullability; but we cannot do the same for bool.
     private bool IsNull(SqlExpression? expression)

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -127,7 +127,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override ShapedQueryExpression? TranslateCollection(
+    protected override ShapedQueryExpression? TranslatePrimitiveCollection(
         SqlExpression sqlExpression,
         IProperty? property,
         string tableAlias)

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlNullabilityProcessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlNullabilityProcessor.cs
@@ -111,5 +111,5 @@ public class SqlServerSqlNullabilityProcessor : SqlNullabilityProcessor
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override bool PreferExistsToComplexIn => true;
+    protected override bool PreferExistsToInWithCoalesce => true;
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryableMethodTranslatingExpressionVisitor.cs
@@ -201,7 +201,7 @@ public class SqliteQueryableMethodTranslatingExpressionVisitor : RelationalQuery
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    protected override ShapedQueryExpression? TranslateCollection(
+    protected override ShapedQueryExpression? TranslatePrimitiveCollection(
         SqlExpression sqlExpression,
         IProperty? property,
         string tableAlias)


### PR DESCRIPTION
Part of #30306

## Stuff I did:

> @roji Is there a better name for SqlNullabilityProcessor.PreferExistsToComplexIn? What makes it complex?

Renamed it to PreferExistsToInWithCoalesce, which explains better when this is used (but still sucks).

>  TranslateCollection should be renamed to TranslateScalarCollection

I ended up renaming to TranslatePrimitiveCollection since that's the naming we ended up using e.g. in the user-facing builder API.

## Stuff I left as-is for now:

> @roji Is there a better name for InlineQueryRootExpression? It seems too generic. Maybe something with *Collection*

I thought about it some more; a query root by definition represents some sort of collection, so I really think adding `Collection` is redundant (note that we'd also have to do it for `ParameterQueryRootExpression`)... For comparison, existing type names for query roots are `EntityQueryRootExpression`, `SqlQueryRootExpression` and `TableValuedFunctionQueryRootExpression`; I think `InlineQueryRootExpression` and `ParameterQueryRootExpression` fit well into this and are reasonably descriptive - but let me know if there are strong feelings here and I will change.

> QueryRootProcessor.ShouldConvertToInlineQueryRoot too

As above.

> @roji Is there a better name for QuerySqlGenerator.TryGenerateWithoutWrappingSelect? It doesn't follow the typical Try- pattern.

Looking at it, this does return a bool to indicate success/failure - though it indeed has no out var. I *think* that's OK and in-line with established patterns - [`DateTime.TryFormat`](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tryformat?view=net-7.0) is a good example of an API which behaves just like this. The rest of the name is a bit long/wonky, but I can't really come up with some better... In some cases we have a `SelectExpression` wrapping something where the `SelectExpression` doesn't actually need to be generated in SQL (one example is `X UNION y`, which we represent as wrapped by a `SelectExpression` although it isn't outputted). This method is what identifies these cases and also writes the SQL out; we could also shorten this to `TryGenerateUnwrapped`, which is shorter but less descriptive - am open to other ideas.

/cc @danmoseley 