### PR TITLE
Separate element type from primitive collection

### DIFF
--- a/src/EFCore/Metadata/Builders/IConventionPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionPropertyBuilder.cs
@@ -545,7 +545,7 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder<ICo
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IConventionElementTypeBuilder? SetElementType(bool elementType, bool fromDataAnnotation = false);
+    IConventionElementTypeBuilder? SetElementType(Type? elementType, bool fromDataAnnotation = false);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -553,5 +553,5 @@ public interface IConventionPropertyBuilder : IConventionPropertyBaseBuilder<ICo
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool CanSetElementType(bool elementType, bool fromDataAnnotation = false);
+    bool CanSetElementType(Type? elementType, bool fromDataAnnotation = false);
 }

--- a/src/EFCore/Metadata/Conventions/PropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/PropertyDiscoveryConvention.cs
@@ -94,7 +94,11 @@ public class PropertyDiscoveryConvention :
             var propertyBuilder = entityTypeBuilder.Property(propertyInfo);
             if (mapping?.ElementTypeMapping != null)
             {
-                propertyBuilder?.SetElementType(true);
+                var elementType = propertyInfo.PropertyType.TryGetElementType(typeof(IEnumerable<>));
+                if (elementType != null)
+                {
+                    propertyBuilder?.SetElementType(elementType);
+                }
             }
         }
     }

--- a/src/EFCore/Metadata/IConventionProperty.cs
+++ b/src/EFCore/Metadata/IConventionProperty.cs
@@ -472,7 +472,7 @@ public interface IConventionProperty : IReadOnlyProperty, IConventionPropertyBas
     /// <param name="elementType">If <see langword="true"/>, then the type mapping has an element type, otherwise it is removed.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The configuration for the elements.</returns>
-    IConventionElementType? SetElementType(bool elementType, bool fromDataAnnotation = false);
+    IConventionElementType? SetElementType(Type? elementType, bool fromDataAnnotation = false);
 
     /// <summary>
     ///     Returns the configuration source for <see cref="IReadOnlyProperty.GetElementType" />.

--- a/src/EFCore/Metadata/IMutableProperty.cs
+++ b/src/EFCore/Metadata/IMutableProperty.cs
@@ -283,7 +283,7 @@ public interface IMutableProperty : IReadOnlyProperty, IMutablePropertyBase
     ///     Sets the configuration for elements of the primitive collection represented by this property.
     /// </summary>
     /// <param name="elementType">If <see langword="true"/>, then this is a collection of primitive elements.</param>
-    void SetElementType(bool elementType);
+    void SetElementType(Type? elementType);
 
     /// <inheritdoc />
     bool IReadOnlyProperty.IsNullable

--- a/src/EFCore/Metadata/IReadOnlyProperty.cs
+++ b/src/EFCore/Metadata/IReadOnlyProperty.cs
@@ -180,6 +180,12 @@ public interface IReadOnlyProperty : IReadOnlyPropertyBase
     IReadOnlyElementType? GetElementType();
 
     /// <summary>
+    ///     A property is a primitive collection if it has an element type that matches the element type of the CLR type.
+    /// </summary>
+    /// <returns><see langword="true"/> if the property represents a primitive collection.</returns>
+    bool IsPrimitiveCollection { get; }
+
+    /// <summary>
     ///     Finds the first principal property that the given property is constrained by
     ///     if the given property is part of a foreign key.
     /// </summary>

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -564,7 +564,7 @@ public class InternalPropertyBuilder
     {
         if (CanSetConverter(converterType, configurationSource))
         {
-            Metadata.SetElementType(false, configurationSource);
+            Metadata.SetElementType(null, configurationSource);
             Metadata.SetProviderClrType(null, configurationSource);
             Metadata.SetValueConverter(converterType, configurationSource);
 
@@ -776,13 +776,13 @@ public class InternalPropertyBuilder
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual InternalElementTypeBuilder? SetElementType(bool elementType, ConfigurationSource configurationSource)
+    public virtual InternalElementTypeBuilder? SetElementType(Type? elementType, ConfigurationSource configurationSource)
     {
         if (CanSetElementType(elementType, configurationSource))
         {
             Metadata.SetElementType(elementType, configurationSource);
             Metadata.SetValueConverter((Type?)null, configurationSource);
-            return new InternalElementTypeBuilder((ElementType)Metadata.GetElementType()!, ModelBuilder);
+            return new InternalElementTypeBuilder(Metadata.GetElementType()!, ModelBuilder);
         }
 
         return null;
@@ -794,9 +794,9 @@ public class InternalPropertyBuilder
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual bool CanSetElementType(bool elementType, ConfigurationSource? configurationSource)
+    public virtual bool CanSetElementType(Type? elementType, ConfigurationSource? configurationSource)
         => configurationSource.Overrides(Metadata.GetElementTypeConfigurationSource())
-            && (elementType != (Metadata.GetElementType() != null));
+            && (elementType != Metadata.GetElementType()?.ClrType);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1523,7 +1523,7 @@ public class InternalPropertyBuilder
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    IConventionElementTypeBuilder? IConventionPropertyBuilder.SetElementType(bool elementType, bool fromDataAnnotation)
+    IConventionElementTypeBuilder? IConventionPropertyBuilder.SetElementType(Type? elementType, bool fromDataAnnotation)
         => SetElementType(elementType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
     /// <summary>
@@ -1532,6 +1532,6 @@ public class InternalPropertyBuilder
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    bool IConventionPropertyBuilder.CanSetElementType(bool elementType, bool fromDataAnnotation)
+    bool IConventionPropertyBuilder.CanSetElementType(Type? elementType, bool fromDataAnnotation)
         => CanSetElementType(elementType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 }

--- a/src/EFCore/Metadata/Internal/InternalTypeBaseBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalTypeBaseBuilder.cs
@@ -333,7 +333,16 @@ public abstract class InternalTypeBaseBuilder : AnnotatableBuilder<TypeBase, Int
     {
         var builder = Property(propertyType, propertyName, memberInfo, typeConfigurationSource, configurationSource);
 
-        builder?.SetElementType(true, configurationSource!.Value);
+        if (builder != null)
+        {
+            var elementClrType = builder.Metadata.ClrType.TryGetElementType(typeof(IEnumerable<>));
+            if (elementClrType == null)
+            {
+                throw new InvalidOperationException(CoreStrings.NotCollection(builder.Metadata.ClrType.ShortDisplayName(), propertyName));
+            }
+
+            builder.SetElementType(elementClrType, configurationSource!.Value);
+        }
 
         return builder;
     }

--- a/src/EFCore/Metadata/RuntimeProperty.cs
+++ b/src/EFCore/Metadata/RuntimeProperty.cs
@@ -155,6 +155,8 @@ public class RuntimeProperty : RuntimePropertyBase, IProperty
 
         SetAnnotation(CoreAnnotationNames.ElementType, elementType);
 
+        IsPrimitiveCollection = ClrType.TryGetElementType(typeof(IEnumerable<>))?.IsAssignableFrom(clrType) == true;
+
         return elementType;
     }
 
@@ -304,6 +306,14 @@ public class RuntimeProperty : RuntimePropertyBase, IProperty
     /// <returns>The configuration for the elements.</returns>
     public virtual IElementType? GetElementType()
         => (IElementType?)this[CoreAnnotationNames.ElementType];
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual bool IsPrimitiveCollection { get; private set; }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -3689,12 +3689,12 @@ public class ConventionDispatcherTest
 
         if (useBuilder)
         {
-            Assert.NotNull(propertyBuilder.SetElementType(true, ConfigurationSource.Convention));
-            elementType = (ElementType)propertyBuilder.Metadata.GetElementType()!;
+            Assert.NotNull(propertyBuilder.SetElementType(typeof(int), ConfigurationSource.Convention));
+            elementType = propertyBuilder.Metadata.GetElementType()!;
         }
         else
         {
-            elementType = (ElementType)propertyBuilder.Metadata.SetElementType(true, ConfigurationSource.Convention);
+            elementType = propertyBuilder.Metadata.SetElementType(typeof(int), ConfigurationSource.Convention);
         }
 
         if (useScope)
@@ -3710,12 +3710,12 @@ public class ConventionDispatcherTest
 
         if (useBuilder)
         {
-            Assert.Null(propertyBuilder.SetElementType(true, ConfigurationSource.Convention));
-            elementType = (ElementType)propertyBuilder.Metadata.GetElementType()!;
+            Assert.Null(propertyBuilder.SetElementType(typeof(int), ConfigurationSource.Convention));
+            elementType = propertyBuilder.Metadata.GetElementType()!;
         }
         else
         {
-            elementType = (ElementType)propertyBuilder.Metadata.SetElementType(true, ConfigurationSource.Convention);
+            elementType = propertyBuilder.Metadata.SetElementType(typeof(int), ConfigurationSource.Convention);
         }
 
         Assert.Equal(new (object, object)[] { (null, elementType) }, convention1.Calls);
@@ -3724,11 +3724,11 @@ public class ConventionDispatcherTest
 
         if (useBuilder)
         {
-            Assert.NotNull(propertyBuilder.SetElementType(false, ConfigurationSource.Convention));
+            Assert.NotNull(propertyBuilder.SetElementType(null, ConfigurationSource.Convention));
         }
         else
         {
-            Assert.Null(propertyBuilder.Metadata.SetElementType(false, ConfigurationSource.Convention));
+            Assert.Null(propertyBuilder.Metadata.SetElementType(null, ConfigurationSource.Convention));
         }
 
         Assert.Equal(new (object, object)[] { (null, elementType), (elementType, null) }, convention1.Calls);
@@ -5069,7 +5069,7 @@ public class ConventionDispatcherTest
         var builder = new InternalModelBuilder(new Model(conventions));
         var elementTypeBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!
             .Property(nameof(SpecialOrder.OrderIds), ConfigurationSource.Convention)!
-            .SetElementType(true, ConfigurationSource.Convention)!;
+            .SetElementType(typeof(int), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -5174,7 +5174,7 @@ public class ConventionDispatcherTest
         var builder = new InternalModelBuilder(model);
         var elementTypeBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!
             .Property(nameof(SpecialOrder.Notes), ConfigurationSource.Convention)!
-            .SetElementType(true, ConfigurationSource.Convention)!;
+            .SetElementType(typeof(string), ConfigurationSource.Convention)!;
 
         if (useBuilder)
         {

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
@@ -91,6 +91,8 @@ public class ClrPropertyGetterFactoryTest
         IReadOnlyElementType IReadOnlyProperty.GetElementType()
             => GetElementType();
 
+        public bool IsPrimitiveCollection { get; }
+
         public IElementType GetElementType()
             => throw new NotImplementedException();
 

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
@@ -103,6 +103,8 @@ public class ClrPropertySetterFactoryTest
         IReadOnlyElementType IReadOnlyProperty.GetElementType()
             => GetElementType();
 
+        public bool IsPrimitiveCollection { get; }
+
         public IElementType GetElementType()
             => throw new NotImplementedException();
 

--- a/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -531,6 +531,42 @@ public class PropertyTest
                 () => property.GetJsonValueReaderWriter()).Message);
     }
 
+    [ConditionalFact]
+    public void Can_set_element_type_for_primitive_collection()
+    {
+        var model = CreateModel();
+        var entityType = model.AddEntityType(typeof(object));
+        var property = entityType.AddProperty("Random", typeof(IList<int>));
+        property.SetElementType(typeof(int));
+
+        Assert.Equal(typeof(int), property.GetElementType()!.ClrType);
+        Assert.True(property.IsPrimitiveCollection);
+    }
+
+    [ConditionalFact]
+    public void Can_set_derived_element_type_for_primitive_collection()
+    {
+        var model = CreateModel();
+        var entityType = model.AddEntityType(typeof(object));
+        var property = entityType.AddProperty("Random", typeof(IList<object>));
+        property.SetElementType(typeof(int));
+
+        Assert.Equal(typeof(int), property.GetElementType()!.ClrType);
+        Assert.True(property.IsPrimitiveCollection);
+    }
+
+    [ConditionalFact]
+    public void Can_set_element_type_for_non_primitive_collection()
+    {
+        var model = CreateModel();
+        var entityType = model.AddEntityType(typeof(object));
+        var property = entityType.AddProperty("Random", typeof(Random));
+        property.SetElementType(typeof(int));
+
+        Assert.Equal(typeof(int), property.GetElementType()!.ClrType);
+        Assert.False(property.IsPrimitiveCollection);
+    }
+
     private class SimpleJasonValueReaderWriter : JsonValueReaderWriter<string>
     {
         public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)


### PR DESCRIPTION
To allow mapping types like ranges, which have an element type, but don't behave as collections.


