### PR TITLE
[release/8.0] Set default discriminator value even when there are no derived types.

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -892,9 +892,10 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
                 .Append('.')
                 .Append("HasDiscriminator");
 
-            if (discriminatorPropertyAnnotation?.Value != null)
+            var discriminatorProperty = entityType.FindDiscriminatorProperty();
+            if (discriminatorPropertyAnnotation?.Value != null
+                && discriminatorProperty != null)
             {
-                var discriminatorProperty = entityType.FindProperty((string)discriminatorPropertyAnnotation.Value)!;
                 var propertyClrType = FindValueConverter(discriminatorProperty)?.ProviderClrType
                         .MakeNullable(discriminatorProperty.IsNullable)
                     ?? discriminatorProperty.ClrType;
@@ -902,7 +903,7 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
                     .Append('<')
                     .Append(Code.Reference(propertyClrType))
                     .Append(">(")
-                    .Append(Code.Literal((string)discriminatorPropertyAnnotation.Value))
+                    .Append(Code.Literal(discriminatorProperty.Name))
                     .Append(')');
             }
             else
@@ -926,7 +927,6 @@ public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
             if (discriminatorValueAnnotation?.Value != null)
             {
                 var value = discriminatorValueAnnotation.Value;
-                var discriminatorProperty = entityType.FindDiscriminatorProperty();
                 if (discriminatorProperty != null)
                 {
                     var valueConverter = FindValueConverter(discriminatorProperty);

--- a/src/EFCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/EFCore/Metadata/Conventions/ConventionSet.cs
@@ -52,6 +52,11 @@ public class ConventionSet
     public virtual List<IEntityTypeMemberIgnoredConvention> EntityTypeMemberIgnoredConventions { get; } = new();
 
     /// <summary>
+    ///     Conventions to run when a discriminator property is set.
+    /// </summary>
+    public virtual List<IDiscriminatorPropertySetConvention> DiscriminatorPropertySetConventions { get; } = new();
+
+    /// <summary>
     ///     Conventions to run when the base entity type is changed.
     /// </summary>
     public virtual List<IEntityTypeBaseTypeChangedConvention> EntityTypeBaseTypeChangedConventions { get; } = new();
@@ -338,6 +343,12 @@ public class ConventionSet
             && !Replace(EntityTypeMemberIgnoredConventions, entityTypeMemberIgnoredConvention, oldConvetionType))
         {
             EntityTypeMemberIgnoredConventions.Add(entityTypeMemberIgnoredConvention);
+        }
+
+        if (newConvention is IDiscriminatorPropertySetConvention discriminatorPropertySetConvention
+            && !Replace(DiscriminatorPropertySetConventions, discriminatorPropertySetConvention, oldConvetionType))
+        {
+            DiscriminatorPropertySetConventions.Add(discriminatorPropertySetConvention);
         }
 
         if (newConvention is IEntityTypeBaseTypeChangedConvention entityTypeBaseTypeChangedConvention
@@ -680,6 +691,11 @@ public class ConventionSet
             EntityTypeMemberIgnoredConventions.Add(entityTypeMemberIgnoredConvention);
         }
 
+        if (convention is IDiscriminatorPropertySetConvention discriminatorPropertySetConvention)
+        {
+            DiscriminatorPropertySetConventions.Add(discriminatorPropertySetConvention);
+        }
+
         if (convention is IEntityTypeBaseTypeChangedConvention entityTypeBaseTypeChangedConvention)
         {
             EntityTypeBaseTypeChangedConventions.Add(entityTypeBaseTypeChangedConvention);
@@ -991,6 +1007,11 @@ public class ConventionSet
         if (typeof(IEntityTypeMemberIgnoredConvention).IsAssignableFrom(conventionType))
         {
             Remove(EntityTypeMemberIgnoredConventions, conventionType);
+        }
+
+        if (typeof(IDiscriminatorPropertySetConvention).IsAssignableFrom(conventionType))
+        {
+            Remove(DiscriminatorPropertySetConventions, conventionType);
         }
 
         if (typeof(IEntityTypeBaseTypeChangedConvention).IsAssignableFrom(conventionType))

--- a/src/EFCore/Metadata/Conventions/DiscriminatorConvention.cs
+++ b/src/EFCore/Metadata/Conventions/DiscriminatorConvention.cs
@@ -9,7 +9,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.
 /// </remarks>
-public class DiscriminatorConvention : IEntityTypeBaseTypeChangedConvention, IEntityTypeRemovedConvention
+public class DiscriminatorConvention :
+    IEntityTypeBaseTypeChangedConvention,
+    IEntityTypeRemovedConvention,
+    IDiscriminatorPropertySetConvention
 {
     /// <summary>
     ///     Creates a new instance of <see cref="DiscriminatorConvention" />.
@@ -25,13 +28,7 @@ public class DiscriminatorConvention : IEntityTypeBaseTypeChangedConvention, IEn
     /// </summary>
     protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
 
-    /// <summary>
-    ///     Called after the base type of an entity type changes.
-    /// </summary>
-    /// <param name="entityTypeBuilder">The builder for the entity type.</param>
-    /// <param name="newBaseType">The new base entity type.</param>
-    /// <param name="oldBaseType">The old base entity type.</param>
-    /// <param name="context">Additional information associated with convention execution.</param>
+    /// <inheritdoc/>
     public virtual void ProcessEntityTypeBaseTypeChanged(
         IConventionEntityTypeBuilder entityTypeBuilder,
         IConventionEntityType? newBaseType,
@@ -45,18 +42,15 @@ public class DiscriminatorConvention : IEntityTypeBaseTypeChangedConvention, IEn
         }
 
         var entityType = entityTypeBuilder.Metadata;
-        var derivedEntityTypes = entityType.GetDerivedTypes().ToList();
-
-        IConventionDiscriminatorBuilder? discriminator;
         if (newBaseType == null)
         {
-            if (derivedEntityTypes.Count == 0)
+            if (!entityType.GetDerivedTypes().Any())
             {
                 entityTypeBuilder.HasNoDiscriminator();
                 return;
             }
 
-            discriminator = entityTypeBuilder.HasDiscriminator(typeof(string));
+            entityTypeBuilder.HasDiscriminator(typeof(string));
         }
         else
         {
@@ -65,28 +59,41 @@ public class DiscriminatorConvention : IEntityTypeBaseTypeChangedConvention, IEn
                 return;
             }
 
-            var rootTypeBuilder = entityType.GetRootType().Builder;
-            discriminator = rootTypeBuilder.HasDiscriminator(typeof(string));
-
-            if (newBaseType.BaseType == null)
+            var rootType = entityType.GetRootType();
+            if (rootType.FindDiscriminatorProperty() == null)
             {
-                discriminator?.HasValue(newBaseType, newBaseType.GetDefaultDiscriminatorValue());
+                rootType.Builder.HasDiscriminator(typeof(string));
             }
-        }
-
-        if (discriminator != null)
-        {
-            discriminator.HasValue(entityTypeBuilder.Metadata, entityTypeBuilder.Metadata.GetDefaultDiscriminatorValue());
-            SetDefaultDiscriminatorValues(derivedEntityTypes, discriminator);
+            else
+            {
+                var discriminator = entityTypeBuilder.HasDiscriminator(typeof(string));
+                if (discriminator != null)
+                {
+                    SetDefaultDiscriminatorValues(entityTypeBuilder.Metadata.GetDerivedTypesInclusive(), discriminator);
+                }
+            }
         }
     }
 
-    /// <summary>
-    ///     Called after an entity type is removed from the model.
-    /// </summary>
-    /// <param name="modelBuilder">The builder for the model.</param>
-    /// <param name="entityType">The removed entity type.</param>
-    /// <param name="context">Additional information associated with convention execution.</param>
+    /// <inheritdoc/>
+    public virtual void ProcessDiscriminatorPropertySet(
+        IConventionEntityTypeBuilder entityTypeBuilder,
+        string? name,
+        IConventionContext<string> context)
+    {
+        if (name == null)
+        {
+            return;
+        }
+
+        var discriminator = entityTypeBuilder.HasDiscriminator(typeof(string));
+        if (discriminator != null)
+        {
+            SetDefaultDiscriminatorValues(entityTypeBuilder.Metadata.GetDerivedTypesInclusive(), discriminator);
+        }
+    }
+
+    /// <inheritdoc/>
     public virtual void ProcessEntityTypeRemoved(
         IConventionModelBuilder modelBuilder,
         IConventionEntityType entityType,

--- a/src/EFCore/Metadata/Conventions/IDiscriminatorPropertySetConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IDiscriminatorPropertySetConvention.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+///     Represents an operation that should be performed when a discriminator property is set for an entity type.
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-conventions">Model building conventions</see> for more information and examples.
+/// </remarks>
+public interface IDiscriminatorPropertySetConvention : IConvention
+{
+    /// <summary>
+    ///     Called after a discriminator property is set.
+    /// </summary>
+    /// <param name="entityTypeBuilder">The builder for the entity type.</param>
+    /// <param name="name">The name of the discriminator property.</param>
+    /// <param name="context">Additional information associated with convention execution.</param>
+    void ProcessDiscriminatorPropertySet(
+        IConventionEntityTypeBuilder entityTypeBuilder,
+        string? name,
+        IConventionContext<string?> context);
+}

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ConventionScope.cs
@@ -69,6 +69,10 @@ public partial class ConventionDispatcher
             IConventionEntityTypeBuilder entityTypeBuilder,
             string name);
 
+        public abstract string? OnDiscriminatorPropertySet(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            string? name);
+
         public abstract IConventionKey? OnEntityTypePrimaryKeyChanged(
             IConventionEntityTypeBuilder entityTypeBuilder,
             IConventionKey? newPrimaryKey,

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.DelayedConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.DelayedConventionScope.cs
@@ -79,6 +79,12 @@ public partial class ConventionDispatcher
             return name;
         }
 
+        public override string? OnDiscriminatorPropertySet(IConventionEntityTypeBuilder entityTypeBuilder, string? name)
+        {
+            Add(new OnDiscriminatorPropertySetNode(entityTypeBuilder, name));
+            return name;
+        }
+
         public override IConventionEntityType? OnEntityTypeBaseTypeChanged(
             IConventionEntityTypeBuilder entityTypeBuilder,
             IConventionEntityType? newBaseType,
@@ -530,6 +536,21 @@ public partial class ConventionDispatcher
 
         public override void Run(ConventionDispatcher dispatcher)
             => dispatcher._immediateConventionScope.OnEntityTypeMemberIgnored(EntityTypeBuilder, Name);
+    }
+
+    private sealed class OnDiscriminatorPropertySetNode : ConventionNode
+    {
+        public OnDiscriminatorPropertySetNode(IConventionEntityTypeBuilder entityTypeBuilder, string? name)
+        {
+            EntityTypeBuilder = entityTypeBuilder;
+            Name = name;
+        }
+
+        public IConventionEntityTypeBuilder EntityTypeBuilder { get; }
+        public string? Name { get; }
+
+        public override void Run(ConventionDispatcher dispatcher)
+            => dispatcher._immediateConventionScope.OnDiscriminatorPropertySet(EntityTypeBuilder, Name);
     }
 
     private sealed class OnEntityTypeBaseTypeChangedNode : ConventionNode

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -129,6 +129,17 @@ public partial class ConventionDispatcher
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public virtual string? OnDiscriminatorPropertySet(
+        IConventionEntityTypeBuilder entityTypeBuilder,
+        string? name)
+        => _scope.OnDiscriminatorPropertySet(entityTypeBuilder, name);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public virtual IConventionEntityType? OnEntityTypeBaseTypeChanged(
         IConventionEntityTypeBuilder entityTypeBuilder,
         IConventionEntityType? newBaseType,

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2937,10 +2937,16 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     /// </summary>
     public virtual Property? SetDiscriminatorProperty(Property? property, ConfigurationSource configurationSource)
     {
+        if ((string?)this[CoreAnnotationNames.DiscriminatorProperty] == property?.Name)
+        {
+            return property;
+        }
+
         CheckDiscriminatorProperty(property);
 
-        return ((string?)SetAnnotation(CoreAnnotationNames.DiscriminatorProperty, property?.Name, configurationSource)?.Value)
-            == property?.Name
+        SetAnnotation(CoreAnnotationNames.DiscriminatorProperty, property?.Name, configurationSource);
+
+        return Model.ConventionDispatcher.OnDiscriminatorPropertySet(Builder, property?.Name) == property?.Name
                 ? property
                 : (Property?)((IReadOnlyEntityType)this).FindDiscriminatorProperty();
     }

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -4392,13 +4392,17 @@ public class InternalEntityTypeBuilder : InternalTypeBaseBuilder, IConventionEnt
     /// </summary>
     public virtual InternalEntityTypeBuilder? HasNoDiscriminator(ConfigurationSource configurationSource)
     {
-        if (Metadata[CoreAnnotationNames.DiscriminatorProperty] != null
-            && !configurationSource.Overrides(Metadata.GetDiscriminatorPropertyConfigurationSource()))
+        if (Metadata[CoreAnnotationNames.DiscriminatorProperty] == null)
+        {
+            return this;
+        }
+
+        if (!configurationSource.Overrides(Metadata.GetDiscriminatorPropertyConfigurationSource()))
         {
             return null;
         }
 
-        if (Metadata.BaseType == null)
+        if (((IReadOnlyEntityType)Metadata).FindDiscriminatorProperty()?.DeclaringType == Metadata)
         {
             RemoveUnusedDiscriminatorProperty(null, configurationSource);
         }
@@ -4457,7 +4461,7 @@ public class InternalEntityTypeBuilder : InternalTypeBaseBuilder, IConventionEnt
         => ((name == null && discriminatorType == null)
                 || ((name == null || discriminatorProperty?.Name == name)
                     && (discriminatorType == null || discriminatorProperty?.ClrType == discriminatorType))
-                || configurationSource.Overrides(Metadata.GetDiscriminatorPropertyConfigurationSource()))
+                || configurationSource.Overrides(Metadata.GetRootType().GetDiscriminatorPropertyConfigurationSource()))
             && (discriminatorProperty != null
                 || Metadata.GetRootType().Builder.CanAddDiscriminatorProperty(
                     discriminatorType ?? DefaultDiscriminatorType,

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -247,8 +247,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static string CannotBeNullableElement(object? entityType, object? property, object? elementType)
             => string.Format(
-                GetString("CannotBeNullableElement", "entityType", "property", "elementType"),
-                property, entityType);
+                GetString("CannotBeNullableElement", nameof(entityType), nameof(property), nameof(elementType)),
+                entityType, property, elementType);
 
         /// <summary>
         ///     The property '{1_entityType}.{0_property}' cannot be marked as nullable/optional because the property is a part of a key. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of a key can be marked as nullable/optional.
@@ -845,7 +845,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType);
 
         /// <summary>
-        ///     The discriminator value '{value}' for the entity type '{entityType}' because it is not assignable to type '{discriminatorType}'.
+        ///     The discriminator value '{value}' for the entity type '{entityType}' cannot be set because it is not assignable to the discriminator property of type '{discriminatorType}'.
         /// </summary>
         public static string DiscriminatorValueIncompatible(object? value, object? entityType, object? discriminatorType)
             => string.Format(
@@ -2114,14 +2114,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 service);
 
         /// <summary>
-        ///     The property '{entityType}.{property}' cannot be mapped as a collection since it does not implement 'IEnumerable&lt;T&gt;'.
-        /// </summary>
-        public static string NotCollection(object? entityType, object? property)
-            => string.Format(
-                GetString("NotCollection", nameof(entityType), nameof(property)),
-                entityType, property);
-
-        /// <summary>
         ///     The database provider attempted to register an implementation of the '{service}' service. This is a service defined by Entity Framework and as such must not be registered using the 'TryAddProviderSpecificServices' method.
         /// </summary>
         public static string NotAProviderService(object? service)
@@ -2136,6 +2128,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("NotAssignableClrBaseType", nameof(entityType), nameof(baseEntityType), nameof(clrType), nameof(baseClrType)),
                 entityType, baseEntityType, clrType, baseClrType);
+
+        /// <summary>
+        ///     The property '{entityType}.{property}' cannot be mapped as a collection since it does not implement 'IEnumerable&lt;T&gt;'.
+        /// </summary>
+        public static string NotCollection(object? entityType, object? property)
+            => string.Format(
+                GetString("NotCollection", nameof(entityType), nameof(property)),
+                entityType, property);
 
         /// <summary>
         ///     The given 'IQueryable' does not support generation of query strings.
@@ -4867,31 +4867,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     A string value was read from JSON for enum '{enumType}'. Starting with EF Core 8, a breaking change was made to store enum values in JSON as numbers by default. See https://aka.ms/efcore-docs-jsonenums for details.
-        /// </summary>
-        public static EventDefinition<string> LogStringEnumValueInJson(IDiagnosticsLogger logger)
-        {
-            var definition = ((LoggingDefinitions)logger.Definitions).LogStringEnumValueInJson;
-            if (definition == null)
-            {
-                definition = NonCapturingLazyInitializer.EnsureInitialized(
-                    ref ((LoggingDefinitions)logger.Definitions).LogStringEnumValueInJson,
-                    logger,
-                    static logger => new EventDefinition<string>(
-                        logger.Options,
-                        CoreEventId.StringEnumValueInJson,
-                        LogLevel.Warning,
-                        "CoreEventId.StringEnumValueInJson",
-                        level => LoggerMessage.Define<string>(
-                            level,
-                            CoreEventId.StringEnumValueInJson,
-                            _resourceManager.GetString("LogStringEnumValueInJson")!)));
-            }
-
-            return (EventDefinition<string>)definition;
-        }
-
-        /// <summary>
         ///     Context '{contextType}' started tracking '{entityType}' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
         /// </summary>
         public static EventDefinition<string, string> LogStartedTracking(IDiagnosticsLogger logger)
@@ -4989,6 +4964,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             }
 
             return (EventDefinition<string, string, string, EntityState, EntityState>)definition;
+        }
+
+        /// <summary>
+        ///     A string value was read from JSON for enum '{enumType}'. Starting with EF Core 8, a breaking change was made to store enum values in JSON as numbers by default. See https://aka.ms/efcore-docs-jsonenums for details.
+        /// </summary>
+        public static EventDefinition<string> LogStringEnumValueInJson(IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogStringEnumValueInJson;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((LoggingDefinitions)logger.Definitions).LogStringEnumValueInJson,
+                    logger,
+                    static logger => new EventDefinition<string>(
+                        logger.Options,
+                        CoreEventId.StringEnumValueInJson,
+                        LogLevel.Warning,
+                        "CoreEventId.StringEnumValueInJson",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            CoreEventId.StringEnumValueInJson,
+                            _resourceManager.GetString("LogStringEnumValueInJson")!)));
+            }
+
+            return (EventDefinition<string>)definition;
         }
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -430,7 +430,7 @@
     <value>Unable to set property '{property}' as a discriminator for entity type '{entityType}' because it is not a property of '{entityType}'.</value>
   </data>
   <data name="DiscriminatorValueIncompatible" xml:space="preserve">
-    <value>The discriminator value '{value}' for the entity type '{entityType}' because it is not assignable to type '{discriminatorType}'.</value>
+    <value>The discriminator value '{value}' for the entity type '{entityType}' cannot be set because it is not assignable to the discriminator property of type '{discriminatorType}'.</value>
   </data>
   <data name="DuplicateAnnotation" xml:space="preserve">
     <value>The annotation '{annotation}' cannot be added because an annotation with the same name already exists on the object {annotatable}</value>
@@ -1033,10 +1033,6 @@
     <value>{addedCount} entities were added and {removedCount} entities were removed from skip navigation '{entityType}.{property}' on entity with key '{keyValues}'.</value>
     <comment>Debug CoreEventId.SkipCollectionChangeDetected int int string string string</comment>
   </data>
-  <data name="LogStringEnumValueInJson" xml:space="preserve">
-    <value>A string value was read from JSON for enum '{enumType}'. Starting with EF Core 8, a breaking change was made to store enum values in JSON as numbers by default. See https://aka.ms/efcore-docs-jsonenums for details.</value>
-    <comment>Warning CoreEventId.StringEnumValueInJson</comment>
-  </data>
   <data name="LogStartedTracking" xml:space="preserve">
     <value>Context '{contextType}' started tracking '{entityType}' entity. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
     <comment>Debug CoreEventId.StartedTracking string string</comment>
@@ -1052,6 +1048,10 @@
   <data name="LogStateChangedSensitive" xml:space="preserve">
     <value>The '{entityType}' entity with key '{keyValues}' tracked by '{contextType}' changed state from '{oldState}' to '{newState}'.</value>
     <comment>Debug CoreEventId.StateChanged string string string EntityState EntityState</comment>
+  </data>
+  <data name="LogStringEnumValueInJson" xml:space="preserve">
+    <value>A string value was read from JSON for enum '{enumType}'. Starting with EF Core 8, a breaking change was made to store enum values in JSON as numbers by default. See https://aka.ms/efcore-docs-jsonenums for details.</value>
+    <comment>Warning CoreEventId.StringEnumValueInJson string</comment>
   </data>
   <data name="LogTempValueGenerated" xml:space="preserve">
     <value>'{contextType}' generated a temporary value for the property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
@@ -1228,14 +1228,14 @@
   <data name="NotAnEFService" xml:space="preserve">
     <value>The database provider attempted to register an implementation of the '{service}' service. This is not a service defined by Entity Framework and as such must be registered as a provider-specific service using the 'TryAddProviderSpecificServices' method.</value>
   </data>
-  <data name="NotCollection" xml:space="preserve">
-    <value>The property '{entityType}.{property}' cannot be mapped as a collection since it does not implement 'IEnumerable&lt;T&gt;'.</value>
-  </data>
   <data name="NotAProviderService" xml:space="preserve">
     <value>The database provider attempted to register an implementation of the '{service}' service. This is a service defined by Entity Framework and as such must not be registered using the 'TryAddProviderSpecificServices' method.</value>
   </data>
   <data name="NotAssignableClrBaseType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{clrType}' is not a descendant of '{baseClrType}'.</value>
+  </data>
+  <data name="NotCollection" xml:space="preserve">
+    <value>The property '{entityType}.{property}' cannot be mapped as a collection since it does not implement 'IEnumerable&lt;T&gt;'.</value>
   </data>
   <data name="NotQueryingEnumerable" xml:space="preserve">
     <value>The given 'IQueryable' does not support generation of query strings.</value>

--- a/test/EFCore.Tests/Metadata/Conventions/DiscriminatorConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/DiscriminatorConventionTest.cs
@@ -126,7 +126,7 @@ public class DiscriminatorConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
 
-        new EntityTypeBuilder(entityTypeBuilder.Metadata).HasDiscriminator("T", typeof(string));
+        new EntityTypeBuilder(entityTypeBuilder.Metadata).HasDiscriminator("T", typeof(int));
 
         var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Convention);
         entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.Convention);

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -23,6 +23,7 @@ public partial class EntityTypeTest
         var model = CreateModel();
 
         var entityTypeA = model.AddEntityType(typeof(A));
+        ((EntityType)entityTypeA).Builder.HasDiscriminator(ConfigurationSource.Explicit);
 
         model.FinalizeModel();
 

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -65,6 +65,19 @@ public abstract partial class ModelBuilderTest
         }
 
         [ConditionalFact]
+        public virtual void Can_specify_discriminator_without_derived_types()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<Q>()
+                .HasDiscriminator<string>("Discriminator");
+
+            var model = modelBuilder.FinalizeModel();
+
+            Assert.Equal("Q", model.FindEntityType(typeof(Q)).GetDiscriminatorValue());
+        }
+
+        [ConditionalFact]
         public virtual void Can_specify_discriminator_values_first()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fixes #31404

**Description**

We set the discriminator values only when there is more than one entity type in the hierarchy.

**Customer impact**

If the user explicitly adds a discriminator property but does not configure a value EF will produce an invalid model.

**How found**

Customer report on 8.0.0-preview.6

**Regression**

Yes, from 7.0

**Testing**

Added regression tests for affected scenario.

**Risk**

Small: Except for this case this area has good test coverage.