### PR TITLE
Fix to #31597 - RC1: UnreachableException when loading with proxies and a JSON-mapped complex property

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -1521,6 +1521,39 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     //sometimes we have shadow value buffer and sometimes not, but type initializer always comes last
                     switch (body.Expressions[^1])
                     {
+                        case UnaryExpression { Operand: BlockExpression innerBlock } jsonEntityTypeInitializerUnary
+                        when jsonEntityTypeInitializerUnary.NodeType is ExpressionType.Convert or ExpressionType.ConvertChecked:
+                        {
+                            // in case of proxies, the entity initializer block is wrapped around Convert node
+                            // that converts from the proxy type to the actual entity type.
+                            // We normalize that into a block by pushing the convert inside the inner block. Rather than:
+                            //
+                            // return (MyEntity)
+                            // {
+                            //     ProxyEntity instance;
+                            //     (...)
+                            //     return instance;
+                            // }
+                            //
+                            // we produce:
+                            // return
+                            // {
+                            //     ProxyEntity instance;
+                            //     MyEntity actualInstance;
+                            //     (...)
+                            //     actualInstance = (MyEntity)instance;
+                            //     return actualInstance;
+                            // }
+                            var newVariables = innerBlock.Variables.ToList();
+                            var proxyConversionVariable = Variable(jsonEntityTypeInitializerUnary.Type);
+                            newVariables.Add(proxyConversionVariable);
+                            var newExpressions = innerBlock.Expressions.ToList()[..^1];
+                            newExpressions.Add(Assign(proxyConversionVariable, jsonEntityTypeInitializerUnary.Update(innerBlock.Expressions[^1])));
+                            newExpressions.Add(proxyConversionVariable);
+                            jsonEntityTypeInitializerBlock = Block(newVariables, newExpressions);
+                            break;
+                        }
+
                         case BlockExpression b:
                             jsonEntityTypeInitializerBlock = b;
                             break;


### PR DESCRIPTION
when processing entity materialization code, adapting it for JSON, we assume the entity type can be a result of BlockExpression (normal case) or a NewExpression (when the ctor is the only thing and we don't need to do any other assignments). However, for proxies, the block is wrapped around Convert node, since the instance generated of of Proxy type, but we expect the actual type there.

Fix is to handle this case and push the convert inside the block to normalize the expression we produce.

Fixes #31597