### PR TITLE
Allow non-list collections in query parameters

### DIFF
--- a/src/EFCore/Storage/Json/JsonCollectionReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCollectionReaderWriter.cs
@@ -16,7 +16,6 @@ public class JsonCollectionReaderWriter<TCollection, TConcreteCollection, TEleme
     JsonValueReaderWriter<IEnumerable<TElement?>>,
     ICompositeJsonValueReaderWriter
     where TCollection : IEnumerable<TElement?>
-    where TConcreteCollection : IList<TElement?>
 {
     private readonly JsonValueReaderWriter<TElement> _elementReaderWriter;
 
@@ -39,7 +38,7 @@ public class JsonCollectionReaderWriter<TCollection, TConcreteCollection, TEleme
         }
         else if (existingObject == null)
         {
-            collection = Activator.CreateInstance<TConcreteCollection>();
+            collection = (IList<TElement?>)Activator.CreateInstance<TConcreteCollection>()!;
         }
         else
         {

--- a/src/EFCore/Storage/Json/JsonNullableStructCollectionReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonNullableStructCollectionReaderWriter.cs
@@ -17,7 +17,6 @@ public class JsonNullableStructCollectionReaderWriter<TCollection, TConcreteColl
     ICompositeJsonValueReaderWriter
     where TElement : struct
     where TCollection : IEnumerable<TElement?>
-    where TConcreteCollection : IList<TElement?>
 {
     private readonly JsonValueReaderWriter<TElement> _elementReaderWriter;
 
@@ -40,7 +39,7 @@ public class JsonNullableStructCollectionReaderWriter<TCollection, TConcreteColl
         }
         else if (existingObject == null)
         {
-            collection = Activator.CreateInstance<TConcreteCollection>();
+            collection = (IList<TElement?>)Activator.CreateInstance<TConcreteCollection>()!;
         }
         else
         {

--- a/src/EFCore/Storage/TypeMappingSourceBase.cs
+++ b/src/EFCore/Storage/TypeMappingSourceBase.cs
@@ -200,18 +200,23 @@ public abstract class TypeMappingSourceBase : ITypeMappingSource
                         return modelClrType;
                     }
 
-                    if (!modelClrType.IsAbstract)
-                    {
-                        var constructor = modelClrType.GetDeclaredConstructor(null);
-                        if (constructor?.IsPublic == true)
-                        {
-                            return modelClrType;
-                        }
-                    }
-
                     var listOfT = typeof(List<>).MakeGenericType(elementType);
 
-                    return modelClrType.IsAssignableFrom(listOfT) ? listOfT : modelClrType;
+                    if (modelClrType.IsAssignableFrom(listOfT))
+                    {
+                        if (!modelClrType.IsAbstract)
+                        {
+                            var constructor = modelClrType.GetDeclaredConstructor(null);
+                            if (constructor?.IsPublic == true)
+                            {
+                                return modelClrType;
+                            }
+                        }
+
+                        return listOfT;
+                    }
+
+                    return modelClrType;
                 }
             }
         }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -1387,6 +1387,223 @@ WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ANATR
 """);
     }
 
+    public override async Task Contains_with_local_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_enumerable_closure(async);
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+""",
+            //
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE"))
+""");
+    }
+
+    public override async Task Contains_with_local_object_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_object_enumerable_closure(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_enumerable_closure_all_null(bool async)
+    {
+        await base.Contains_with_local_enumerable_closure_all_null(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND (true = false))
+"""
+            );
+    }
+
+    public override async Task Contains_with_local_enumerable_inline(bool async)
+    {
+        // Issue #31776
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () =>
+                await base.Contains_with_local_enumerable_inline(async));
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_local_enumerable_inline_closure_mix(bool async)
+    {
+        // Issue #31776
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () =>
+                await base.Contains_with_local_enumerable_inline_closure_mix(async));
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_local_ordered_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_closure(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+""",
+//
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE"))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_object_ordered_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_object_ordered_enumerable_closure(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_ordered_enumerable_closure_all_null(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_closure_all_null(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_ordered_enumerable_inline(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_inline(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_ordered_enumerable_inline_closure_mix(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_inline_closure_mix(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+""",
+//
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ANATR"))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_read_only_collection_closure(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_closure(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+""",
+//
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE"))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_object_read_only_collection_closure(bool async)
+    {
+        await base.Contains_with_local_object_read_only_collection_closure(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_ordered_read_only_collection_all_null(bool async)
+    {
+        await base.Contains_with_local_ordered_read_only_collection_all_null(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND (c["CustomerID"] = null))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_read_only_collection_inline(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_inline(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+"""
+        );
+    }
+
+    public override async Task Contains_with_local_read_only_collection_inline_closure_mix(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_inline_closure_mix(async);
+
+        AssertSql(
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ALFKI"))
+""",
+//
+            """
+SELECT c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["CustomerID"] IN ("ABCDE", "ANATR"))
+"""
+        );
+    }
+
     public override async Task Contains_with_local_collection_false(bool async)
     {
         await base.Contains_with_local_collection_false(async);

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindAggregateOperatorsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindAggregateOperatorsQueryInMemoryTest.cs
@@ -44,4 +44,16 @@ public class NorthwindAggregateOperatorsQueryInMemoryTest : NorthwindAggregateOp
     public override Task Collection_Last_member_access_in_projection_translated(bool async)
         => Assert.ThrowsAsync<InvalidOperationException>(
             () => base.Collection_Last_member_access_in_projection_translated(async));
+
+    // Issue #31776
+    public override async Task Contains_with_local_enumerable_inline(bool async)
+        => await Assert.ThrowsAsync<InvalidOperationException>(
+            async () =>
+                await base.Contains_with_local_enumerable_inline(async));
+
+    // Issue #31776
+    public override async Task Contains_with_local_enumerable_inline_closure_mix(bool async)
+        => await Assert.ThrowsAsync<InvalidOperationException>(
+            async () =>
+                await base.Contains_with_local_enumerable_inline_closure_mix(async));
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -1015,6 +1015,194 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_local_enumerable_closure(bool async)
+    {
+        var ids = new[] { "ABCDE", "ALFKI" }.Where(e => e != null);
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
+
+        ids = new[] { "ABCDE" }.Where(e => e != null);
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_object_enumerable_closure(bool async)
+    {
+        var ids = new List<object> { "ABCDE", "ALFKI" }.Where(e => e != null);
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(EF.Property<object>(c, nameof(Customer.CustomerID)))), entryCount: 1);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_enumerable_closure_all_null(bool async)
+    {
+        var ids = new List<string> { null, null }.Where(e => e != null);
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_local_enumerable_inline(bool async)
+        => await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(
+                c => new List<string> { "ABCDE", "ALFKI" }.Where(e => e != null).Contains(c.CustomerID)), entryCount: 1);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_local_enumerable_inline_closure_mix(bool async)
+    {
+        var id = "ALFKI";
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => new List<string> { "ABCDE", id }.Where(e => e != null).Contains(c.CustomerID)),
+            entryCount: 1);
+
+        id = "ANATR";
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => new List<string> { "ABCDE", id }.Where(e => e != null).Contains(c.CustomerID)),
+            entryCount: 1);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_local_ordered_enumerable_closure(bool async)
+    {
+        var ids = new[] { "ABCDE", "ALFKI" }.Order();
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
+
+        ids = new[] { "ABCDE" }.Order();
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_object_ordered_enumerable_closure(bool async)
+    {
+        var ids = new List<object> { "ABCDE", "ALFKI" }.Order();
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(EF.Property<object>(c, nameof(Customer.CustomerID)))), entryCount: 1);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_ordered_enumerable_closure_all_null(bool async)
+    {
+        var ids = new List<string> { null, null }.Order();
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_ordered_enumerable_inline(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(
+                c => new List<string> { "ABCDE", "ALFKI" }.Order().Contains(c.CustomerID)), entryCount: 1);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_local_ordered_enumerable_inline_closure_mix(bool async)
+    {
+        var id = "ALFKI";
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => new List<string> { "ABCDE", id }.Order().Contains(c.CustomerID)), entryCount: 1);
+
+        id = "ANATR";
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => new List<string> { "ABCDE", id }.Order().Contains(c.CustomerID)), entryCount: 1);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_local_read_only_collection_closure(bool async)
+    {
+        var ids = new[] { "ABCDE", "ALFKI" }.AsReadOnly();
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
+
+        ids = new[] { "ABCDE" }.AsReadOnly();
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_object_read_only_collection_closure(bool async)
+    {
+        var ids = new List<object> { "ABCDE", "ALFKI" }.AsReadOnly();
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(EF.Property<object>(c, nameof(Customer.CustomerID)))), entryCount: 1);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_ordered_read_only_collection_all_null(bool async)
+    {
+        var ids = new List<string> { null, null }.AsReadOnly();
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_with_local_read_only_collection_inline(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(
+                c => new List<string> { "ABCDE", "ALFKI" }.AsReadOnly().Contains(c.CustomerID)), entryCount: 1);
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Contains_with_local_read_only_collection_inline_closure_mix(bool async)
+    {
+        var id = "ALFKI";
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => new List<string> { "ABCDE", id }.AsReadOnly().Contains(c.CustomerID)), entryCount: 1);
+
+        id = "ANATR";
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => new List<string> { "ABCDE", id }.AsReadOnly().Contains(c.CustomerID)), entryCount: 1);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual async Task Contains_with_local_non_primitive_list_inline_closure_mix(bool async)
     {
         var id = "ALFKI";

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -1793,6 +1793,262 @@ WHERE [c].[CustomerID] IN (
 """);
     }
 
+    public override async Task Contains_with_local_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_enumerable_closure(async);
+
+        AssertSql(
+"""
+@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+)
+""",
+            //
+"""
+@__ids_0='["ABCDE"]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+)
+""");
+    }
+
+    public override async Task Contains_with_local_object_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_object_enumerable_closure(async);
+
+        AssertSql(
+"""
+@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+)
+""");
+    }
+
+    public override async Task Contains_with_local_enumerable_closure_all_null(bool async)
+    {
+        await base.Contains_with_local_enumerable_closure_all_null(async);
+
+        AssertSql(
+"""
+@__ids_0='[]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+)
+""");
+    }
+
+    public override async Task Contains_with_local_enumerable_inline(bool async)
+    {
+        // Issue #31776
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () =>
+                await base.Contains_with_local_enumerable_inline(async));
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_local_enumerable_inline_closure_mix(bool async)
+    {
+        // Issue #31776
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () =>
+                await base.Contains_with_local_enumerable_inline_closure_mix(async));
+
+        AssertSql();
+    }
+
+    public override async Task Contains_with_local_ordered_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_closure(async);
+
+        AssertSql(
+"""
+@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+)
+""",
+            //
+"""
+@__ids_0='["ABCDE"]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+)
+""");
+    }
+
+    public override async Task Contains_with_local_object_ordered_enumerable_closure(bool async)
+    {
+        await base.Contains_with_local_object_ordered_enumerable_closure(async);
+
+        AssertSql(
+"""
+@__ids_0='["ABCDE","ALFKI"]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+)
+""");
+    }
+
+    public override async Task Contains_with_local_ordered_enumerable_closure_all_null(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_closure_all_null(async);
+
+        AssertSql(
+"""
+@__ids_0='[null,null]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] nchar(5) '$') AS [i]
+)
+""");
+    }
+
+    public override async Task Contains_with_local_ordered_enumerable_inline(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_inline(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
+""");
+    }
+
+    public override async Task Contains_with_local_ordered_enumerable_inline_closure_mix(bool async)
+    {
+        await base.Contains_with_local_ordered_enumerable_inline_closure_mix(async);
+
+        AssertSql(
+"""
+@__Order_0='["ABCDE","ALFKI"]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [o].[value]
+    FROM OPENJSON(@__Order_0) WITH ([value] nchar(5) '$') AS [o]
+)
+""",
+            //
+"""
+@__Order_0='["ABCDE","ANATR"]' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [o].[value]
+    FROM OPENJSON(@__Order_0) WITH ([value] nchar(5) '$') AS [o]
+)
+""");
+    }
+
+    public override async Task Contains_with_local_read_only_collection_closure(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_closure(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
+""",
+            //
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ABCDE'
+""");
+    }
+
+    public override async Task Contains_with_local_object_read_only_collection_closure(bool async)
+    {
+        await base.Contains_with_local_object_read_only_collection_closure(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
+""");
+    }
+
+    public override async Task Contains_with_local_ordered_read_only_collection_all_null(bool async)
+    {
+        await base.Contains_with_local_ordered_read_only_collection_all_null(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE 0 = 1
+""");
+    }
+
+    public override async Task Contains_with_local_read_only_collection_inline(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_inline(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
+""");
+    }
+
+    public override async Task Contains_with_local_read_only_collection_inline_closure_mix(bool async)
+    {
+        await base.Contains_with_local_read_only_collection_inline_closure_mix(async);
+
+        AssertSql(
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')
+""",
+            //
+"""
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ANATR')
+""");
+    }
+
     public override async Task Contains_with_local_non_primitive_list_closure_mix(bool async)
     {
         await base.Contains_with_local_non_primitive_list_closure_mix(async);


### PR DESCRIPTION
Query parameters cannot be constrained to implement `IList` because they were not constrained for `Contains` queries prior to 8. This is okay, because the comparer is never used in these cases since its all about translating to SQL.

Fixes #31768
