### PR TITLE
[release/8.0] Handle more types of value converters in the compiled model

### DIFF
--- a/src/EFCore/Storage/ValueConversion/BoolToTwoValuesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/BoolToTwoValuesConverter.cs
@@ -43,10 +43,11 @@ public class BoolToTwoValuesConverter<TProvider> : ValueConverter<bool, TProvide
     {
         var param = Expression.Parameter(typeof(bool), "v");
         return Expression.Lambda<Func<bool, TProvider>>(
-            Expression.Condition(
-                param,
-                Expression.Constant(trueValue, typeof(TProvider)),
-                Expression.Constant(falseValue, typeof(TProvider))),
+            Expression.Convert(
+                Expression.Condition(
+                    param,
+                    Expression.Constant(trueValue, typeof(TProvider)),
+                    Expression.Constant(falseValue, typeof(TProvider))), typeof(TProvider)),
             param);
     }
 

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBinaryConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBinaryConverter.cs
@@ -35,13 +35,33 @@ public class DateTimeOffsetToBinaryConverter : ValueConverter<DateTimeOffset, lo
     /// </param>
     public DateTimeOffsetToBinaryConverter(ConverterMappingHints? mappingHints)
         : base(
-            v => ((v.Ticks / 1000) << 11) | ((long)v.Offset.TotalMinutes & 0x7FF),
-            v => new DateTimeOffset(
-                new DateTime((v >> 11) * 1000),
-                new TimeSpan(0, (int)((v << 53) >> 53), 0)),
+            v => ToLong(v),
+            v => ToDateTimeOffset(v),
             mappingHints)
     {
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static DateTimeOffset ToDateTimeOffset(long v)
+        => new(
+            new DateTime((v >> 11) * 1000),
+            new TimeSpan(0, (int)((v << 53) >> 53), 0));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static long ToLong(DateTimeOffset v)
+        => ((v.Ticks / 1000) << 11) | ((long)v.Offset.TotalMinutes & 0x7FF);
 
     /// <summary>
     ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToBytesConverter.cs
@@ -50,14 +50,28 @@ public class DateTimeOffsetToBytesConverter : ValueConverter<DateTimeOffset, byt
     public static ValueConverterInfo DefaultInfo { get; }
         = new(typeof(DateTimeOffset), typeof(byte[]), i => new DateTimeOffsetToBytesConverter(i.MappingHints), DefaultHints);
 
-    private static byte[] ToBytes(DateTimeOffset value)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static byte[] ToBytes(DateTimeOffset value)
     {
         var timeBytes = (byte[])LongToBytes.ConvertToProvider(value.DateTime.ToBinary())!;
         var offsetBytes = (byte[])ShortToBytes.ConvertToProvider(value.Offset.TotalMinutes)!;
         return timeBytes.Concat(offsetBytes).ToArray();
     }
 
-    private static DateTimeOffset FromBytes(byte[] bytes)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static DateTimeOffset FromBytes(byte[] bytes)
     {
         var timeBinary = (long)LongToBytes.ConvertFromProvider(bytes)!;
         var offsetMins = (short)ShortToBytes.ConvertFromProvider(bytes.Skip(8).ToArray())!;

--- a/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
@@ -55,7 +55,13 @@ public class StringEnumConverter<TModel, TProvider, TEnum> : ValueConverter<TMod
         return v => ConvertToEnum(v);
     }
 
-    private static TEnum ConvertToEnum(string value)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static TEnum ConvertToEnum(string value)
         => Enum.TryParse<TEnum>(value, out var result)
             ? result
             : Enum.TryParse(value, true, out result)

--- a/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToBytesConverter.cs
@@ -62,7 +62,14 @@ public class NumberToBytesConverter<TNumber> : ValueConverter<TNumber, byte[]>
     public static ValueConverterInfo DefaultInfo { get; }
         = new(typeof(TNumber), typeof(byte[]), i => new NumberToBytesConverter<TNumber>(i.MappingHints), DefaultHints);
 
-    private static Expression<Func<TNumber, byte[]>> ToBytes()
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static Expression<Func<TNumber, byte[]>> ToBytes()
     {
         var type = typeof(TNumber).UnwrapNullableType();
 
@@ -109,7 +116,14 @@ public class NumberToBytesConverter<TNumber> : ValueConverter<TNumber, byte[]>
         return Expression.Lambda<Func<TNumber, byte[]>>(output, param);
     }
 
-    private static Expression<Func<byte[], TNumber>> ToNumber()
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static Expression<Func<byte[], TNumber>> ToNumber()
     {
         var type = typeof(TNumber).UnwrapNullableType();
         var param = Expression.Parameter(typeof(byte[]), "v");
@@ -178,25 +192,46 @@ public class NumberToBytesConverter<TNumber> : ValueConverter<TNumber, byte[]>
     private static readonly MethodInfo ReverseLongMethod
         = typeof(NumberToBytesConverter<TNumber>).GetMethod(
             nameof(ReverseLong),
-            BindingFlags.Static | BindingFlags.NonPublic)!;
+            BindingFlags.Static | BindingFlags.Public)!;
 
     private static readonly MethodInfo ReverseIntMethod
         = typeof(NumberToBytesConverter<TNumber>).GetMethod(
             nameof(ReverseInt),
-            BindingFlags.Static | BindingFlags.NonPublic)!;
+            BindingFlags.Static | BindingFlags.Public)!;
 
     private static readonly MethodInfo ReverseShortMethod
         = typeof(NumberToBytesConverter<TNumber>).GetMethod(
             nameof(ReverseShort),
-            BindingFlags.Static | BindingFlags.NonPublic)!;
+            BindingFlags.Static | BindingFlags.Public)!;
 
-    private static byte[] ReverseLong(byte[] bytes)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static byte[] ReverseLong(byte[] bytes)
         => new[] { bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0] };
 
-    private static byte[] ReverseInt(byte[] bytes)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static byte[] ReverseInt(byte[] bytes)
         => new[] { bytes[3], bytes[2], bytes[1], bytes[0] };
 
-    private static byte[] ReverseShort(byte[] bytes)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static byte[] ReverseShort(byte[] bytes)
         => new[] { bytes[1], bytes[0] };
 
     private static int GetByteCount()
@@ -228,9 +263,16 @@ public class NumberToBytesConverter<TNumber> : ValueConverter<TNumber, byte[]>
     private static readonly MethodInfo ToBytesMethod
         = typeof(NumberToBytesConverter<TNumber>).GetMethod(
             nameof(DecimalToBytes),
-            BindingFlags.Static | BindingFlags.NonPublic)!;
+            BindingFlags.Static | BindingFlags.Public)!;
 
-    private static byte[] DecimalToBytes(decimal value)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static byte[] DecimalToBytes(decimal value)
     {
         var bits = decimal.GetBits(value);
 
@@ -246,9 +288,16 @@ public class NumberToBytesConverter<TNumber> : ValueConverter<TNumber, byte[]>
     private static readonly MethodInfo ToDecimalMethod
         = typeof(NumberToBytesConverter<TNumber>).GetMethod(
             nameof(BytesToDecimal),
-            BindingFlags.Static | BindingFlags.NonPublic)!;
+            BindingFlags.Static | BindingFlags.Public)!;
 
-    private static decimal BytesToDecimal(byte[] bytes)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public static decimal BytesToDecimal(byte[] bytes)
     {
         var gotBytes = bytes;
         if (BitConverter.IsLittleEndian)

--- a/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
+++ b/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
@@ -52,6 +52,7 @@
     <ProjectReference Include="..\..\src\EFCore.Sqlite.NTS\EFCore.Sqlite.NTS.csproj" />
     <ProjectReference Include="..\EFCore.Relational.Tests\EFCore.Relational.Tests.csproj" />
     <ProjectReference Include="..\EFCore.SqlServer.FunctionalTests\EFCore.SqlServer.FunctionalTests.csproj" />
+    <ProjectReference Include="..\EFCore.Sqlite.FunctionalTests\EFCore.Sqlite.FunctionalTests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #31827

### Description

We changed the way value converters are saved in the compiled model as part of moving towards AOT. Some built-in converters were not working correctly with this change.

### Customer impact

Crash when compiling the model.

### How found

Customer reported.

### Regression

Yes.

### Testing

Tests added for built-in converters.

### Risk

Low.


