### PR TITLE
Rename "country"

### DIFF
--- a/benchmark/EFCore.Benchmarks/Models/Orders/Customer.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/Customer.cs
@@ -24,7 +24,7 @@ public class Customer
     public string City { get; set; }
     public string StateOrProvince { get; set; }
     public string ZipOrPostalCode { get; set; }
-    public string Country { get; set; }
+    public string County { get; set; }
 
     public ICollection<Order> Orders { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/Orders/Order.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/Order.cs
@@ -21,7 +21,7 @@ public class Order
     public string City { get; set; }
     public string StateOrProvince { get; set; }
     public string ZipOrPostalCode { get; set; }
-    public string Country { get; set; }
+    public string County { get; set; }
 
     public int CustomerId { get; set; }
     public Customer Customer { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/Orders/OrdersFixtureSeedBase.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/OrdersFixtureSeedBase.cs
@@ -30,7 +30,7 @@ public abstract class OrdersFixtureSeedBase
                     City = "Sampleville",
                     StateOrProvince = "SMP",
                     ZipOrPostalCode = "00000",
-                    Country = "United States"
+                    County = "United States"
                 });
         }
 
@@ -83,7 +83,7 @@ public abstract class OrdersFixtureSeedBase
                         City = "Sampleville",
                         StateOrProvince = "SMP",
                         ZipOrPostalCode = "00000",
-                        Country = "United States"
+                        County = "United States"
                     });
             }
         }


### PR DESCRIPTION
It was there before, but the code cleanup likely messed up the exclusion rule, so just renaming rather trying to fix the exclusion.


