### PR TITLE
[release/8.0] Fix to #30391 - JSON column issue with SetTableName()

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -2527,6 +2527,18 @@ public class RelationalModelValidator : ModelValidator
                 continue;
             }
 
+            foreach (var jsonEntityType in mappedTypes.Where(x => x.IsMappedToJson()))
+            {
+                var ownership = jsonEntityType.FindOwnership()!;
+                var ownerTableOrViewName = ownership.PrincipalEntityType.GetViewName() ?? ownership.PrincipalEntityType.GetTableName();
+                if (table.Name != ownerTableOrViewName)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.JsonEntityMappedToDifferentTableOrViewThanOwner(
+                            jsonEntityType.DisplayName(), table.Name, ownership.PrincipalEntityType.DisplayName(), ownerTableOrViewName));
+                }
+            }
+
             var nonOwnedTypes = mappedTypes.Where(x => !x.IsOwned());
             var nonOwnedTypesCount = nonOwnedTypes.Count();
             if (nonOwnedTypesCount == 0)
@@ -2610,12 +2622,12 @@ public class RelationalModelValidator : ModelValidator
             }
 
             var ownership = jsonEntityType.FindOwnership()!;
-            var ownerViewName = ownership.PrincipalEntityType.GetViewName();
-            if (viewName != ownerViewName)
+            var ownerTableOrViewName = ownership.PrincipalEntityType.GetViewName() ?? ownership.PrincipalEntityType.GetTableName();
+            if (viewName != ownerTableOrViewName)
             {
                 throw new InvalidOperationException(
-                    RelationalStrings.JsonEntityMappedToDifferentViewThanOwner(
-                        jsonEntityType.DisplayName(), viewName, ownership.PrincipalEntityType.DisplayName(), ownerViewName));
+                    RelationalStrings.JsonEntityMappedToDifferentTableOrViewThanOwner(
+                        jsonEntityType.DisplayName(), viewName, ownership.PrincipalEntityType.DisplayName(), ownerTableOrViewName));
             }
         }
     }

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1040,12 +1040,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 jsonEntity, parentEntity, navigation);
 
         /// <summary>
-        ///     Entity '{jsonType}' is mapped to JSON and also to a view '{viewName}', but its owner '{ownerType}' is mapped to a different view '{ownerViewName}'. Every entity mapped to JSON must also map to the same view as its owner.
+        ///     Entity '{jsonType}' is mapped to JSON and also to a table or view '{tableOrViewName}', but its owner '{ownerType}' is mapped to a different table or view '{ownerTableOrViewName}'. Every entity mapped to JSON must also map to the same table or view as its owner.
         /// </summary>
-        public static string JsonEntityMappedToDifferentViewThanOwner(object? jsonType, object? viewName, object? ownerType, object? ownerViewName)
+        public static string JsonEntityMappedToDifferentTableOrViewThanOwner(object? jsonType, object? tableOrViewName, object? ownerType, object? ownerTableOrViewName)
             => string.Format(
-                GetString("JsonEntityMappedToDifferentViewThanOwner", nameof(jsonType), nameof(viewName), nameof(ownerType), nameof(ownerViewName)),
-                jsonType, viewName, ownerType, ownerViewName);
+                GetString("JsonEntityMappedToDifferentTableOrViewThanOwner", nameof(jsonType), nameof(tableOrViewName), nameof(ownerType), nameof(ownerTableOrViewName)),
+                jsonType, tableOrViewName, ownerType, ownerTableOrViewName);
 
         /// <summary>
         ///     JSON entity '{jsonEntity}' is missing key information. This is not allowed for tracking queries since EF can't correctly build identity for this entity object.

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -508,8 +508,8 @@
   <data name="JsonCantNavigateToParentEntity" xml:space="preserve">
     <value>Can't navigate from JSON-mapped entity '{jsonEntity}' to its parent entity '{parentEntity}' using navigation '{navigation}'. Entities mapped to JSON can only navigate to their children.</value>
   </data>
-  <data name="JsonEntityMappedToDifferentViewThanOwner" xml:space="preserve">
-    <value>Entity '{jsonType}' is mapped to JSON and also to a view '{viewName}', but its owner '{ownerType}' is mapped to a different view '{ownerViewName}'. Every entity mapped to JSON must also map to the same view as its owner.</value>
+  <data name="JsonEntityMappedToDifferentTableOrViewThanOwner" xml:space="preserve">
+    <value>Entity '{jsonType}' is mapped to JSON and also to a table or view '{tableOrViewName}', but its owner '{ownerType}' is mapped to a different table or view '{ownerTableOrViewName}'. Every entity mapped to JSON must also map to the same table or view as its owner.</value>
   </data>
   <data name="JsonEntityMissingKeyInformation" xml:space="preserve">
     <value>JSON entity '{jsonEntity}' is missing key information. This is not allowed for tracking queries since EF can't correctly build identity for this entity object.</value>

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.Json.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.Json.cs
@@ -460,7 +460,7 @@ public partial class RelationalModelValidatorTest
             });
 
         VerifyError(
-            RelationalStrings.JsonEntityMappedToDifferentViewThanOwner(
+            RelationalStrings.JsonEntityMappedToDifferentTableOrViewThanOwner(
                 nameof(ValidatorJsonOwnedRoot), "MyOtherView", nameof(ValidatorJsonEntityBasic), "MyView"),
             modelBuilder);
     }
@@ -485,8 +485,83 @@ public partial class RelationalModelValidatorTest
             });
 
         VerifyError(
-            RelationalStrings.JsonEntityMappedToDifferentViewThanOwner(
+            RelationalStrings.JsonEntityMappedToDifferentTableOrViewThanOwner(
                 nameof(ValidatorJsonOwnedBranch), "MyOtherView", nameof(ValidatorJsonOwnedRoot), "MyView"),
+            modelBuilder);
+    }
+
+    [ConditionalFact]
+    public void Json_entity_mapped_to_different_table_than_its_parent()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<ValidatorJsonEntityBasic>(
+            b =>
+            {
+                b.ToTable("MyTable");
+                b.OwnsOne(
+                    x => x.OwnedReference, bb =>
+                    {
+                        bb.ToJson();
+                        bb.ToTable("MyJsonTable");
+                        bb.Ignore(x => x.NestedCollection);
+                        bb.Ignore(x => x.NestedReference);
+                    });
+                b.Ignore(x => x.OwnedCollection);
+            });
+
+        VerifyError(
+            RelationalStrings.JsonEntityMappedToDifferentTableOrViewThanOwner(
+                nameof(ValidatorJsonOwnedRoot), "MyJsonTable", nameof(ValidatorJsonEntityBasic), "MyTable"),
+            modelBuilder);
+    }
+
+    [ConditionalFact]
+    public void Json_entity_mapped_to_a_view_but_its_parent_is_mapped_to_a_table()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<ValidatorJsonEntityBasic>(
+            b =>
+            {
+                b.ToTable("MyTable");
+                b.OwnsOne(
+                    x => x.OwnedReference, bb =>
+                    {
+                        bb.ToJson();
+                        bb.ToView("MyJsonView");
+                        bb.Ignore(x => x.NestedCollection);
+                        bb.Ignore(x => x.NestedReference);
+                    });
+                b.Ignore(x => x.OwnedCollection);
+            });
+
+        VerifyError(
+            RelationalStrings.JsonEntityMappedToDifferentTableOrViewThanOwner(
+                nameof(ValidatorJsonOwnedRoot), "MyJsonView", nameof(ValidatorJsonEntityBasic), "MyTable"),
+            modelBuilder);
+    }
+
+    [ConditionalFact]
+    public void Json_entity_mapped_to_a_table_but_its_parent_is_mapped_to_a_view()
+    {
+        var modelBuilder = CreateConventionModelBuilder();
+        modelBuilder.Entity<ValidatorJsonEntityBasic>(
+            b =>
+            {
+                b.ToView("MyView");
+                b.OwnsOne(
+                    x => x.OwnedReference, bb =>
+                    {
+                        bb.ToJson();
+                        bb.ToTable("MyJsonTable");
+                        bb.Ignore(x => x.NestedCollection);
+                        bb.Ignore(x => x.NestedReference);
+                    });
+                b.Ignore(x => x.OwnedCollection);
+            });
+
+        VerifyError(
+            RelationalStrings.JsonEntityMappedToDifferentTableOrViewThanOwner(
+                nameof(ValidatorJsonOwnedRoot), "MyJsonTable", nameof(ValidatorJsonEntityBasic), "MyView"),
             modelBuilder);
     }
 


### PR DESCRIPTION
Fixes #30391

**Description**

We were not checking if JSON entity was mapped to the same table as its owner. We already made that check when mapping to views.

**Customer impact**

When customer maps JSON entity to a different table/view than it's owner we throw a meaningless exception (sequence contains no elements).

**How found**

Multiple customer reports on 7.0

**Regression**

No. JSON has been added in 7.0

**Testing**

Added validation tests for affected scenarios.

**Risk**

Very low: Fix just adds validation step which throws a better exception message for a negative scenario (that used to throw bad exception before). Hard to think what we could break with this.


