### PR TITLE
[release/6.0] Stop storing model references in the ValueGeneratorCache

### DIFF
--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -312,7 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     createTableOperation.PrimaryKey = AddPrimaryKeyOperation.CreateFrom(primaryKey);
                 }
 
-                foreach (var column in table.Columns.Where(c => c.Order.HasValue).OrderBy(c => c.Order.Value)
+                foreach (var column in table.Columns.Where(c => c.Order.HasValue).OrderBy(c => c.Order!.Value)
                     .Concat(table.Columns.Where(c => !c.Order.HasValue)))
                 {
                     if (!column.TryGetDefaultValue(out var defaultValue))

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -54,6 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         protected virtual RuntimeModel Create(IModel model)
         {
             var runtimeModel = new RuntimeModel();
+            runtimeModel.ModelId = model.ModelId;
             runtimeModel.SetSkipDetectChanges(((IRuntimeModel)model).SkipDetectChanges);
             ((IModel)runtimeModel).ModelDependencies = model.ModelDependencies!;
 

--- a/src/EFCore/Metadata/IReadOnlyModel.cs
+++ b/src/EFCore/Metadata/IReadOnlyModel.cs
@@ -199,6 +199,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         /// <summary>
+        ///     A unique identifier for the <see cref="Model"/> instance and the <see cref="IRuntimeModel"/> created from it.
+        /// </summary>
+        public Guid ModelId { get; }
+
+        /// <summary>
         ///     <para>
         ///         Creates a human-readable representation of the given metadata.
         ///     </para>

--- a/src/EFCore/Metadata/IReadOnlyModel.cs
+++ b/src/EFCore/Metadata/IReadOnlyModel.cs
@@ -199,8 +199,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         /// <summary>
-        ///     A unique identifier for the <see cref="Model"/> instance and the <see cref="IRuntimeModel"/> created from it.
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [EntityFrameworkInternal]
         public Guid ModelId { get; }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -471,7 +471,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 : result;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual Guid ModelId { get; } = Guid.NewGuid();
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -471,6 +471,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 : result;
         }
 
+        /// <inheritdoc />
+        public virtual Guid ModelId { get; } = Guid.NewGuid();
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore/Metadata/RuntimeModel.cs
+++ b/src/EFCore/Metadata/RuntimeModel.cs
@@ -136,6 +136,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         /// <summary>
+        ///     A unique identifier for the <see cref="Model"/> instance and the <see cref="IRuntimeModel"/> created from it.
+        /// </summary>
+        public virtual Guid ModelId { get; set; }
+
+        /// <summary>
         ///     Adds configuration for a scalar type.
         /// </summary>
         /// <param name="clrType">The type of value the property will hold.</param>
@@ -302,5 +307,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             => _typeConfigurations.Count == 0
                 ? null
                 : _typeConfigurations.GetValueOrDefault(propertyType);
+
+        /// <inheritdoc />
+        Guid IReadOnlyModel.ModelId
+            => ModelId;
     }
 }

--- a/src/EFCore/Metadata/RuntimeModel.cs
+++ b/src/EFCore/Metadata/RuntimeModel.cs
@@ -136,8 +136,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         /// <summary>
-        ///     A unique identifier for the <see cref="Model"/> instance and the <see cref="IRuntimeModel"/> created from it.
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [EntityFrameworkInternal]
         public virtual Guid ModelId { get; set; }
 
         /// <summary>

--- a/src/EFCore/ValueGeneration/ValueGeneratorCache.cs
+++ b/src/EFCore/ValueGeneration/ValueGeneratorCache.cs
@@ -49,24 +49,27 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
 
         private readonly struct CacheKey : IEquatable<CacheKey>
         {
+            private readonly Guid _modelId;
+            private readonly string _property;
+            private readonly string _entityType;
+
             public CacheKey(IProperty property, IEntityType entityType)
             {
-                Property = property;
-                EntityType = entityType;
+                _modelId = entityType.Model.ModelId;
+                _property = property.Name;
+                _entityType = entityType.Name;
             }
 
-            public IProperty Property { get; }
-
-            public IEntityType EntityType { get; }
-
             public bool Equals(CacheKey other)
-                => Property.Equals(other.Property) && EntityType.Equals(other.EntityType);
+                => _property.Equals(other._property, StringComparison.Ordinal)
+                    && _entityType.Equals(other._entityType, StringComparison.Ordinal)
+                    && _modelId.Equals(other._modelId);
 
             public override bool Equals(object? obj)
                 => obj is CacheKey cacheKey && Equals(cacheKey);
 
             public override int GetHashCode()
-                => HashCode.Combine(Property, EntityType);
+                => HashCode.Combine(_property, _entityType, _modelId);
         }
 
         /// <summary>
@@ -88,7 +91,8 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
             Check.NotNull(property, nameof(property));
             Check.NotNull(factory, nameof(factory));
 
-            return _cache.GetOrAdd(new CacheKey(property, entityType), static (ck, f) => f(ck.Property, ck.EntityType), factory);
+            return _cache.GetOrAdd(
+                new CacheKey(property, entityType), static (ck, p) => p.factory(p.property, p.entityType), (factory, entityType, property));
         }
     }
 }

--- a/src/EFCore/ValueGeneration/ValueGeneratorCache.cs
+++ b/src/EFCore/ValueGeneration/ValueGeneratorCache.cs
@@ -29,6 +29,9 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
     /// </remarks>
     public class ValueGeneratorCache : IValueGeneratorCache
     {
+        private static readonly bool _useOldBehavior31539 =
+            AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue31539", out var enabled31539) && enabled31539;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="ValueGeneratorCache" /> class.
         /// </summary>
@@ -50,26 +53,47 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         private readonly struct CacheKey : IEquatable<CacheKey>
         {
             private readonly Guid _modelId;
-            private readonly string _property;
-            private readonly string _entityType;
+            private readonly string? _property;
+            private readonly string? _entityType;
 
             public CacheKey(IProperty property, IEntityType entityType)
             {
-                _modelId = entityType.Model.ModelId;
-                _property = property.Name;
-                _entityType = entityType.Name;
+                if (_useOldBehavior31539)
+                {
+                    _modelId = default;
+                    _property = null;
+                    _entityType = null;
+                    Property = property;
+                    EntityType = entityType;
+                }
+                else
+                {
+                    _modelId = entityType.Model.ModelId;
+                    _property = property.Name;
+                    _entityType = entityType.Name;
+                    Property = null;
+                    EntityType = null;
+                }
             }
 
+            public IProperty? Property { get; }
+
+            public IEntityType? EntityType { get; }
+
             public bool Equals(CacheKey other)
-                => _property.Equals(other._property, StringComparison.Ordinal)
-                    && _entityType.Equals(other._entityType, StringComparison.Ordinal)
-                    && _modelId.Equals(other._modelId);
+                => _useOldBehavior31539
+                    ? Property!.Equals(other.Property) && EntityType!.Equals(other.EntityType)
+                    : (_property!.Equals(other._property, StringComparison.Ordinal)
+                        && _entityType!.Equals(other._entityType, StringComparison.Ordinal)
+                        && _modelId.Equals(other._modelId));
 
             public override bool Equals(object? obj)
                 => obj is CacheKey cacheKey && Equals(cacheKey);
 
             public override int GetHashCode()
-                => HashCode.Combine(_property, _entityType, _modelId);
+                => _useOldBehavior31539
+                    ? HashCode.Combine(Property!, EntityType!)
+                    : HashCode.Combine(_property!, _entityType!, _modelId);
         }
 
         /// <summary>

--- a/test/EFCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
@@ -169,18 +169,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         [InlineData(true, true)]
         public void Identifying_foreign_key_value_is_propagated_if_principal_key_is_generated(bool generateTemporary, bool async)
         {
-            var model = BuildModel(generateTemporary);
-
             var principal = new Product();
             var dependent = new ProductDetail { Product = principal };
 
-            var contextServices = CreateContextServices(model);
+            var contextServices = CreateContextServices(BuildModel(generateTemporary));
             var stateManager = contextServices.GetRequiredService<IStateManager>();
             var principalEntry = stateManager.GetOrCreateEntry(principal);
             principalEntry.SetEntityState(EntityState.Added);
             var dependentEntry = stateManager.GetOrCreateEntry(dependent);
-            var principalProperty = model.FindEntityType(typeof(Product)).FindProperty(nameof(Product.Id));
-            var dependentProperty = model.FindEntityType(typeof(ProductDetail)).FindProperty(nameof(ProductDetail.Id));
+            var runtimeModel = contextServices.GetRequiredService<IModel>();
+            var principalProperty = runtimeModel.FindEntityType(typeof(Product))!.FindProperty(nameof(Product.Id))!;
+            var dependentProperty = runtimeModel.FindEntityType(typeof(ProductDetail))!.FindProperty(nameof(ProductDetail.Id))!;
             var keyPropagator = contextServices.GetRequiredService<IKeyPropagator>();
 
             PropagateValue(keyPropagator, dependentEntry, dependentProperty, async);


### PR DESCRIPTION
Fixes #31539

### Description

Storing references to the model resulted in a customer reported memory leak in multi-tenant application.

### Customer impact

Customer-reported large memory leak.

### How found

Customer reported.

### Regression

No.

### Testing

Existing tests cover that there is no regression with the cache key changed. Manual testing that the model is no longer referenced.

### Risk

Low. Also quirked.