### PR TITLE
[release/8.0] Fail fast when using EF8 primitive collections with the Cosmos provider

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -310,6 +310,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 property1, entityType1, storeName1, property2, entityType2, storeName2);
 
         /// <summary>
+        ///     The property '{entityType}.{property}' is configured as an EF8 primitive collection. Primitive collections in a Cosmos model are discovered by convention.
+        /// </summary>
+        public static string PrimitiveCollectionsNotSupported(object? entityType, object? property)
+            => string.Format(
+                GetString("PrimitiveCollectionsNotSupported", nameof(entityType), nameof(property)),
+                entityType, property);
+
+        /// <summary>
         ///     Unable to execute a 'ReadItem' query since the 'id' value is missing and cannot be generated.
         /// </summary>
         public static string ResourceIdMissing

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -259,6 +259,9 @@
   <data name="PartitionKeyStoreNameMismatch" xml:space="preserve">
     <value>The partition key property '{property1}' on '{entityType1}' is mapped as '{storeName1}', but the partition key property '{property2}' on '{entityType2}' is mapped as '{storeName2}'. All partition key properties need to be mapped to the same store property for entity types mapped to the same container.</value>
   </data>
+  <data name="PrimitiveCollectionsNotSupported" xml:space="preserve">
+    <value>The property '{entityType}.{property}' is configured as an EF8 primitive collection. Primitive collections in a Cosmos model are discovered by convention.</value>
+  </data>
   <data name="ResourceIdMissing" xml:space="preserve">
     <value>Unable to execute a 'ReadItem' query since the 'id' value is missing and cannot be generated.</value>
   </data>

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.ObjectModel;
 using Microsoft.EntityFrameworkCore.Cosmos.ChangeTracking.Internal;
 using Newtonsoft.Json.Linq;
 
@@ -101,7 +102,9 @@ public class CosmosTypeMappingSource : TypeMappingSource
             var genericTypeDefinition = clrType.GetGenericTypeDefinition();
             if (genericTypeDefinition == typeof(List<>)
                 || genericTypeDefinition == typeof(IList<>)
-                || genericTypeDefinition == typeof(IReadOnlyList<>))
+                || genericTypeDefinition == typeof(IReadOnlyList<>)
+                || genericTypeDefinition == typeof(ObservableCollection<>)
+                || genericTypeDefinition == typeof(Collection<>))
             {
                 var elementMappingInfo = new TypeMappingInfo(elementType);
                 var elementMapping = FindPrimitiveMapping(elementMappingInfo)

--- a/test/EFCore.Cosmos.FunctionalTests/JsonTypesCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/JsonTypesCosmosTest.cs
@@ -12,17 +12,215 @@ public class JsonTypesCosmosTest : JsonTypesTestBase
     // #25765 - the Cosmos type mapping source doesn't support primitive collections, so we end up with a Property
     // that has no ElementType; that causes the assertion on the element nullability to fail.
     public override void Can_read_write_collection_of_string_JSON_values()
-        => Assert.Throws<EqualException>(() => base.Can_read_write_collection_of_string_JSON_values());
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_string_JSON_values());
 
     // #25765 - the Cosmos type mapping source doesn't support primitive collections, so we end up with a Property
     // that has no ElementType; that causes the assertion on the element nullability to fail.
     public override void Can_read_write_collection_of_binary_JSON_values()
-        => Assert.Throws<EqualException>(() => base.Can_read_write_collection_of_binary_JSON_values());
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_binary_JSON_values());
 
     // #25765 - the Cosmos type mapping source doesn't support primitive collections, so we end up with a Property
     // that has no ElementType; that causes the assertion on the element nullability to fail.
     public override void Can_read_write_collection_of_nullable_string_JSON_values()
-        => Assert.Throws<EqualException>(() => base.Can_read_write_collection_of_nullable_string_JSON_values());
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_string_JSON_values());
+
+    public override void Can_read_write_binary_as_collection()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_binary_as_collection());
+
+    public override void Can_read_write_collection_of_bool_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_bool_JSON_values());
+
+    public override void Can_read_write_collection_of_byte_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_byte_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_byte_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_byte_JSON_values());
+
+    public override void Can_read_write_collection_of_char_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_char_JSON_values());
+
+    public override void Can_read_write_collection_of_DateOnly_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_DateOnly_JSON_values());
+
+    public override void Can_read_write_collection_of_DateTime_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_DateTime_JSON_values());
+
+    public override void Can_read_write_collection_of_DateTimeOffset_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_DateTimeOffset_JSON_values());
+
+    public override void Can_read_write_collection_of_decimal_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_decimal_JSON_values());
+
+    public override void Can_read_write_collection_of_decimal_with_precision_and_scale_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_decimal_with_precision_and_scale_JSON_values());
+
+    public override void Can_read_write_collection_of_double_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_double_JSON_values());
+
+    public override void Can_read_write_collection_of_float_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_float_JSON_values());
+
+    public override void Can_read_write_collection_of_Guid_converted_to_bytes_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_Guid_converted_to_bytes_JSON_values());
+
+    public override void Can_read_write_collection_of_GUID_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_GUID_JSON_values());
+
+    public override void Can_read_write_collection_of_int_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_int_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_int_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_int_JSON_values());
+
+    public override void Can_read_write_collection_of_int_with_converter_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_int_with_converter_JSON_values());
+
+    public override void Can_read_write_collection_of_long_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_long_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_long_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_long_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_binary_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_binary_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_bool_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_bool_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_byte_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_byte_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_byte_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_byte_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_char_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_char_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_DateOnly_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_DateOnly_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_DateTime_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_DateTime_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_DateTimeOffset_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_DateTimeOffset_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_decimal_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_decimal_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_double_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_double_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_float_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_float_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_GUID_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_GUID_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_int_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_int_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_int_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_int_JSON_values());
+
+    public override void Can_read_write_collection_of_ushort_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_ushort_JSON_values());
+
+    public override void Can_read_write_collection_of_ushort_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_ushort_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_URI_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_URI_JSON_values());
+
+    public override void Can_read_write_collection_of_ulong_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_ulong_JSON_values());
+
+    public override void Can_read_write_collection_of_ulong_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_ulong_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_uint_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_uint_JSON_values());
+
+    public override void Can_read_write_collection_of_uint_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_uint_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_TimeSpan_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_TimeSpan_JSON_values());
+
+    public override void Can_read_write_collection_of_TimeOnly_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_TimeOnly_JSON_values());
+
+    public override void Can_read_write_collection_of_short_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_short_JSON_values());
+
+    public override void Can_read_write_collection_of_short_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_short_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_sbyte_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_sbyte_JSON_values());
+
+    public override void Can_read_write_collection_of_sbyte_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_sbyte_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_physical_address_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_physical_address_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_ushort_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_ushort_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_ushort_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_ushort_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_URI_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_URI_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_ulong_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_ulong_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_ulong_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_ulong_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_uint_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_uint_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_uint_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_uint_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_TimeSpan_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_TimeSpan_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_TimeOnly_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_TimeOnly_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_short_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_short_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_short_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_short_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_sbyte_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_sbyte_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_sbyte_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_sbyte_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_physical_address_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_physical_address_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_long_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_long_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_long_enum_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_long_enum_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_IP_address_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_IP_address_JSON_values());
+
+    public override void Can_read_write_collection_of_nullable_int_with_converter_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_nullable_int_with_converter_JSON_values());
+
+    public override void Can_read_write_collection_of_IP_address_JSON_values()
+        => Assert.Throws<InvalidOperationException>(() => base.Can_read_write_collection_of_IP_address_JSON_values());
 
     public override void Can_read_write_point()
         // No built-in JSON support for spatial types in the Cosmos provider

--- a/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -11,6 +11,186 @@ public class CosmosModelBuilderGenericTest : ModelBuilderGenericTest
 {
     public class CosmosGenericNonRelationship : GenericNonRelationship
     {
+        public override void Can_set_composite_key_for_primitive_collection_on_an_entity_with_fields()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(EntityWithFields), "CollectionCompanyId"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_composite_key_for_primitive_collection_on_an_entity_with_fields()).Message);
+
+        public override void Access_mode_can_be_overridden_at_entity_and_primitive_collection_levels()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Access_mode_can_be_overridden_at_entity_and_primitive_collection_levels()).Message);
+
+        public override void Can_set_custom_value_generator_for_primitive_collections()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_custom_value_generator_for_primitive_collections()).Message);
+
+        public override void Can_set_element_type_annotation()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Notes"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_element_type_annotation()).Message);
+
+        public override void Can_set_max_length_for_primitive_collections()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_max_length_for_primitive_collections()).Message);
+
+        public override void Can_set_primitive_collection_annotation()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Notes"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_primitive_collection_annotation()).Message);
+
+        public override void Can_set_primitive_collection_annotation_by_type()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Notes"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_primitive_collection_annotation_by_type()).Message);
+
+        public override void Can_set_primitive_collection_annotation_when_no_clr_property()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Notes"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_primitive_collection_annotation_when_no_clr_property()).Message);
+
+        public override void Can_set_sentinel_for_primitive_collections()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_sentinel_for_primitive_collections()).Message);
+
+        public override void Can_set_unicode_for_primitive_collections()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_unicode_for_primitive_collections()).Message);
+
+        public override void Element_types_are_nullable_by_default_if_the_type_is_nullable()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_are_nullable_by_default_if_the_type_is_nullable()).Message);
+
+        public override void Element_types_can_be_made_required()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_can_be_made_required()).Message);
+
+        public override void Element_types_can_have_custom_type_value_converter_type_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_can_have_custom_type_value_converter_type_set()).Message);
+
+        public override void Element_types_can_have_max_length()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_can_have_max_length()).Message);
+
+        public override void Element_types_can_have_non_generic_value_converter_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_can_have_non_generic_value_converter_set()).Message);
+
+        public override void Element_types_can_have_precision_and_scale()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_can_have_precision_and_scale()).Message);
+
+        public override void Element_types_can_have_provider_type_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_can_have_provider_type_set()).Message);
+
+        public override void Element_types_can_have_unicode_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_can_have_unicode_set()).Message);
+
+        public override void Element_types_have_default_precision_and_scale()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_have_default_precision_and_scale()).Message);
+
+        public override void Element_types_have_default_unicode()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_have_default_unicode()).Message);
+
+        public override void Element_types_have_no_max_length_by_default()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Element_types_have_no_max_length_by_default()).Message);
+
+        public override void Primitive_collections_are_required_by_default_only_if_CLR_type_is_nullable()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_are_required_by_default_only_if_CLR_type_is_nullable()).Message);
+
+        public override void Primitive_collections_can_be_made_optional()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_be_made_optional()).Message);
+
+        public override void Primitive_collections_can_be_made_required()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_be_made_required()).Message);
+
+        public override void Primitive_collections_can_be_set_to_generate_values_on_Add()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_be_set_to_generate_values_on_Add()).Message);
+
+        public override void Primitive_collections_can_have_access_mode_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_have_access_mode_set()).Message);
+
+        public override void Primitive_collections_can_have_field_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_have_field_set()).Message);
+
+        public override void Primitive_collections_can_have_value_converter_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_have_value_converter_set()).Message);
+
+        public override void Primitive_collections_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()).Message);
+
+        public override void Value_converter_type_on_primitive_collection_is_checked()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Up"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Value_converter_type_on_primitive_collection_is_checked()).Message);
+
         public override void Properties_can_set_row_version()
             => Assert.Equal(
                 CosmosStrings.NonETagConcurrencyToken(nameof(Quarks), "Charm"),
@@ -245,87 +425,9 @@ public class CosmosModelBuilderGenericTest : ModelBuilderGenericTest
 
         public override void Primitive_collections_can_be_made_concurrency_tokens()
             => Assert.Equal(
-                CosmosStrings.NonETagConcurrencyToken(nameof(CollectionQuarks), "Charm"),
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.Primitive_collections_can_be_made_concurrency_tokens()).Message);
-
-        [ConditionalFact]
-        public virtual void Primitive_collections_key_is_added_to_the_keys()
-        {
-            var modelBuilder = CreateModelBuilder();
-
-            modelBuilder.Entity<Customer>()
-                .Ignore(b => b.Details)
-                .Ignore(b => b.Orders)
-                .HasPartitionKey(b => b.Notes)
-                .PrimitiveCollection(b => b.Notes);
-
-            var model = modelBuilder.FinalizeModel();
-
-            var entity = model.FindEntityType(typeof(Customer))!;
-
-            Assert.Equal(
-                new[] { nameof(Customer.Id), nameof(Customer.Notes) },
-                entity.FindPrimaryKey()!.Properties.Select(p => p.Name));
-            Assert.Equal(
-                new[] { StoreKeyConvention.DefaultIdPropertyName, nameof(Customer.Notes) },
-                entity.GetKeys().First(k => k != entity.FindPrimaryKey()).Properties.Select(p => p.Name));
-
-            var idProperty = entity.FindProperty(StoreKeyConvention.DefaultIdPropertyName)!;
-            Assert.Single(idProperty.GetContainingKeys());
-            Assert.NotNull(idProperty.GetValueGeneratorFactory());
-        }
-
-        [ConditionalFact]
-        public virtual void No_id_property_created_if_another_primitive_collection_mapped_to_id()
-        {
-            var modelBuilder = CreateModelBuilder();
-
-            modelBuilder.Entity<Customer>()
-                .PrimitiveCollection(c => c.Notes)
-                .ToJsonProperty(StoreKeyConvention.IdPropertyJsonName);
-            modelBuilder.Entity<Customer>()
-                .Ignore(b => b.Details)
-                .Ignore(b => b.Orders);
-
-            var model = modelBuilder.FinalizeModel();
-
-            var entity = model.FindEntityType(typeof(Customer))!;
-
-            Assert.Null(entity.FindProperty(StoreKeyConvention.DefaultIdPropertyName));
-            Assert.Single(entity.GetKeys().Where(k => k != entity.FindPrimaryKey()));
-
-            var idProperty = entity.GetDeclaredProperties()
-                .Single(p => p.GetJsonPropertyName() == StoreKeyConvention.IdPropertyJsonName);
-            Assert.Single(idProperty.GetContainingKeys());
-            Assert.Null(idProperty.GetValueGeneratorFactory());
-        }
-
-        [ConditionalFact]
-        public virtual void No_id_property_created_if_another_primitive_collection_to_id_in_pk()
-        {
-            var modelBuilder = CreateModelBuilder();
-
-            modelBuilder.Entity<Customer>()
-                .PrimitiveCollection(c => c.Notes)
-                .ToJsonProperty(StoreKeyConvention.IdPropertyJsonName);
-            modelBuilder.Entity<Customer>()
-                .Ignore(c => c.Details)
-                .Ignore(c => c.Orders)
-                .HasKey(c => c.Notes);
-
-            var model = modelBuilder.FinalizeModel();
-
-            var entity = model.FindEntityType(typeof(Customer))!;
-
-            Assert.Null(entity.FindProperty(StoreKeyConvention.DefaultIdPropertyName));
-            Assert.Empty(entity.GetKeys().Where(k => k != entity.FindPrimaryKey()));
-
-            var idProperty = entity.GetDeclaredProperties()
-                .Single(p => p.GetJsonPropertyName() == StoreKeyConvention.IdPropertyJsonName);
-            Assert.Single(idProperty.GetContainingKeys());
-            Assert.Null(idProperty.GetValueGeneratorFactory());
-        }
 
         protected override TestModelBuilder CreateModelBuilder(Action<ModelConfigurationBuilder> configure = null)
             => CreateTestModelBuilder(CosmosTestHelpers.Instance, configure);
@@ -333,6 +435,102 @@ public class CosmosModelBuilderGenericTest : ModelBuilderGenericTest
 
     public class CosmosGenericComplexType : GenericComplexType
     {
+        public override void Access_mode_can_be_overridden_at_entity_and_property_levels()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Access_mode_can_be_overridden_at_entity_and_property_levels()).Message);
+
+        public override void Can_add_shadow_primitive_collections_when_they_have_been_ignored()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Shadow"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_add_shadow_primitive_collections_when_they_have_been_ignored()).Message);
+
+        public override void Can_call_PrimitiveCollection_on_a_field()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(EntityWithFields), "CollectionId"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_call_PrimitiveCollection_on_a_field()).Message);
+
+        public override void Can_set_custom_value_generator_for_primitive_collections()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_custom_value_generator_for_primitive_collections()).Message);
+
+        public override void Can_set_max_length_for_primitive_collections()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_max_length_for_primitive_collections()).Message);
+
+        public override void Can_set_primitive_collection_annotation_when_no_clr_property()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(Customer), "Ints"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_primitive_collection_annotation_when_no_clr_property()).Message);
+
+        public override void Can_set_sentinel_for_primitive_collections()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_sentinel_for_primitive_collections()).Message);
+
+        public override void Can_set_unicode_for_primitive_collections()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Can_set_unicode_for_primitive_collections()).Message);
+
+        public override void Primitive_collections_are_required_by_default_only_if_CLR_type_is_nullable()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_are_required_by_default_only_if_CLR_type_is_nullable()).Message);
+
+        public override void Primitive_collections_can_be_made_concurrency_tokens()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_be_made_concurrency_tokens()).Message);
+
+        public override void Primitive_collections_can_be_made_optional()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_be_made_optional()).Message);
+
+        public override void Primitive_collections_can_be_made_required()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_be_made_required()).Message);
+
+        public override void Primitive_collections_can_be_set_to_generate_values_on_Add()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Bottom"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_be_set_to_generate_values_on_Add()).Message);
+
+        public override void Primitive_collections_can_have_field_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_can_have_field_set()).Message);
+
+        public override void Primitive_collections_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Charm"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Primitive_collections_specified_by_string_are_shadow_properties_unless_already_known_to_be_CLR_properties()).Message);
+
+        public override void Properties_can_have_access_mode_set()
+            => Assert.Equal(
+                CosmosStrings.PrimitiveCollectionsNotSupported(nameof(CollectionQuarks), "Down"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.Properties_can_have_access_mode_set()).Message);
+
         public override void Can_set_complex_property_annotation()
         {
             var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/ComplexTypeTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ComplexTypeTestBase.cs
@@ -1775,6 +1775,7 @@ public abstract partial class ModelBuilderTest
             Assert.True(complexType.FindProperty("Strange")!.IsNullable);
         }
 
+        [ConditionalFact]
         public virtual void Can_ignore_shadow_primitive_collections_when_they_have_been_added_explicitly()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fixes #31862

### Description

EF8 primitive collections are not supported with the Cosmos provider. Fail fast in model validation for this.

### Customer impact

Avoids bad experience trying to get primitive collections to work with Cosmos.

### How found

Testing.

### Regression

No.

### Testing

Tests added.

### Risk

Low.
