### PR TITLE
Set the key comparer as well as the normal comparer when mapping a primitive collection

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMapping.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMapping.cs
@@ -63,9 +63,10 @@ public class CosmosTypeMapping : CoreTypeMapping
     public override CoreTypeMapping Clone(
         ValueConverter? converter,
         ValueComparer? comparer = null,
+        ValueComparer? keyComparer = null,
         CoreTypeMapping? elementMapping = null,
         JsonValueReaderWriter? jsonValueReaderWriter = null)
-        => new CosmosTypeMapping(Parameters.WithComposedConverter(converter, comparer, elementMapping, jsonValueReaderWriter));
+        => new CosmosTypeMapping(Parameters.WithComposedConverter(converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMapping.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMapping.cs
@@ -56,9 +56,10 @@ public class InMemoryTypeMapping : CoreTypeMapping
     public override CoreTypeMapping Clone(
         ValueConverter? converter,
         ValueComparer? comparer = null,
+        ValueComparer? keyComparer = null,
         CoreTypeMapping? elementMapping = null,
         JsonValueReaderWriter? jsonValueReaderWriter = null)
-        => new InMemoryTypeMapping(Parameters.WithComposedConverter(converter, comparer, elementMapping, jsonValueReaderWriter));
+        => new InMemoryTypeMapping(Parameters.WithComposedConverter(converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -808,8 +808,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                         // (OPENJSON, json_each, etc), but we can't use it for distinct, as it would warp the results.
                         // Instead, we will treat every non-key property as identifier.
 
-                        // TODO: hack/workaround, see #31398
-                        foreach (var property in entityType.GetDeclaredProperties().Where(p => !p.IsPrimaryKey() && p.GetRelationalTypeMapping().ElementTypeMapping == null))
+                        foreach (var property in entityType.GetDeclaredProperties().Where(p => !p.IsPrimaryKey()))
                         {
                             typeProjectionIdentifiers.Add(entityProjection.BindProperty(property));
                             typeProjectionValueComparers.Add(property.GetKeyValueComparer());
@@ -826,8 +825,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                         // entity type would have wiped the identifiers when generating the join.
                         Check.DebugAssert(primaryKey != null, "primary key is null.");
 
-                        // TODO: hack/workaround, see #31398
-                        foreach (var property in primaryKey.Properties.Where(x => x.GetRelationalTypeMapping().ElementTypeMapping == null))
+                        foreach (var property in primaryKey.Properties)
                         {
                             typeProjectionIdentifiers.Add(entityProjection.BindProperty(property));
                             typeProjectionValueComparers.Add(property.GetKeyValueComparer());
@@ -1851,7 +1849,7 @@ public sealed partial class SelectExpression : TableExpressionBase
                     {
                         ownerEntity = ownership.PrincipalEntityType;
                     }
-                } 
+                }
                 while (ownerEntity.IsMappedToJson());
 
                 var keyPropertyCount = ownerEntity.FindPrimaryKey()!.Properties.Count;

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -231,16 +231,18 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
         /// </summary>
         /// <param name="converter">The converter.</param>
         /// <param name="comparer">The comparer.</param>
+        /// <param name="keyComparer">The key comparer.</param>
         /// <param name="elementMapping">The element mapping, or <see langword="null" /> for non-collection mappings.</param>
         /// <param name="jsonValueReaderWriter">The JSON reader/writer, or <see langword="null" /> to leave unchanged.</param>
         /// <returns>The new parameter object.</returns>
         public RelationalTypeMappingParameters WithComposedConverter(
             ValueConverter? converter,
             ValueComparer? comparer,
+            ValueComparer? keyComparer,
             CoreTypeMapping? elementMapping,
             JsonValueReaderWriter? jsonValueReaderWriter)
             => new(
-                CoreParameters.WithComposedConverter(converter, comparer, elementMapping, jsonValueReaderWriter),
+                CoreParameters.WithComposedConverter(converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter),
                 StoreType,
                 StoreTypePostfix,
                 DbType,
@@ -431,9 +433,10 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
     public override CoreTypeMapping Clone(
         ValueConverter? converter,
         ValueComparer? comparer = null,
+        ValueComparer? keyComparer = null,
         CoreTypeMapping? elementMapping = null,
         JsonValueReaderWriter? jsonValueReaderWriter = null)
-        => Clone(Parameters.WithComposedConverter(converter, comparer, elementMapping, jsonValueReaderWriter));
+        => Clone(Parameters.WithComposedConverter(converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter));
 
     /// <summary>
     ///     Clones the type mapping to update facets from the mapping info, if needed.

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -111,12 +111,14 @@ public abstract class CoreTypeMapping
         /// </summary>
         /// <param name="converter">The converter.</param>
         /// <param name="comparer">The comparer.</param>
+        /// <param name="keyComparer">The key comparer.</param>
         /// <param name="elementMapping">The element mapping, or <see langword="null" /> for non-collection mappings.</param>
         /// <param name="jsonValueReaderWriter">The JSON reader/writer, or <see langword="null" /> to leave unchanged.</param>
         /// <returns>The new parameter object.</returns>
         public CoreTypeMappingParameters WithComposedConverter(
             ValueConverter? converter,
             ValueComparer? comparer,
+            ValueComparer? keyComparer,
             CoreTypeMapping? elementMapping,
             JsonValueReaderWriter? jsonValueReaderWriter)
         {
@@ -126,7 +128,7 @@ public abstract class CoreTypeMapping
                 ClrType,
                 converter ?? Converter,
                 comparer ?? Comparer,
-                KeyComparer,
+                keyComparer?? KeyComparer,
                 ProviderValueComparer,
                 ValueGeneratorFactory,
                 elementMapping ?? ElementTypeMapping,
@@ -266,12 +268,14 @@ public abstract class CoreTypeMapping
     /// </summary>
     /// <param name="converter">The converter to use.</param>
     /// <param name="comparer">The comparer to use, or <see langword="null" /> for to keep the default.</param>
+    /// <param name="keyComparer">The comparer to use when the value is a key, or <see langword="null" /> for to keep the default.</param>
     /// <param name="elementMapping">The element mapping, or <see langword="null" /> for non-collection mappings.</param>
     /// <param name="jsonValueReaderWriter">The JSON reader/writer, or <see langword="null" /> to leave unchanged.</param>
     /// <returns>A new type mapping</returns>
     public abstract CoreTypeMapping Clone(
         ValueConverter? converter,
         ValueComparer? comparer = null,
+        ValueComparer? keyComparer = null,
         CoreTypeMapping? elementMapping = null,
         JsonValueReaderWriter? jsonValueReaderWriter = null);
 

--- a/src/EFCore/Storage/TypeMappingSource.cs
+++ b/src/EFCore/Storage/TypeMappingSource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using ValueComparer = Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer;
 
 namespace Microsoft.EntityFrameworkCore.Storage;
 
@@ -182,25 +183,30 @@ public abstract class TypeMappingSource : TypeMappingSourceBase
         Type? providerType,
         CoreTypeMapping? elementMapping)
     {
-        var elementType = modelType.TryGetElementType(typeof(IEnumerable<>))!;
+        if (TryFindJsonCollectionMapping(
+                info, modelType, providerType, ref elementMapping, out var collectionReaderWriter))
+        {
+            var elementType = modelType.TryGetElementType(typeof(IEnumerable<>))!;
+            var comparer = (ValueComparer?)Activator.CreateInstance(
+                elementType.IsNullableValueType()
+                    ? typeof(NullableValueTypeListComparer<>).MakeGenericType(elementType.UnwrapNullableType())
+                    : typeof(ListComparer<>).MakeGenericType(elementMapping!.Comparer.Type),
+                elementMapping!.Comparer);
 
-        return TryFindJsonCollectionMapping(
-            info, modelType, providerType, ref elementMapping, out var collectionReaderWriter)
-            ? FindMapping(
+            return FindMapping(
                     info.WithConverter(
                         // Note that the converter info is only used temporarily here and never creates an instance.
                         new ValueConverterInfo(modelType, typeof(string), _ => null!)))!
                 .Clone(
                     (ValueConverter)Activator.CreateInstance(
                         typeof(CollectionToJsonStringConverter<>).MakeGenericType(elementType), collectionReaderWriter!)!,
-                    (ValueComparer?)Activator.CreateInstance(
-                        elementType.IsNullableValueType()
-                            ? typeof(NullableValueTypeListComparer<>).MakeGenericType(elementType.UnwrapNullableType())
-                            : typeof(ListComparer<>).MakeGenericType(elementMapping!.Comparer.Type),
-                        elementMapping!.Comparer),
+                    comparer,
+                    comparer,
                     elementMapping,
-                    collectionReaderWriter)
-            : null;
+                    collectionReaderWriter);
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -1338,7 +1338,7 @@ OUTER APPLY (
         [OwnedReferenceBranch] nvarchar(max) '$.OwnedReferenceBranch' AS JSON
     ) AS [o]
 ) AS [t]
-ORDER BY [j].[Id], [t].[Name]
+ORDER BY [j].[Id], [t].[Name], [t].[Names], [t].[Number]
 """);
     }
 
@@ -1400,7 +1400,7 @@ OUTER APPLY (
     ) AS [t2]
 ) AS [t1]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
-ORDER BY [j].[Id], [t].[c], [t].[key], [t0].[Name], [t0].[Number], [t1].[c1], [t1].[key], [t1].[c10], [t1].[key0]
+ORDER BY [j].[Id], [t].[c], [t].[key], [t0].[Name], [t0].[Names], [t0].[Number], [t0].[Numbers], [t1].[c1], [t1].[key], [t1].[c10], [t1].[key0]
 """);
     }
 
@@ -1426,7 +1426,7 @@ OUTER APPLY (
     ) AS [o]
 ) AS [t]
 LEFT JOIN [JsonEntitiesBasicForCollection] AS [j0] ON [j].[Id] = [j0].[ParentId]
-ORDER BY [j].[Id], [t].[Date], [t].[Enum], [t].[Fraction], [t].[NullableEnum]
+ORDER BY [j].[Id], [t].[Date], [t].[Enum], [t].[Enums], [t].[Fraction], [t].[NullableEnum], [t].[NullableEnums]
 """);
     }
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -314,9 +314,11 @@ public class ChangeDetectorTest
         public override CoreTypeMapping Clone(
             ValueConverter converter,
             ValueComparer comparer = null,
+            ValueComparer keyComparer = null,
             CoreTypeMapping elementMapping = null,
             JsonValueReaderWriter jsonValueReaderWriter = null)
-            => new ConcreteTypeMapping(Parameters.WithComposedConverter(converter, comparer, elementMapping, jsonValueReaderWriter));
+            => new ConcreteTypeMapping(Parameters.WithComposedConverter(
+                converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter));
 
         protected override CoreTypeMapping Clone(CoreTypeMappingParameters parameters)
             => new ConcreteTypeMapping(parameters);


### PR DESCRIPTION
Fixes #31398
