### PR TITLE
[release/8.0] Preserve `convertsNulls` in the compiled model

### DIFF
--- a/src/EFCore/Design/Internal/CSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore/Design/Internal/CSharpRuntimeAnnotationCodeGenerator.cs
@@ -373,7 +373,16 @@ public class CSharpRuntimeAnnotationCodeGenerator : ICSharpRuntimeAnnotationCode
                 .IncrementIndent()
                 .Append(codeHelper.Expression(converter.ConvertToProviderExpression, parameters.Namespaces))
                 .AppendLine(",")
-                .Append(codeHelper.Expression(converter.ConvertFromProviderExpression, parameters.Namespaces))
+                .Append(codeHelper.Expression(converter.ConvertFromProviderExpression, parameters.Namespaces));
+
+            if (converter.ConvertsNulls)
+            {
+                mainBuilder
+                    .AppendLine(",")
+                    .Append("convertsNulls: true");
+            }
+
+            mainBuilder
                 .Append(")")
                 .DecrementIndent();
         }


### PR DESCRIPTION
Fixes #31942

### Description

Updates to the compiled model resulted in losing the `convertsNulls` state of a value converter.

### Customer impact

Silent regression from 7 resulting in different data returned.

### How found

Customer reported on daily build.

### Regression

Yes.

### Testing

Added tests.

### Risk

Low.

