### PR TITLE
Replace explicit richCodeNavigationEnvironment in azure-pipelines-richnav.yml

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -14,7 +14,6 @@ stages:
       parameters:
         enableMicrobuild: true
         enableRichCodeNavigation: true
-        richCodeNavigationEnvironment: production
         helixRepo: dotnet/efcore
         jobs:
           - job: Windows


### PR DESCRIPTION
This is managed by the arcade defaults, we should be using the "internal" environment as requested by the RichNav team.
