### PR TITLE
Add some enum generic constraints

### DIFF
--- a/src/EFCore/Storage/Json/JsonSignedEnumReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonSignedEnumReaderWriter.cs
@@ -9,6 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Json;
 ///     Reads and writes JSON for <see langword="enum" /> values backed by a signed integer.
 /// </summary>
 public sealed class JsonSignedEnumReaderWriter<TEnum> : JsonValueReaderWriter<TEnum>
+    where TEnum : struct, Enum
 {
     /// <summary>
     ///     The singleton instance of this stateless reader/writer.

--- a/src/EFCore/Storage/Json/JsonUnsignedEnumReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonUnsignedEnumReaderWriter.cs
@@ -9,6 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Json;
 ///     Reads and writes JSON for <see langword="enum" /> values backed by an unsigned integer.
 /// </summary>
 public sealed class JsonUnsignedEnumReaderWriter<TEnum> : JsonValueReaderWriter<TEnum>
+    where TEnum : struct, Enum
 {
     /// <summary>
     ///     The singleton instance of this stateless reader/writer.

--- a/src/EFCore/Storage/Json/JsonWarningEnumReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonWarningEnumReaderWriter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Json;
 ///     happens, a warning is generated.
 /// </summary>
 public sealed class JsonWarningEnumReaderWriter<TEnum> : JsonValueReaderWriter<TEnum>
-    where TEnum : struct
+    where TEnum : struct, Enum
 {
     /// <summary>
     ///     The singleton instance of this stateless reader/writer.

--- a/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToNumberConverter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 ///     See <see href="https://aka.ms/efcore-docs-value-converters">EF Core value converters</see> for more information and examples.
 /// </remarks>
 public class EnumToNumberConverter<TEnum, TNumber> : ValueConverter<TEnum, TNumber>
-    where TEnum : struct
+    where TEnum : struct, Enum
     where TNumber : struct
 {
     // ReSharper disable once StaticMemberInGenericType

--- a/src/EFCore/Storage/ValueConversion/EnumToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/EnumToStringConverter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 ///     See <see href="https://aka.ms/efcore-docs-value-converters">EF Core value converters</see> for more information and examples.
 /// </remarks>
 public class EnumToStringConverter<TEnum> : StringEnumConverter<TEnum, string, TEnum>
-    where TEnum : struct
+    where TEnum : struct, Enum
 {
     /// <summary>
     ///     Creates a new instance of this converter. This converter does not preserve order.

--- a/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
 public class StringEnumConverter<TModel, TProvider, TEnum> : ValueConverter<TModel, TProvider>
-    where TEnum : struct
+    where TEnum : struct, Enum
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 ///     See <see href="https://aka.ms/efcore-docs-value-converters">EF Core value converters</see> for more information and examples.
 /// </remarks>
 public class StringToEnumConverter<TEnum> : StringEnumConverter<string, TEnum, TEnum>
-    where TEnum : struct
+    where TEnum : struct, Enum
 {
     /// <summary>
     ///     Creates a new instance of this converter. This converter does not preserve order.

--- a/test/EFCore.Tests/Storage/EnumToNumberConverterTest.cs
+++ b/test/EFCore.Tests/Storage/EnumToNumberConverterTest.cs
@@ -265,26 +265,6 @@ public class EnumToNumberConverterTest
         Assert.Equal(default, converter(0));
     }
 
-    [ConditionalFact]
-    public void Enum_to_integer_converter_throws_for_bad_types()
-    {
-        Assert.Equal(
-            CoreStrings.ConverterBadType(
-                typeof(EnumToNumberConverter<Guid, int>).ShortDisplayName(),
-                "Guid",
-                "enum types"),
-            Assert.Throws<InvalidOperationException>(
-                () => new EnumToNumberConverter<Guid, int>()).Message);
-
-        Assert.Equal(
-            CoreStrings.ConverterBadType(
-                typeof(EnumToNumberConverter<Beatles, Guid>).ShortDisplayName(),
-                "Guid",
-                "'int', 'long', 'short', 'byte', 'uint', 'ulong', 'ushort', 'sbyte', 'double', 'float', 'decimal'"),
-            Assert.Throws<InvalidOperationException>(
-                () => new EnumToNumberConverter<Beatles, Guid>()).Message);
-    }
-
     private enum Beatles
     {
         John = 7,

--- a/test/EFCore.Tests/Storage/EnumToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/EnumToStringConverterTest.cs
@@ -77,16 +77,6 @@ public class EnumToStringConverterTest
         Assert.Null(converter(null));
     }
 
-    [ConditionalFact]
-    public void Enum_to_string_converter_throws_for_bad_types()
-        => Assert.Equal(
-            CoreStrings.ConverterBadType(
-                typeof(StringEnumConverter<Guid, string, Guid>).ShortDisplayName(),
-                "Guid",
-                "enum types"),
-            Assert.Throws<InvalidOperationException>(
-                () => new EnumToStringConverter<Guid>()).Message);
-
     private enum Beatles
     {
         John = 7,

--- a/test/EFCore.Tests/Storage/StringToEnumConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToEnumConverterTest.cs
@@ -78,16 +78,6 @@ public class StringToEnumConverterTest
         Assert.Null(converter(null));
     }
 
-    [ConditionalFact]
-    public void String_to_enum_converter_throws_for_bad_types()
-        => Assert.Equal(
-            CoreStrings.ConverterBadType(
-                typeof(StringEnumConverter<string, Guid, Guid>).ShortDisplayName(),
-                "Guid",
-                "enum types"),
-            Assert.Throws<InvalidOperationException>(
-                () => new StringToEnumConverter<Guid>()).Message);
-
     private enum Beatles
     {
         John = 7,


### PR DESCRIPTION
These are contexts which would fail at runtime if a non-enum type is used; the constraint moves the error to compile-time.