### PR TITLE
[release/8.0] Change error to warning for trigger defined on non-base type

### DIFF
--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -103,6 +103,7 @@ public static class RelationalEventId
         TpcStoreGeneratedIdentityWarning,
         KeyPropertiesNotMappedToTable,
         StoredProcedureConcurrencyTokenNotMapped,
+        TriggerOnNonRootTphEntity,
 
         // Update events
         BatchReadyForExecution = CoreEventId.RelationalBaseId + 700,
@@ -886,6 +887,20 @@ public static class RelationalEventId
     /// </remarks>
     public static readonly EventId StoredProcedureConcurrencyTokenNotMapped =
         MakeValidationId(Id.StoredProcedureConcurrencyTokenNotMapped);
+
+    /// <summary>
+    ///     Can't configure a trigger on the non-root entity type in a TPH hierarchy.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+    ///     </para>
+    ///     <para>
+    ///         This event uses the <see cref="EntityTypeEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    ///     </para>
+    /// </remarks>
+    public static readonly EventId TriggerOnNonRootTphEntity =
+        MakeValidationId(Id.TriggerOnNonRootTphEntity);
 
     /// <summary>
     ///     A foreign key specifies properties which don't map to the related tables.

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -1721,6 +1721,40 @@ public static class RelationalLoggerExtensions
     ///     Logs for the <see cref="RelationalEventId.TransactionError" /> event.
     /// </summary>
     /// <param name="diagnostics">The diagnostics logger to use.</param>
+    /// <param name="entityType">The entity type.</param>
+    public static void TriggerOnNonRootTphEntity(
+        this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+        IEntityType entityType)
+    {
+        var definition = RelationalResources.LogTriggerOnNonRootTphEntity(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(diagnostics, entityType.DisplayName(), entityType.GetRootType().DisplayName());
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new EntityTypeEventData(
+                definition,
+                TriggerOnNonRootTphEntity,
+                entityType);
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string TriggerOnNonRootTphEntity(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string, string>)definition;
+        var e = (EntityTypeEventData)payload;
+        return d.GenerateMessage(e.EntityType.DisplayName(), e.EntityType.GetRootType().DisplayName());
+    }
+
+    /// <summary>
+    ///     Logs for the <see cref="RelationalEventId.TransactionError" /> event.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics logger to use.</param>
     /// <param name="connection">The connection.</param>
     /// <param name="transaction">The transaction.</param>
     /// <param name="transactionId">The correlation ID associated with the <see cref="DbTransaction" />.</param>

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -681,4 +681,13 @@ public abstract class RelationalLoggingDefinitions : LoggingDefinitions
     /// </summary>
     [EntityFrameworkInternal]
     public EventDefinitionBase? LogUnexpectedTrailingResultSetWhenSaving;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public EventDefinitionBase? LogTriggerOnNonRootTphEntity;
 }

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -60,7 +60,6 @@ public class RelationalModelValidator : ModelValidator
         ValidateDefaultValuesOnKeys(model, logger);
         ValidateBoolsWithDefaults(model, logger);
         ValidateIndexProperties(model, logger);
-        ValidateTriggers(model, logger);
         ValidateJsonEntities(model, logger);
     }
 
@@ -2483,9 +2482,7 @@ public class RelationalModelValidator : ModelValidator
             if (entityType.BaseType is not null
                 && entityType.GetMappingStrategy() == RelationalAnnotationNames.TphMappingStrategy)
             {
-                throw new InvalidOperationException(
-                    RelationalStrings.CannotConfigureTriggerNonRootTphEntity(
-                        entityType.DisplayName(), entityType.GetRootType().DisplayName()));
+                logger.TriggerOnNonRootTphEntity(entityType);
             }
 
             var tableName = entityType.GetTableName();

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -60,14 +60,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("CannotCompareComplexTypeToNull");
 
         /// <summary>
-        ///     Can't configure a trigger on entity type '{entityType}', which is in a TPH hierarchy and isn't the root. Configure the trigger on the TPH root entity type '{rootEntityType}' instead.
-        /// </summary>
-        public static string CannotConfigureTriggerNonRootTphEntity(object? entityType, object? rootEntityType)
-            => string.Format(
-                GetString("CannotConfigureTriggerNonRootTphEntity", nameof(entityType), nameof(rootEntityType)),
-                entityType, rootEntityType);
-
-        /// <summary>
         ///     You are attempting to project out complex type '{complexType}' via an optional navigation; that is currently not supported. Either project out the complex type in a non-optional context, or project the containing entity type along with the complex type.
         /// </summary>
         public static string CannotProjectNullableComplexType(object? complexType)
@@ -3868,6 +3860,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             }
 
             return (EventDefinition)definition;
+        }
+
+        /// <summary>
+        ///     Can't configure a trigger on entity type '{entityType}', which is in a TPH hierarchy and isn't the root. Configure the trigger on the TPH root entity type '{rootEntityType}' instead.
+        /// </summary>
+        public static EventDefinition<string, string> LogTriggerOnNonRootTphEntity(IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogTriggerOnNonRootTphEntity;
+            if (definition == null)
+            {
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogTriggerOnNonRootTphEntity,
+                    logger,
+                    static logger => new EventDefinition<string, string>(
+                        logger.Options,
+                        RelationalEventId.TriggerOnNonRootTphEntity,
+                        LogLevel.Warning,
+                        "RelationalEventId.TriggerOnNonRootTphEntity",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            RelationalEventId.TriggerOnNonRootTphEntity,
+                            _resourceManager.GetString("LogTriggerOnNonRootTphEntity")!)));
+            }
+
+            return (EventDefinition<string, string>)definition;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -133,9 +133,6 @@
   <data name="CannotCompareComplexTypeToNull" xml:space="preserve">
     <value>Comparing complex types to null is not supported.</value>
   </data>
-  <data name="CannotConfigureTriggerNonRootTphEntity" xml:space="preserve">
-    <value>Can't configure a trigger on entity type '{entityType}', which is in a TPH hierarchy and isn't the root. Configure the trigger on the TPH root entity type '{rootEntityType}' instead.</value>
-  </data>
   <data name="CannotProjectNullableComplexType" xml:space="preserve">
     <value>You are attempting to project out complex type '{complexType}' via an optional navigation; that is currently not supported. Either project out the complex type in a non-optional context, or project the containing entity type along with the complex type.</value>
   </data>
@@ -845,6 +842,10 @@
   <data name="LogTransactionError" xml:space="preserve">
     <value>An error occurred using a transaction.</value>
     <comment>Error RelationalEventId.TransactionError</comment>
+  </data>
+  <data name="LogTriggerOnNonRootTphEntity" xml:space="preserve">
+    <value>Can't configure a trigger on entity type '{entityType}', which is in a TPH hierarchy and isn't the root. Configure the trigger on the TPH root entity type '{rootEntityType}' instead.</value>
+    <comment>Warning RelationalEventId.TriggerOnNonRootTphEntity string string</comment>
   </data>
   <data name="LogUnexpectedTrailingResultSetWhenSaving" xml:space="preserve">
     <value>An unexpected trailing result set was found when reading the results of a SaveChanges operation; this may indicate that a stored procedure returned a result set without being configured for it in the EF model. Check your stored procedure definitions.</value>

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -3769,11 +3769,8 @@ public partial class RelationalModelValidatorTest : ModelValidatorTest
         modelBuilder.Entity<Animal>();
         modelBuilder.Entity<Cat>().ToTable(tb => tb.HasTrigger("SomeTrigger"));
 
-        VerifyError(
-            RelationalStrings.CannotConfigureTriggerNonRootTphEntity(
-                modelBuilder.Model.FindEntityType(typeof(Cat))!.DisplayName(),
-                modelBuilder.Model.FindEntityType(typeof(Animal))!.DisplayName()),
-            modelBuilder);
+        VerifyWarning(RelationalResources.LogTriggerOnNonRootTphEntity(new TestLogger<TestRelationalLoggingDefinitions>())
+            .GenerateMessage("Cat", "Animal"), modelBuilder);
     }
 
     private class TpcBase


### PR DESCRIPTION
Part of #31627

### Description

In EF8, we introduced validation that triggers are not defined on a non-base type in a TPH hierarchy. However, our guidance for configuring triggers on every type violates this. Therefore, we are updating the error to a warning, since having the trigger defined doesn't do much harm and so is likely to have been working in the past. We are also updating the guidance for configuring triggers on every type.

### Customer impact

Application that was working in EF7 will throw with EF8.

### How found

Customer reported on preview.

### Regression

Yes.

### Testing

Updated tests.

### Risk

Low.
