### PR TITLE
Make expression methods of list comparer private since they are not now needed for the compiled model

### DIFF
--- a/src/EFCore/ChangeTracking/ListComparer.cs
+++ b/src/EFCore/ChangeTracking/ListComparer.cs
@@ -37,14 +37,7 @@ public sealed class ListComparer<TElement> : ValueComparer<IEnumerable<TElement>
     /// </summary>
     public ValueComparer ElementComparer { get; }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer<TElement> elementComparer)
+    private static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer<TElement> elementComparer)
     {
         if (ReferenceEquals(a, b))
         {
@@ -101,14 +94,7 @@ public sealed class ListComparer<TElement> : ValueComparer<IEnumerable<TElement>
                 typeof(IList<>).MakeGenericType(elementComparer.Type).ShortDisplayName()));
     }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static int GetHashCode(IEnumerable<TElement> source, ValueComparer<TElement> elementComparer)
+    private static int GetHashCode(IEnumerable<TElement> source, ValueComparer<TElement> elementComparer)
     {
         var hash = new HashCode();
 
@@ -120,14 +106,7 @@ public sealed class ListComparer<TElement> : ValueComparer<IEnumerable<TElement>
         return hash.ToHashCode();
     }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static IList<TElement> Snapshot(IEnumerable<TElement> source, ValueComparer<TElement> elementComparer)
+    private static IList<TElement> Snapshot(IEnumerable<TElement> source, ValueComparer<TElement> elementComparer)
     {
         if (source is not IList<TElement> sourceList)
         {

--- a/src/EFCore/ChangeTracking/NullableValueTypeListComparer.cs
+++ b/src/EFCore/ChangeTracking/NullableValueTypeListComparer.cs
@@ -38,14 +38,7 @@ public sealed class NullableValueTypeListComparer<TElement> : ValueComparer<IEnu
     /// </summary>
     public ValueComparer ElementComparer { get; }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static bool Compare(IEnumerable<TElement?>? a, IEnumerable<TElement?>? b, ValueComparer<TElement?> elementComparer)
+    private static bool Compare(IEnumerable<TElement?>? a, IEnumerable<TElement?>? b, ValueComparer<TElement?> elementComparer)
     {
         if (ReferenceEquals(a, b))
         {
@@ -102,14 +95,7 @@ public sealed class NullableValueTypeListComparer<TElement> : ValueComparer<IEnu
                 typeof(IList<>).MakeGenericType(elementComparer.Type.MakeNullable()).ShortDisplayName()));
     }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static int GetHashCode(IEnumerable<TElement?> source, ValueComparer<TElement?> elementComparer)
+    private static int GetHashCode(IEnumerable<TElement?> source, ValueComparer<TElement?> elementComparer)
     {
         var hash = new HashCode();
 
@@ -121,14 +107,7 @@ public sealed class NullableValueTypeListComparer<TElement> : ValueComparer<IEnu
         return hash.ToHashCode();
     }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static IList<TElement?> Snapshot(IEnumerable<TElement?> source, ValueComparer<TElement?> elementComparer)
+    private static IList<TElement?> Snapshot(IEnumerable<TElement?> source, ValueComparer<TElement?> elementComparer)
     {
         if (source is not IList<TElement?> sourceList)
         {

--- a/src/EFCore/ChangeTracking/ObjectListComparer.cs
+++ b/src/EFCore/ChangeTracking/ObjectListComparer.cs
@@ -36,14 +36,7 @@ public sealed class ObjectListComparer<TElement> : ValueComparer<IEnumerable<TEl
     /// </summary>
     public ValueComparer ElementComparer { get; }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer elementComparer)
+    private static bool Compare(IEnumerable<TElement>? a, IEnumerable<TElement>? b, ValueComparer elementComparer)
     {
         if (ReferenceEquals(a, b))
         {
@@ -100,14 +93,7 @@ public sealed class ObjectListComparer<TElement> : ValueComparer<IEnumerable<TEl
                 typeof(IList<>).MakeGenericType(elementComparer.Type).ShortDisplayName()));
     }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static int GetHashCode(IEnumerable<TElement> source, ValueComparer elementComparer)
+    private static int GetHashCode(IEnumerable<TElement> source, ValueComparer elementComparer)
     {
         var hash = new HashCode();
 
@@ -119,14 +105,7 @@ public sealed class ObjectListComparer<TElement> : ValueComparer<IEnumerable<TEl
         return hash.ToHashCode();
     }
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public static IList<TElement> Snapshot(IEnumerable<TElement> source, ValueComparer elementComparer)
+    private static IList<TElement> Snapshot(IEnumerable<TElement> source, ValueComparer elementComparer)
     {
         if (source is not IList<TElement> sourceList)
         {


### PR DESCRIPTION
Part of #30306
