### PR TITLE
[SMALL] Fix to #31760 - System.ArgumentException on List<T> with OwnsOne ToJson

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -907,7 +907,6 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             INavigationBase navigation,
             Func<QueryContext, object[], JsonReaderData, TEntity> innerShaper)
             where TEntity : class
-            where TResult : ICollection<TEntity>
         {
             if (jsonReaderData == null)
             {
@@ -945,7 +944,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 {
                     manager.CaptureState();
                     var entity = innerShaper(queryContext, newKeyPropertyValues, jsonReaderData);
-                    result.Add(entity);
+                    collectionAccessor.AddStandalone(result, entity);
                     manager = new Utf8JsonReaderManager(manager.Data, queryContext.QueryLogger);
 
                     if (manager.CurrentReader.TokenType != JsonTokenType.EndObject)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryAdHocSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryAdHocSqlServerTest.cs
@@ -139,6 +139,21 @@ N'{{""ShadowInt"":143,""Name"":""e1_r ctor""}}',
 1,
 N'e1')");
 
+    protected override void SeedNotICollection(MyContextNotICollection ctx)
+    {
+        ctx.Database.ExecuteSqlRaw(
+            @"INSERT INTO [Entities] ([Json], [Id])
+VALUES(
+N'{{""Collection"":[{{""Bar"":11,""Foo"":""c11""}},{{""Bar"":12,""Foo"":""c12""}},{{""Bar"":13,""Foo"":""c13""}}]}}',
+1)");
+
+        ctx.Database.ExecuteSqlRaw(
+            @"INSERT INTO [Entities] ([Json], [Id])
+VALUES(
+N'{{""Collection"":[{{""Bar"":21,""Foo"":""c21""}},{{""Bar"":22,""Foo"":""c22""}}]}}',
+2)");
+    }
+
     #region EnumLegacyValues
 
     [ConditionalTheory]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQueryAdHocSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQueryAdHocSqliteTest.cs
@@ -134,4 +134,19 @@ VALUES(
 '{{""ShadowInt"":143,""Name"":""e1_r ctor""}}',
 1,
 'e1')");
+
+    protected override void SeedNotICollection(MyContextNotICollection ctx)
+    {
+        ctx.Database.ExecuteSqlRaw(
+            @"INSERT INTO ""Entities"" (""Json"", ""Id"")
+VALUES(
+'{{""Collection"":[{{""Bar"":11,""Foo"":""c11""}},{{""Bar"":12,""Foo"":""c12""}},{{""Bar"":13,""Foo"":""c13""}}]}}',
+1)");
+
+        ctx.Database.ExecuteSqlRaw(
+            @"INSERT INTO ""Entities"" (""Json"", ""Id"")
+VALUES(
+'{{""Collection"":[{{""Bar"":21,""Foo"":""c21""}},{{""Bar"":22,""Foo"":""c22""}}]}}',
+2)");
+    }
 }


### PR DESCRIPTION
We were using type constraint on MaterializeJsonEntityCollection, so that we could leverage ICollection.Add. Fix is to use collection accessor AddStandalone instead.

Fixes #31760