### PR TITLE
[TEST ONLY] More AssertQuery refactoring

### DIFF
--- a/test/EFCore.Specification.Tests/Query/FiltersInheritanceQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FiltersInheritanceQueryTestBase.cs
@@ -95,8 +95,7 @@ public abstract class FiltersInheritanceQueryTestBase<TFixture> : FilteredQueryT
     {
         return AssertFirst(
             async,
-            ss => ss.Set<Animal>().OfType<Bird>().OrderBy(a => a.Species),
-            entryCount: 1);
+            ss => ss.Set<Animal>().OfType<Bird>().OrderBy(a => a.Species));
     }
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/InheritanceQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceQueryTestBase.cs
@@ -22,18 +22,15 @@ public abstract class InheritanceQueryTestBase<TFixture> : QueryTestBase<TFixtur
     {
         await AssertSingle(
             async,
-            ss => ss.Set<Coke>(),
-            entryCount: 1);
+            ss => ss.Set<Coke>());
 
         await AssertSingle(
             async,
-            ss => ss.Set<Lilt>(),
-            entryCount: 1);
+            ss => ss.Set<Lilt>());
 
         await AssertSingle(
             async,
-            ss => ss.Set<Tea>(),
-            entryCount: 1);
+            ss => ss.Set<Tea>());
     }
 
     [ConditionalTheory]
@@ -121,8 +118,7 @@ public abstract class InheritanceQueryTestBase<TFixture> : QueryTestBase<TFixtur
     public virtual Task Can_use_of_type_bird_first(bool async)
         => AssertFirst(
             async,
-            ss => ss.Set<Animal>().OfType<Bird>().OrderBy(a => a.Species),
-            entryCount: 1);
+            ss => ss.Set<Animal>().OfType<Bird>().OrderBy(a => a.Species));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -200,16 +196,14 @@ public abstract class InheritanceQueryTestBase<TFixture> : QueryTestBase<TFixtur
     public virtual Task Can_query_just_kiwis(bool async)
         => AssertSingle(
             async,
-            ss => ss.Set<Kiwi>(),
-            entryCount: 1);
+            ss => ss.Set<Kiwi>());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Can_query_just_roses(bool async)
         => AssertSingle(
             async,
-            ss => ss.Set<Rose>(),
-            entryCount: 1);
+            ss => ss.Set<Rose>());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -234,8 +228,7 @@ public abstract class InheritanceQueryTestBase<TFixture> : QueryTestBase<TFixtur
             asserter: (e, a) =>
             {
                 AssertInclude(e, a, new ExpectedInclude<Eagle>(x => x.Prey));
-            },
-            entryCount: 2);
+            });
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
@@ -88,16 +88,14 @@ public abstract class ManyToManyQueryTestBase<TFixture> : QueryTestBase<TFixture
     public virtual Task Skip_navigation_select_many_max(bool async)
         => AssertMax(
             async,
-            ss => ss.Set<EntityThree>().SelectMany(e => e.CompositeKeySkipFull.Select(e => e.Key1)),
-            entryCount: 0);
+            ss => ss.Set<EntityThree>().SelectMany(e => e.CompositeKeySkipFull.Select(e => e.Key1)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Skip_navigation_select_many_min(bool async)
         => AssertMin(
             async,
-            ss => ss.Set<EntityThree>().SelectMany(e => e.RootSkipShared.Select(e => e.Id)),
-            entryCount: 0);
+            ss => ss.Set<EntityThree>().SelectMany(e => e.RootSkipShared.Select(e => e.Id)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -672,16 +672,14 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertSingle(
             async,
             ss => ss.Set<Customer>(),
-            predicate: c => c.CustomerID == "ALFKI",
-            entryCount: 1);
+            predicate: c => c.CustomerID == "ALFKI");
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_Single(bool async)
         => AssertSingle(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-            entryCount: 1);
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -696,24 +694,21 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertSingle(
             async,
             ss => ss.Set<Customer>(),
-            predicate: c => c.CustomerID == "ALFKI",
-            entryCount: 1);
+            predicate: c => c.CustomerID == "ALFKI");
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_SingleOrDefault(bool async)
         => AssertSingleOrDefault(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-            entryCount: 1);
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task First(bool async)
         => AssertFirst(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.ContactName),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.ContactName));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -721,8 +716,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertFirst(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.ContactName),
-            predicate: c => c.City == "London",
-            entryCount: 1);
+            predicate: c => c.City == "London");
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -730,16 +724,14 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertFirst(
             async,
             // ReSharper disable once ReplaceWithSingleCallToFirst
-            ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Where(c => c.City == "London"),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Where(c => c.City == "London"));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task FirstOrDefault(bool async)
         => AssertFirstOrDefault(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.ContactName),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.ContactName));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -747,16 +739,14 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertFirstOrDefault(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.ContactName),
-            predicate: c => c.City == "London",
-            entryCount: 1);
+            predicate: c => c.City == "London");
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_FirstOrDefault(bool async)
         => AssertFirstOrDefault(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Where(c => c.City == "London"),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Where(c => c.City == "London"));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -804,24 +794,21 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
     public virtual Task Last(bool async)
         => AssertLast(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.ContactName),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.ContactName));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Last_when_no_order_by(bool async)
         => AssertLast(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-            entryCount: 1);
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task LastOrDefault_when_no_order_by(bool async)
         => AssertLastOrDefault(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"),
-            entryCount: 1);
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI"));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -829,24 +816,21 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertLast(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.ContactName),
-            predicate: c => c.City == "London",
-            entryCount: 1);
+            predicate: c => c.City == "London");
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_Last(bool async)
         => AssertLast(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Where(c => c.City == "London"),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Where(c => c.City == "London"));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task LastOrDefault(bool async)
         => AssertLastOrDefault(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.ContactName),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.ContactName));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -854,16 +838,14 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertLastOrDefault(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.ContactName),
-            predicate: c => c.City == "London",
-            entryCount: 1);
+            predicate: c => c.City == "London");
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_LastOrDefault(bool async)
         => AssertLastOrDefault(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Where(c => c.City == "London"),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.ContactName).Where(c => c.City == "London"));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1405,16 +1387,14 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
     public virtual Task OrderBy_Take_Last_gives_correct_result(bool async)
         => AssertLast(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(20),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(20));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task OrderBy_Skip_Last_gives_correct_result(bool async)
         => AssertLast(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Skip(20),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Skip(20));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2272,7 +2272,6 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture> : QueryTestBase<TF
                 .Take(0)
                 .GroupBy(o => o.CustomerID)
                 .Select(g => new { g.Key, Total = g.Count() }),
-            elementSorter: o => o.Key,
             assertEmpty: true);
 
     [ConditionalTheory]
@@ -2286,7 +2285,6 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture> : QueryTestBase<TF
                 .Skip(0)
                 .Take(0)
                 .Select(g => new { g.Key, Total = g.Count() }),
-            elementSorter: o => o.Key,
             assertEmpty: true);
 
     [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -81,8 +81,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
             asserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<Customer>(c => c.Orders),
-                new ExpectedInclude<Order>(o => o.OrderDetails, "Orders")),
-            entryCount: 55);
+                new ExpectedInclude<Order>(o => o.OrderDetails, "Orders")));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -143,16 +142,14 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
         => AssertLast(
             async,
             ss => ss.Set<Customer>().Include(c => c.Orders).OrderBy(c => c.CompanyName),
-            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)),
-            entryCount: 8);
+            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_with_last_no_orderby(bool async)
         => AssertLast(
             async,
-            ss => ss.Set<Customer>().Include(c => c.Orders),
-            entryCount: 8);
+            ss => ss.Set<Customer>().Include(c => c.Orders));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -373,8 +370,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
                 .Include(c => c.Orders)
                 .Where(c => c.CustomerID.StartsWith("W"))
                 .OrderByDescending(c => c.Orders.OrderByDescending(oo => oo.OrderDate).FirstOrDefault().OrderDate),
-            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)),
-            entryCount: 15);
+            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -417,8 +413,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
         => AssertFirstOrDefault(
             async,
             ss => ss.Set<Customer>().Include(c => c.Orders).OrderByDescending(c => c.CompanyName),
-            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)),
-            entryCount: 8);
+            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -429,8 +424,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
                 .Include(c => c.Orders)
                 .Where(c => c.CustomerID == "ALFKI")
                 .OrderBy(c => c.Orders.OrderBy(o => o.EmployeeID).Select(o => o.OrderDate).FirstOrDefault()),
-            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)),
-            entryCount: 7);
+            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -599,8 +593,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
             asserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<Order>(o => o.Customer),
-                new ExpectedInclude<Customer>(c => c.Orders, "Customer")),
-            entryCount: 6);
+                new ExpectedInclude<Customer>(c => c.Orders, "Customer")));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -612,8 +605,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
             asserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<Order>(o => o.OrderDetails),
-                new ExpectedInclude<OrderDetail>(od => od.Product, "OrderDetails")),
-            entryCount: 7);
+                new ExpectedInclude<OrderDetail>(od => od.Product, "OrderDetails")));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -825,8 +817,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
             asserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<Customer>(c => c.Orders),
-                new ExpectedInclude<Order>(o => o.OrderDetails, "Orders")),
-            entryCount: 19);
+                new ExpectedInclude<Order>(o => o.OrderDetails, "Orders")));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -861,8 +852,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
             asserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<Order>(o => o.Customer),
-                new ExpectedInclude<Customer>(c => c.Orders, "Customer")),
-            entryCount: 6);
+                new ExpectedInclude<Customer>(c => c.Orders, "Customer")));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1265,8 +1255,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
             async,
             ss => ss.Set<Employee>().Include(e => e.Manager),
             e => e.Manager == null,
-            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Employee>(emp => emp.Manager)),
-            entryCount: 1);
+            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Employee>(emp => emp.Manager)));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1297,8 +1286,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
                 AssertCollection(
                     e.Orders, a.Orders,
                     elementAsserter: (eo, ao) => AssertInclude(eo, ao, new ExpectedInclude<Order>(o => o.OrderDetails)));
-            },
-            entryCount: 14);
+            });
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1315,8 +1303,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
                 AssertCollection(
                     e.Orders, a.Orders,
                     elementAsserter: (eo, ao) => AssertInclude(eo, ao, new ExpectedInclude<Order>(o => o.OrderDetails)));
-            },
-            entryCount: 18);
+            });
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1333,8 +1320,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture> : QueryTestBase<TF
                 AssertCollection(
                     e.Orders, a.Orders,
                     elementAsserter: (eo, ao) => AssertInclude(eo, ao, new ExpectedInclude<Order>(o => o.OrderDetails)));
-            },
-            entryCount: 14);
+            });
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -214,8 +214,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
         return AssertSingle(
             async,
             ss => ss.Set<Customer>(),
-            predicate: c => c.CustomerID == (string)context.Arguments["customerId"],
-            entryCount: 1);
+            predicate: c => c.CustomerID == (string)context.Arguments["customerId"]);
     }
 
     private static IQueryable<Customer> QueryableArgQuery(NorthwindContext context, IQueryable<string> ids)
@@ -1028,8 +1027,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
     public virtual Task Take_with_single(bool async)
         => AssertSingle(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(1),
-            entryCount: 1);
+            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(1));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1041,8 +1039,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
                    orderby c.CustomerID, o.OrderID
                    select new { c, o })
                 .Take(1)
-                .Cast<object>(),
-            entryCount: 2);
+                .Cast<object>());
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
@@ -1058,8 +1055,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
             () => AssertFirst(
                 async,
                 ss => ss.Set<Customer>().OrderBy(c => c.CustomerID),
-                predicate: c => c.IsLondon,
-                entryCount: 1),
+                predicate: c => c.IsLondon),
             CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
 
     [ConditionalTheory]
@@ -3284,8 +3280,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
             ss => from c in ss.Set<Customer>().OrderBy(c => c.CustomerID)
                   from o in ss.Set<Order>()
                   from e in ss.Set<Employee>()
-                  select new { c },
-            entryCount: 1);
+                  select new { c });
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -2212,8 +2212,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture> : QueryTestBase<TFi
                                 .Skip(0)
                                 .Take(10)
                                 .ToList()
-                        }),
-            entryCount: 2);
+                        }));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -163,9 +163,8 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Func<int> index,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertElementAt(async, query, query, index, index, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertElementAt(async, query, query, index, index, asserter);
 
     protected Task AssertElementAt<TResult>(
         bool async,
@@ -173,18 +172,16 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Func<int> actualIndex,
         Func<int> expectedIndex,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertElementAt(
-            actualQuery, expectedQuery, actualIndex, expectedIndex, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualIndex, expectedIndex, asserter, async);
 
     protected Task AssertElementAtOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Func<int> index,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertElementAtOrDefault(async, query, query, index, index, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertElementAtOrDefault(async, query, query, index, index, asserter);
 
     protected Task AssertElementAtOrDefault<TResult>(
         bool async,
@@ -192,34 +189,30 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Func<int> actualIndex,
         Func<int> expectedIndex,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertElementAtOrDefault(
-            actualQuery, expectedQuery, actualIndex, expectedIndex, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualIndex, expectedIndex, asserter, async);
 
     protected Task AssertFirst<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertFirst(async, query, query, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertFirst(async, query, query, asserter);
 
     protected Task AssertFirst<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertFirst(
-            actualQuery, expectedQuery, asserter, entryCount, async);
+            actualQuery, expectedQuery, asserter, async);
 
     protected Task AssertFirst<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, bool>> predicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertFirst(async, query, query, predicate, predicate, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertFirst(async, query, query, predicate, predicate, asserter);
 
     protected Task AssertFirst<TResult>(
         bool async,
@@ -227,17 +220,15 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertFirst(
-            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async);
 
     protected Task AssertFirstOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertFirstOrDefault(async, query, query, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertFirstOrDefault(async, query, query, asserter);
 
     protected Task AssertFirstOrDefault<TResult>(
         bool async,
@@ -246,15 +237,14 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Action<TResult, TResult> asserter = null,
         int entryCount = 0)
         => QueryAsserter.AssertFirstOrDefault(
-            actualQuery, expectedQuery, asserter, entryCount, async);
+            actualQuery, expectedQuery, asserter, async);
 
     protected Task AssertFirstOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, bool>> predicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertFirstOrDefault(async, query, query, predicate, predicate, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertFirstOrDefault(async, query, query, predicate, predicate, asserter);
 
     protected Task AssertFirstOrDefault<TResult>(
         bool async,
@@ -262,34 +252,30 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertFirstOrDefault(
-            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async);
 
     protected Task AssertSingle<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertSingle(async, query, query, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertSingle(async, query, query, asserter);
 
     protected Task AssertSingle<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertSingle(
-            actualQuery, expectedQuery, asserter, entryCount, async);
+            actualQuery, expectedQuery, asserter, async);
 
     protected Task AssertSingle<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, bool>> predicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertSingle(async, query, query, predicate, predicate, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertSingle(async, query, query, predicate, predicate, asserter);
 
     protected Task AssertSingle<TResult>(
         bool async,
@@ -297,34 +283,30 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertSingle(
-            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async);
 
     protected Task AssertSingleOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertSingleOrDefault(async, query, query, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertSingleOrDefault(async, query, query, asserter);
 
     protected Task AssertSingleOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertSingleOrDefault(
-            actualQuery, expectedQuery, asserter, entryCount, async);
+            actualQuery, expectedQuery, asserter, async);
 
     protected Task AssertSingleOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, bool>> predicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertSingleOrDefault(async, query, query, predicate, predicate, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertSingleOrDefault(async, query, query, predicate, predicate, asserter);
 
     protected Task AssertSingleOrDefault<TResult>(
         bool async,
@@ -332,34 +314,30 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertSingleOrDefault(
-            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async);
 
     protected Task AssertLast<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertLast(async, query, query, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertLast(async, query, query, asserter);
 
     protected Task AssertLast<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertLast(
-            actualQuery, expectedQuery, asserter, entryCount, async);
+            actualQuery, expectedQuery, asserter, async);
 
     protected Task AssertLast<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, bool>> predicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertLast(async, query, query, predicate, predicate, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertLast(async, query, query, predicate, predicate, asserter);
 
     protected Task AssertLast<TResult>(
         bool async,
@@ -367,34 +345,30 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertLast(
-            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async);
 
     protected Task AssertLastOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertLastOrDefault(async, query, query, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertLastOrDefault(async, query, query, asserter);
 
     protected Task AssertLastOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertLastOrDefault(
-            actualQuery, expectedQuery, asserter, entryCount, async);
+            actualQuery, expectedQuery, asserter, async);
 
     protected Task AssertLastOrDefault<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, bool>> predicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertLastOrDefault(async, query, query, predicate, predicate, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertLastOrDefault(async, query, query, predicate, predicate, asserter);
 
     protected Task AssertLastOrDefault<TResult>(
         bool async,
@@ -402,10 +376,9 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertLastOrDefault(
-            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualPredicate, expectedPredicate, asserter, async);
 
     protected Task AssertCount<TResult>(
         bool async,
@@ -462,26 +435,23 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
     protected Task AssertMin<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertMin(async, query, query, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertMin(async, query, query, asserter);
 
     protected Task AssertMin<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertMin(
-            actualQuery, expectedQuery, asserter, entryCount, async);
+            actualQuery, expectedQuery, asserter, async);
 
     protected Task AssertMin<TResult, TSelector>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, TSelector>> selector,
-        Action<TSelector, TSelector> asserter = null,
-        int entryCount = 0)
-        => AssertMin(async, query, query, selector, selector, asserter, entryCount);
+        Action<TSelector, TSelector> asserter = null)
+        => AssertMin(async, query, query, selector, selector, asserter);
 
     protected Task AssertMin<TResult, TSelector>(
         bool async,
@@ -489,34 +459,30 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, TSelector>> actualSelector,
         Expression<Func<TResult, TSelector>> expectedSelector,
-        Action<TSelector, TSelector> asserter = null,
-        int entryCount = 0)
+        Action<TSelector, TSelector> asserter = null)
         => QueryAsserter.AssertMin(
-            actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async);
 
     protected Task AssertMax<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
-        => AssertMax(async, query, query, asserter, entryCount);
+        Action<TResult, TResult> asserter = null)
+        => AssertMax(async, query, query, asserter);
 
     protected Task AssertMax<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Action<TResult, TResult> asserter = null,
-        int entryCount = 0)
+        Action<TResult, TResult> asserter = null)
         => QueryAsserter.AssertMax(
-            actualQuery, expectedQuery, asserter, entryCount, async);
+            actualQuery, expectedQuery, asserter, async);
 
     protected Task AssertMax<TResult, TSelector>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
         Expression<Func<TResult, TSelector>> selector,
-        Action<TSelector, TSelector> asserter = null,
-        int entryCount = 0)
-        => AssertMax(async, query, query, selector, selector, asserter, entryCount);
+        Action<TSelector, TSelector> asserter = null)
+        => AssertMax(async, query, query, selector, selector, asserter);
 
     protected Task AssertMax<TResult, TSelector>(
         bool async,
@@ -524,10 +490,9 @@ public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Expression<Func<TResult, TSelector>> actualSelector,
         Expression<Func<TResult, TSelector>> expectedSelector,
-        Action<TSelector, TSelector> asserter = null,
-        int entryCount = 0)
+        Action<TSelector, TSelector> asserter = null)
         => QueryAsserter.AssertMax(
-            actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, entryCount, async);
+            actualQuery, expectedQuery, actualSelector, expectedSelector, asserter, async);
 
     protected Task AssertSum(
         bool async,

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -318,7 +318,6 @@ public class QueryAsserter
         Func<int> actualIndex,
         Func<int> expectedIndex,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -331,7 +330,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).ElementAt(expectedIndex());
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertElementAtOrDefault<TResult>(
@@ -340,7 +338,6 @@ public class QueryAsserter
         Func<int> actualIndex,
         Func<int> expectedIndex,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -353,14 +350,12 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).ElementAtOrDefault(expectedIndex());
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertFirst<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -373,7 +368,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).First();
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertFirst<TResult>(
@@ -382,7 +376,6 @@ public class QueryAsserter
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -397,14 +390,12 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).First(rewrittenExpectedPredicate);
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertFirstOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -417,7 +408,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).FirstOrDefault();
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertFirstOrDefault<TResult>(
@@ -426,7 +416,6 @@ public class QueryAsserter
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -441,14 +430,12 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).FirstOrDefault(rewrittenExpectedPredicate);
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertSingle<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -461,7 +448,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).Single();
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertSingle<TResult>(
@@ -470,7 +456,6 @@ public class QueryAsserter
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -485,14 +470,12 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).Single(rewrittenExpectedPredicate);
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertSingleOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -505,7 +488,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).SingleOrDefault();
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertSingleOrDefault<TResult>(
@@ -514,7 +496,6 @@ public class QueryAsserter
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -529,14 +510,12 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).SingleOrDefault(rewrittenExpectedPredicate);
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertLast<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -549,7 +528,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).Last();
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertLast<TResult>(
@@ -558,7 +536,6 @@ public class QueryAsserter
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -573,14 +550,12 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).Last(rewrittenExpectedPredicate);
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertLastOrDefault<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -593,7 +568,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).LastOrDefault();
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertLastOrDefault<TResult>(
@@ -602,7 +576,6 @@ public class QueryAsserter
         Expression<Func<TResult, bool>> actualPredicate,
         Expression<Func<TResult, bool>> expectedPredicate,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -617,7 +590,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).LastOrDefault(rewrittenExpectedPredicate);
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertCount<TResult>(
@@ -704,7 +676,6 @@ public class QueryAsserter
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -717,7 +688,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).Min();
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertMin<TResult, TSelector>(
@@ -726,7 +696,6 @@ public class QueryAsserter
         Expression<Func<TResult, TSelector>> actualSelector,
         Expression<Func<TResult, TSelector>> expectedSelector,
         Action<TSelector, TSelector> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -742,14 +711,12 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).Min(rewrittenExpectedSelector);
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertMax<TResult>(
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
         Action<TResult, TResult> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -762,7 +729,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).Max();
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertMax<TResult, TSelector>(
@@ -771,7 +737,6 @@ public class QueryAsserter
         Expression<Func<TResult, TSelector>> actualSelector,
         Expression<Func<TResult, TSelector>> expectedSelector,
         Action<TSelector, TSelector> asserter = null,
-        int entryCount = 0,
         bool async = false,
         bool filteredQuery = false)
     {
@@ -787,7 +752,6 @@ public class QueryAsserter
         var expected = RewriteExpectedQuery(expectedQuery(expectedData)).Max(rewrittenExpectedSelector);
 
         AssertEqual(expected, actual, asserter);
-        AssertEntryCount(context, entryCount);
     }
 
     public async Task AssertSum(


### PR DESCRIPTION
- remove entryCount checks from other Assert* methods,
- remove (useless) sorter/asserter for tests that are supposed to return no results