### PR TITLE
[release/8.0] Don't remove entry from dependent map if it's not found in identity map.

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/IdentityMap.cs
+++ b/src/EFCore/ChangeTracking/Internal/IdentityMap.cs
@@ -436,11 +436,13 @@ public class IdentityMap<TKey> : IIdentityMap<TKey>
 
         if (otherEntry == null)
         {
-            if (_identityMap.TryGetValue(key, out var existingEntry)
-                && existingEntry == entry)
+            if (!_identityMap.TryGetValue(key, out var existingEntry)
+                || existingEntry != entry)
             {
-                _identityMap.Remove(key);
+                return;
             }
+
+            _identityMap.Remove(key);
         }
         else
         {

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -1098,9 +1098,11 @@ public class NavigationFixer : INavigationFixer
 
             SetForeignKeyProperties(
                 joinEntry, arguments.Entry, arguments.SkipNavigation.ForeignKey, arguments.SetModified, arguments.FromQuery);
+            SetNavigation(joinEntry, arguments.SkipNavigation.ForeignKey.DependentToPrincipal, arguments.Entry, arguments.FromQuery);
             SetForeignKeyProperties(
                 joinEntry, arguments.OtherEntry, arguments.SkipNavigation.Inverse.ForeignKey, arguments.SetModified,
                 arguments.FromQuery);
+            SetNavigation(joinEntry, arguments.SkipNavigation.Inverse.ForeignKey.DependentToPrincipal, arguments.OtherEntry, arguments.FromQuery);
 
             joinEntry.SetEntityState(
                 arguments.SetModified


### PR DESCRIPTION
Fixes #31559

### Description

When the join entity has a store-generated non-FK primary key we create the join entry first and afterwards generate a temporary key for it. This should update the corresponding dependents maps, but due to a missing check the dependents maps are cleared instead resulting in temporary key values being sent to the database.

### Customer impact

Customers using many-to-many relationships where the join entity has a non-FK primary key will get an exception or **data corruption**.

### How found

Customer reported.

### Regression

No.

### Testing

Tests added for the affected scenario.

### Risk

Low.

