### PR TITLE
[release/8.0] Synthesize concurrency tokens for derived tables in TPC and TPT

### DIFF
--- a/src/EFCore.Relational/Metadata/ITable.cs
+++ b/src/EFCore.Relational/Metadata/ITable.cs
@@ -95,6 +95,7 @@ public interface ITable : ITableBase
     {
         var builder = new StringBuilder();
         var indentString = new string(' ', indent);
+        var designTime = EntityTypeMappings.FirstOrDefault()?.TypeBase is not RuntimeEntityType;
 
         try
         {
@@ -111,8 +112,8 @@ public interface ITable : ITableBase
 
             builder.Append(Name);
 
-            if (EntityTypeMappings.Any()
-                && EntityTypeMappings.First().TypeBase is not RuntimeEntityType
+            if (designTime
+                && EntityTypeMappings.Any()
                 && IsExcludedFromMigrations)
             {
                 builder.Append(" ExcludedFromMigrations");
@@ -132,7 +133,9 @@ public interface ITable : ITableBase
                 builder.Append(PrimaryKey.ToDebugString(options, indent + 2));
             }
 
-            if ((options & MetadataDebugStringOptions.SingleLine) == 0 && Comment != null)
+            if ((options & MetadataDebugStringOptions.SingleLine) == 0
+                 && designTime
+                 && Comment != null)
             {
                 builder
                     .AppendLine()
@@ -194,13 +197,16 @@ public interface ITable : ITableBase
                     }
                 }
 
-                var checkConstraints = CheckConstraints.ToList();
-                if (checkConstraints.Count != 0)
+                if (designTime)
                 {
-                    builder.AppendLine().Append(indentString).Append("  Check constraints: ");
-                    foreach (var checkConstraint in checkConstraints)
+                    var checkConstraints = CheckConstraints.ToList();
+                    if (checkConstraints.Count != 0)
                     {
-                        builder.AppendLine().Append(checkConstraint.ToDebugString(options, indent + 4));
+                        builder.AppendLine().Append(indentString).Append("  Check constraints: ");
+                        foreach (var checkConstraint in checkConstraints)
+                        {
+                            builder.AppendLine().Append(checkConstraint.ToDebugString(options, indent + 4));
+                        }
                     }
                 }
 

--- a/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
@@ -149,7 +149,7 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
                 var fanVersion1 = fanEntry.Property<TVersion>(propertyName).CurrentValue;
                 var swagVersion1 = default(TVersion);
 
-                if (mapping == Mapping.Tph) // Issue #29750
+                if (mapping != Mapping.Tpt) // Issue #22060
                 {
                     swagVersion1 = swagEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
 
@@ -190,7 +190,7 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
                 Assert.NotEqual(fanVersion1, fanVersion2);
 
                 var swagVersion2 = default(TVersion);
-                if (mapping == Mapping.Tph) // Issue #29750
+                if (mapping != Mapping.Tpt) // Issue #22060
                 {
                     swagVersion2 = swagEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
                     Assert.Equal(fanVersion2, swagVersion2);
@@ -229,7 +229,7 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
                 var fanVersion3 = fanEntry.Property<TVersion>(propertyName).CurrentValue;
                 Assert.NotEqual(fanVersion2, fanVersion3);
 
-                if (mapping == Mapping.Tph) // Issue #29750
+                if (mapping != Mapping.Tpt) // Issue #22060
                 {
                     var swagVersion3 = swagEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
                     Assert.Equal(fanVersion3, swagVersion3);
@@ -261,7 +261,7 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
                 var circuitVersion1 = circuitEntry.Property<TVersion>(propertyName).CurrentValue;
                 var cityVersion1 = default(TVersion);
 
-                if (mapping == Mapping.Tph) // Issue #29750
+                if (mapping != Mapping.Tpt) // Issue #22060
                 {
                     cityVersion1 = cityEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
 
@@ -302,7 +302,7 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
                 Assert.NotEqual(circuitVersion1, circuitVersion2);
 
                 var cityVersion2 = default(TVersion);
-                if (mapping == Mapping.Tph) // Issue #29750
+                if (mapping != Mapping.Tpt) // Issue #22060
                 {
                     cityVersion2 = cityEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
                     Assert.Equal(circuitVersion2, cityVersion2);
@@ -341,7 +341,7 @@ public abstract class OptimisticConcurrencySqlServerTestBase<TFixture, TRowVersi
                 var circuitVersion3 = circuitEntry.Property<TVersion>(propertyName).CurrentValue;
                 Assert.NotEqual(circuitVersion2, circuitVersion3);
 
-                if (mapping == Mapping.Tph) // Issue #29750
+                if (mapping != Mapping.Tpt) // Issue #22060
                 {
                     var cityVersion3 = cityEntry.Property<TVersion>(synthesizedPropertyName).CurrentValue;
                     Assert.Equal(circuitVersion3, cityVersion3);


### PR DESCRIPTION
Fixes #29750

### Description

We didn't correctly detect table sharing in derived types using TPC and TPT when synthesizing concurrency token properties for table sharing.

### Customer impact

For models with matching shape the changes made only for the table-sharing entities don't trigger an update of the concurrency token and the next `SaveChanges` throws an exception.

### How found

Discovered during testing on 8.0

### Regression

No.

### Testing

Added tests.

### Risk

Low. 