### PR TITLE
[main] Fix to #32062 - Altering a nullable column to not null generates invalid SQL commands for migration

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -2473,6 +2473,15 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                         // if only difference is in temporal annotations being removed or history table changed etc - we can ignore this operation
                         if (!CanSkipAlterColumnOperation(alterColumnOperation.OldColumn, alterColumnOperation))
                         {
+                            // for alter column operation converting column from nullable to non-nullable in the temporal table
+                            // we must disable versioning in order to properly handle it
+                            // specifically, for null -> non-null, switching values in history table from
+                            // null to the default value for the non-nullable column
+                            if (alterColumnOperation.OldColumn.IsNullable && !alterColumnOperation.IsNullable)
+                            {
+                                DisableVersioning(table!, schema, historyTableName!, historyTableSchema, suppressTransaction);
+                            }
+
                             operations.Add(operation);
 
                             // when modifying a period column, we need to perform the operations as a normal column first, and only later enable period


### PR DESCRIPTION
Problem was that alter column from nullable to non-nullable on a temporal table requires us to disable versioning, so that null values could be properly updated to the new defaults.

Fixes #32062