### PR TITLE
[release/7.0] Trim the mapping store type base name (#30593)

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -298,7 +298,7 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
             var openParen = storeType.IndexOf("(", StringComparison.Ordinal);
             if (openParen >= 0)
             {
-                storeType = storeType[..openParen];
+                storeType = storeType[..openParen].TrimEnd();
             }
 
             return storeType;

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -22,6 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Storage;
 /// </remarks>
 public abstract class RelationalTypeMapping : CoreTypeMapping
 {
+    private static readonly bool UseOldBehavior30592
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue30592", out var enabled30592) && enabled30592;
+
     /// <summary>
     ///     Parameter object for use in the <see cref="RelationalTypeMapping" /> hierarchy.
     /// </summary>
@@ -298,7 +301,11 @@ public abstract class RelationalTypeMapping : CoreTypeMapping
             var openParen = storeType.IndexOf("(", StringComparison.Ordinal);
             if (openParen >= 0)
             {
-                storeType = storeType[..openParen].TrimEnd();
+                storeType = storeType[..openParen];
+                if (!UseOldBehavior30592)
+                {
+                    storeType = storeType.TrimEnd();
+                }
             }
 
             return storeType;

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
@@ -222,6 +222,21 @@ public class RelationalTypeMapperTest : RelationalTypeMapperTestBase
         Assert.False(mapping.IsFixedLength);
     }
 
+    [ConditionalFact]
+    public void StoreTypeNameBase_is_trimmed()
+    {
+        var mapping = GetTypeMapping(
+            typeof(string),
+            storeTypeName: "ansi_string_fixed (666)",
+            useConfiguration: true);
+
+        Assert.Equal("ansi_string_fixed (666)", mapping.StoreType);
+        Assert.Equal("ansi_string_fixed", mapping.StoreTypeNameBase);
+        Assert.Equal(666, mapping.Size);
+        Assert.False(mapping.IsUnicode);
+        Assert.False(mapping.IsFixedLength);
+    }
+
     protected override IRelationalTypeMappingSource CreateRelationalTypeMappingSource()
         => new TestRelationalTypeMappingSource(
             TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/30593
Fixes #30592

### Description

Store type names with trailing whitespace were not mapped correctly.

### Customer impact

Crash on attempting to map the store type.

### How found

Customer reported on 7.0.

### Regression

No.

### Testing

Added regression test.

### Risk

Very low; quirked anyway.