### PR TITLE
Queries for struct complex types

### DIFF
--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingInterceptor.cs
@@ -38,7 +38,11 @@ public class ProxyBindingInterceptor : IInstantiationBindingInterceptor
     /// </summary>
     public virtual InstantiationBinding ModifyBinding(InstantiationBindingInterceptionData interceptionData, InstantiationBinding binding)
     {
-        var entityType = interceptionData.TypeBase as IEntityType ?? throw new NotImplementedException();
+        if (interceptionData.TypeBase is not IEntityType entityType)
+        {
+            return binding;
+        }
+
         var proxyType = _proxyFactory.CreateProxyType(entityType);
 
         if ((bool?)entityType.Model[ProxyAnnotationNames.LazyLoading] == true)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -123,7 +123,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                         {
                             var methodCall = Expression.Call(
                                 // Declaring types would be derived db context.
-                                Expression.Constant(null, methodInfo.DeclaringType!),
+                                Expression.Default(methodInfo.DeclaringType!),
                                 methodInfo,
                                 tableValuedFunctionQueryRootExpression.Arguments);
 
@@ -2549,7 +2549,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             shaper = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), nullableResultType);
             var resultVariable = Expression.Variable(nullableResultType, "result");
             var returnValueForNull = resultType.IsNullableType()
-                ? (Expression)Expression.Constant(null, resultType)
+                ? (Expression)Expression.Default(resultType)
                 : translation.Type.IsNullableType()
                     ? Expression.Default(resultType)
                     : Expression.Throw(

--- a/src/EFCore/Metadata/DefaultValueBinding.cs
+++ b/src/EFCore/Metadata/DefaultValueBinding.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata;
+
+/// <summary>
+///     Defines the binding of parameters to create the default value of a type.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-constructor-binding">Entity types with constructors</see> for more information and examples.
+/// </remarks>
+public class DefaultValueBinding : InstantiationBinding
+{
+    /// <summary>
+    ///     Creates a new <see cref="DefaultValueBinding" /> instance.
+    /// </summary>
+    /// <param name="runtimeType">The CLR type of the instance created by the factory method.</param>
+    public DefaultValueBinding(Type runtimeType)
+        : base(new List<ParameterBinding>())
+    {
+        Check.NotNull(runtimeType, nameof(runtimeType));
+
+        RuntimeType = runtimeType;
+    }
+
+    /// <summary>
+    ///     Creates a <see cref="MethodCallExpression" /> using the given method.
+    /// </summary>
+    /// <param name="bindingInfo">Information needed to create the expression.</param>
+    /// <returns>The expression tree.</returns>
+    public override Expression CreateConstructorExpression(ParameterBindingInfo bindingInfo)
+        => Expression.Default(RuntimeType);
+
+    /// <summary>
+    ///     The type that will be created from the expression tree created for this binding.
+    /// </summary>
+    public override Type RuntimeType { get; }
+
+    /// <summary>
+    ///     Creates a copy that contains the given parameter bindings.
+    /// </summary>
+    /// <param name="parameterBindings">The new parameter bindings.</param>
+    /// <returns>A copy with replaced parameter bindings.</returns>
+    public override InstantiationBinding With(IReadOnlyList<ParameterBinding> parameterBindings)
+        => this;
+}

--- a/src/EFCore/Metadata/Internal/ConstructorBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/ConstructorBindingFactory.cs
@@ -175,11 +175,7 @@ public class ConstructorBindingFactory : IConstructorBindingFactory
             && constructors.Count == 0
             && clrType.IsValueType)
         {
-            foundBindings.Add(
-                new FactoryMethodBinding(
-                    _createInstance,
-                    new ParameterBinding[0],
-                    clrType));
+            foundBindings.Add(new DefaultValueBinding(clrType));
         }
 
         if (foundBindings.Count == 0)

--- a/src/EFCore/Query/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/EntityMaterializerSource.cs
@@ -275,7 +275,11 @@ public class EntityMaterializerSource : IEntityMaterializerSource
         blockExpressions.Add(Expression.Assign(instanceVariable, constructorExpression));
 
         AddInitializeExpressions(properties, bindingInfo, instanceVariable, blockExpressions);
-        AddAttachServiceExpressions(bindingInfo, instanceVariable, blockExpressions);
+
+        if (bindingInfo.StructuralType is IEntityType)
+        {
+            AddAttachServiceExpressions(bindingInfo, instanceVariable, blockExpressions);
+        }
 
         blockExpressions.Add(instanceVariable);
 
@@ -449,7 +453,11 @@ public class EntityMaterializerSource : IEntityMaterializerSource
             var initializeBlockExpressions = new List<Expression>();
 
             AddInitializeExpressions(properties, bindingInfo, instanceVariable, initializeBlockExpressions);
-            AddAttachServiceExpressions(bindingInfo, instanceVariable, blockExpressions);
+
+            if (bindingInfo.StructuralType is IEntityType)
+            {
+                AddAttachServiceExpressions(bindingInfo, instanceVariable, blockExpressions);
+            }
 
             return Expression.Block(initializeBlockExpressions);
         }

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -371,7 +371,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
 
             var instanceVariable = Variable(clrType, "instance" + _currentEntityIndex);
             variables.Add(instanceVariable);
-            expressions.Add(Assign(instanceVariable, Constant(null, clrType)));
+            expressions.Add(Assign(instanceVariable, Default(clrType)));
 
             if (_queryStateManager
                 && primaryKey != null)
@@ -521,7 +521,7 @@ public abstract class ShapedQueryCompilingExpressionVisitor : ExpressionVisitor
 
             var materializationExpression = Switch(
                 concreteEntityTypeVariable,
-                Constant(null, returnType),
+                Default(returnType),
                 switchCases);
 
             expressions.Add(Assign(instanceVariable, materializationExpression));

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexTypeQueryRelationalTestBase.cs
@@ -51,6 +51,38 @@ public abstract class ComplexTypeQueryRelationalTestBase<TFixture> : ComplexType
         AssertSql();
     }
 
+    public override async Task Subquery_over_struct_complex_type(bool async)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.Subquery_over_struct_complex_type(async));
+
+        Assert.Equal(
+            RelationalStrings.SubqueryOverComplexTypesNotSupported("ValuedCustomer.ShippingAddress#AddressStruct"), exception.Message);
+
+        AssertSql();
+    }
+
+    public override async Task Concat_two_different_struct_complex_type(bool async)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.Concat_two_different_struct_complex_type(async));
+
+        Assert.Equal(
+            RelationalStrings.SetOperationOverDifferentStructuralTypes(
+                "ValuedCustomer.ShippingAddress#AddressStruct", "ValuedCustomer.BillingAddress#AddressStruct"), exception.Message);
+
+        AssertSql();
+    }
+
+    public override async Task Union_two_different_struct_complex_type(bool async)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.Union_two_different_struct_complex_type(async));
+
+        Assert.Equal(
+            RelationalStrings.SetOperationOverDifferentStructuralTypes(
+                "ValuedCustomer.ShippingAddress#AddressStruct", "ValuedCustomer.BillingAddress#AddressStruct"), exception.Message);
+
+        AssertSql();
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexTypeQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexTypeQueryFixtureBase.cs
@@ -45,6 +45,23 @@ public abstract class ComplexTypeQueryFixtureBase : SharedStoreFixtureBase<Poola
                 cgb.Navigation(cg => cg.RequiredCustomer).AutoInclude();
                 cgb.Navigation(cg => cg.OptionalCustomer).AutoInclude();
             });
+
+        modelBuilder.Entity<ValuedCustomer>(
+            cb =>
+            {
+                cb.Property(c => c.Id).ValueGeneratedNever();
+
+                cb.ComplexProperty(c => c.ShippingAddress, sab => sab.ComplexProperty(sa => sa.Country));
+                cb.ComplexProperty(c => c.BillingAddress, sab => sab.ComplexProperty(sa => sa.Country));
+            });
+
+        modelBuilder.Entity<ValuedCustomerGroup>(
+            cgb =>
+            {
+                cgb.Property(cg => cg.Id).ValueGeneratedNever();
+                cgb.Navigation(cg => cg.RequiredCustomer).AutoInclude();
+                cgb.Navigation(cg => cg.OptionalCustomer).AutoInclude();
+            });
     }
 
     public Func<DbContext> GetContextCreator()
@@ -53,63 +70,97 @@ public abstract class ComplexTypeQueryFixtureBase : SharedStoreFixtureBase<Poola
     public ISetSource GetExpectedData()
         => _expectedData ??= new ComplexTypeData();
 
-    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object?>>
+    public IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, object>
     {
-        { typeof(Customer), e => ((Customer)e).Id },
-        { typeof(CustomerGroup), e => ((CustomerGroup)e).Id },
+        { typeof(Customer), (Func<Customer, object>)(e => e.Id) },
+        { typeof(CustomerGroup), (Func<CustomerGroup, object>)(e => e.Id) },
+        { typeof(ValuedCustomer), (Func<ValuedCustomer, object>)(e => e.Id) },
+        { typeof(ValuedCustomerGroup), (Func<ValuedCustomerGroup, object>)(e => e.Id) },
 
         // Complex types - still need comparers for cases where they are projected directly
-        { typeof(Address), e => ((Address?)e)?.ZipCode },
-        { typeof(Country), e => ((Country?)e)?.Code }
-    }.ToDictionary(e => e.Key, e => (object)e.Value);
+        { typeof(Address), (Func<Address, object>)(e => e.ZipCode) },
+        { typeof(Country), (Func<Country, object>)(e => e.Code) },
+        { typeof(AddressStruct), (Func<AddressStruct, object>)(e => e.ZipCode) },
+        { typeof(CountryStruct), (Func<CountryStruct, object>)(e => e.Code) }
+    }.ToDictionary(e => e.Key, e => e.Value);
 
-    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    public IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, object>
     {
         {
-            typeof(Customer), (e, a) =>
+            typeof(Customer), (Customer e, Customer a) =>
             {
                 Assert.Equal(e == null, a == null);
                 if (a is not null && e is not null)
                 {
-                    AssertCustomer((Customer)e, (Customer)a);
+                    AssertCustomer(e, a);
                 }
             }
         },
         {
-            typeof(Address), (e, a) =>
+            typeof(Address), (Address e, Address a) =>
             {
                 Assert.Equal(e == null, a == null);
                 if (a is not null && e is not null)
                 {
-                    AssertAddress((Address)e, (Address)e);
+                    AssertAddress(e, a);
                 }
             }
         },
         {
-            typeof(Country), (e, a) =>
+            typeof(Country), (Country e, Country a) =>
             {
                 Assert.Equal(e == null, a == null);
                 if (a is not null && e is not null)
                 {
-                    AssertCountry((Country)e, (Country)e);
+                    AssertCountry(e, a);
                 }
             }
         },
         {
-            typeof(CustomerGroup), (e, a) =>
+            typeof(CustomerGroup), (CustomerGroup e, CustomerGroup a) =>
             {
                 Assert.Equal(e == null, a == null);
                 if (a is not null && e is not null)
                 {
-                    var ee = (CustomerGroup)e;
-                    var aa = (CustomerGroup)a;
-
-                    AssertCustomer(ee.RequiredCustomer, aa.RequiredCustomer);
-                    AssertCustomer(ee.OptionalCustomer, aa.OptionalCustomer);
+                    AssertCustomer(e.RequiredCustomer, a.RequiredCustomer);
+                    AssertCustomer(e.OptionalCustomer, a.OptionalCustomer);
+                }
+            }
+        },
+        {
+            typeof(ValuedCustomer), (ValuedCustomer e, ValuedCustomer a) =>
+            {
+                Assert.Equal(e == null, a == null);
+                if (a is not null && e is not null)
+                {
+                    AssertValuedCustomer(e, a);
+                }
+            }
+        },
+        {
+            typeof(AddressStruct), (AddressStruct e, AddressStruct a) =>
+            {
+                AssertAddressStruct(e, a);
+            }
+        },
+        {
+            typeof(CountryStruct), (CountryStruct e, CountryStruct a) =>
+            {
+                    AssertCountryStruct(e, e);
+            }
+        },
+        {
+            typeof(ValuedCustomerGroup), (ValuedCustomerGroup e, ValuedCustomerGroup a) =>
+            {
+                Assert.Equal(e == null, a == null);
+                if (a is not null && e is not null)
+                {
+                    AssertValuedCustomer(e.RequiredCustomer, a.RequiredCustomer);
+                    AssertValuedCustomer(e.OptionalCustomer, a.OptionalCustomer);
                 }
             }
         }
-    }.ToDictionary(e => e.Key, e => (object)e.Value);
+    }.ToDictionary(e => e.Key, e => e.Value);
 
     private static void AssertCustomer(Customer? expected, Customer? actual)
     {
@@ -148,6 +199,50 @@ public abstract class ComplexTypeQueryFixtureBase : SharedStoreFixtureBase<Poola
         {
             Assert.Equal(expected.FullName, actual.FullName);
             Assert.Equal(expected.Code, actual.Code);
+        }
+        else
+        {
+            Assert.Equal(expected is null, actual is null);
+        }
+    }
+
+    private static void AssertValuedCustomer(ValuedCustomer? expected, ValuedCustomer? actual)
+    {
+        if (expected is not null && actual is not null)
+        {
+            Assert.Equal(expected.Id, actual.Id);
+            Assert.Equal(expected.Name, actual.Name);
+            AssertAddressStruct(expected.ShippingAddress, actual.ShippingAddress);
+            AssertAddressStruct(expected.BillingAddress, actual.BillingAddress);
+        }
+        else
+        {
+            Assert.Equal(expected is null, actual is null);
+        }
+    }
+
+    private static void AssertAddressStruct(object? expected, object? actual)
+    {
+        if (expected is AddressStruct expectedStruct && actual is AddressStruct actualStruct)
+        {
+            Assert.Equal(expectedStruct.AddressLine1, actualStruct.AddressLine1);
+            Assert.Equal(expectedStruct.AddressLine2, actualStruct.AddressLine2);
+            Assert.Equal(expectedStruct.ZipCode, actualStruct.ZipCode);
+
+            AssertCountryStruct(expectedStruct.Country, actualStruct.Country);
+        }
+        else
+        {
+            Assert.Equal(expected is null, actual is null);
+        }
+    }
+
+    private static void AssertCountryStruct(object? expected, object? actual)
+    {
+        if (expected is CountryStruct expectedStruct && actual is CountryStruct actualStruct)
+        {
+            Assert.Equal(expectedStruct.FullName, actualStruct.FullName);
+            Assert.Equal(expectedStruct.Code, actualStruct.Code);
         }
         else
         {

--- a/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexTypeQueryTestBase.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Query;
 public abstract class ComplexTypeQueryTestBase<TFixture> : QueryTestBase<TFixture>
     where TFixture : ComplexTypeQueryFixtureBase, new()
 {
-    public ComplexTypeQueryTestBase(TFixture fixture)
+    protected ComplexTypeQueryTestBase(TFixture fixture)
         : base(fixture)
     {
         fixture.ListLoggerFactory.Clear();
@@ -262,6 +262,249 @@ public abstract class ComplexTypeQueryTestBase<TFixture> : QueryTestBase<TFixtur
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Select(c => c.ShippingAddress).Union(ss.Set<Customer>().Select(c => c.BillingAddress)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(c => c.ShippingAddress.ZipCode == 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_nested_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(c => c.ShippingAddress.Country.Code == "DE"));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_struct_complex_type_after_subquery(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>()
+                .OrderBy(c => c.Id)
+                .Skip(1)
+                .Distinct()
+                .Where(c => c.ShippingAddress.ZipCode == 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_property_inside_nested_struct_complex_type_after_subquery(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>()
+                .OrderBy(c => c.Id)
+                .Skip(1)
+                .Distinct()
+                .Where(c => c.ShippingAddress.Country.Code == "DE"));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_required_property_inside_required_struct_complex_type_on_optional_navigation(bool async)
+    {
+        return AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomerGroup>().Where(cg => cg.OptionalCustomer!.ShippingAddress.ZipCode != 07728),
+            ss => ss.Set<ValuedCustomerGroup>().Where(cg => cg.OptionalCustomer == null || cg.OptionalCustomer.ShippingAddress.ZipCode != 07728));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Filter_on_required_property_inside_required_struct_complex_type_on_required_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomerGroup>().Where(cg => cg.RequiredCustomer.ShippingAddress.ZipCode != 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_struct_complex_type_via_optional_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomerGroup>().Select(cg => cg.OptionalCustomer!.ShippingAddress));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Project_struct_complex_type_via_required_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomerGroup>().Select(cg => cg.RequiredCustomer.ShippingAddress));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Load_struct_complex_type_after_subquery_on_entity_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>()
+                .OrderBy(c => c.Id)
+                .Skip(1)
+                .Distinct());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_nested_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress.Country));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_single_property_on_nested_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress.Country.FullName));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_struct_complex_type_Where(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress).Where(a => a.ZipCode == 07728));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Select_struct_complex_type_Distinct(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress).Distinct());
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Struct_complex_type_equals_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(c => c.ShippingAddress == c.BillingAddress));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Struct_complex_type_equals_constant(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(
+                c => c.ShippingAddress
+                    == new AddressStruct
+                    {
+                        AddressLine1 = "804 S. Lakeshore Road",
+                        ZipCode = 38654,
+                        Country = new CountryStruct { FullName = "United States", Code = "US" }
+                    }));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Struct_complex_type_equals_parameter(bool async)
+    {
+        var address = new AddressStruct
+        {
+            AddressLine1 = "804 S. Lakeshore Road",
+            ZipCode = 38654,
+            Country = new CountryStruct { FullName = "United States", Code = "US" }
+        };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(c => c.ShippingAddress == address));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Subquery_over_struct_complex_type(bool async)
+    {
+        var address = new AddressStruct
+        {
+            AddressLine1 = "804 S. Lakeshore Road",
+            ZipCode = 38654,
+            Country = new CountryStruct { FullName = "United States", Code = "US" }
+        };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(
+                c => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress).OrderBy(a => a.ZipCode).First() == address));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_over_struct_complex_type(bool async)
+    {
+        var address = new AddressStruct
+        {
+            AddressLine1 = "804 S. Lakeshore Road",
+            ZipCode = 38654,
+            Country = new CountryStruct { FullName = "United States", Code = "US" }
+        };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(
+                c => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress).Contains(address)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Concat_entity_type_containing_struct_complex_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(c => c.Id == 1).Concat(ss.Set<ValuedCustomer>().Where(c => c.Id == 2)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_entity_type_containing_struct_complex_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(c => c.Id == 1).Union(ss.Set<ValuedCustomer>().Where(c => c.Id == 2)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Concat_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(c => c.Id == 1).Select(c => c.ShippingAddress)
+                .Concat(ss.Set<ValuedCustomer>().Where(c => c.Id == 2).Select(c => c.ShippingAddress)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Where(c => c.Id == 1).Select(c => c.ShippingAddress)
+                .Union(ss.Set<ValuedCustomer>().Where(c => c.Id == 2).Select(c => c.ShippingAddress)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Concat_property_in_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress.AddressLine1)
+                .Concat(ss.Set<ValuedCustomer>().Select(c => c.BillingAddress.AddressLine1)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_property_in_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress.AddressLine1)
+                .Union(ss.Set<ValuedCustomer>().Select(c => c.BillingAddress.AddressLine1)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Concat_two_different_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress).Concat(ss.Set<ValuedCustomer>().Select(c => c.BillingAddress)));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Union_two_different_struct_complex_type(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<ValuedCustomer>().Select(c => c.ShippingAddress).Union(ss.Set<ValuedCustomer>().Select(c => c.BillingAddress)));
 
     protected DbContext CreateContext()
         => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -43,7 +43,6 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         bool assertOrder = false,
         int entryCount = 0,
         [CallerMemberName] string testMethodName = null)
-        where TResult : class
         => AssertQuery(async, query, query, elementSorter, elementAsserter, assertOrder, entryCount, testMethodName);
 
     public Task AssertQuery<TResult>(
@@ -55,7 +54,6 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         bool assertOrder = false,
         int entryCount = 0,
         [CallerMemberName] string testMethodName = null)
-        where TResult : class
         => QueryAsserter.AssertQuery(
             actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, async, testMethodName);
 

--- a/test/EFCore.Specification.Tests/TestModels/ComplexTypeModel/ComplexTypeData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexTypeModel/ComplexTypeData.cs
@@ -9,11 +9,15 @@ public class ComplexTypeData : ISetSource
 {
     private readonly IReadOnlyList<Customer> _customers;
     private readonly IReadOnlyList<CustomerGroup> _customerGroups;
+    private readonly IReadOnlyList<ValuedCustomer> _valuedCustomers;
+    private readonly IReadOnlyList<ValuedCustomerGroup> _valuedCustomerGroups;
 
     public ComplexTypeData()
     {
         _customers = CreateCustomers();
         _customerGroups = CreateCustomerGroups(_customers);
+        _valuedCustomers = CreateValuedCustomers();
+        _valuedCustomerGroups = CreateValuedCustomerGroups(_valuedCustomers);
     }
 
     public IQueryable<TEntity> Set<TEntity>()
@@ -27,6 +31,16 @@ public class ComplexTypeData : ISetSource
         if (typeof(TEntity) == typeof(CustomerGroup))
         {
             return (IQueryable<TEntity>)_customerGroups.AsQueryable();
+        }
+
+        if (typeof(TEntity) == typeof(ValuedCustomer))
+        {
+            return (IQueryable<TEntity>)_valuedCustomers.AsQueryable();
+        }
+
+        if (typeof(TEntity) == typeof(ValuedCustomerGroup))
+        {
+            return (IQueryable<TEntity>)_valuedCustomerGroups.AsQueryable();
         }
 
         throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
@@ -121,13 +135,106 @@ public class ComplexTypeData : ISetSource
         };
     }
 
+    private static IReadOnlyList<ValuedCustomer> CreateValuedCustomers()
+    {
+        var address1 = new AddressStruct
+        {
+            AddressLine1 = "804 S. Lakeshore Road",
+            ZipCode = 38654,
+            Country = new CountryStruct { FullName = "United States", Code = "US" }
+        };
+
+        var customer1 = new ValuedCustomer
+        {
+            Id = 1,
+            Name = "Mona Cy",
+            ShippingAddress = address1,
+            BillingAddress = address1
+        };
+
+        var customer2 = new ValuedCustomer
+        {
+            Id = 2,
+            Name = "Antigonus Mitul",
+            ShippingAddress = new AddressStruct
+            {
+                AddressLine1 = "72 Hickory Rd.",
+                ZipCode = 07728,
+                Country = new CountryStruct { FullName = "Germany", Code = "DE" }
+            },
+            BillingAddress = new AddressStruct
+            {
+                AddressLine1 = "79 Main St.",
+                ZipCode = 29293,
+                Country = new CountryStruct { FullName = "Germany", Code = "DE" }
+            }
+        };
+
+        var address3 = new AddressStruct
+        {
+            AddressLine1 = "79 Main St.",
+            ZipCode = 29293,
+            Country = new CountryStruct { FullName = "Germany", Code = "DE" }
+        };
+
+        var customer3 = new ValuedCustomer
+        {
+            Id = 3,
+            Name = "Monty Elias",
+            ShippingAddress = address3,
+            BillingAddress = address3
+        };
+
+        return new List<ValuedCustomer>
+        {
+            customer1,
+            customer2,
+            customer3
+        };
+    }
+
+    private static IReadOnlyList<ValuedCustomerGroup> CreateValuedCustomerGroups(IReadOnlyList<ValuedCustomer> customers)
+    {
+        var group1 = new ValuedCustomerGroup
+        {
+            Id = 1,
+            RequiredCustomer = customers[0],
+            OptionalCustomer = customers[1]
+        };
+
+        var group2 = new ValuedCustomerGroup
+        {
+            Id = 2,
+            RequiredCustomer = customers[1],
+            OptionalCustomer = customers[0]
+        };
+
+        var group3 = new ValuedCustomerGroup
+        {
+            Id = 3,
+            RequiredCustomer = customers[0],
+            OptionalCustomer = null
+        };
+
+        return new List<ValuedCustomerGroup>
+        {
+            group1,
+            group2,
+            group3
+        };
+    }
+
     public static void Seed(PoolableDbContext context)
     {
         var customers = CreateCustomers();
         var customerGroups = CreateCustomerGroups(customers);
+        var valuedCustomers = CreateValuedCustomers();
+        var valuedCustomerGroups = CreateValuedCustomerGroups(valuedCustomers);
 
-        context.Set<Customer>().AddRange(customers);
-        context.Set<CustomerGroup>().AddRange(customerGroups);
+        context.AddRange(customers);
+        context.AddRange(customerGroups);
+        context.AddRange(valuedCustomers);
+        context.AddRange(valuedCustomerGroups);
 
         context.SaveChanges();
     }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexTypeModel/Model.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexTypeModel/Model.cs
@@ -38,3 +38,37 @@ public class CustomerGroup
     public required Customer RequiredCustomer { get; set; }
     public Customer? OptionalCustomer { get; set; }
 }
+
+public class ValuedCustomer
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+
+    public required AddressStruct ShippingAddress { get; set; }
+    public required AddressStruct BillingAddress { get; set; }
+}
+
+public record struct AddressStruct
+{
+    public required string AddressLine1 { get; set; }
+    public string? AddressLine2 { get; set; }
+    public int ZipCode { get; set; }
+
+    public required CountryStruct Country { get; set; }
+}
+
+public record struct CountryStruct
+{
+    public required string FullName { get; set; }
+    public required string Code { get; set; }
+}
+
+// Regular entity type referencing ValuedCustomer, which is also a regular entity type.
+// Used to test complex types on nullable/required entity types.
+public class ValuedCustomerGroup
+{
+    public int Id { get; set; }
+
+    public required ValuedCustomer RequiredCustomer { get; set; }
+    public ValuedCustomer? OptionalCustomer { get; set; }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexTypeQuerySqlServerTest.cs
@@ -380,6 +380,366 @@ FROM [Customer] AS [c0]
         AssertSql();
     }
 
+    public override async Task Filter_on_property_inside_struct_complex_type(bool async)
+    {
+        await base.Filter_on_property_inside_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[ShippingAddress_ZipCode] = 7728
+""");
+    }
+
+    public override async Task Filter_on_property_inside_nested_struct_complex_type(bool async)
+    {
+        await base.Filter_on_property_inside_nested_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[ShippingAddress_Country_Code] = N'DE'
+""");
+    }
+
+    public override async Task Filter_on_property_inside_struct_complex_type_after_subquery(bool async)
+    {
+        await base.Filter_on_property_inside_struct_complex_type_after_subquery(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+FROM (
+    SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+    FROM [ValuedCustomer] AS [v]
+    ORDER BY [v].[Id]
+    OFFSET @__p_0 ROWS
+) AS [t]
+WHERE [t].[ShippingAddress_ZipCode] = 7728
+""");
+    }
+
+    public override async Task Filter_on_property_inside_nested_struct_complex_type_after_subquery(bool async)
+    {
+        await base.Filter_on_property_inside_nested_struct_complex_type_after_subquery(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+FROM (
+    SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+    FROM [ValuedCustomer] AS [v]
+    ORDER BY [v].[Id]
+    OFFSET @__p_0 ROWS
+) AS [t]
+WHERE [t].[ShippingAddress_Country_Code] = N'DE'
+""");
+    }
+
+    public override async Task Filter_on_required_property_inside_required_struct_complex_type_on_optional_navigation(bool async)
+    {
+        await base.Filter_on_required_property_inside_required_struct_complex_type_on_optional_navigation(async);
+
+        AssertSql(
+"""
+SELECT [v].[Id], [v].[OptionalCustomerId], [v].[RequiredCustomerId], [v0].[Id], [v0].[Name], [v0].[BillingAddress_AddressLine1], [v0].[BillingAddress_AddressLine2], [v0].[BillingAddress_ZipCode], [v0].[BillingAddress_Country_Code], [v0].[BillingAddress_Country_FullName], [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName], [v1].[Id], [v1].[Name], [v1].[BillingAddress_AddressLine1], [v1].[BillingAddress_AddressLine2], [v1].[BillingAddress_ZipCode], [v1].[BillingAddress_Country_Code], [v1].[BillingAddress_Country_FullName], [v1].[ShippingAddress_AddressLine1], [v1].[ShippingAddress_AddressLine2], [v1].[ShippingAddress_ZipCode], [v1].[ShippingAddress_Country_Code], [v1].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomerGroup] AS [v]
+LEFT JOIN [ValuedCustomer] AS [v0] ON [v].[OptionalCustomerId] = [v0].[Id]
+INNER JOIN [ValuedCustomer] AS [v1] ON [v].[RequiredCustomerId] = [v1].[Id]
+WHERE [v0].[ShippingAddress_ZipCode] <> 7728 OR [v0].[ShippingAddress_ZipCode] IS NULL
+""");
+    }
+
+    public override async Task Filter_on_required_property_inside_required_struct_complex_type_on_required_navigation(bool async)
+    {
+        await base.Filter_on_required_property_inside_required_struct_complex_type_on_required_navigation(async);
+
+        AssertSql(
+"""
+SELECT [v].[Id], [v].[OptionalCustomerId], [v].[RequiredCustomerId], [v1].[Id], [v1].[Name], [v1].[BillingAddress_AddressLine1], [v1].[BillingAddress_AddressLine2], [v1].[BillingAddress_ZipCode], [v1].[BillingAddress_Country_Code], [v1].[BillingAddress_Country_FullName], [v1].[ShippingAddress_AddressLine1], [v1].[ShippingAddress_AddressLine2], [v1].[ShippingAddress_ZipCode], [v1].[ShippingAddress_Country_Code], [v1].[ShippingAddress_Country_FullName], [v0].[Id], [v0].[Name], [v0].[BillingAddress_AddressLine1], [v0].[BillingAddress_AddressLine2], [v0].[BillingAddress_ZipCode], [v0].[BillingAddress_Country_Code], [v0].[BillingAddress_Country_FullName], [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomerGroup] AS [v]
+INNER JOIN [ValuedCustomer] AS [v0] ON [v].[RequiredCustomerId] = [v0].[Id]
+LEFT JOIN [ValuedCustomer] AS [v1] ON [v].[OptionalCustomerId] = [v1].[Id]
+WHERE [v0].[ShippingAddress_ZipCode] <> 7728
+""");
+    }
+
+    // This test fails because when OptionalCustomer is null, we get all-null results because of the LEFT JOIN, and we materialize this
+    // as an empty ShippingAddress instead of null (see SQL). The proper solution here would be to project the Customer ID just for the
+    // purpose of knowing that it's there.
+    public override async Task Project_struct_complex_type_via_optional_navigation(bool async)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.Project_struct_complex_type_via_optional_navigation(async));
+
+        Assert.Equal(RelationalStrings.CannotProjectNullableComplexType("ValuedCustomer.ShippingAddress#AddressStruct"), exception.Message);
+    }
+
+    public override async Task Project_struct_complex_type_via_required_navigation(bool async)
+    {
+        await base.Project_struct_complex_type_via_required_navigation(async);
+
+        AssertSql(
+"""
+SELECT [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomerGroup] AS [v]
+INNER JOIN [ValuedCustomer] AS [v0] ON [v].[RequiredCustomerId] = [v0].[Id]
+""");
+    }
+
+    public override async Task Load_struct_complex_type_after_subquery_on_entity_type(bool async)
+    {
+        await base.Load_struct_complex_type_after_subquery_on_entity_type(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT [t].[Id], [t].[Name], [t].[BillingAddress_AddressLine1], [t].[BillingAddress_AddressLine2], [t].[BillingAddress_ZipCode], [t].[BillingAddress_Country_Code], [t].[BillingAddress_Country_FullName], [t].[ShippingAddress_AddressLine1], [t].[ShippingAddress_AddressLine2], [t].[ShippingAddress_ZipCode], [t].[ShippingAddress_Country_Code], [t].[ShippingAddress_Country_FullName]
+FROM (
+    SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+    FROM [ValuedCustomer] AS [v]
+    ORDER BY [v].[Id]
+    OFFSET @__p_0 ROWS
+) AS [t]
+""");
+    }
+
+    public override async Task Select_struct_complex_type(bool async)
+    {
+        await base.Select_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+""");
+    }
+
+    public override async Task Select_nested_struct_complex_type(bool async)
+    {
+        await base.Select_nested_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+""");
+    }
+
+    public override async Task Select_single_property_on_nested_struct_complex_type(bool async)
+    {
+        await base.Select_single_property_on_nested_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+""");
+    }
+
+    public override async Task Select_struct_complex_type_Where(bool async)
+    {
+        await base.Select_struct_complex_type_Where(async);
+
+        AssertSql(
+"""
+SELECT [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[ShippingAddress_ZipCode] = 7728
+""");
+    }
+
+    public override async Task Select_struct_complex_type_Distinct(bool async)
+    {
+        await base.Select_struct_complex_type_Distinct(async);
+
+        AssertSql(
+"""
+SELECT DISTINCT [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+""");
+    }
+
+    public override async Task Struct_complex_type_equals_struct_complex_type(bool async)
+    {
+        await base.Struct_complex_type_equals_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[ShippingAddress_AddressLine1] = [v].[BillingAddress_AddressLine1] AND ([v].[ShippingAddress_AddressLine2] = [v].[BillingAddress_AddressLine2] OR ([v].[ShippingAddress_AddressLine2] IS NULL AND [v].[BillingAddress_AddressLine2] IS NULL)) AND [v].[ShippingAddress_ZipCode] = [v].[BillingAddress_ZipCode]
+""");
+    }
+
+    public override async Task Struct_complex_type_equals_constant(bool async)
+    {
+        await base.Struct_complex_type_equals_constant(async);
+
+        AssertSql(
+"""
+SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[ShippingAddress_AddressLine1] = N'804 S. Lakeshore Road' AND [v].[ShippingAddress_AddressLine2] IS NULL AND [v].[ShippingAddress_ZipCode] = 38654 AND [v].[ShippingAddress_Country_Code] = N'US' AND [v].[ShippingAddress_Country_FullName] = N'United States'
+""");
+    }
+
+    public override async Task Struct_complex_type_equals_parameter(bool async)
+    {
+        await base.Struct_complex_type_equals_parameter(async);
+
+        AssertSql(
+"""
+@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
+@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
+@__entity_equality_address_0_Code='US' (Size = 4000)
+@__entity_equality_address_0_FullName='United States' (Size = 4000)
+
+SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [v].[ShippingAddress_AddressLine2] IS NULL AND [v].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [v].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Code AND [v].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_FullName
+""");
+    }
+
+    public override async Task Subquery_over_struct_complex_type(bool async)
+    {
+        await base.Subquery_over_struct_complex_type(async);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_over_struct_complex_type(bool async)
+    {
+        await base.Contains_over_struct_complex_type(async);
+
+        AssertSql(
+"""
+@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 4000)
+@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
+@__entity_equality_address_0_Code='US' (Size = 4000)
+@__entity_equality_address_0_FullName='United States' (Size = 4000)
+
+SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE EXISTS (
+    SELECT 1
+    FROM [ValuedCustomer] AS [v0]
+    WHERE [v0].[ShippingAddress_AddressLine1] = @__entity_equality_address_0_AddressLine1 AND [v0].[ShippingAddress_AddressLine2] IS NULL AND [v0].[ShippingAddress_ZipCode] = @__entity_equality_address_0_ZipCode AND [v0].[ShippingAddress_Country_Code] = @__entity_equality_address_0_Code AND [v0].[ShippingAddress_Country_FullName] = @__entity_equality_address_0_FullName)
+""");
+    }
+
+    public override async Task Concat_struct_complex_type(bool async)
+    {
+        await base.Concat_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[Id] = 1
+UNION ALL
+SELECT [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v0]
+WHERE [v0].[Id] = 2
+""");
+    }
+
+    public override async Task Concat_entity_type_containing_struct_complex_property(bool async)
+    {
+        await base.Concat_entity_type_containing_struct_complex_property(async);
+
+        AssertSql(
+"""
+SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[Id] = 1
+UNION ALL
+SELECT [v0].[Id], [v0].[Name], [v0].[BillingAddress_AddressLine1], [v0].[BillingAddress_AddressLine2], [v0].[BillingAddress_ZipCode], [v0].[BillingAddress_Country_Code], [v0].[BillingAddress_Country_FullName], [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v0]
+WHERE [v0].[Id] = 2
+""");
+    }
+
+    public override async Task Union_entity_type_containing_struct_complex_property(bool async)
+    {
+        await base.Union_entity_type_containing_struct_complex_property(async);
+
+        AssertSql(
+"""
+SELECT [v].[Id], [v].[Name], [v].[BillingAddress_AddressLine1], [v].[BillingAddress_AddressLine2], [v].[BillingAddress_ZipCode], [v].[BillingAddress_Country_Code], [v].[BillingAddress_Country_FullName], [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[Id] = 1
+UNION
+SELECT [v0].[Id], [v0].[Name], [v0].[BillingAddress_AddressLine1], [v0].[BillingAddress_AddressLine2], [v0].[BillingAddress_ZipCode], [v0].[BillingAddress_Country_Code], [v0].[BillingAddress_Country_FullName], [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v0]
+WHERE [v0].[Id] = 2
+""");
+    }
+
+    public override async Task Union_struct_complex_type(bool async)
+    {
+        await base.Union_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[ShippingAddress_AddressLine1], [v].[ShippingAddress_AddressLine2], [v].[ShippingAddress_ZipCode], [v].[ShippingAddress_Country_Code], [v].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v]
+WHERE [v].[Id] = 1
+UNION
+SELECT [v0].[ShippingAddress_AddressLine1], [v0].[ShippingAddress_AddressLine2], [v0].[ShippingAddress_ZipCode], [v0].[ShippingAddress_Country_Code], [v0].[ShippingAddress_Country_FullName]
+FROM [ValuedCustomer] AS [v0]
+WHERE [v0].[Id] = 2
+""");
+    }
+
+    public override async Task Concat_property_in_struct_complex_type(bool async)
+    {
+        await base.Concat_property_in_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[ShippingAddress_AddressLine1]
+FROM [ValuedCustomer] AS [v]
+UNION ALL
+SELECT [v0].[BillingAddress_AddressLine1] AS [ShippingAddress_AddressLine1]
+FROM [ValuedCustomer] AS [v0]
+""");
+    }
+
+    public override async Task Union_property_in_struct_complex_type(bool async)
+    {
+        await base.Union_property_in_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT [v].[ShippingAddress_AddressLine1]
+FROM [ValuedCustomer] AS [v]
+UNION
+SELECT [v0].[BillingAddress_AddressLine1] AS [ShippingAddress_AddressLine1]
+FROM [ValuedCustomer] AS [v0]
+""");
+    }
+
+    public override async Task Concat_two_different_struct_complex_type(bool async)
+    {
+        await base.Concat_two_different_struct_complex_type(async);
+
+        AssertSql();
+    }
+
+    public override async Task Union_two_different_struct_complex_type(bool async)
+    {
+        await base.Union_two_different_struct_complex_type(async);
+
+        AssertSql();
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexTypeQuerySqliteTest.cs
@@ -380,6 +380,366 @@ FROM "Customer" AS "c0"
         AssertSql();
     }
 
+    public override async Task Filter_on_property_inside_struct_complex_type(bool async)
+    {
+        await base.Filter_on_property_inside_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."ShippingAddress_ZipCode" = 7728
+""");
+    }
+
+    public override async Task Filter_on_property_inside_nested_struct_complex_type(bool async)
+    {
+        await base.Filter_on_property_inside_nested_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."ShippingAddress_Country_Code" = 'DE'
+""");
+    }
+
+    public override async Task Filter_on_property_inside_struct_complex_type_after_subquery(bool async)
+    {
+        await base.Filter_on_property_inside_struct_complex_type_after_subquery(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName"
+FROM (
+    SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+    FROM "ValuedCustomer" AS "v"
+    ORDER BY "v"."Id"
+    LIMIT -1 OFFSET @__p_0
+) AS "t"
+WHERE "t"."ShippingAddress_ZipCode" = 7728
+""");
+    }
+
+    public override async Task Filter_on_property_inside_nested_struct_complex_type_after_subquery(bool async)
+    {
+        await base.Filter_on_property_inside_nested_struct_complex_type_after_subquery(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName"
+FROM (
+    SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+    FROM "ValuedCustomer" AS "v"
+    ORDER BY "v"."Id"
+    LIMIT -1 OFFSET @__p_0
+) AS "t"
+WHERE "t"."ShippingAddress_Country_Code" = 'DE'
+""");
+    }
+
+    public override async Task Filter_on_required_property_inside_required_struct_complex_type_on_optional_navigation(bool async)
+    {
+        await base.Filter_on_required_property_inside_required_struct_complex_type_on_optional_navigation(async);
+
+        AssertSql(
+"""
+SELECT "v"."Id", "v"."OptionalCustomerId", "v"."RequiredCustomerId", "v0"."Id", "v0"."Name", "v0"."BillingAddress_AddressLine1", "v0"."BillingAddress_AddressLine2", "v0"."BillingAddress_ZipCode", "v0"."BillingAddress_Country_Code", "v0"."BillingAddress_Country_FullName", "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName", "v1"."Id", "v1"."Name", "v1"."BillingAddress_AddressLine1", "v1"."BillingAddress_AddressLine2", "v1"."BillingAddress_ZipCode", "v1"."BillingAddress_Country_Code", "v1"."BillingAddress_Country_FullName", "v1"."ShippingAddress_AddressLine1", "v1"."ShippingAddress_AddressLine2", "v1"."ShippingAddress_ZipCode", "v1"."ShippingAddress_Country_Code", "v1"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomerGroup" AS "v"
+LEFT JOIN "ValuedCustomer" AS "v0" ON "v"."OptionalCustomerId" = "v0"."Id"
+INNER JOIN "ValuedCustomer" AS "v1" ON "v"."RequiredCustomerId" = "v1"."Id"
+WHERE "v0"."ShippingAddress_ZipCode" <> 7728 OR "v0"."ShippingAddress_ZipCode" IS NULL
+""");
+    }
+
+    public override async Task Filter_on_required_property_inside_required_struct_complex_type_on_required_navigation(bool async)
+    {
+        await base.Filter_on_required_property_inside_required_struct_complex_type_on_required_navigation(async);
+
+        AssertSql(
+"""
+SELECT "v"."Id", "v"."OptionalCustomerId", "v"."RequiredCustomerId", "v1"."Id", "v1"."Name", "v1"."BillingAddress_AddressLine1", "v1"."BillingAddress_AddressLine2", "v1"."BillingAddress_ZipCode", "v1"."BillingAddress_Country_Code", "v1"."BillingAddress_Country_FullName", "v1"."ShippingAddress_AddressLine1", "v1"."ShippingAddress_AddressLine2", "v1"."ShippingAddress_ZipCode", "v1"."ShippingAddress_Country_Code", "v1"."ShippingAddress_Country_FullName", "v0"."Id", "v0"."Name", "v0"."BillingAddress_AddressLine1", "v0"."BillingAddress_AddressLine2", "v0"."BillingAddress_ZipCode", "v0"."BillingAddress_Country_Code", "v0"."BillingAddress_Country_FullName", "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomerGroup" AS "v"
+INNER JOIN "ValuedCustomer" AS "v0" ON "v"."RequiredCustomerId" = "v0"."Id"
+LEFT JOIN "ValuedCustomer" AS "v1" ON "v"."OptionalCustomerId" = "v1"."Id"
+WHERE "v0"."ShippingAddress_ZipCode" <> 7728
+""");
+    }
+
+    // This test fails because when OptionalCustomer is null, we get all-null results because of the LEFT JOIN, and we materialize this
+    // as an empty ShippingAddress instead of null (see SQL). The proper solution here would be to project the Customer ID just for the
+    // purpose of knowing that it's there.
+    public override async Task Project_struct_complex_type_via_optional_navigation(bool async)
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => base.Project_struct_complex_type_via_optional_navigation(async));
+
+        Assert.Equal(RelationalStrings.CannotProjectNullableComplexType("ValuedCustomer.ShippingAddress#AddressStruct"), exception.Message);
+    }
+
+    public override async Task Project_struct_complex_type_via_required_navigation(bool async)
+    {
+        await base.Project_struct_complex_type_via_required_navigation(async);
+
+        AssertSql(
+"""
+SELECT "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomerGroup" AS "v"
+INNER JOIN "ValuedCustomer" AS "v0" ON "v"."RequiredCustomerId" = "v0"."Id"
+""");
+    }
+
+    public override async Task Load_struct_complex_type_after_subquery_on_entity_type(bool async)
+    {
+        await base.Load_struct_complex_type_after_subquery_on_entity_type(async);
+
+        AssertSql(
+"""
+@__p_0='1'
+
+SELECT DISTINCT "t"."Id", "t"."Name", "t"."BillingAddress_AddressLine1", "t"."BillingAddress_AddressLine2", "t"."BillingAddress_ZipCode", "t"."BillingAddress_Country_Code", "t"."BillingAddress_Country_FullName", "t"."ShippingAddress_AddressLine1", "t"."ShippingAddress_AddressLine2", "t"."ShippingAddress_ZipCode", "t"."ShippingAddress_Country_Code", "t"."ShippingAddress_Country_FullName"
+FROM (
+    SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+    FROM "ValuedCustomer" AS "v"
+    ORDER BY "v"."Id"
+    LIMIT -1 OFFSET @__p_0
+) AS "t"
+""");
+    }
+
+    public override async Task Select_struct_complex_type(bool async)
+    {
+        await base.Select_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+""");
+    }
+
+    public override async Task Select_nested_struct_complex_type(bool async)
+    {
+        await base.Select_nested_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+""");
+    }
+
+    public override async Task Select_single_property_on_nested_struct_complex_type(bool async)
+    {
+        await base.Select_single_property_on_nested_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+""");
+    }
+
+    public override async Task Select_struct_complex_type_Where(bool async)
+    {
+        await base.Select_struct_complex_type_Where(async);
+
+        AssertSql(
+"""
+SELECT "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."ShippingAddress_ZipCode" = 7728
+""");
+    }
+
+    public override async Task Select_struct_complex_type_Distinct(bool async)
+    {
+        await base.Select_struct_complex_type_Distinct(async);
+
+        AssertSql(
+"""
+SELECT DISTINCT "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+""");
+    }
+
+    public override async Task Struct_complex_type_equals_struct_complex_type(bool async)
+    {
+        await base.Struct_complex_type_equals_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."ShippingAddress_AddressLine1" = "v"."BillingAddress_AddressLine1" AND ("v"."ShippingAddress_AddressLine2" = "v"."BillingAddress_AddressLine2" OR ("v"."ShippingAddress_AddressLine2" IS NULL AND "v"."BillingAddress_AddressLine2" IS NULL)) AND "v"."ShippingAddress_ZipCode" = "v"."BillingAddress_ZipCode"
+""");
+    }
+
+    public override async Task Struct_complex_type_equals_constant(bool async)
+    {
+        await base.Struct_complex_type_equals_constant(async);
+
+        AssertSql(
+"""
+SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."ShippingAddress_AddressLine1" = '804 S. Lakeshore Road' AND "v"."ShippingAddress_AddressLine2" IS NULL AND "v"."ShippingAddress_ZipCode" = 38654 AND "v"."ShippingAddress_Country_Code" = 'US' AND "v"."ShippingAddress_Country_FullName" = 'United States'
+""");
+    }
+
+    public override async Task Struct_complex_type_equals_parameter(bool async)
+    {
+        await base.Struct_complex_type_equals_parameter(async);
+
+        AssertSql(
+"""
+@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
+@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
+@__entity_equality_address_0_Code='US' (Size = 2)
+@__entity_equality_address_0_FullName='United States' (Size = 13)
+
+SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "v"."ShippingAddress_AddressLine2" IS NULL AND "v"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "v"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Code AND "v"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_FullName
+""");
+    }
+
+    public override async Task Subquery_over_struct_complex_type(bool async)
+    {
+        await base.Subquery_over_struct_complex_type(async);
+
+        AssertSql();
+    }
+
+    public override async Task Contains_over_struct_complex_type(bool async)
+    {
+        await base.Contains_over_struct_complex_type(async);
+
+        AssertSql(
+"""
+@__entity_equality_address_0_AddressLine1='804 S. Lakeshore Road' (Size = 21)
+@__entity_equality_address_0_ZipCode='38654' (Nullable = true)
+@__entity_equality_address_0_Code='US' (Size = 2)
+@__entity_equality_address_0_FullName='United States' (Size = 13)
+
+SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE EXISTS (
+    SELECT 1
+    FROM "ValuedCustomer" AS "v0"
+    WHERE "v0"."ShippingAddress_AddressLine1" = @__entity_equality_address_0_AddressLine1 AND "v0"."ShippingAddress_AddressLine2" IS NULL AND "v0"."ShippingAddress_ZipCode" = @__entity_equality_address_0_ZipCode AND "v0"."ShippingAddress_Country_Code" = @__entity_equality_address_0_Code AND "v0"."ShippingAddress_Country_FullName" = @__entity_equality_address_0_FullName)
+""");
+    }
+
+    public override async Task Concat_struct_complex_type(bool async)
+    {
+        await base.Concat_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."Id" = 1
+UNION ALL
+SELECT "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v0"
+WHERE "v0"."Id" = 2
+""");
+    }
+
+    public override async Task Concat_entity_type_containing_struct_complex_property(bool async)
+    {
+        await base.Concat_entity_type_containing_struct_complex_property(async);
+
+        AssertSql(
+"""
+SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."Id" = 1
+UNION ALL
+SELECT "v0"."Id", "v0"."Name", "v0"."BillingAddress_AddressLine1", "v0"."BillingAddress_AddressLine2", "v0"."BillingAddress_ZipCode", "v0"."BillingAddress_Country_Code", "v0"."BillingAddress_Country_FullName", "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v0"
+WHERE "v0"."Id" = 2
+""");
+    }
+
+    public override async Task Union_entity_type_containing_struct_complex_property(bool async)
+    {
+        await base.Union_entity_type_containing_struct_complex_property(async);
+
+        AssertSql(
+"""
+SELECT "v"."Id", "v"."Name", "v"."BillingAddress_AddressLine1", "v"."BillingAddress_AddressLine2", "v"."BillingAddress_ZipCode", "v"."BillingAddress_Country_Code", "v"."BillingAddress_Country_FullName", "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."Id" = 1
+UNION
+SELECT "v0"."Id", "v0"."Name", "v0"."BillingAddress_AddressLine1", "v0"."BillingAddress_AddressLine2", "v0"."BillingAddress_ZipCode", "v0"."BillingAddress_Country_Code", "v0"."BillingAddress_Country_FullName", "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v0"
+WHERE "v0"."Id" = 2
+""");
+    }
+
+    public override async Task Union_struct_complex_type(bool async)
+    {
+        await base.Union_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."ShippingAddress_AddressLine1", "v"."ShippingAddress_AddressLine2", "v"."ShippingAddress_ZipCode", "v"."ShippingAddress_Country_Code", "v"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v"
+WHERE "v"."Id" = 1
+UNION
+SELECT "v0"."ShippingAddress_AddressLine1", "v0"."ShippingAddress_AddressLine2", "v0"."ShippingAddress_ZipCode", "v0"."ShippingAddress_Country_Code", "v0"."ShippingAddress_Country_FullName"
+FROM "ValuedCustomer" AS "v0"
+WHERE "v0"."Id" = 2
+""");
+    }
+
+    public override async Task Concat_property_in_struct_complex_type(bool async)
+    {
+        await base.Concat_property_in_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."ShippingAddress_AddressLine1"
+FROM "ValuedCustomer" AS "v"
+UNION ALL
+SELECT "v0"."BillingAddress_AddressLine1" AS "ShippingAddress_AddressLine1"
+FROM "ValuedCustomer" AS "v0"
+""");
+    }
+
+    public override async Task Union_property_in_struct_complex_type(bool async)
+    {
+        await base.Union_property_in_struct_complex_type(async);
+
+        AssertSql(
+"""
+SELECT "v"."ShippingAddress_AddressLine1"
+FROM "ValuedCustomer" AS "v"
+UNION
+SELECT "v0"."BillingAddress_AddressLine1" AS "ShippingAddress_AddressLine1"
+FROM "ValuedCustomer" AS "v0"
+""");
+    }
+
+    public override async Task Concat_two_different_struct_complex_type(bool async)
+    {
+        await base.Concat_two_different_struct_complex_type(async);
+
+        AssertSql();
+    }
+
+    public override async Task Union_two_different_struct_complex_type(bool async)
+    {
+        await base.Union_two_different_struct_complex_type(async);
+
+        AssertSql();
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
Fixes #31609

**Description**

Projecting a complex type represented by a value type throws.

**Customer impact**

Using value types as complex types is a new feature for EF8.

**How found**

Testing.

**Regression**

No.

**Testing**

Tests added for complex types represented by value types.

**Risk**

Small.