### PR TITLE
[release/8.0] Revert Azure SQL streaming breaking change

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
@@ -114,12 +114,7 @@ public class SqlServerOptionsExtension : RelationalOptionsExtension, IDbContextO
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual bool IsAzureSql
-        => _azureSql ?? IsAzureSqlDefault;
-
-    private bool IsAzureSqlDefault
-        => (ConnectionString ?? Connection?.ConnectionString)
-            ?.Contains(".database.windows.net", StringComparison.InvariantCultureIgnoreCase)
-            == true;
+        => _azureSql ?? false;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
+++ b/src/EFCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
@@ -31,9 +31,9 @@ public class SqlServerRetryingExecutionStrategy : ExecutionStrategy
     private readonly HashSet<int>? _additionalErrorNumbers;
 
     /// <summary>
-    ///     The default minimum time delay between retries for Azure SQL.
+    ///     The default minimum time delay between retries for throttling errors.
     /// </summary>
-    protected static readonly TimeSpan DefaultMinDelayAzureSql = TimeSpan.FromSeconds(5);
+    protected static readonly TimeSpan DefaultMinDelayThrottling = TimeSpan.FromSeconds(5);
 
     /// <summary>
     ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
@@ -193,7 +193,7 @@ public class SqlServerRetryingExecutionStrategy : ExecutionStrategy
         return CallOnWrappedException(lastException, IsMemoryOptimizedError)
             ? TimeSpan.FromMilliseconds(baseDelay.Value.TotalSeconds)
             : CallOnWrappedException(lastException, IsThrottlingError)
-                ? baseDelay + DefaultMinDelayAzureSql
+                ? baseDelay + DefaultMinDelayThrottling
                 : baseDelay;
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -462,26 +462,20 @@ public class SqlServerConfigPatternsTest
         [InlineData(true)]
         [InlineData(false)]
         [ConditionalTheory]
-        public void Retry_on_failure_enabled_by_default_on_Azure_SQL(bool azure)
+        public void Retry_on_failure_not_enabled_by_default_on_Azure_SQL(bool configured)
         {
-            using var context = new NorthwindContext(azure);
-            if (azure)
-            {
-                Assert.IsType<SqlServerRetryingExecutionStrategy>(context.Database.CreateExecutionStrategy());
-            }
-            else
-            {
-                Assert.IsType<SqlServerExecutionStrategy>(context.Database.CreateExecutionStrategy());
-            }
+            using var context = new NorthwindContext(configured);
+
+            Assert.IsType<SqlServerExecutionStrategy>(context.Database.CreateExecutionStrategy());
         }
 
         private class NorthwindContext : DbContext
         {
-            private readonly bool _isAzure;
+            private readonly bool _azureConfigured;
 
-            public NorthwindContext(bool azure)
+            public NorthwindContext(bool configured)
             {
-                _isAzure = azure;
+                _azureConfigured = configured;
             }
 
             public DbSet<Customer> Customers { get; set; }
@@ -493,7 +487,7 @@ public class SqlServerConfigPatternsTest
                         @"Server=test.database.windows.net:4040;Database=Test;ConnectRetryCount=0",
                         a =>
                         {
-                            if (!_isAzure)
+                            if (_azureConfigured)
                             {
                                 a.UseAzureSqlDefaults(false);
                             }
@@ -509,10 +503,10 @@ public class SqlServerConfigPatternsTest
         [InlineData(true)]
         [InlineData(false)]
         [ConditionalTheory]
-        public void Retry_on_failure_enabled_if_Azure_SQL_configured(bool azure)
+        public void Retry_on_failure_enabled_if_Azure_SQL_configured(bool configured)
         {
-            using var context = new NorthwindContext(azure);
-            if (azure)
+            using var context = new NorthwindContext(configured);
+            if (configured)
             {
                 Assert.IsType<SqlServerRetryingExecutionStrategy>(context.Database.CreateExecutionStrategy());
             }


### PR DESCRIPTION
Fixes #32052

### Description

When the connection string points to an Azure SQL database we now by default configure a retrying execution strategy, per official recommendation. This in turn forces all the streaming queries to buffer (because we can't reliably retry a query if it fails in the middle of reading the results). This makes it a breaking change for apps that weren't using a retrying execution strategy as it increases the peak memory usage proportionally to the largest result set queried.

### Customer impact

OutOfMemoryException thrown in some cases.

### How found

Customer reported on RC2

### Regression

Yes, from RC1.

### Testing

Added tests.

### Risk

Low. 