### PR TITLE
[release/8.0] Fix to #30589 - Query/Json: improve JSON entity/collection comparisons to null (fails currently for optional dependent with all nullable properties)

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1755,6 +1755,23 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             {
                 var nonNullEntityReference = (IsNullSqlConstantExpression(left) ? rightReference : leftReference)!;
                 var nullComparedEntityType = (IEntityType)nonNullEntityReference.StructuralType;
+
+                if (nonNullEntityReference is { Parameter.ValueBufferExpression: JsonQueryExpression jsonQueryExpression })
+                {
+                    var jsonScalarExpression = new JsonScalarExpression(
+                        jsonQueryExpression.JsonColumn,
+                        jsonQueryExpression.Path,
+                        jsonQueryExpression.JsonColumn.Type,
+                        jsonQueryExpression.JsonColumn.TypeMapping!,
+                        jsonQueryExpression.IsNullable);
+
+                    result = nodeType == ExpressionType.Equal
+                        ? _sqlExpressionFactory.IsNull(jsonScalarExpression)
+                        : _sqlExpressionFactory.IsNotNull(jsonScalarExpression);
+
+                    return true;
+                }
+
                 var nullComparedEntityTypePrimaryKeyProperties = nullComparedEntityType.FindPrimaryKey()?.Properties;
                 if (nullComparedEntityTypePrimaryKeyProperties == null)
                 {

--- a/test/EFCore.Relational.Specification.Tests/Query/OptionalDependentQueryFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OptionalDependentQueryFixtureBase.cs
@@ -70,14 +70,14 @@ public abstract class OptionalDependentQueryFixtureBase : SharedStoreFixtureBase
         Assert.Equal(expected.OpProp1, actual.OpProp1);
         Assert.Equal(expected.OpProp2, actual.OpProp2);
 
-        if (expected.OpNested1 is not null || actual.OpNested1 is not null)
+        if (expected.OpNav1 is not null || actual.OpNav1 is not null)
         {
-            AssertOptionalDependentNestedJsonAllOptional(expected.OpNested1, actual.OpNested1);
+            AssertOptionalDependentNestedJsonAllOptional(expected.OpNav1, actual.OpNav1);
         }
 
-        if (expected.OpNested2 is not null || actual.OpNested2 is not null)
+        if (expected.OpNav2 is not null || actual.OpNav2 is not null)
         {
-            AssertOptionalDependentNestedJsonSomeRequired(expected.OpNested2, actual.OpNested2);
+            AssertOptionalDependentNestedJsonSomeRequired(expected.OpNav2, actual.OpNav2);
         }
     }
 
@@ -90,18 +90,18 @@ public abstract class OptionalDependentQueryFixtureBase : SharedStoreFixtureBase
         Assert.Equal(expected.ReqProp, actual.ReqProp);
 
 
-        if (expected.OpNested1 is not null || actual.OpNested1 is not null)
+        if (expected.OpNav1 is not null || actual.OpNav1 is not null)
         {
-            AssertOptionalDependentNestedJsonAllOptional(expected.OpNested1, actual.OpNested1);
+            AssertOptionalDependentNestedJsonAllOptional(expected.OpNav1, actual.OpNav1);
         }
 
-        if (expected.OpNested2 is not null || actual.OpNested2 is not null)
+        if (expected.OpNav2 is not null || actual.OpNav2 is not null)
         {
-            AssertOptionalDependentNestedJsonSomeRequired(expected.OpNested2, actual.OpNested2);
+            AssertOptionalDependentNestedJsonSomeRequired(expected.OpNav2, actual.OpNav2);
         }
 
-        AssertOptionalDependentNestedJsonAllOptional(expected.ReqNested1, actual.ReqNested1);
-        AssertOptionalDependentNestedJsonSomeRequired(expected.ReqNested2, actual.ReqNested2);
+        AssertOptionalDependentNestedJsonAllOptional(expected.ReqNav1, actual.ReqNav1);
+        AssertOptionalDependentNestedJsonSomeRequired(expected.ReqNav2, actual.ReqNav2);
     }
 
     public static void AssertOptionalDependentNestedJsonAllOptional(
@@ -143,8 +143,8 @@ public abstract class OptionalDependentQueryFixtureBase : SharedStoreFixtureBase
             {
                 b.ToJson();
 
-                b.OwnsOne(x => x.OpNested1);
-                b.OwnsOne(x => x.OpNested2);
+                b.OwnsOne(x => x.OpNav1);
+                b.OwnsOne(x => x.OpNav2);
             });
 
         modelBuilder.Entity<OptionalDependentEntitySomeRequired>().OwnsOne(
@@ -152,13 +152,13 @@ public abstract class OptionalDependentQueryFixtureBase : SharedStoreFixtureBase
             {
                 b.ToJson();
 
-                b.OwnsOne(x => x.OpNested1);
-                b.OwnsOne(x => x.OpNested2);
+                b.OwnsOne(x => x.OpNav1);
+                b.OwnsOne(x => x.OpNav2);
 
-                b.OwnsOne(x => x.ReqNested1);
-                b.Navigation(x => x.ReqNested1).IsRequired();
-                b.OwnsOne(x => x.ReqNested2);
-                b.Navigation(x => x.ReqNested2).IsRequired();
+                b.OwnsOne(x => x.ReqNav1);
+                b.Navigation(x => x.ReqNav1).IsRequired();
+                b.OwnsOne(x => x.ReqNav2);
+                b.Navigation(x => x.ReqNav2).IsRequired();
             });
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/OptionalDependentQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OptionalDependentQueryTestBase.cs
@@ -19,7 +19,7 @@ public abstract class OptionalDependentQueryTestBase<TFixture> : QueryTestBase<T
         => AssertQuery(
             async,
             ss => ss.Set<OptionalDependentEntityAllOptional>(),
-            entryCount: 35);
+            entryCount: 36);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -27,17 +27,17 @@ public abstract class OptionalDependentQueryTestBase<TFixture> : QueryTestBase<T
         => AssertQuery(
             async,
             ss => ss.Set<OptionalDependentEntitySomeRequired>(),
-            entryCount: 59);
+            entryCount: 60);
 
-    [ConditionalTheory(Skip = "issue #30589")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Filter_optional_dependent_with_all_optional_compared_to_null(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<OptionalDependentEntityAllOptional>().Where(x => x.Json == null),
-            entryCount: 35);
+            entryCount: 1);
 
-    [ConditionalTheory(Skip = "issue #30589")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Filter_optional_dependent_with_all_optional_compared_to_not_null(bool async)
         => AssertQuery(
@@ -51,7 +51,7 @@ public abstract class OptionalDependentQueryTestBase<TFixture> : QueryTestBase<T
         => AssertQuery(
             async,
             ss => ss.Set<OptionalDependentEntitySomeRequired>().Where(x => x.Json == null),
-            entryCount: 0);
+            entryCount: 1);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -61,35 +61,35 @@ public abstract class OptionalDependentQueryTestBase<TFixture> : QueryTestBase<T
             ss => ss.Set<OptionalDependentEntitySomeRequired>().Where(x => x.Json != null),
             entryCount: 59);
 
-    [ConditionalTheory(Skip = "issue #30589")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Filter_nested_optional_dependent_with_all_optional_compared_to_null(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OptionalDependentEntityAllOptional>().Where(x => x.Json.OpNested1 == null),
-            entryCount: 59);
+            ss => ss.Set<OptionalDependentEntityAllOptional>().Where(x => x.Json.OpNav1 == null),
+            entryCount: 10);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Filter_nested_optional_dependent_with_all_optional_compared_to_not_null(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OptionalDependentEntityAllOptional>().Where(x => x.Json.OpNested2 != null),
+            ss => ss.Set<OptionalDependentEntityAllOptional>().Where(x => x.Json.OpNav2 != null),
             entryCount: 23);
 
-    [ConditionalTheory(Skip = "issue #30589")]
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Filter_nested_optional_dependent_with_some_required_compared_to_null(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OptionalDependentEntitySomeRequired>().Where(x => x.Json.ReqNested1 == null),
-            entryCount: 59);
+            ss => ss.Set<OptionalDependentEntitySomeRequired>().Where(x => x.Json.ReqNav1 == null),
+            entryCount: 1);
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Filter_nested_optional_dependent_with_some_required_compared_to_not_null(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OptionalDependentEntitySomeRequired>().Where(x => x.Json.ReqNested2 != null),
+            ss => ss.Set<OptionalDependentEntitySomeRequired>().Where(x => x.Json.ReqNav2 != null),
             entryCount: 59);
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/OptionalDependent/OptionalDependentData.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/OptionalDependent/OptionalDependentData.cs
@@ -24,8 +24,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "1",
                 OpProp2 = 1,
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "11", OpNested2 = 11 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2001, 1, 1), OpNested1 = "1001", OpNested2 = 1001 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "11", OpNested2 = 11 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2001, 1, 1), OpNested1 = "1001", OpNested2 = 1001 }
             }
         };
 
@@ -37,8 +37,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "2",
                 OpProp2 = 2,
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 21 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2002, 1, 1), OpNested1 = "2001", OpNested2 = 2001 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 21 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2002, 1, 1), OpNested1 = "2001", OpNested2 = 2001 }
             }
         };
 
@@ -50,8 +50,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "3",
                 OpProp2 = 3,
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2003, 1, 1), OpNested1 = "3001", OpNested2 = 3001 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2003, 1, 1), OpNested1 = "3001", OpNested2 = 3001 }
             }
         };
 
@@ -63,8 +63,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "4",
                 OpProp2 = 4,
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 41 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2004, 1, 1), OpNested1 = null, OpNested2 = 4001 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 41 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2004, 1, 1), OpNested1 = null, OpNested2 = 4001 }
             }
         };
 
@@ -76,8 +76,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "5",
                 OpProp2 = 5,
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 51 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2005, 1, 1), OpNested1 = null, OpNested2 = null }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 51 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2005, 1, 1), OpNested1 = null, OpNested2 = null }
             }
         };
 
@@ -89,8 +89,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "6",
                 OpProp2 = 6,
-                OpNested1 = null,
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2005, 1, 1), OpNested1 = null, OpNested2 = 6001 }
+                OpNav1 = null,
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(2005, 1, 1), OpNested1 = null, OpNested2 = 6001 }
             }
         };
 
@@ -102,8 +102,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "7",
                 OpProp2 = 7,
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 71 },
-                OpNested2 = null
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 71 },
+                OpNav2 = null
             }
         };
 
@@ -115,8 +115,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "8",
                 OpProp2 = 8,
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
-                OpNested2 = null
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
+                OpNav2 = null
             }
         };
 
@@ -128,8 +128,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "9",
                 OpProp2 = 9,
-                OpNested1 = null,
-                OpNested2 = null
+                OpNav1 = null,
+                OpNav2 = null
             }
         };
 
@@ -141,8 +141,8 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = "10",
                 OpProp2 = null,
-                OpNested1 = null,
-                OpNested2 = null
+                OpNav1 = null,
+                OpNav2 = null
             }
         };
 
@@ -154,12 +154,19 @@ public class OptionalDependentData : ISetSource
             {
                 OpProp1 = null,
                 OpProp2 = null,
-                OpNested1 = null,
-                OpNested2 = null
+                OpNav1 = null,
+                OpNav2 = null
             }
         };
 
-        return new List<OptionalDependentEntityAllOptional> { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11 };
+        var e12 = new OptionalDependentEntityAllOptional
+        {
+            Id = 12,
+            Name = "op_e12",
+            Json = null
+        };
+
+        return new List<OptionalDependentEntityAllOptional> { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 };
     }
 
     public static IReadOnlyList<OptionalDependentEntitySomeRequired> CreateEntitiesSomeRequired()
@@ -174,11 +181,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "1",
                 OpProp2 = 1,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "11", OpNested2 = 11 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4001, 1, 1), OpNested1 = "12", OpNested2 = 12 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "11", OpNested2 = 11 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4001, 1, 1), OpNested1 = "12", OpNested2 = 12 },
 
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "13", OpNested2 = 13 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5001, 1, 1), OpNested1 = "14", OpNested2 = 14 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "13", OpNested2 = 13 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5001, 1, 1), OpNested1 = "14", OpNested2 = 14 }
             }
         };
 
@@ -192,11 +199,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "2",
                 OpProp2 = 2,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 21 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4002, 1, 1), OpNested1 = "22", OpNested2 = 22 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = 21 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4002, 1, 1), OpNested1 = "22", OpNested2 = 22 },
 
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "23", OpNested2 = 23 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5002, 1, 1), OpNested1 = "24", OpNested2 = 24 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "23", OpNested2 = 23 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5002, 1, 1), OpNested1 = "24", OpNested2 = 24 }
             }
         };
 
@@ -210,11 +217,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "3",
                 OpProp2 = 3,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4003, 1, 1), OpNested1 = "32", OpNested2 = 32 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4003, 1, 1), OpNested1 = "32", OpNested2 = 32 },
 
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "33", OpNested2 = 33 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5003, 1, 1), OpNested1 = "34", OpNested2 = 34 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "33", OpNested2 = 33 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5003, 1, 1), OpNested1 = "34", OpNested2 = 34 }
             }
         };
 
@@ -228,11 +235,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "4",
                 OpProp2 = 4,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "41", OpNested2 = 41 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4004, 1, 1), OpNested1 = null, OpNested2 = null },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "41", OpNested2 = 41 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4004, 1, 1), OpNested1 = null, OpNested2 = null },
 
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "43", OpNested2 = 43 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5004, 1, 1), OpNested1 = "44", OpNested2 = 44 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "43", OpNested2 = 43 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5004, 1, 1), OpNested1 = "44", OpNested2 = 44 }
             }
         };
 
@@ -246,11 +253,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "5",
                 OpProp2 = 5,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "51", OpNested2 = 51 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4005, 1, 1), OpNested1 = "52", OpNested2 = 52 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "51", OpNested2 = 51 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4005, 1, 1), OpNested1 = "52", OpNested2 = 52 },
 
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5005, 1, 1), OpNested1 = "54", OpNested2 = 54 }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5005, 1, 1), OpNested1 = "54", OpNested2 = 54 }
             }
         };
 
@@ -264,11 +271,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "6",
                 OpProp2 = 6,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "61", OpNested2 = 61 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4006, 1, 1), OpNested1 = "62", OpNested2 = 62 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "61", OpNested2 = 61 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4006, 1, 1), OpNested1 = "62", OpNested2 = 62 },
 
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "63", OpNested2 = 63 },
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5006, 1, 1), OpNested1 = null, OpNested2 = null }
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "63", OpNested2 = 63 },
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5006, 1, 1), OpNested1 = null, OpNested2 = null }
             }
         };
 
@@ -282,11 +289,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "7",
                 OpProp2 = 7,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "71", OpNested2 = 71 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4007, 1, 1), OpNested1 = "72", OpNested2 = 72 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "71", OpNested2 = 71 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4007, 1, 1), OpNested1 = "72", OpNested2 = 72 },
 
-                OpNested1 = null,
-                OpNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5007, 1, 1), OpNested1 = "74", OpNested2 = 74 }
+                OpNav1 = null,
+                OpNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = false, ReqNested2 = new DateTime(5007, 1, 1), OpNested1 = "74", OpNested2 = 74 }
             }
         };
 
@@ -300,11 +307,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "8",
                 OpProp2 = 8,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "81", OpNested2 = 81 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4008, 1, 1), OpNested1 = "82", OpNested2 = 82 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "81", OpNested2 = 81 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4008, 1, 1), OpNested1 = "82", OpNested2 = 82 },
 
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "83", OpNested2 = 83 },
-                OpNested2 = null
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "83", OpNested2 = 83 },
+                OpNav2 = null
             }
         };
 
@@ -318,11 +325,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "9",
                 OpProp2 = 9,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "91", OpNested2 = 91 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4009, 1, 1), OpNested1 = "92", OpNested2 = 92 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "91", OpNested2 = 91 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4009, 1, 1), OpNested1 = "92", OpNested2 = 92 },
 
-                OpNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
-                OpNested2 = null
+                OpNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = null, OpNested2 = null },
+                OpNav2 = null
             }
         };
 
@@ -336,11 +343,11 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = "10",
                 OpProp2 = 10,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "101", OpNested2 = 101 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4010, 1, 1), OpNested1 = "102", OpNested2 = 102 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "101", OpNested2 = 101 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4010, 1, 1), OpNested1 = "102", OpNested2 = 102 },
 
-                OpNested1 = null,
-                OpNested2 = null
+                OpNav1 = null,
+                OpNav2 = null
             }
         };
 
@@ -354,15 +361,22 @@ public class OptionalDependentData : ISetSource
                 OpProp1 = null,
                 OpProp2 = null,
 
-                ReqNested1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "111", OpNested2 = 111 },
-                ReqNested2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4011, 1, 1), OpNested1 = "112", OpNested2 = 112 },
+                ReqNav1 = new OptionalDependentNestedJsonAllOptional { OpNested1 = "111", OpNested2 = 111 },
+                ReqNav2 = new OptionalDependentNestedJsonSomeRequired { ReqNested1 = true, ReqNested2 = new DateTime(4011, 1, 1), OpNested1 = "112", OpNested2 = 112 },
 
-                OpNested1 = null,
-                OpNested2 = null
+                OpNav1 = null,
+                OpNav2 = null
             }
         };
 
-        return new List<OptionalDependentEntitySomeRequired> { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11 };
+        var e12 = new OptionalDependentEntitySomeRequired
+        {
+            Id = 12,
+            Name = "req_e12",
+            Json = null
+        };
+
+        return new List<OptionalDependentEntitySomeRequired> { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12 };
     }
 
     public IQueryable<TEntity> Set<TEntity>()

--- a/test/EFCore.Relational.Specification.Tests/TestModels/OptionalDependent/OptionalDependentJsonAllOptional.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/OptionalDependent/OptionalDependentJsonAllOptional.cs
@@ -8,6 +8,6 @@ public class OptionalDependentJsonAllOptional
     public string OpProp1 { get; set; }
     public int? OpProp2 { get; set; }
 
-    public OptionalDependentNestedJsonAllOptional OpNested1 { get; set; }
-    public OptionalDependentNestedJsonSomeRequired OpNested2 { get; set; }
+    public OptionalDependentNestedJsonAllOptional OpNav1 { get; set; }
+    public OptionalDependentNestedJsonSomeRequired OpNav2 { get; set; }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/OptionalDependent/OptionalDependentJsonSomeRequired.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/OptionalDependent/OptionalDependentJsonSomeRequired.cs
@@ -10,9 +10,9 @@ public class OptionalDependentJsonSomeRequired
 
     public double ReqProp { get; set; }
 
-    public OptionalDependentNestedJsonAllOptional OpNested1 { get; set; }
-    public OptionalDependentNestedJsonSomeRequired OpNested2 { get; set; }
+    public OptionalDependentNestedJsonAllOptional OpNav1 { get; set; }
+    public OptionalDependentNestedJsonSomeRequired OpNav2 { get; set; }
 
-    public OptionalDependentNestedJsonAllOptional ReqNested1 { get; set; }
-    public OptionalDependentNestedJsonSomeRequired ReqNested2 { get; set; }
+    public OptionalDependentNestedJsonAllOptional ReqNav1 { get; set; }
+    public OptionalDependentNestedJsonSomeRequired ReqNav2 { get; set; }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OptionalDependentQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OptionalDependentQuerySqlServerTest.cs
@@ -37,14 +37,24 @@ FROM [EntitiesSomeRequired] AS [e]
     {
         await base.Filter_optional_dependent_with_all_optional_compared_to_null(async);
 
-        AssertSql("");
+        AssertSql(
+"""
+SELECT [e].[Id], [e].[Name], [e].[Json]
+FROM [EntitiesAllOptional] AS [e]
+WHERE [e].[Json] IS NULL
+""");
     }
 
     public override async Task Filter_optional_dependent_with_all_optional_compared_to_not_null(bool async)
     {
         await base.Filter_optional_dependent_with_all_optional_compared_to_not_null(async);
 
-        AssertSql("");
+        AssertSql(
+"""
+SELECT [e].[Id], [e].[Name], [e].[Json]
+FROM [EntitiesAllOptional] AS [e]
+WHERE [e].[Json] IS NOT NULL
+""");
     }
 
     public override async Task Filter_optional_dependent_with_some_required_compared_to_null(bool async)
@@ -55,7 +65,7 @@ FROM [EntitiesSomeRequired] AS [e]
 """
 SELECT [e].[Id], [e].[Name], [e].[Json]
 FROM [EntitiesSomeRequired] AS [e]
-WHERE CAST(JSON_VALUE([e].[Json], '$.ReqProp') AS float) IS NULL
+WHERE [e].[Json] IS NULL
 """);
     }
 
@@ -67,7 +77,7 @@ WHERE CAST(JSON_VALUE([e].[Json], '$.ReqProp') AS float) IS NULL
 """
 SELECT [e].[Id], [e].[Name], [e].[Json]
 FROM [EntitiesSomeRequired] AS [e]
-WHERE CAST(JSON_VALUE([e].[Json], '$.ReqProp') AS float) IS NOT NULL
+WHERE [e].[Json] IS NOT NULL
 """);
     }
 
@@ -75,7 +85,12 @@ WHERE CAST(JSON_VALUE([e].[Json], '$.ReqProp') AS float) IS NOT NULL
     {
         await base.Filter_nested_optional_dependent_with_all_optional_compared_to_null(async);
 
-        AssertSql("");
+        AssertSql(
+"""
+SELECT [e].[Id], [e].[Name], [e].[Json]
+FROM [EntitiesAllOptional] AS [e]
+WHERE JSON_QUERY([e].[Json], '$.OpNav1') IS NULL
+""");
     }
 
     public override async Task Filter_nested_optional_dependent_with_all_optional_compared_to_not_null(bool async)
@@ -86,7 +101,7 @@ WHERE CAST(JSON_VALUE([e].[Json], '$.ReqProp') AS float) IS NOT NULL
 """
 SELECT [e].[Id], [e].[Name], [e].[Json]
 FROM [EntitiesAllOptional] AS [e]
-WHERE CAST(JSON_VALUE([e].[Json], '$.OpNested2.ReqNested1') AS bit) IS NOT NULL AND CAST(JSON_VALUE([e].[Json], '$.OpNested2.ReqNested2') AS datetime2) IS NOT NULL
+WHERE JSON_QUERY([e].[Json], '$.OpNav2') IS NOT NULL
 """);
     }
 
@@ -94,7 +109,12 @@ WHERE CAST(JSON_VALUE([e].[Json], '$.OpNested2.ReqNested1') AS bit) IS NOT NULL 
     {
         await base.Filter_nested_optional_dependent_with_some_required_compared_to_null(async);
 
-        AssertSql("");
+        AssertSql(
+"""
+SELECT [e].[Id], [e].[Name], [e].[Json]
+FROM [EntitiesSomeRequired] AS [e]
+WHERE JSON_QUERY([e].[Json], '$.ReqNav1') IS NULL
+""");
     }
 
     public override async Task Filter_nested_optional_dependent_with_some_required_compared_to_not_null(bool async)
@@ -105,7 +125,7 @@ WHERE CAST(JSON_VALUE([e].[Json], '$.OpNested2.ReqNested1') AS bit) IS NOT NULL 
 """
 SELECT [e].[Id], [e].[Name], [e].[Json]
 FROM [EntitiesSomeRequired] AS [e]
-WHERE CAST(JSON_VALUE([e].[Json], '$.ReqNested2.ReqNested1') AS bit) IS NOT NULL AND CAST(JSON_VALUE([e].[Json], '$.ReqNested2.ReqNested2') AS datetime2) IS NOT NULL
+WHERE JSON_QUERY([e].[Json], '$.ReqNav2') IS NOT NULL
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OptionalDependentQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OptionalDependentQuerySqliteTest.cs
@@ -38,14 +38,24 @@ FROM "EntitiesSomeRequired" AS "e"
     {
         await base.Filter_optional_dependent_with_all_optional_compared_to_null(async);
 
-        AssertSql("");
+        AssertSql(
+"""
+SELECT "e"."Id", "e"."Name", "e"."Json"
+FROM "EntitiesAllOptional" AS "e"
+WHERE "e"."Json" IS NULL
+""");
     }
 
     public override async Task Filter_optional_dependent_with_all_optional_compared_to_not_null(bool async)
     {
         await base.Filter_optional_dependent_with_all_optional_compared_to_not_null(async);
 
-        AssertSql("");
+        AssertSql(
+"""
+SELECT "e"."Id", "e"."Name", "e"."Json"
+FROM "EntitiesAllOptional" AS "e"
+WHERE "e"."Json" IS NOT NULL
+""");
     }
 
     public override async Task Filter_optional_dependent_with_some_required_compared_to_null(bool async)
@@ -56,7 +66,7 @@ FROM "EntitiesSomeRequired" AS "e"
 """
 SELECT "e"."Id", "e"."Name", "e"."Json"
 FROM "EntitiesSomeRequired" AS "e"
-WHERE "e"."Json" ->> 'ReqProp' IS NULL
+WHERE "e"."Json" IS NULL
 """);
     }
 
@@ -68,7 +78,7 @@ WHERE "e"."Json" ->> 'ReqProp' IS NULL
 """
 SELECT "e"."Id", "e"."Name", "e"."Json"
 FROM "EntitiesSomeRequired" AS "e"
-WHERE "e"."Json" ->> 'ReqProp' IS NOT NULL
+WHERE "e"."Json" IS NOT NULL
 """);
     }
 
@@ -76,7 +86,12 @@ WHERE "e"."Json" ->> 'ReqProp' IS NOT NULL
     {
         await base.Filter_nested_optional_dependent_with_all_optional_compared_to_null(async);
 
-        AssertSql("");
+        AssertSql(
+"""
+SELECT "e"."Id", "e"."Name", "e"."Json"
+FROM "EntitiesAllOptional" AS "e"
+WHERE "e"."Json" ->> 'OpNav1' IS NULL
+""");
     }
 
     public override async Task Filter_nested_optional_dependent_with_all_optional_compared_to_not_null(bool async)
@@ -87,7 +102,7 @@ WHERE "e"."Json" ->> 'ReqProp' IS NOT NULL
 """
 SELECT "e"."Id", "e"."Name", "e"."Json"
 FROM "EntitiesAllOptional" AS "e"
-WHERE "e"."Json" ->> '$.OpNested2.ReqNested1' IS NOT NULL AND "e"."Json" ->> '$.OpNested2.ReqNested2' IS NOT NULL
+WHERE "e"."Json" ->> 'OpNav2' IS NOT NULL
 """);
     }
 
@@ -95,7 +110,12 @@ WHERE "e"."Json" ->> '$.OpNested2.ReqNested1' IS NOT NULL AND "e"."Json" ->> '$.
     {
         await base.Filter_nested_optional_dependent_with_some_required_compared_to_null(async);
 
-        AssertSql("");
+        AssertSql(
+"""
+SELECT "e"."Id", "e"."Name", "e"."Json"
+FROM "EntitiesSomeRequired" AS "e"
+WHERE "e"."Json" ->> 'ReqNav1' IS NULL
+""");
     }
 
     public override async Task Filter_nested_optional_dependent_with_some_required_compared_to_not_null(bool async)
@@ -106,7 +126,7 @@ WHERE "e"."Json" ->> '$.OpNested2.ReqNested1' IS NOT NULL AND "e"."Json" ->> '$.
 """
 SELECT "e"."Id", "e"."Name", "e"."Json"
 FROM "EntitiesSomeRequired" AS "e"
-WHERE "e"."Json" ->> '$.ReqNested2.ReqNested1' IS NOT NULL AND "e"."Json" ->> '$.ReqNested2.ReqNested2' IS NOT NULL
+WHERE "e"."Json" ->> 'ReqNav2' IS NOT NULL
 """);
     }
 


### PR DESCRIPTION
Fixes #30589

**Description**

Handling of optional dependent json entity was incorrect. We were using the same logic as for regular entities, however in case of JSON we don't have the same issues. We can simply compare the json column to null, or navigate to appropriate json property inside the column and compare that to null. Additionally, this should give exactly the same results as LINQ to objects - we don't have the problem where we can't distinguish null entity from entity with all values being null, if they are all optional.

**Customer impact**

Translation error for optional dependent JSON entities being compared to null, if all the properties are nullable. Inefficient sql generated when there are some non-nullable properties.

**How found**

Customer report on 7.0

**Regression**

No. JSON has been added in 7.0

**Testing**

Added regression tests for affected scenarios.

**Risk**

Very low: Fix is isolated to only affect scenarios where we compare JSON entity to null, and it is very simple - just compare the JSON column or appropriate JSON_QUERY to null. Before we would apply the same logic as for regular entities (looking at individual columns), which was much more complicated (on top of not being 100% correct)


