### PR TITLE
[release/8.0] Fix to #29156 - TemporalAll for temporal owned entities mapped to parent table.

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerNavigationExpansionExtensibilityHelper.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerNavigationExpansionExtensibilityHelper.cs
@@ -51,7 +51,9 @@ public class SqlServerNavigationExpansionExtensibilityHelper : NavigationExpansi
     /// </summary>
     public override void ValidateQueryRootCreation(IEntityType entityType, EntityQueryRootExpression? source)
     {
-        if (source is TemporalQueryRootExpression && !entityType.IsMappedToJson())
+        if (source is TemporalQueryRootExpression
+            && !entityType.IsMappedToJson()
+            && !OwnedEntityMappedToSameTableAsOwner(entityType))
         {
             if (!entityType.GetRootType().IsTemporal())
             {
@@ -68,6 +70,12 @@ public class SqlServerNavigationExpansionExtensibilityHelper : NavigationExpansi
 
         base.ValidateQueryRootCreation(entityType, source);
     }
+
+    private bool OwnedEntityMappedToSameTableAsOwner(IEntityType entityType)
+        => entityType.IsOwned()
+            && entityType.FindOwnership()!.PrincipalEntityType.GetTableMappings().FirstOrDefault()?.Table is ITable ownerTable
+                && entityType.GetTableMappings().FirstOrDefault()?.Table is ITable entityTable
+                && ownerTable == entityTable;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to


### PR DESCRIPTION
Similar to JSON entities, owned entities that are mapped to the same table as their owner should be treated as scalars for the purpose of temporal query validation - they are always in sync with the parent entity, so all operations should be allowed for them, not only AsOf.

Fixes #29156

**Risk**

Low - this is very similar to the JSON scenario fixed approved for 8.0 recently (see https://github.com/dotnet/efcore/pull/32006) - we relax the validation we had when encountering navigations with temporal operations. We normally only allow AsOf, otherwise the results are not very useful/coherent, but in case of owned entities mapped to the same table, they are always in sync with parent, so all operations are fine. 