### PR TITLE
[release/8.0] Fix to #30478 - TemporalAll fails with JSON columns

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerNavigationExpansionExtensibilityHelper.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerNavigationExpansionExtensibilityHelper.cs
@@ -51,7 +51,7 @@ public class SqlServerNavigationExpansionExtensibilityHelper : NavigationExpansi
     /// </summary>
     public override void ValidateQueryRootCreation(IEntityType entityType, EntityQueryRootExpression? source)
     {
-        if (source is TemporalQueryRootExpression)
+        if (source is TemporalQueryRootExpression && !entityType.IsMappedToJson())
         {
             if (!entityType.GetRootType().IsTemporal())
             {


### PR DESCRIPTION
We had a validation step preventing non AsOf temporal queries when we use navigation properties, as well as checking that all entities in the navigation chain are set as temporal. This should not apply to JSON entities, since those always part of the entity.

Fix is to no longer perform the check for navigations mapped to JSON.

Fixes #30478

**Risk**

Low - we just stop doing incorrect validation for queries navigating into json entities, they were blocked before now they will work. The only realistic issue I can see is that a particular temporal+json scenario has a bug, before we would block it with this validation step and now the bug would be hit.
