### PR TITLE
[release/6.0] Stop storing model references in the EntityMaterializerSource

### DIFF
--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -312,7 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     createTableOperation.PrimaryKey = AddPrimaryKeyOperation.CreateFrom(primaryKey);
                 }
 
-                foreach (var column in table.Columns.Where(c => c.Order.HasValue).OrderBy(c => c.Order.Value)
+                foreach (var column in table.Columns.Where(c => c.Order.HasValue).OrderBy(c => c.Order!.Value)
                     .Concat(table.Columns.Where(c => !c.Order.HasValue)))
                 {
                     if (!column.TryGetDefaultValue(out var defaultValue))

--- a/src/EFCore/ChangeTracking/Internal/ArrayPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/ArrayPropertyValues.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override object ToObject()
-            => MaterializerSource.GetMaterializer(EntityType)(
+            => EntityType.GetOrCreateMaterializer(MaterializerSource)(
                 new MaterializationContext(
                     new ValueBuffer(_values),
                     InternalEntry.StateManager.Context));

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -319,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             var valueBuffer = new ValueBuffer(valuesArray);
-            var entity = EntityMaterializerSource.GetMaterializer(entityType)(new MaterializationContext(valueBuffer, Context));
+            var entity = entityType.GetOrCreateMaterializer(EntityMaterializerSource)(new MaterializationContext(valueBuffer, Context));
 
             var shadowPropertyValueBuffer = new ValueBuffer(shadowPropertyValuesArray);
             var entry = new InternalEntityEntry(this, entityType, entity, shadowPropertyValueBuffer);

--- a/src/EFCore/Metadata/IReadOnlyEntityType.cs
+++ b/src/EFCore/Metadata/IReadOnlyEntityType.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -802,6 +804,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns>The service properties defined on this entity type.</returns>
         IEnumerable<IReadOnlyServiceProperty> GetServiceProperties();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -13,6 +13,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -3550,6 +3551,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private void UpdateServiceOnlyConstructorBindingConfigurationSource(ConfigurationSource configurationSource)
             => _serviceOnlyConstructorBindingConfigurationSource =
                 configurationSource.Max(_serviceOnlyConstructorBindingConfigurationSource);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public virtual Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
+            => source.GetMaterializer(this);
 
         #endregion
 

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -13,6 +13,8 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
@@ -72,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         private Func<MaterializationContext, object>? _instanceFactory;
         private IProperty[]? _foreignKeyProperties;
         private IProperty[]? _valueGeneratingProperties;
+        private Func<MaterializationContext, object>? _materializer;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -813,6 +816,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <returns>An indexer property or <see langword="null" />.</returns>
         public static PropertyInfo? FindIndexerProperty(Type type)
             => type.FindIndexerProperty();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public virtual Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
+            => EntityMaterializerSource.UseOldBehavior31866
+                ? source.GetMaterializer(this)
+                : NonCapturingLazyInitializer.EnsureInitialized(
+                    ref _materializer, this, source,
+                    static (e, s) => s.GetMaterializer(e));
 
         /// <summary>
         ///     Returns a string that represents the current object.

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -15,6 +15,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Newtonsoft.Json;
@@ -560,6 +561,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 => throw new NotImplementedException();
 
             public IEnumerable<IServiceProperty> GetServiceProperties()
+                => throw new NotImplementedException();
+
+            public Func<MaterializationContext, object> GetOrCreateMaterializer(IEntityMaterializerSource source)
                 => throw new NotImplementedException();
 
             public IEnumerable<ISkipNavigation> GetSkipNavigations()


### PR DESCRIPTION
Fixes #31866

This is the second part of the memory leak fix from https://github.com/dotnet/efcore/pull/31867

### Description

Storing references to the model resulted in a customer reported memory leak in multi-tenant application.

### Customer impact

Customer-reported large memory leak.

### How found

Customer reported.

### Regression

No.

### Testing

Existing tests cover that there is no regression with the change in cache location. Manual testing that the model is no longer referenced.

### Risk

Low. Also quirked.


