### PR TITLE
[release/6.0] Validate single discriminator values

### DIFF
--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -626,14 +626,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         protected virtual void ValidateDiscriminatorValues(IEntityType rootEntityType)
         {
             var derivedTypes = rootEntityType.GetDerivedTypesInclusive().ToList();
-            if (derivedTypes.Count == 1)
-            {
-                return;
-            }
-
             var discriminatorProperty = rootEntityType.FindDiscriminatorProperty();
             if (discriminatorProperty == null)
             {
+                if (derivedTypes.Count == 1)
+                {
+                    return;
+                }
+
                 throw new InvalidOperationException(
                     CoreStrings.NoDiscriminatorProperty(rootEntityType.DisplayName()));
             }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1809,7 +1809,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     The entity type '{entityType}' is part of a hierarchy, but does not have a discriminator value configured.
+        ///     The entity type '{entityType}' has a discriminator property, but does not have a discriminator value configured.
         /// </summary>
         public static string NoDiscriminatorValue(object? entityType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1121,7 +1121,7 @@
     <value>The entity type '{entityType}' is part of a hierarchy, but does not have a discriminator property configured.</value>
   </data>
   <data name="NoDiscriminatorValue" xml:space="preserve">
-    <value>The entity type '{entityType}' is part of a hierarchy, but does not have a discriminator value configured.</value>
+    <value>The entity type '{entityType}' has a discriminator property, but does not have a discriminator value configured.</value>
   </data>
   <data name="NoEfServices" xml:space="preserve">
     <value>Entity Framework services have not been added to the internal service provider. Either remove the call to 'UseInternalServiceProvider' so that Entity Framework will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. 'AddEntityFrameworkSqlServer').</value>

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -292,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             modelBuilder.Entity<Customer>().ToContainer("Orders").HasDiscriminator().HasValue(null);
             modelBuilder.Entity<Order>().ToContainer("Orders");
 
-            VerifyError(CosmosStrings.NoDiscriminatorValue(typeof(Customer).Name, "Orders"), modelBuilder);
+            VerifyError(CoreStrings.NoDiscriminatorValue(typeof(Customer).Name), modelBuilder);
         }
 
         [ConditionalFact]
@@ -313,8 +314,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .ToContainer("Orders")
                 .Property<string>("_etag")
                 .IsConcurrencyToken();
-
-            Validate(modelBuilder);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -335,7 +335,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         ? validAnnotations[annotationName].Value
                         : null);
 
-                    modelBuilder.FinalizeModel(designTime: true);
+                    modelBuilder.FinalizeModel(designTime: true, skipValidation: true);
 
                     var sb = new IndentedStringBuilder();
 


### PR DESCRIPTION
Port of https://github.com/dotnet/efcore/pull/31916
Fixes #31547

### Description

When there is only a single type in the hierarchy we don't validate the discriminator value, this means that if it is invalid the user will get obscure exceptions at runtime.

### Customer impact

Unhelpful exception.

### How found

Customer reported on 6.0

### Regression

No.

### Testing

Added tests.

### Risk

Low.

