### PR TITLE
[release/8.0] Fix to #29297 - Seeding issue with JSON columns in EF Core 7

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -828,6 +828,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 propertySpecification, function);
 
         /// <summary>
+        ///     Can't use HasData for entity type '{entity}'. HasData is not supported for entities mapped to JSON.
+        /// </summary>
+        public static string HasDataNotSupportedForEntitiesMappedToJson(object? entity)
+            => string.Format(
+                GetString("HasDataNotSupportedForEntitiesMappedToJson", nameof(entity)),
+                entity);
+
+        /// <summary>
         ///     Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and the comment '{comment}' does not match the comment '{otherComment}'.
         /// </summary>
         public static string IncompatibleTableCommentMismatch(object? table, object? entityType, object? otherEntityType, object? comment, object? otherComment)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -427,6 +427,9 @@
   <data name="FunctionOverrideMismatch" xml:space="preserve">
     <value>The property '{propertySpecification}' has specific configuration for the function '{function}', but it isn't mapped to a column on that function return. Remove the specific configuration, or map an entity type that contains this property to '{function}'.</value>
   </data>
+  <data name="HasDataNotSupportedForEntitiesMappedToJson" xml:space="preserve">
+    <value>Can't use HasData for entity type '{entity}'. HasData is not supported for entities mapped to JSON.</value>
+  </data>
   <data name="IncompatibleTableCommentMismatch" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and the comment '{comment}' does not match the comment '{otherComment}'.</value>
   </data>


### PR DESCRIPTION
Adding validation step when using HasData with entities mapped to JSON, as well as normal entities navigating into JSON.

Fixes #29297

**Risk**

Minimal. Adding validation for scenarios that were not supported in the first place. We now throw meaningful exception.