### PR TITLE
[release/8.0] Remove the owned navigation on the derived type when configuring it on the base.

### DIFF
--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -294,6 +294,43 @@ public abstract partial class ModelBuilderTest
         }
 
         [ConditionalFact]
+        public virtual void Can_configure_on_derived_type_first()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Ignore<Product>();
+            modelBuilder.Ignore<Customer>();
+            modelBuilder.Entity<OtherCustomer>().OwnsOne(c => c.Details);
+            modelBuilder.Entity<Customer>().OwnsOne(c => c.Details);
+
+            var model = modelBuilder.FinalizeModel();
+
+            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+            Assert.Equal(typeof(CustomerDetails), ownership.DeclaringEntityType.ClrType);
+            Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(CustomerDetails)));
+            Assert.Single(ownership.DeclaringEntityType.GetForeignKeys());
+        }
+
+        [ConditionalFact]
+        public virtual void Can_configure_on_derived_types_first()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Ignore<Product>();
+            modelBuilder.Ignore<Customer>();
+            modelBuilder.Entity<OtherCustomer>().OwnsOne(c => c.Details);
+            modelBuilder.Entity<SpecialCustomer>().OwnsOne(c => c.Details);
+            modelBuilder.Entity<Customer>().OwnsOne(c => c.Details);
+
+            var model = modelBuilder.FinalizeModel();
+
+            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+            Assert.Equal(typeof(CustomerDetails), ownership.DeclaringEntityType.ClrType);
+            Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(CustomerDetails)));
+            Assert.Single(ownership.DeclaringEntityType.GetForeignKeys());
+        }
+
+        [ConditionalFact]
         public virtual void Can_configure_multiple_ownerships()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fixes #26218
Fixes #27404

### Description

When configuring an owned entity when there is another one in the model using the same CLR type already we transform them both to shared type entity types, preserving the existing navigations. However, if the existing owned navigation was on a derived type it cannot be added to point to the shared type entity type as it would conflict with the newly added navigation on the base type, thus leaving the existing type stranded. We usually remove entity types that don't have incoming navigation as part of model cleanup, but since it was created explicitly we can't do that. Moreover, if the given owned entity is not referenced from other types, it doesn't need to be converted to a shared type entity type in the first place.

### Customer impact

An unhelpful exception during model validation.

### How found

Several customer reports since 3.1

### Regression

No.

### Testing

Added tests.

### Risk

Low. 
