### PR TITLE
Treat Sql Error Number 1222 as Transient

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
@@ -590,6 +590,9 @@ public static class SqlServerTransientExceptionDetector
                     // SQL Error Code: 1232
                     // Failed to acquire lock with lock manager service, it could be due to many reasons including transient service failure.
                     case 1232:
+                    // SQL Error Code: 1222
+                    // Lock request time out period exceeded.
+                    case 1222:
                     // SQL Error Code: 1221
                     // The Database Engine is attempting to release a group of locks that are not currently held by the transaction.
                     // Retry the transaction. If the problem persists, contact your support provider.


### PR DESCRIPTION
Error number 1222 is defined as

> Lock request time out period exceeded

And official Microsoft recommendation is to retry the transaction after it has been aborted [Source](https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-1222-database-engine-error)

Fixes #31724

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

