### PR TITLE
[release/8.0] Allow creating properties implicitly even when type is configured as non-property

### DIFF
--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -116,28 +116,7 @@ public static class EntityTypeExtensions
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public static bool IsInOwnershipPath(this IReadOnlyEntityType entityType, IReadOnlyEntityType targetType)
-    {
-        if (entityType == targetType)
-        {
-            return true;
-        }
-
-        var owner = entityType;
-        while (true)
-        {
-            var ownership = owner.FindOwnership();
-            if (ownership == null)
-            {
-                return false;
-            }
-
-            owner = ownership.PrincipalEntityType;
-            if (owner.IsAssignableFrom(targetType))
-            {
-                return true;
-            }
-        }
-    }
+        => entityType.IsInOwnershipPath(targetType);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/InternalComplexTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalComplexTypeBuilder.cs
@@ -43,9 +43,11 @@ public class InternalComplexTypeBuilder : InternalTypeBaseBuilder, IConventionCo
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? propertyType,
         string propertyName,
         ConfigurationSource configurationSource,
-        bool checkClrProperty = false)
+        bool checkClrProperty,
+        bool skipTypeCheck)
         => !IsIgnored(propertyName, configurationSource)
             && (propertyType == null
+                || skipTypeCheck
                 || Metadata.Model.Builder.CanBeConfigured(propertyType, TypeConfigurationType.Property, configurationSource))
             && (!checkClrProperty
                 || propertyType != null

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -1129,8 +1129,7 @@ public class InternalForeignKeyBuilder : AnnotatableBuilder<ForeignKey, Internal
         var newOwnership = newEntityType.GetForeignKeys().SingleOrDefault(fk => fk.IsOwnership);
         if (newOwnership == null)
         {
-            Check.DebugAssert(Metadata.IsInModel, "Metadata isn't in the model");
-            return Metadata.Builder;
+            return Metadata.IsInModel ? Metadata.Builder : null;
         }
 
         Check.DebugAssert(!Metadata.IsInModel, "Metadata is in the model");
@@ -2922,11 +2921,6 @@ public class InternalForeignKeyBuilder : AnnotatableBuilder<ForeignKey, Internal
                 ConfigurationSource.Convention)!;
         }
 
-        foreach (var removedForeignKey in removedForeignKeys)
-        {
-            Metadata.DeclaringEntityType.Model.ConventionDispatcher.Tracker.Update(removedForeignKey, newRelationshipBuilder.Metadata);
-        }
-
         if (tempIndex?.IsInModel == true)
         {
             dependentEntityType.RemoveIndex(tempIndex.Properties);
@@ -2935,6 +2929,16 @@ public class InternalForeignKeyBuilder : AnnotatableBuilder<ForeignKey, Internal
         if (keyTempIndex?.IsInModel == true)
         {
             keyTempIndex.DeclaringEntityType.RemoveIndex(keyTempIndex.Properties);
+        }
+
+        if (newRelationshipBuilder == null)
+        {
+            return null;
+        }
+
+        foreach (var removedForeignKey in removedForeignKeys)
+        {
+            Metadata.DeclaringEntityType.Model.ConventionDispatcher.Tracker.Update(removedForeignKey, newRelationshipBuilder.Metadata);
         }
 
         return newRelationshipBuilder;

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -2670,7 +2670,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.AmbiguousOneToOneRelationship("SelfRef.SelfRef1", "SelfRef.SelfRef2"),
-                Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
+                Assert.Throws<InvalidOperationException>(modelBuilder.FinalizeModel).Message);
         }
 
         [ConditionalFact]
@@ -2684,7 +2684,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.AmbiguousOneToOneRelationship("SelfRef.SelfRef1", "SelfRef.SelfRef2"),
-                Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
+                Assert.Throws<InvalidOperationException>(modelBuilder.FinalizeModel).Message);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Fixes #30373
Fixes #28515

### Description

When an owned entity type is configured, conventions can no longer discover properties of that type as properties. This incorrectly also affects implicitly created properties for FKs and PKs.

### Customer impact

For models with the matching shape an exception is thrown. There is no workaround that would result in the desired model.

### How found

Customer reported on 7.0

### Regression

No.

### Testing

Added tests.

### Risk

Low. 