### PR TITLE
[release/6.0] Switch to interpreted client-evaluation in parameter extractor

### DIFF
--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 return Expression.Lambda<Func<object>>(
                         Expression.Convert(expression, typeof(object)))
-                    .Compile()
+                    .Compile(preferInterpretation: true)
                     .Invoke();
             }
             catch (Exception exception)


### PR DESCRIPTION
Partial port of #29815
Fixes #31782

**Description**

As part of EF's LINQ query processing, we identify fragments of the query tree which can be client-evaluated, and evaluate them using a lambda delegate. The lambda is currently compiled rather than interpreted.

**Customer impact**

On high application load spikes, application memory usage may grow uncontrollably and performance may deteriorate to a point where only a restart is workable.

**How found**

Customer report on 7.0

**Regression**

No.

**Testing**

This is a performance-related change, and so regression testing isn't relevant.

**Risk**

Extremely small - this simply adds "preferInterpretation: true" to [`Expression.Lambda<T>.Compile`](https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions.expression-1.compile?view=net-7.0#system-linq-expressions-expression-1-compile(system-boolean)). The lambda in question is only ever invoked once, so this can only help performance (including beyond the spike issue that this issue fixes).

Note that this change was also merged for 8.0.0-preview.1 as part of #29815, and we've received no reports of trouble.