### PR TITLE
Throw better exception when attempting to map a read-only collection as a primitive collection

### DIFF
--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2508,6 +2508,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type);
 
         /// <summary>
+        ///     The type '{givenType}' cannot be used as a primitive collection because it is read-only. Read-only collections of primitive types are not supported.
+        /// </summary>
+        public static string ReadOnlyListType(object? givenType)
+            => string.Format(
+                GetString("ReadOnlyListType", nameof(givenType)),
+                givenType);
+
+        /// <summary>
         ///     An attempt was made to use the context instance while it is being configured. A DbContext instance cannot be used inside 'OnConfiguring' since it is still being configured at this point. This can happen if a second operation is started on this context instance before a previous operation completed. Any instance members are not guaranteed to be thread safe.
         /// </summary>
         public static string RecursiveOnConfiguring

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1381,6 +1381,9 @@
   <data name="QueryUnhandledQueryRootExpression" xml:space="preserve">
     <value>Query root of type '{type}' wasn't handled by provider code. This issue happens when using a provider specific method on a different provider where it is not supported.</value>
   </data>
+  <data name="ReadOnlyListType" xml:space="preserve">
+    <value>The type '{givenType}' cannot be used as a primitive collection because it is read-only. Read-only collections of primitive types are not supported.</value>
+  </data>
   <data name="RecursiveOnConfiguring" xml:space="preserve">
     <value>An attempt was made to use the context instance while it is being configured. A DbContext instance cannot be used inside 'OnConfiguring' since it is still being configured at this point. This can happen if a second operation is started on this context instance before a previous operation completed. Any instance members are not guaranteed to be thread safe.</value>
   </data>

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -205,6 +205,52 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     }
 
     [ConditionalFact]
+    public virtual void Throws_when_mapping_an_IReadOnlyCollection()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+
+        modelBuilder.Entity<WithReadOnlyCollection>(
+            eb =>
+            {
+                eb.Property(e => e.Id);
+                eb.PrimitiveCollection(e => e.Tags);
+            });
+
+        VerifyError(
+            CoreStrings.ReadOnlyListType("IReadOnlyCollection<int>"),
+            modelBuilder, sensitiveDataLoggingEnabled: false);
+    }
+
+    protected class WithReadOnlyCollection
+    {
+        public int Id { get; set; }
+        public IReadOnlyCollection<int> Tags { get; set; }
+    }
+
+    [ConditionalFact]
+    public virtual void Throws_when_mapping_an_IReadOnlyList()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+
+        modelBuilder.Entity<WithReadOnlyList>(
+            eb =>
+            {
+                eb.Property(e => e.Id);
+                eb.PrimitiveCollection(e => e.Tags);
+            });
+
+        VerifyError(
+            CoreStrings.ReadOnlyListType("IReadOnlyList<char>"),
+            modelBuilder, sensitiveDataLoggingEnabled: false);
+    }
+
+    protected class WithReadOnlyList
+    {
+        public int Id { get; set; }
+        public IReadOnlyList<char> Tags { get; set; }
+    }
+
+    [ConditionalFact]
     public virtual void Ignores_binary_keys_and_strings_without_custom_comparer()
     {
         var modelBuilder = CreateConventionlessModelBuilder();


### PR DESCRIPTION
Part of #31722
