### PR TITLE
[release/6.0] Cosmos: Persist non-shadow int keys on owned entity types

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -17,6 +18,9 @@ namespace Microsoft.EntityFrameworkCore
     /// </remarks>
     public static class CosmosPropertyExtensions
     {
+        private static readonly bool _useOldBehavior31664 =
+            AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue31664", out var enabled31664) && enabled31664;
+
         /// <summary>
         ///     Returns the property name that the property is mapped to when targeting Cosmos.
         /// </summary>
@@ -37,6 +41,7 @@ namespace Microsoft.EntityFrameworkCore
                 var pk = property.FindContainingPrimaryKey();
                 if (pk != null
                     && (property.ClrType == typeof(int) || ownership.Properties.Contains(property))
+                    && (property.IsShadowProperty() || _useOldBehavior31664)
                     && pk.Properties.Count == ownership.Properties.Count + (ownership.IsUnique ? 0 : 1)
                     && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
                 {

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
@@ -21,6 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         ValueGenerationConvention,
         IEntityTypeAnnotationChangedConvention
     {
+        private static readonly bool _useOldBehavior31664 =
+            AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue31664", out var enabled31664) && enabled31664;
+
         /// <summary>
         ///     Creates a new instance of <see cref="CosmosValueGenerationConvention" />.
         /// </summary>
@@ -82,8 +85,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 {
                     var pk = property.FindContainingPrimaryKey();
                     if (pk != null
-                        && !ownership.Properties.Contains(property)
+                        && !property.IsForeignKey()
                         && pk.Properties.Count == ownership.Properties.Count + 1
+                        && (property.IsShadowProperty() || _useOldBehavior31664)
                         && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
                     {
                         return base.GetValueGenerated(property);

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
@@ -24,13 +24,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
         {
             Check.DebugAssert(
                 property.DeclaringEntityType.IsOwned(), $"Expected {property.DeclaringEntityType.DisplayName()} to be owned.");
-            Check.DebugAssert(property.GetJsonPropertyName().Length == 0, $"Expected {property.Name} to be non-persisted.");
 
             return property.FindContainingPrimaryKey() is IReadOnlyKey key
                 && key.Properties.Count > 1
                 && !property.IsForeignKey()
                 && property.ClrType == typeof(int)
-                && property.ValueGenerated == ValueGenerated.OnAdd;
+                && property.ValueGenerated == ValueGenerated.OnAdd
+                && property.GetJsonPropertyName().Length == 0;
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/31933
Fixes #31664

### Description

When an owned entity type contains and int property that is configured as the key EF assumes that it is a client-generated ordinal that shouldn't be persisted.

### Customer impact

For models with matching shape the key property values are replaced with ordinals, causing data loss.

### How found

Customer reported on 6.0

### Regression

No.

### Testing

Added tests.

### Risk

Low. Quirked.