### PR TITLE
[release/8.0] Make Contains work again over hierarchyid

### DIFF
--- a/src/EFCore.Relational/Extensions/TableExpressionExtensions.cs
+++ b/src/EFCore.Relational/Extensions/TableExpressionExtensions.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+///     Type extension methods for <see cref="TableExpressionBase" /> and related types.
+/// </summary>
+public static class TableExpressionExtensions
+{
+    /// <summary>
+    ///     If the given <paramref name="table" /> is a <see cref="JoinExpressionBase" />, returns the table it joins to. Otherwise, returns
+    ///     <paramref name="table" />.
+    /// </summary>
+    public static TableExpressionBase UnwrapJoin(this TableExpressionBase table)
+        => table is JoinExpressionBase join ? join.Table : table;
+}

--- a/test/EFCore.SqlServer.HierarchyId.Tests/QueryTests.cs
+++ b/test/EFCore.SqlServer.HierarchyId.Tests/QueryTests.cs
@@ -356,6 +356,31 @@ public class QueryTests : IDisposable
         Assert.Equal(new[] { HierarchyId.Parse("/") }, results);
     }
 
+    [ConditionalFact]
+    public void Contains_with_parameter_list_can_translate()
+    {
+        var ids = new[] { HierarchyId.Parse("/1/1/7/"), HierarchyId.Parse("/1/1/99/") };
+        var result = (from p in _db.Patriarchy
+                       where ids.Contains(p.Id)
+                       select p.Name).Single();
+
+        Assert.Equal(
+            """
+@__ids_0='?' (Size = 4000)
+
+SELECT TOP(2) [p].[Name]
+FROM [Patriarchy] AS [p]
+WHERE [p].[Id] IN (
+    SELECT CAST([i].[value] AS hierarchyid) AS [value]
+    FROM OPENJSON(@__ids_0) AS [i]
+)
+""",
+            _db.Sql,
+            ignoreLineEndingDifferences: true);
+
+        Assert.Equal("Dan", result);
+    }
+
     public void Dispose()
         => _db.Dispose();
 


### PR DESCRIPTION
Fixes #31912

### Description

The primitive collection improvements to 8.0 changed the translation of Contains to use OPENJSON with WITH, but that's incompatible with hierarchyid (SQL Server CLR type).

### Customer impact

Queries which apply Contains to a parameter list of HierarchyId no longer work in 8.0.

### How found

Customer reported.

### Regression

Yes (when the community hierarchyid package was used)

### Testing

Added.

### Risk

Very low, the mechanism to transform the incompatible OPENJSON with WITH to OPENJSON without WITH already existed for other purposes; this change only extends its usage for hierarchyid.