### PR TITLE
[release/8.0] Open the connection before creating the DbCommand

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommand.cs
@@ -507,13 +507,11 @@ public class RelationalCommand : IRelationalCommand
         // Guid.NewGuid is expensive, do it only if needed
         var commandId = shouldLogCommandCreate || shouldLogCommandExecute ? Guid.NewGuid() : default;
 
-        var command = CreateDbCommand(parameterObject, commandId, DbCommandMethod.ExecuteReader);
-
         connection.Open();
 
+        var command = CreateDbCommand(parameterObject, commandId, DbCommandMethod.ExecuteReader);
         var readerOpen = false;
         DbDataReader reader;
-
         var stopwatch = SharedStopwatch.StartNew();
 
         try
@@ -635,13 +633,11 @@ public class RelationalCommand : IRelationalCommand
         // Guid.NewGuid is expensive, do it only if needed
         var commandId = shouldLogCommandCreate || shouldLogCommandExecute ? Guid.NewGuid() : default;
 
-        var command = CreateDbCommand(parameterObject, commandId, DbCommandMethod.ExecuteReader);
-
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
+        var command = CreateDbCommand(parameterObject, commandId, DbCommandMethod.ExecuteReader);
         var readerOpen = false;
         DbDataReader reader;
-
         var stopwatch = SharedStopwatch.StartNew();
 
         try

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -384,13 +384,13 @@ public abstract class TransactionTestBase<TFixture> : IClassFixture<TFixture>
                 Assert.Equal(
                     RelationalResources.LogAmbientTransactionEnlisted(new TestLogger<TestRelationalLoggingDefinitions>())
                         .GenerateMessage("Serializable"),
-                    Fixture.ListLoggerFactory.Log.Skip(3).First().Message);
+                    Fixture.ListLoggerFactory.Log.First().Message);
             }
             else
             {
                 Assert.Equal(
                     RelationalResources.LogAmbientTransaction(new TestLogger<TestRelationalLoggingDefinitions>()).GenerateMessage(),
-                    Fixture.ListLoggerFactory.Log.Skip(3).First().Message);
+                    Fixture.ListLoggerFactory.Log.First().Message);
 
                 using var context = CreateContext();
                 context.Entry(context.Set<TransactionCustomer>().Single(c => c.Id == -77)).State = EntityState.Deleted;

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -209,7 +209,7 @@ public class TestRelationalCommandBuilderFactory : IRelationalCommandBuilderFact
             RelationalCommandParameterObject parameterObject,
             Guid commandId,
             DbCommandMethod commandMethod)
-            => throw new NotSupportedException();
+            => _realRelationalCommand.CreateDbCommand(parameterObject, commandId, commandMethod);
 
         public void PopulateFrom(IRelationalCommandTemplate commandTemplate)
             => _realRelationalCommand.PopulateFrom(commandTemplate);


### PR DESCRIPTION
Fixes #31000

### Description

We didn't cleanup the `DbCommand` to be executed if the connection fails to open.

### Customer impact

Users invoking `FromSql` with an explicit `SqlParameter` will get an exception on the first retry when the connection fails to open due to a transient error.

### How found

Customer reported on 7.0

### Regression

No.

### Testing

Added tests.

### Risk

Low. 