### PR TITLE
[release/8.0] Send update commands for the deleted shared identity entity when not mapped to the same table.

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
@@ -213,12 +213,9 @@ public static class RelationalForeignKeyExtensions
     {
         var entityType = foreignKey.DeclaringEntityType;
         var primaryKey = entityType.FindPrimaryKey();
-        if (primaryKey == null || entityType.IsMappedToJson())
-        {
-            return false;
-        }
-
-        if (!foreignKey.PrincipalKey.IsPrimaryKey()
+        if (primaryKey == null
+            || entityType.IsMappedToJson()
+            || !foreignKey.PrincipalKey.IsPrimaryKey()
             || foreignKey.PrincipalEntityType.IsAssignableFrom(foreignKey.DeclaringEntityType)
             || !foreignKey.Properties.SequenceEqual(primaryKey.Properties)
             || !IsMapped(foreignKey, storeObject))

--- a/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeExtensions.cs
@@ -28,38 +28,46 @@ public static class RelationalEntityTypeExtensions
     public static IEnumerable<IForeignKey> FindDeclaredReferencingRowInternalForeignKeys(
         this IEntityType entityType,
         StoreObjectIdentifier storeObject)
+        => entityType.IsMappedToJson()
+            ? Enumerable.Empty<IForeignKey>()
+            : entityType.GetDeclaredReferencingForeignKeys().Where(fk => fk.IsRowInternal(storeObject));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool IsMainFragment(
+        this IReadOnlyTypeBase type,
+        StoreObjectIdentifier storeObject)
     {
-        if (entityType.IsMappedToJson())
+        var storeObjectType = storeObject.StoreObjectType;
+        var declaredStoreObject = StoreObjectIdentifier.Create(type, storeObjectType);
+        if (declaredStoreObject != null)
         {
-            yield break;
+            return storeObject == declaredStoreObject;
         }
 
-        foreach (var foreignKey in entityType.GetDeclaredReferencingForeignKeys())
+        if (storeObjectType is StoreObjectType.Function or StoreObjectType.SqlQuery)
         {
-            var dependentPrimaryKey = foreignKey.DeclaringEntityType.FindPrimaryKey();
-            if (dependentPrimaryKey == null)
-            {
-                yield break;
-            }
-
-            if (!foreignKey.PrincipalKey.IsPrimaryKey()
-                || foreignKey.PrincipalEntityType.IsAssignableFrom(foreignKey.DeclaringEntityType)
-                || !foreignKey.Properties.SequenceEqual(dependentPrimaryKey.Properties)
-                || !IsMapped(foreignKey, storeObject))
-            {
-                continue;
-            }
-
-            yield return foreignKey;
+            return false;
         }
 
-        static bool IsMapped(IReadOnlyForeignKey foreignKey, StoreObjectIdentifier storeObject)
-            => (StoreObjectIdentifier.Create(foreignKey.DeclaringEntityType, storeObject.StoreObjectType) == storeObject
-                    || foreignKey.DeclaringEntityType.GetMappingFragments(storeObject.StoreObjectType)
-                        .Any(f => f.StoreObject == storeObject))
-                && (StoreObjectIdentifier.Create(foreignKey.PrincipalEntityType, storeObject.StoreObjectType) == storeObject
-                    || foreignKey.PrincipalEntityType.GetMappingFragments(storeObject.StoreObjectType)
-                        .Any(f => f.StoreObject == storeObject));
+        if (type is not IReadOnlyEntityType entityType)
+        {
+            return false;
+        }
+
+        foreach (var derivedType in entityType.GetDirectlyDerivedTypes())
+        {
+            if (IsMainFragment(derivedType, storeObject))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -215,56 +215,31 @@ public class CommandBatchPreparer : ICommandBatchPreparer
                 continue;
             }
 
-            var foundMapping = false;
+            using var sharedIdentityTableMappings =
+                entry.SharedIdentityEntry != null
+                    && entry.SharedIdentityEntry.EntityState == EntityState.Deleted
+                    ? entry.SharedIdentityEntry.EntityType.GetTableMappings().GetEnumerator()
+                    : null;
 
+            var foundMapping = false;
             foreach (var tableMapping in entry.EntityType.GetTableMappings())
             {
-                var sprocMapping = entry.EntityState switch
+                if (sharedIdentityTableMappings != null
+                    && sharedIdentityTableMappings.MoveNext()
+                    && sharedIdentityTableMappings.Current.Table != tableMapping.Table)
                 {
-                    EntityState.Added => tableMapping.InsertStoredProcedureMapping,
-                    EntityState.Modified => tableMapping.UpdateStoredProcedureMapping,
-                    EntityState.Deleted => tableMapping.DeleteStoredProcedureMapping,
-
-                    _ => throw new ArgumentOutOfRangeException("Unexpected entry.EntityState: " + entry.EntityState)
-                };
-
-                var table = tableMapping.Table;
-
-                IModificationCommand command;
-                var isMainEntry = true;
-                if (table.IsShared)
-                {
-                    Check.DebugAssert(sprocMapping is null, "Shared table with sproc mapping");
-
-                    sharedTablesCommandsMap ??= new Dictionary<(string Name, string? Schema), SharedTableEntryMap<IModificationCommand>>();
-
-                    var tableKey = (table.Name, table.Schema);
-                    if (!sharedTablesCommandsMap.TryGetValue(tableKey, out var sharedCommandsMap))
-                    {
-                        sharedCommandsMap = new SharedTableEntryMap<IModificationCommand>(table, updateAdapter);
-                        sharedTablesCommandsMap.Add(tableKey, sharedCommandsMap);
-                    }
-
-                    command = sharedCommandsMap.GetOrAddValue(
-                        entry,
-                        (t, comparer) => Dependencies.ModificationCommandFactory.CreateModificationCommand(
-                            new ModificationCommandParameters(
-                                t, _sensitiveLoggingEnabled, _detailedErrorsEnabled, comparer, generateParameterName,
-                                Dependencies.UpdateLogger)));
-                    isMainEntry = sharedCommandsMap.IsMainEntry(entry);
-                }
-                else
-                {
-                    command = Dependencies.ModificationCommandFactory.CreateModificationCommand(
-                        new ModificationCommandParameters(
-                            table, sprocMapping?.StoreStoredProcedure, _sensitiveLoggingEnabled, _detailedErrorsEnabled,
-                            comparer: null, generateParameterName, Dependencies.UpdateLogger));
+                    ProcessEntry(entry.SharedIdentityEntry!, sharedIdentityTableMappings.Current, commands, updateAdapter, generateParameterName, ref sharedTablesCommandsMap);
                 }
 
-                command.AddEntry(entry, isMainEntry);
-                commands.Add(command);
+                ProcessEntry(entry, tableMapping, commands, updateAdapter, generateParameterName, ref sharedTablesCommandsMap);
 
                 foundMapping = true;
+            }
+
+            while (sharedIdentityTableMappings != null
+                    && sharedIdentityTableMappings.MoveNext())
+            {
+                ProcessEntry(entry.SharedIdentityEntry!, sharedIdentityTableMappings.Current, commands, updateAdapter, generateParameterName, ref sharedTablesCommandsMap);
             }
 
             if (!foundMapping)
@@ -279,6 +254,60 @@ public class CommandBatchPreparer : ICommandBatchPreparer
         }
 
         return commands;
+
+        void ProcessEntry(
+            IUpdateEntry entry,
+            ITableMapping tableMapping,
+            List<IModificationCommand> commands,
+            IUpdateAdapter updateAdapter,
+            Func<string> generateParameterName,
+            ref Dictionary<(string Name, string? Schema), SharedTableEntryMap<IModificationCommand>>? sharedTablesCommandsMap)
+        {
+            var sprocMapping = entry.EntityState switch
+            {
+                EntityState.Added => tableMapping.InsertStoredProcedureMapping,
+                EntityState.Modified => tableMapping.UpdateStoredProcedureMapping,
+                EntityState.Deleted => tableMapping.DeleteStoredProcedureMapping,
+
+                _ => throw new ArgumentOutOfRangeException("Unexpected entry.EntityState: " + entry.EntityState)
+            };
+
+            var table = tableMapping.Table;
+
+            IModificationCommand command;
+            var isMainEntry = true;
+            if (table.IsShared)
+            {
+                Check.DebugAssert(sprocMapping is null, "Shared table with sproc mapping");
+
+                sharedTablesCommandsMap ??= new Dictionary<(string Name, string? Schema), SharedTableEntryMap<IModificationCommand>>();
+
+                var tableKey = (table.Name, table.Schema);
+                if (!sharedTablesCommandsMap.TryGetValue(tableKey, out var sharedCommandsMap))
+                {
+                    sharedCommandsMap = new SharedTableEntryMap<IModificationCommand>(table, updateAdapter);
+                    sharedTablesCommandsMap.Add(tableKey, sharedCommandsMap);
+                }
+
+                command = sharedCommandsMap.GetOrAddValue(
+                    entry,
+                    (t, comparer) => Dependencies.ModificationCommandFactory.CreateModificationCommand(
+                        new ModificationCommandParameters(
+                            t, _sensitiveLoggingEnabled, _detailedErrorsEnabled, comparer, generateParameterName,
+                            Dependencies.UpdateLogger)));
+                isMainEntry = sharedCommandsMap.IsMainEntry(entry);
+            }
+            else
+            {
+                command = Dependencies.ModificationCommandFactory.CreateModificationCommand(
+                    new ModificationCommandParameters(
+                        table, sprocMapping?.StoreStoredProcedure, _sensitiveLoggingEnabled, _detailedErrorsEnabled,
+                        comparer: null, generateParameterName, Dependencies.UpdateLogger));
+            }
+
+            command.AddEntry(entry, isMainEntry);
+            commands.Add(command);
+        }
     }
 
     private static void AddUnchangedSharingEntries(

--- a/src/EFCore/Metadata/Internal/PropertyListComparer.cs
+++ b/src/EFCore/Metadata/Internal/PropertyListComparer.cs
@@ -86,7 +86,7 @@ public sealed class PropertyListComparer : IComparer<IReadOnlyList<IReadOnlyProp
         var hash = new HashCode();
         for (var i = 0; i < obj.Count; i++)
         {
-            hash.Add(obj[i]);
+            hash.Add(obj[i].Name);
         }
 
         return hash.ToHashCode();

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTPCTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTPCTest.cs
@@ -110,7 +110,7 @@ WHERE [p].[Discriminator] = N'Product' AND [p].[DependentId] = @__category_Princ
             base.OnModelCreating(modelBuilder, context);
 
             modelBuilder.Entity<Category>().UseTpcMappingStrategy();
-            // modelBuilder.Entity<GiftObscurer>().UseTpcMappingStrategy(); Issue #29874
+            modelBuilder.Entity<GiftObscurer>().UseTpcMappingStrategy();
             modelBuilder.Entity<LiftObscurer>().UseTpcMappingStrategy();
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTPTTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTPTTest.cs
@@ -14,10 +14,6 @@ public class UpdatesSqlServerTPTTest : UpdatesSqlServerTestBase<UpdatesSqlServer
     {
     }
 
-    [ConditionalTheory(Skip = "Issue #29874. Skipped because the database is in a bad state, but the test may or may not fail.")]
-    public override Task Can_change_type_of_pk_to_pk_dependent_by_replacing_with_new_dependent(bool async)
-        => Task.CompletedTask;
-
     public override void Save_with_shared_foreign_key()
     {
         base.Save_with_shared_foreign_key();


### PR DESCRIPTION
Fixes #29874

### Description

We assumed that when an entity was deleted and a new entity with the same key value was added they were or the same type or at least mapped to the same table, however this is not always the case for entity types using TPC or TPT.

### Customer impact

When replacing an entity with one of a different type, but still using the same key the old entity wasn't deleted leaving the database in an invalid state.

### How found

Discovered during testing on 8.0

### Regression

No.

### Testing

Added tests.

### Risk

Low. 