### PR TITLE
[release/8.0] Treat SQL Pool warmup/pause errors as transient

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
@@ -92,6 +92,12 @@ public static class SqlServerTransientExceptionDetector
                     // Management Service is not currently available. Please retry the operation later. If the problem persists,
                     // contact customer support, and provide them the session tracing ID of '%ls'.
                     case 45153:
+                    // SQL Error Code: 42109
+                    // The SQL pool is warming up. Please try again.
+                    case 42109:
+                    // SQL Error Code: 42108
+                    // Can not connect to the SQL pool since it is paused. Please resume the SQL pool and try again.
+                    case 42108:
                     // SQL Error Code: 42029
                     // An internal error happened while generating a new DBTS for database %.*ls. Please retry the operation.
                     case 42029:


### PR DESCRIPTION
Fixes #31724 (these are the additional error codes referenced in this conversation)

### Description

While researching SQL Server transient error codes in the SqlClient library, I noticed several that were not also represented in the EF Core transient error detection strategy. This PR includes those two error codes to bring us up to date with the current state of the transient error detection in SqlClient.

- [Microsoft Documentation on 42108](https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-42108-database-engine-error?view=sql-server-2017)
- [Microsoft Documentation on 42109](https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-42109-database-engine-error?view=sql-server-ver16)

### Customer impact

When these errors are returned by the database they won't be retried, causing the application to crash.

### How found

Customer reported on 8.0

### Regression

No.

### Testing

Tested manually.

### Risk

Low. 
