### PR TITLE
[release/8.0] Validate single discriminator values

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -1863,11 +1863,6 @@ public class RelationalModelValidator : ModelValidator
                 continue;
             }
 
-            if (!entityType.GetDirectlyDerivedTypes().Any())
-            {
-                continue;
-            }
-
             // Hierarchy mapping strategy must be the same across all types of mappings
             if (entityType.FindDiscriminatorProperty() != null)
             {
@@ -1890,7 +1885,8 @@ public class RelationalModelValidator : ModelValidator
             else
             {
                 if (mappingStrategy != RelationalAnnotationNames.TpcMappingStrategy
-                    && entityType.FindPrimaryKey() == null)
+                    && entityType.FindPrimaryKey() == null
+                    && entityType.GetDirectlyDerivedTypes().Any())
                 {
                     throw new InvalidOperationException(
                         RelationalStrings.KeylessMappingStrategy(
@@ -1907,12 +1903,13 @@ public class RelationalModelValidator : ModelValidator
                 var discriminatorValues = new Dictionary<string, IEntityType>();
                 foreach (var derivedType in derivedTypes)
                 {
-                    if (!derivedType.ClrType.IsInstantiable())
+                    var discriminatorValue = derivedType.GetDiscriminatorValue();
+                    if (!derivedType.ClrType.IsInstantiable()
+                        || discriminatorValue is null)
                     {
                         continue;
                     }
 
-                    var discriminatorValue = derivedType.GetDiscriminatorValue();
                     if (discriminatorValue is not string valueString)
                     {
                         throw new InvalidOperationException(

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1112,7 +1112,7 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
                     return matchingCaseWhenClauses.Count == 1
                         ? matchingCaseWhenClauses[0].Test
                         : matchingCaseWhenClauses.Select(e => e.Test)
-                            .Aggregate((l, r) => _sqlExpressionFactory.OrElse(l, r));
+                            .Aggregate(_sqlExpressionFactory.OrElse);
                 }
 
                 return discriminatorValues.Count == 1

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -631,14 +631,14 @@ public class ModelValidator : IModelValidator
     protected virtual void ValidateDiscriminatorValues(IEntityType rootEntityType)
     {
         var derivedTypes = rootEntityType.GetDerivedTypesInclusive().ToList();
-        if (derivedTypes.Count == 1)
-        {
-            return;
-        }
-
         var discriminatorProperty = rootEntityType.FindDiscriminatorProperty();
         if (discriminatorProperty == null)
         {
+            if (derivedTypes.Count == 1)
+            {
+                return;
+            }
+
             throw new InvalidOperationException(
                 CoreStrings.NoDiscriminatorProperty(rootEntityType.DisplayName()));
         }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1960,7 +1960,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     The entity type '{entityType}' is part of a hierarchy, but does not have a discriminator value configured.
+        ///     The entity type '{entityType}' has a discriminator property, but does not have a discriminator value configured.
         /// </summary>
         public static string NoDiscriminatorValue(object? entityType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1169,7 +1169,7 @@
     <value>The entity type '{entityType}' is part of a hierarchy, but does not have a discriminator property configured.</value>
   </data>
   <data name="NoDiscriminatorValue" xml:space="preserve">
-    <value>The entity type '{entityType}' is part of a hierarchy, but does not have a discriminator value configured.</value>
+    <value>The entity type '{entityType}' has a discriminator property, but does not have a discriminator value configured.</value>
   </data>
   <data name="NoEfServices" xml:space="preserve">
     <value>Entity Framework services have not been added to the internal service provider. Either remove the call to 'UseInternalServiceProvider' so that Entity Framework will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. 'AddEntityFrameworkSqlServer').</value>

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -402,7 +402,6 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
                             b.Property<Guid>("Id");
                         }));
             },
-            additionalModelCacheKey: "Guid_key",
             seed: false);
 
         Address address;
@@ -594,18 +593,15 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
 
         public virtual CosmosTestStore TestStore { get; }
         private Action<ModelBuilder> OnModelCreatingAction { get; set; }
-        private object AdditionalModelCacheKey { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
             => OnModelCreatingAction?.Invoke(modelBuilder);
 
         public DbContextOptions CreateOptions(
             Action<ModelBuilder> onModelCreating = null,
-            object additionalModelCacheKey = null,
             bool seed = true)
         {
             OnModelCreatingAction = onModelCreating;
-            AdditionalModelCacheKey = additionalModelCacheKey;
             var options = CreateOptions(TestStore);
             TestStore.Initialize(
                 ServiceProvider, () => new EmbeddedTransportationContext(options), c =>
@@ -621,30 +617,16 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
         }
 
         protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
-            => base.AddServices(serviceCollection)
-                .AddSingleton<IModelCacheKeyFactory>(new TestModelCacheKeyFactory(() => AdditionalModelCacheKey));
+            => base.AddServices(serviceCollection);
+
+        protected override object GetAdditionalModelCacheKey(DbContext context)
+            => OnModelCreatingAction?.GetHashCode();
 
         public Task InitializeAsync()
             => Task.CompletedTask;
 
         public Task DisposeAsync()
             => TestStore.DisposeAsync();
-
-        private class TestModelCacheKeyFactory : IModelCacheKeyFactory
-        {
-            private readonly Func<object> _getAdditionalKey;
-
-            public TestModelCacheKeyFactory(Func<object> getAdditionalKey)
-            {
-                _getAdditionalKey = getAdditionalKey;
-            }
-
-            public object Create(DbContext context)
-                => Tuple.Create(context.GetType(), _getAdditionalKey());
-
-            public object Create(DbContext context, bool designTime)
-                => Tuple.Create(context.GetType(), _getAdditionalKey(), designTime);
-        }
     }
 
     protected class EmbeddedTransportationContext : TransportationContext

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -317,7 +317,7 @@ public class CosmosModelValidatorTest : ModelValidatorTestBase
         modelBuilder.Entity<Customer>().ToContainer("Orders").HasDiscriminator().HasValue(null);
         modelBuilder.Entity<Order>().ToContainer("Orders");
 
-        VerifyError(CosmosStrings.NoDiscriminatorValue(typeof(Customer).Name, "Orders"), modelBuilder);
+        VerifyError(CoreStrings.NoDiscriminatorValue(typeof(Customer).Name), modelBuilder);
     }
 
     [ConditionalFact]

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -382,7 +382,7 @@ public class CSharpMigrationsGeneratorTest
                         ? validAnnotations[annotationName].Value
                         : null);
 
-                modelBuilder.FinalizeModel(designTime: true);
+                modelBuilder.FinalizeModel(designTime: true, skipValidation: true);
 
                 var sb = new IndentedStringBuilder();
 

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -1691,6 +1691,15 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     }
 
     [ConditionalFact]
+    public virtual void Detects_missing_non_hierarchy_discriminator_value()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<A>().HasDiscriminator<byte>("ClassType");
+
+        VerifyError(CoreStrings.NoDiscriminatorValue(typeof(A).Name), modelBuilder);
+    }
+
+    [ConditionalFact]
     public virtual void Detects_missing_non_string_discriminator_values()
     {
         var modelBuilder = CreateConventionModelBuilder();


### PR DESCRIPTION
Fixes #31547

### Description

When there is only a single type in the hierarchy we don't validate the discriminator value, this means that if it is invalid the user will get obscure exceptions at runtime.

### Customer impact

Unhelpful exception.

### How found

Customer reported on 6.0

### Regression

No.

### Testing

Added tests.

### Risk

Low.

