### PR TITLE
[release/8.0] Cosmos: persist non-shadow int keys on owned entity types

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
@@ -35,6 +35,7 @@ public static class CosmosPropertyExtensions
             var pk = property.FindContainingPrimaryKey();
             if (pk != null
                 && (property.ClrType == typeof(int) || ownership.Properties.Contains(property))
+                && property.IsShadowProperty()
                 && pk.Properties.Count == ownership.Properties.Count + (ownership.IsUnique ? 0 : 1)
                 && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
             {

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
@@ -80,6 +80,7 @@ public class CosmosValueGenerationConvention :
                 if (pk != null
                     && !property.IsForeignKey()
                     && pk.Properties.Count == ownership.Properties.Count + 1
+                    && property.IsShadowProperty()
                     && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
                 {
                     return ValueGenerated.OnAddOrUpdate;

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
@@ -21,11 +21,11 @@ public static class CosmosPropertyExtensions
     {
         Check.DebugAssert(
             (property.DeclaringType as IEntityType)?.IsOwned() == true, $"Expected {property.DeclaringType.DisplayName()} to be owned.");
-        Check.DebugAssert(property.GetJsonPropertyName().Length == 0, $"Expected {property.Name} to be non-persisted.");
 
-        return property.FindContainingPrimaryKey() is { Properties.Count: > 1 }
+        return property.ClrType == typeof(int)
             && !property.IsForeignKey()
-            && property.ClrType == typeof(int)
-            && (property.ValueGenerated & ValueGenerated.OnAdd) != 0;
+            && (property.ValueGenerated & ValueGenerated.OnAdd) != 0
+            && property.FindContainingPrimaryKey() is { Properties.Count: > 1 }
+            && property.GetJsonPropertyName().Length == 0;
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -118,7 +118,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
             {
                 existingAddress1Person2.IdNotes = new List<NoteWithId>
                 {
-                    new() { Content = "First note" }, new() { Content = "Second note" }
+                    new() { Id = 4, Content = "First note" }, new() { Id = 3, Content = "Second note" }
                 };
             }
             else
@@ -260,15 +260,15 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
 
             await context.SaveChangesAsync();
 
-            await AssertState(context);
+            await AssertState(context, useIds);
         }
 
         using (var context = new EmbeddedTransportationContext(options))
         {
-            await AssertState(context);
+            await AssertState(context, useIds);
         }
 
-        async Task AssertState(EmbeddedTransportationContext context)
+        async Task AssertState(EmbeddedTransportationContext context, bool useIds)
         {
             var people = await context.Set<Person>().OrderBy(o => o.Id).ToListAsync();
             var firstAddress = people[0].Addresses.Single();
@@ -294,9 +294,17 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
             {
                 var notes = addresses[1].IdNotes;
                 Assert.Equal(2, notes.Count);
-                Assert.Equal(1, notes.First().Id);
+                if (useIds)
+                {
+                    Assert.Equal(4, notes.First().Id);
+                    Assert.Equal(3, notes.Last().Id);
+                }
+                else
+                {
+                    Assert.Equal(1, notes.First().Id);
+                    Assert.Equal(2, notes.Last().Id);
+                }
                 Assert.Equal("First note", notes.First().Content);
-                Assert.Equal(2, notes.Last().Id);
                 Assert.Equal("Second note", notes.Last().Content);
             }
             else
@@ -339,7 +347,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
             if (useIds)
             {
                 Assert.Equal(1, addresses[1].IdNotes.Count);
-                Assert.Equal(1, addresses[1].IdNotes.First().Id);
+                Assert.Equal(-1, addresses[1].IdNotes.First().Id);
                 Assert.Equal("Another note", addresses[1].IdNotes.First().Content);
             }
             else
@@ -354,7 +362,7 @@ public class EmbeddedDocumentsTest : IClassFixture<EmbeddedDocumentsTest.CosmosF
             if (useIds)
             {
                 Assert.Equal(1, addresses[2].IdNotes.Count);
-                Assert.Equal(1, addresses[2].IdNotes.First().Id);
+                Assert.Equal(4, addresses[2].IdNotes.First().Id);
                 Assert.Equal("City note", addresses[2].IdNotes.First().Content);
             }
             else


### PR DESCRIPTION
Fixes #31664

### Description

When an owned entity type contains and int property that is configured as the key EF assumes that it is a client-generated ordinal that shouldn't be persisted.

### Customer impact

For models with matching shape the key property values are replaced with ordinals, causing data loss.

### How found

Customer reported on 6.0

### Regression

No.

### Testing

Added tests.

### Risk

Low.
