### PR TITLE
[release/8.0] Validate that the owner in TPC or TPT is mapped.

### DIFF
--- a/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeExtensions.cs
@@ -76,6 +76,22 @@ public static class RelationalEntityTypeExtensions
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public static ConfigurationSource? GetStoreObjectConfigurationSource(this IConventionEntityType entityType, StoreObjectType type)
+        => type switch
+        {
+            StoreObjectType.Table => entityType.FindAnnotation(RelationalAnnotationNames.TableName)?.GetConfigurationSource(),
+            StoreObjectType.View => entityType.FindAnnotation(RelationalAnnotationNames.ViewName)?.GetConfigurationSource(),
+            StoreObjectType.SqlQuery => entityType.FindAnnotation(RelationalAnnotationNames.SqlQuery)?.GetConfigurationSource(),
+            StoreObjectType.Function => entityType.FindAnnotation(RelationalAnnotationNames.FunctionName)?.GetConfigurationSource(),
+            _ => StoredProcedure.GetStoredProcedureConfigurationSource(entityType, type),
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public static List<IProperty> GetNonPrincipalSharedNonPkProperties(this IEntityType entityType, ITableBase table)
     {
         var principalEntityTypes = new HashSet<IEntityType>();

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -84,14 +84,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 newArrayExpression);
 
         /// <summary>
-        ///     ExecuteUpdate is being used over a LINQ operator which isn't natively supported by the database; this cannot be translated because complex type '{complexType}' is projected out. Rewrite your query to project out the containing entity type instead.
-        /// </summary>
-        public static string ExecuteUpdateSubqueryNotSupportedOverComplexTypes(object? complexType)
-            => string.Format(
-                GetString("ExecuteUpdateSubqueryNotSupportedOverComplexTypes", nameof(complexType)),
-                complexType);
-
-        /// <summary>
         ///     Unable to translate the given 'GroupBy' pattern. Call 'AsEnumerable' before 'GroupBy' to evaluate it client-side.
         /// </summary>
         public static string ClientGroupByNotSupported
@@ -806,6 +798,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 operation);
 
         /// <summary>
+        ///     ExecuteUpdate is being used over a LINQ operator which isn't natively supported by the database; this cannot be translated because complex type '{complexType}' is projected out. Rewrite your query to project out the containing entity type instead.
+        /// </summary>
+        public static string ExecuteUpdateSubqueryNotSupportedOverComplexTypes(object? complexType)
+            => string.Format(
+                GetString("ExecuteUpdateSubqueryNotSupportedOverComplexTypes", nameof(complexType)),
+                complexType);
+
+        /// <summary>
         ///     The required column '{column}' was not present in the results of a 'FromSql' operation.
         /// </summary>
         public static string FromSqlMissingColumn(object? column)
@@ -1314,18 +1314,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, keyValues, entityState);
 
         /// <summary>
+        ///     Multiple relational database provider configurations found. A context can only be configured to use a single database provider.
+        /// </summary>
+        public static string MultipleProvidersConfigured
+            => GetString("MultipleProvidersConfigured");
+
+        /// <summary>
         ///     Multiple 'SetProperty' invocations refer to different tables ('{propertySelector1}' and '{propertySelector2}'). A single 'ExecuteUpdate' call can only update the columns of a single table.
         /// </summary>
         public static string MultipleTablesInExecuteUpdate(object? propertySelector1, object? propertySelector2)
             => string.Format(
                 GetString("MultipleTablesInExecuteUpdate", nameof(propertySelector1), nameof(propertySelector2)),
                 propertySelector1, propertySelector2);
-
-        /// <summary>
-        ///     Multiple relational database provider configurations found. A context can only be configured to use a single database provider.
-        /// </summary>
-        public static string MultipleProvidersConfigured
-            => GetString("MultipleProvidersConfigured");
 
         /// <summary>
         ///     A named connection string was used, but the name '{name}' was not found in the application's configuration. Note that named connection strings are only supported when using 'IConfiguration' and a service provider, such as in a typical ASP.NET Core application. See https://go.microsoft.com/fwlink/?linkid=850912 for more information.
@@ -1546,18 +1546,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     Unable to translate set operation after client projection has been applied. Consider moving the set operation before the last 'Select' call.
-        /// </summary>
-        public static string SetOperationsNotAllowedAfterClientEvaluation
-            => GetString("SetOperationsNotAllowedAfterClientEvaluation");
-
-        /// <summary>
         ///     Set operations over different entity or complex types are not supported ('{type1}' and '{type2}').
         /// </summary>
         public static string SetOperationOverDifferentStructuralTypes(object? type1, object? type2)
             => string.Format(
                 GetString("SetOperationOverDifferentStructuralTypes", nameof(type1), nameof(type2)),
                 type1, type2);
+
+        /// <summary>
+        ///     Unable to translate set operation after client projection has been applied. Consider moving the set operation before the last 'Select' call.
+        /// </summary>
+        public static string SetOperationsNotAllowedAfterClientEvaluation
+            => GetString("SetOperationsNotAllowedAfterClientEvaluation");
 
         /// <summary>
         ///     A set operation '{setOperationType}' requires valid type mapping for at least one of its sides.
@@ -2038,6 +2038,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 sqlGeneratorType, operationType);
 
         /// <summary>
+        ///     The entity type '{ownerType}' is not mapped, so by default the owned type '{navigation}.{ownedType}' will also be unmapped. If this is intended explicitly map the owned type to 'null', otherwise map it to a named '{storeObjectType}'.
+        /// </summary>
+        public static string UnmappedNonTPHOwner(object? ownerType, object? navigation, object? ownedType, object? storeObjectType)
+            => string.Format(
+                GetString("UnmappedNonTPHOwner", nameof(ownerType), nameof(navigation), nameof(ownedType), nameof(storeObjectType)),
+                ownerType, navigation, ownedType, storeObjectType);
+
+        /// <summary>
         ///     The store type '{type}' used for the column '{column}' in a migration data operation is not supported by the current provider.
         /// </summary>
         public static string UnsupportedDataOperationStoreType(object? type, object? column)
@@ -2054,7 +2062,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -141,9 +141,6 @@
   </data>
   <data name="CannotTranslateNonConstantNewArrayExpression" xml:space="preserve">
     <value>The query contained a new array expression containing non-constant elements, which could not be translated: '{newArrayExpression}'.</value>
-  </data>
-  <data name="ExecuteUpdateSubqueryNotSupportedOverComplexTypes" xml:space="preserve">
-    <value>ExecuteUpdate is being used over a LINQ operator which isn't natively supported by the database; this cannot be translated because complex type '{complexType}' is projected out. Rewrite your query to project out the containing entity type instead.</value>
   </data>
   <data name="ClientGroupByNotSupported" xml:space="preserve">
     <value>Unable to translate the given 'GroupBy' pattern. Call 'AsEnumerable' before 'GroupBy' to evaluate it client-side.</value>
@@ -417,6 +414,9 @@
   </data>
   <data name="ExecuteOperationWithUnsupportedOperatorInSqlGeneration" xml:space="preserve">
     <value>The operation '{operation}' contains a select expression feature that isn't supported in the query SQL generator, but has been declared as supported by provider during translation phase. This is a bug in your EF Core provider, please file an issue.</value>
+  </data>
+  <data name="ExecuteUpdateSubqueryNotSupportedOverComplexTypes" xml:space="preserve">
+    <value>ExecuteUpdate is being used over a LINQ operator which isn't natively supported by the database; this cannot be translated because complex type '{complexType}' is projected out. Rewrite your query to project out the containing entity type instead.</value>
   </data>
   <data name="FromSqlMissingColumn" xml:space="preserve">
     <value>The required column '{column}' was not present in the results of a 'FromSql' operation.</value>
@@ -911,11 +911,11 @@
   <data name="ModificationCommandInvalidEntityStateSensitive" xml:space="preserve">
     <value>Cannot save changes for an entity of type '{entityType}' with primary key values {keyValues} in state '{entityState}'. This may indicate a bug in Entity Framework, please open an issue at https://go.microsoft.com/fwlink/?linkid=2142044.</value>
   </data>
-  <data name="MultipleTablesInExecuteUpdate" xml:space="preserve">
-    <value>Multiple 'SetProperty' invocations refer to different tables ('{propertySelector1}' and '{propertySelector2}'). A single 'ExecuteUpdate' call can only update the columns of a single table.</value>
-  </data>
   <data name="MultipleProvidersConfigured" xml:space="preserve">
     <value>Multiple relational database provider configurations found. A context can only be configured to use a single database provider.</value>
+  </data>
+  <data name="MultipleTablesInExecuteUpdate" xml:space="preserve">
+    <value>Multiple 'SetProperty' invocations refer to different tables ('{propertySelector1}' and '{propertySelector2}'). A single 'ExecuteUpdate' call can only update the columns of a single table.</value>
   </data>
   <data name="NamedConnectionStringNotFound" xml:space="preserve">
     <value>A named connection string was used, but the name '{name}' was not found in the application's configuration. Note that named connection strings are only supported when using 'IConfiguration' and a service provider, such as in a typical ASP.NET Core application. See https://go.microsoft.com/fwlink/?linkid=850912 for more information.</value>
@@ -1007,11 +1007,11 @@
   <data name="SelectExpressionNonTphWithCustomTable" xml:space="preserve">
     <value>Cannot create a 'SelectExpression' with a custom 'TableExpressionBase' since the result type '{entityType}' is part of a hierarchy and does not contain a discriminator property.</value>
   </data>
-  <data name="SetOperationsNotAllowedAfterClientEvaluation" xml:space="preserve">
-    <value>Unable to translate set operation after client projection has been applied. Consider moving the set operation before the last 'Select' call.</value>
-  </data>
   <data name="SetOperationOverDifferentStructuralTypes" xml:space="preserve">
     <value>Set operations over different entity or complex types are not supported ('{type1}' and '{type2}').</value>
+  </data>
+  <data name="SetOperationsNotAllowedAfterClientEvaluation" xml:space="preserve">
+    <value>Unable to translate set operation after client projection has been applied. Consider moving the set operation before the last 'Select' call.</value>
   </data>
   <data name="SetOperationsRequireAtLeastOneSideWithValidTypeMapping" xml:space="preserve">
     <value>A set operation '{setOperationType}' requires valid type mapping for at least one of its sides.</value>
@@ -1195,6 +1195,9 @@
   </data>
   <data name="UnknownOperation" xml:space="preserve">
     <value>The current migration SQL generator '{sqlGeneratorType}' is unable to generate SQL for operations of type '{operationType}'.</value>
+  </data>
+  <data name="UnmappedNonTPHOwner" xml:space="preserve">
+    <value>The entity type '{ownerType}' is not mapped, so by default the owned type '{navigation}.{ownedType}' will also be unmapped. If this is intended explicitly map the owned type to 'null', otherwise map it to a named '{storeObjectType}'.</value>
   </data>
   <data name="UnsupportedDataOperationStoreType" xml:space="preserve">
     <value>The store type '{type}' used for the column '{column}' in a migration data operation is not supported by the current provider.</value>

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.PropertyMapping.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.PropertyMapping.cs
@@ -312,11 +312,17 @@ public partial class ModelValidatorTest
         public IList<INavigationEntity> Navigation { get; set; }
     }
 
-    protected class Animal
+    protected abstract class LivingBeing
     {
         public int Id { get; set; }
         public string Name { get; set; }
 
+        [NotMapped]
+        public OwnedEntity Details { get; set; }
+    }
+
+    protected class Animal : LivingBeing
+    {
         public Person FavoritePerson { get; set; }
     }
 
@@ -340,10 +346,8 @@ public partial class ModelValidatorTest
         public int Identity { get; set; }
     }
 
-    protected class Person
+    protected class Person : LivingBeing
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
         public string FavoriteBreed { get; set; }
     }
 


### PR DESCRIPTION
Fixes #31749

### Description

We don't support table-splitting for entity types in TPC hierarchy, however when the entity type is abstract we don't map it or owned types to any table by default, so the validation doesn't run.

### Customer impact

In this case the owned entity will be silently ignored.

### How found

Customer reported on 8.0

### Regression

No.

### Testing

Added tests.

### Risk

Low. 