### PR TITLE
Make FK property nullability take precedence over navigation nullability

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -88,7 +88,7 @@ public class ForeignKeyPropertyDiscoveryConvention :
             if (property.IsNullable)
             {
                 shouldBeRequired = false;
-                relationshipBuilder.IsRequired(false);
+                relationshipBuilder = relationshipBuilder.IsRequired(false) ?? relationshipBuilder;
                 break;
             }
         }

--- a/src/EFCore/Metadata/Conventions/NonNullableNavigationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableNavigationConvention.cs
@@ -67,7 +67,13 @@ public class NonNullableNavigationConvention :
 
         if (navigation.IsOnDependent)
         {
-            foreignKey.Builder.IsRequired(true);
+            if (foreignKey.Properties.All(p =>
+                !p.IsNullable
+                || (p.IsShadowProperty()
+                    && ConfigurationSource.Convention.Overrides(p.GetIsNullableConfigurationSource()))))
+            {
+                foreignKey.Builder.IsRequired(true);
+            }
         }
         else
         {

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2196,6 +2196,27 @@ public abstract partial class ModelBuilderTest
         }
 
         [ConditionalFact]
+        public virtual void Nullable_FK_overrides_NRT_navigation()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity<DependentEntity>(eb =>
+            {
+                eb.Property(d => d.PrincipalEntityId);
+                eb.Ignore(d => d.Nav);
+                eb.HasOne(d => d.Nav).WithMany(p => p.InverseNav);
+            });
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(DependentEntity));
+            var fk = entityType.GetForeignKeys().Single();
+            Assert.False(fk.IsRequired);
+            var fkProperty = entityType.FindProperty(nameof(DependentEntity.PrincipalEntityId));
+            Assert.True(fkProperty.IsNullable);
+            Assert.Contains(fkProperty, fk.Properties);
+        }
+
+        [ConditionalFact]
         public virtual void Can_change_delete_behavior()
         {
             var modelBuilder = HobNobBuilder();

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -484,7 +484,7 @@ public abstract partial class ModelBuilderTest
         public int Id { get; set; }
 
         [NotMapped]
-        public int PrincipalEntityId { get; set; }
+        public int? PrincipalEntityId { get; set; }
 
         public required PrincipalEntity Nav { get; set; }
     }


### PR DESCRIPTION
Annotating the navigation with [Required] will still override nullable properties.

Fixes #29452
Fixes #30227