### PR TITLE
Use OrderedDictionary or Dictionary instead of SortedDictionary in RuntimeModel

### DIFF
--- a/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
@@ -66,6 +66,6 @@ public abstract class InitializationTests
         AdventureWorksContextBase.ConfigureModel(builder);
 
         // ReSharper disable once UnusedVariable
-        var model = builder.Model;
+        var model = builder.FinalizeModel();
     }
 }

--- a/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
+++ b/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
@@ -147,7 +147,7 @@ public class SnapshotModelProcessor : ISnapshotModelProcessor
             .Select(a => new Sequence(model, a.Name));
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        var sequencesDictionary = new SortedDictionary<(string, string?), ISequence>();
+        var sequencesDictionary = new Dictionary<(string, string?), ISequence>();
         foreach (var sequence in sequences)
         {
             sequencesDictionary[(sequence.Name, sequence.ModelSchema)] = sequence;

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -173,9 +173,11 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
         }
     }
 
-    model.Customize();
-    _instance = model;
-}")
+    model.Customize();")
+                .Append("    _instance = (")
+                .Append(className)
+                .AppendLine(")model.FinalizeModel();")
+                .AppendLine("}")
                 .AppendLine()
                 .Append("private static ").Append(className).AppendLine(" _instance;")
                 .AppendLine("public static IModel Instance => _instance;")
@@ -225,6 +227,32 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
 
         using (mainBuilder.Indent())
         {
+            AddNamespace(typeof(Guid), namespaces);
+            mainBuilder
+                .AppendLine($"private {className}()")
+                .IncrementIndent()
+                .Append(": base(skipDetectChanges: ")
+                .Append(_code.Literal(((IRuntimeModel)model).SkipDetectChanges))
+                .Append(", modelId: ")
+                .Append(_code.Literal(model.ModelId))
+                .Append(", entityTypeCount: ")
+                .Append(_code.Literal(model.GetEntityTypes().Count()));
+
+            var typeConfigurationCount = model.GetTypeMappingConfigurations().Count();
+            if (typeConfigurationCount > 0)
+            {
+                mainBuilder
+                    .Append(", typeConfigurationCount: ")
+                    .Append(_code.Literal(typeConfigurationCount));
+            }
+
+            mainBuilder
+                .AppendLine(")")
+                .DecrementIndent()
+                .AppendLine("{")
+                .AppendLine("}")
+                .AppendLine();
+
             mainBuilder
                 .AppendLine("partial void Initialize()")
                 .AppendLine("{");
@@ -690,6 +718,82 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
             mainBuilder.AppendLine(",")
                 .Append("discriminatorValue: ")
                 .Append(_code.UnknownLiteral(discriminatorValue));
+        }
+
+        var derivedTypesCount = entityType.GetDirectlyDerivedTypes().Count();
+        if (derivedTypesCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("derivedTypesCount: ")
+                .Append(_code.Literal(derivedTypesCount));
+        }
+
+        mainBuilder.AppendLine(",")
+            .Append("propertyCount: ")
+            .Append(_code.Literal(entityType.GetDeclaredProperties().Count()));
+
+        var complexPropertyCount = entityType.GetDeclaredComplexProperties().Count();
+        if (complexPropertyCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("complexPropertyCount: ")
+                .Append(_code.Literal(complexPropertyCount));
+        }
+
+        var navigationCount = entityType.GetDeclaredNavigations().Count();
+        if (navigationCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("navigationCount: ")
+                .Append(_code.Literal(navigationCount));
+        }
+
+        var skipNavigationCount = entityType.GetDeclaredSkipNavigations().Count();
+        if (skipNavigationCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("skipNavigationCount: ")
+                .Append(_code.Literal(skipNavigationCount));
+        }
+
+        var servicePropertyCount = entityType.GetDeclaredServiceProperties().Count();
+        if (servicePropertyCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("servicePropertyCount: ")
+                .Append(_code.Literal(servicePropertyCount));
+        }
+
+        var foreignKeyCount = entityType.GetDeclaredForeignKeys().Count();
+        if (foreignKeyCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("foreignKeyCount: ")
+                .Append(_code.Literal(foreignKeyCount));
+        }
+
+        var unnamedIndexCount = entityType.GetDeclaredIndexes().Count(i => i.Name == null);
+        if (unnamedIndexCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("unnamedIndexCount: ")
+                .Append(_code.Literal(unnamedIndexCount));
+        }
+
+        var namedIndexCount = entityType.GetDeclaredIndexes().Count(i => i.Name != null);
+        if (namedIndexCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("namedIndexCount: ")
+                .Append(_code.Literal(namedIndexCount));
+        }
+
+        var keyCount = entityType.GetDeclaredKeys().Count();
+        if (keyCount != 0)
+        {
+            mainBuilder.AppendLine(",")
+                .Append("keyCount: ")
+                .Append(_code.Literal(keyCount));
         }
 
         mainBuilder
@@ -1262,6 +1366,18 @@ public class CSharpRuntimeModelCodeGenerator : ICompiledModelCodeGenerator
                     mainBuilder.AppendLine(",")
                         .Append("propertyBag: ")
                         .Append(_code.Literal(true));
+                }
+
+                mainBuilder.AppendLine(",")
+                    .Append("propertyCount: ")
+                    .Append(_code.Literal(complexType.GetDeclaredProperties().Count()));
+
+                var complexPropertyCount = complexType.GetDeclaredComplexProperties().Count();
+                if (complexPropertyCount != 0)
+                {
+                    mainBuilder.AppendLine(",")
+                        .Append("complexPropertyCount: ")
+                        .Append(_code.Literal(complexPropertyCount));
                 }
 
                 mainBuilder

--- a/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/Internal/RelationalCSharpRuntimeAnnotationCodeGenerator.cs
@@ -66,15 +66,15 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
 
             if (annotations.TryGetAndRemove(
                     RelationalAnnotationNames.DbFunctions,
-                    out SortedDictionary<string, IDbFunction> functions))
+                    out IReadOnlyDictionary<string, IDbFunction> functions))
             {
-                parameters.Namespaces.Add(typeof(SortedDictionary<,>).Namespace!);
+                parameters.Namespaces.Add(typeof(Dictionary<,>).Namespace!);
                 parameters.Namespaces.Add(typeof(BindingFlags).Namespace!);
                 var functionsVariable = Dependencies.CSharpHelper.Identifier("functions", parameters.ScopeVariables, capitalize: false);
                 parameters.MainBuilder
-                    .Append("var ").Append(functionsVariable).AppendLine(" = new SortedDictionary<string, IDbFunction>();");
+                    .Append("var ").Append(functionsVariable).AppendLine(" = new Dictionary<string, IDbFunction>();");
 
-                foreach (var function in functions.Values)
+                foreach (var function in functions.OrderBy(t => t.Key).Select(t => t.Value))
                 {
                     Create(function, functionsVariable, parameters);
                 }
@@ -84,12 +84,12 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
 
             if (annotations.TryGetAndRemove(
                     RelationalAnnotationNames.Sequences,
-                    out SortedDictionary<(string, string?), ISequence> sequences))
+                    out IReadOnlyDictionary<(string, string?), ISequence> sequences))
             {
-                parameters.Namespaces.Add(typeof(SortedDictionary<,>).Namespace!);
+                parameters.Namespaces.Add(typeof(Dictionary<,>).Namespace!);
                 var sequencesVariable = Dependencies.CSharpHelper.Identifier("sequences", parameters.ScopeVariables, capitalize: false);
                 var mainBuilder = parameters.MainBuilder;
-                mainBuilder.Append("var ").Append(sequencesVariable).Append(" = new SortedDictionary<(string, string");
+                mainBuilder.Append("var ").Append(sequencesVariable).Append(" = new Dictionary<(string, string");
 
                 if (parameters.UseNullableReferenceTypes)
                 {
@@ -98,9 +98,9 @@ public class RelationalCSharpRuntimeAnnotationCodeGenerator : CSharpRuntimeAnnot
 
                 mainBuilder.AppendLine("), ISequence>();");
 
-                foreach (var sequencePair in sequences)
+                foreach (var sequence in sequences.OrderBy(t => t.Key).Select(t => t.Value))
                 {
-                    Create(sequencePair.Value, sequencesVariable, parameters);
+                    Create(sequence, sequencesVariable, parameters);
                 }
 
                 GenerateSimpleAnnotation(RelationalAnnotationNames.Sequences, sequencesVariable, parameters);

--- a/src/EFCore.Relational/Extensions/RelationalModelExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalModelExtensions.cs
@@ -313,7 +313,7 @@ public static class RelationalModelExtensions
     /// <param name="method">The <see cref="MethodInfo" /> for the method that is mapped to the function.</param>
     /// <returns>The function or <see langword="null" /> if the method is not mapped.</returns>
     public static IDbFunction? FindDbFunction(this IModel model, MethodInfo method)
-        => (IDbFunction?)((IReadOnlyModel)model).FindDbFunction(method);
+        => DbFunction.FindDbFunction(model, method);
 
     /// <summary>
     ///     Finds a function that is mapped to the method represented by the given name.
@@ -349,7 +349,7 @@ public static class RelationalModelExtensions
     /// <param name="name">The model name of the function.</param>
     /// <returns>The function or <see langword="null" /> if the method is not mapped.</returns>
     public static IDbFunction? FindDbFunction(this IModel model, string name)
-        => (IDbFunction?)((IReadOnlyModel)model).FindDbFunction(name);
+        => DbFunction.FindDbFunction(model, name);
 
     /// <summary>
     ///     Creates an <see cref="IMutableDbFunction" /> mapped to the given method.

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalRuntimeModelConvention.cs
@@ -62,8 +62,8 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
 
             if (annotations.TryGetValue(RelationalAnnotationNames.DbFunctions, out var functions))
             {
-                var runtimeFunctions = new SortedDictionary<string, IDbFunction>(StringComparer.Ordinal);
-                foreach (var (key, dbFunction) in (SortedDictionary<string, IDbFunction>)functions!)
+                var runtimeFunctions = new Dictionary<string, IDbFunction>(StringComparer.Ordinal);
+                foreach (var (key, dbFunction) in (Dictionary<string, IDbFunction>)functions!)
                 {
                     var runtimeFunction = Create(dbFunction, runtimeModel);
                     runtimeFunctions[key] = runtimeFunction;
@@ -87,8 +87,8 @@ public class RelationalRuntimeModelConvention : RuntimeModelConvention
 
             if (annotations.TryGetValue(RelationalAnnotationNames.Sequences, out var sequences))
             {
-                var runtimeSequences = new SortedDictionary<(string, string?), ISequence>();
-                foreach (var (key, value) in (SortedDictionary<(string, string?), ISequence>)sequences!)
+                var runtimeSequences = new Dictionary<(string, string?), ISequence>();
+                foreach (var (key, value) in (Dictionary<(string, string?), ISequence>)sequences!)
                 {
                     var runtimeSequence = Create(value, runtimeModel);
                     runtimeSequences[key] = runtimeSequence;

--- a/src/EFCore.Relational/Metadata/Conventions/SequenceUniquificationConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SequenceUniquificationConvention.cs
@@ -44,14 +44,13 @@ public class SequenceUniquificationConvention : IModelFinalizingConvention
         IConventionContext<IConventionModelBuilder> context)
     {
         var model = modelBuilder.Metadata;
-        var modelSequences =
-            (SortedDictionary<(string Name, string? Schema), ISequence>?)model[RelationalAnnotationNames.Sequences];
-
+        var modelSequences = 
+            (IReadOnlyDictionary<(string Name, string? Schema), ISequence>?)model[RelationalAnnotationNames.Sequences];
         if (modelSequences != null)
         {
             var maxLength = model.GetMaxIdentifierLength();
             var toReplace = modelSequences
-                .Where(s => s.Key.Name.Length > maxLength).ToList();
+                .Where(s => s.Key.Name.Length > maxLength).OrderBy(s => s.Key).ToList();
 
             foreach (var ((name, schema), sequence) in toReplace)
             {

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -193,8 +193,8 @@ public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConvention
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public static IEnumerable<IDbFunction> GetDbFunctions(IReadOnlyModel model)
-        => ((SortedDictionary<string, IDbFunction>?)model[RelationalAnnotationNames.DbFunctions])
-            ?.Values
+        => ((Dictionary<string, IDbFunction>?)model[RelationalAnnotationNames.DbFunctions])
+            ?.OrderBy(t => t.Key).Select(t => t.Value)
             ?? Enumerable.Empty<IDbFunction>();
 
     /// <summary>
@@ -203,8 +203,8 @@ public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConvention
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static IReadOnlyDbFunction? FindDbFunction(IReadOnlyModel model, MethodInfo methodInfo)
-        => model[RelationalAnnotationNames.DbFunctions] is SortedDictionary<string, IDbFunction> functions
+    public static IDbFunction? FindDbFunction(IReadOnlyModel model, MethodInfo methodInfo)
+        => model[RelationalAnnotationNames.DbFunctions] is Dictionary<string, IDbFunction> functions
             && functions.TryGetValue(GetFunctionName(methodInfo), out var dbFunction)
                 ? dbFunction
                 : null;
@@ -215,8 +215,8 @@ public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConvention
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static IReadOnlyDbFunction? FindDbFunction(IReadOnlyModel model, string name)
-        => model[RelationalAnnotationNames.DbFunctions] is SortedDictionary<string, IDbFunction> functions
+    public static IDbFunction? FindDbFunction(IReadOnlyModel model, string name)
+        => model[RelationalAnnotationNames.DbFunctions] is Dictionary<string, IDbFunction> functions
             && functions.TryGetValue(name, out var dbFunction)
                 ? dbFunction
                 : null;
@@ -256,9 +256,9 @@ public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConvention
         return function;
     }
 
-    private static SortedDictionary<string, IDbFunction> GetOrCreateFunctions(IMutableModel model)
-        => (SortedDictionary<string, IDbFunction>)(
-            model[RelationalAnnotationNames.DbFunctions] ??= new SortedDictionary<string, IDbFunction>(StringComparer.Ordinal));
+    private static Dictionary<string, IDbFunction> GetOrCreateFunctions(IMutableModel model)
+        => (Dictionary<string, IDbFunction>)(
+            model[RelationalAnnotationNames.DbFunctions] ??= new Dictionary<string, IDbFunction>(StringComparer.Ordinal));
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -270,7 +270,7 @@ public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConvention
         IMutableModel model,
         MethodInfo methodInfo)
     {
-        if (model[RelationalAnnotationNames.DbFunctions] is SortedDictionary<string, IDbFunction> functions)
+        if (model[RelationalAnnotationNames.DbFunctions] is Dictionary<string, IDbFunction> functions)
         {
             var name = GetFunctionName(methodInfo);
             if (functions.TryGetValue(name, out var function))
@@ -296,7 +296,7 @@ public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConvention
         IMutableModel model,
         string name)
     {
-        if (model[RelationalAnnotationNames.DbFunctions] is SortedDictionary<string, IDbFunction> functions
+        if (model[RelationalAnnotationNames.DbFunctions] is Dictionary<string, IDbFunction> functions
             && functions.TryGetValue(name, out var function))
         {
             functions.Remove(name);

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -130,8 +130,8 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public static IEnumerable<ISequence> GetSequences(IReadOnlyModel model)
-        => ((SortedDictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences])
-            ?.Values
+        => ((Dictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences])
+            ?.OrderBy(t => t.Key).Select(t => t.Value)
             ?? Enumerable.Empty<ISequence>();
 
     /// <summary>
@@ -142,7 +142,7 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     /// </summary>
     public static ISequence? FindSequence(IReadOnlyModel model, string name, string? schema)
     {
-        var sequences = (SortedDictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences];
+        var sequences = (Dictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences];
         if (sequences == null
             || !sequences.TryGetValue((name, schema), out var sequence))
         {
@@ -165,10 +165,10 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
         ConfigurationSource configurationSource)
     {
         var sequence = new Sequence(name, schema, model, configurationSource);
-        var sequences = (SortedDictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences];
+        var sequences = (Dictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences];
         if (sequences == null)
         {
-            sequences = new SortedDictionary<(string, string?), ISequence>();
+            sequences = new Dictionary<(string, string?), ISequence>();
             model[RelationalAnnotationNames.Sequences] = sequences;
         }
 
@@ -189,7 +189,7 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     {
         sequence.EnsureMutable();
 
-        var sequences = (SortedDictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences];
+        var sequences = (Dictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences];
         var tuple = (sequence.Name, sequence.ModelSchema);
         if (sequences == null
             || !sequences.ContainsKey(tuple))
@@ -214,7 +214,7 @@ public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequ
     /// </summary>
     public static Sequence? RemoveSequence(IMutableModel model, string name, string? schema)
     {
-        var sequences = (SortedDictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences];
+        var sequences = (Dictionary<(string, string?), ISequence>?)model[RelationalAnnotationNames.Sequences];
         if (sequences == null
             || !sequences.TryGetValue((name, schema), out var sequence))
         {

--- a/src/EFCore.Relational/Migrations/Operations/AddCheckConstraintOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/AddCheckConstraintOperation.cs
@@ -51,7 +51,6 @@ public class AddCheckConstraintOperation : MigrationOperation, ITableMigrationOp
             Schema = checkConstraint.EntityType.GetSchema(),
             Table = checkConstraint.EntityType.GetTableName()!
         };
-        operation.AddAnnotations(checkConstraint.GetAnnotations());
 
         return operation;
     }

--- a/src/EFCore/Infrastructure/AnnotatableBase.cs
+++ b/src/EFCore/Infrastructure/AnnotatableBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure;
 /// </remarks>
 public class AnnotatableBase : IAnnotatable
 {
-    private SortedDictionary<string, Annotation>? _annotations;
+    private Dictionary<string, Annotation>? _annotations;
     private ConcurrentDictionary<string, Annotation>? _runtimeAnnotations;
 
     /// <summary>
@@ -52,7 +52,7 @@ public class AnnotatableBase : IAnnotatable
     ///     Gets all annotations on the current object.
     /// </summary>
     public virtual IEnumerable<Annotation> GetAnnotations()
-        => _annotations?.Values ?? Enumerable.Empty<Annotation>();
+        => _annotations?.Values.OrderBy(a => a.Name, StringComparer.Ordinal) ?? Enumerable.Empty<Annotation>();
 
     /// <summary>
     ///     Adds an annotation to this object. Throws if an annotation with the specified name already exists.
@@ -148,7 +148,7 @@ public class AnnotatableBase : IAnnotatable
     {
         EnsureMutable();
 
-        _annotations ??= new SortedDictionary<string, Annotation>(StringComparer.Ordinal);
+        _annotations ??= new Dictionary<string, Annotation>(StringComparer.Ordinal);
         _annotations[name] = annotation;
 
         return OnAnnotationSet(name, annotation, oldAnnotation);
@@ -280,9 +280,7 @@ public class AnnotatableBase : IAnnotatable
     ///     Gets all runtime annotations on the current object.
     /// </summary>
     public virtual IEnumerable<Annotation> GetRuntimeAnnotations()
-        => _runtimeAnnotations == null
-            ? Enumerable.Empty<Annotation>()
-            : _runtimeAnnotations.OrderBy(p => p.Key).Select(p => p.Value);
+        => _runtimeAnnotations?.OrderBy(p => p.Key).Select(p => p.Value) ?? Enumerable.Empty<Annotation>();
 
     /// <summary>
     ///     Adds a runtime annotation to this object. Throws if an annotation with the specified name already exists.

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -31,7 +32,7 @@ public class RuntimeModelConvention : IModelFinalizedConvention
 
     /// <inheritdoc />
     public virtual IModel ProcessModelFinalized(IModel model)
-        => Create(model);
+        => Create(model).FinalizeModel();
 
     /// <summary>
     ///     Creates an optimized model base on the supplied one.
@@ -40,9 +41,11 @@ public class RuntimeModelConvention : IModelFinalizedConvention
     /// <returns>An optimized model.</returns>
     protected virtual RuntimeModel Create(IModel model)
     {
-        var runtimeModel = new RuntimeModel();
-        runtimeModel.ModelId = model.ModelId;
-        runtimeModel.SetSkipDetectChanges(((IRuntimeModel)model).SkipDetectChanges);
+        var runtimeModel = new RuntimeModel(
+            skipDetectChanges: ((IRuntimeModel)model).SkipDetectChanges,
+            modelId: model.ModelId,
+            entityTypeCount: model.GetEntityTypes().Count(),
+            typeConfigurationCount: model.GetTypeMappingConfigurations().Count());
         ((IModel)runtimeModel).ModelDependencies = model.ModelDependencies!;
 
         var entityTypes = model.GetEntityTypesInHierarchicalOrder();
@@ -195,7 +198,7 @@ public class RuntimeModelConvention : IModelFinalizedConvention
         TTarget target,
         Action<RuntimeModelConvention, Dictionary<string, object?>, TSource, TTarget, bool> process)
         where TSource : IAnnotatable
-        where TTarget : AnnotatableBase
+        where TTarget : RuntimeAnnotatableBase
     {
         var annotations = source.GetAnnotations().ToDictionary(a => a.Name, a => a.Value);
         process(this, annotations, source, target, false);
@@ -248,7 +251,17 @@ public class RuntimeModelConvention : IModelFinalizedConvention
             entityType.GetChangeTrackingStrategy(),
             entityType.FindIndexerPropertyInfo(),
             entityType.IsPropertyBag,
-            entityType.GetDiscriminatorValue());
+            entityType.GetDiscriminatorValue(),
+            derivedTypesCount: entityType.GetDirectlyDerivedTypes().Count(),
+            propertyCount: entityType.GetDeclaredProperties().Count(),
+            complexPropertyCount: entityType.GetDeclaredComplexProperties().Count(),
+            navigationCount: entityType.GetDeclaredNavigations().Count(),
+            skipNavigationCount: entityType.GetDeclaredSkipNavigations().Count(),
+            servicePropertyCount: entityType.GetDeclaredServiceProperties().Count(),
+            foreignKeyCount: entityType.GetDeclaredForeignKeys().Count(),
+            unnamedIndexCount: entityType.GetDeclaredIndexes().Count(i => i.Name == null),
+            namedIndexCount: entityType.GetDeclaredProperties().Count(i => i.Name != null),
+            keyCount: entityType.GetDeclaredKeys().Count());
 
     private static ParameterBinding Create(ParameterBinding parameterBinding, RuntimeEntityType entityType)
         => parameterBinding.With(
@@ -497,7 +510,7 @@ public class RuntimeModelConvention : IModelFinalizedConvention
         }
     }
 
-    private RuntimeComplexProperty Create(IComplexProperty complexProperty, RuntimeEntityType runtimeEntityType)
+    private RuntimeComplexProperty Create(IComplexProperty complexProperty, RuntimeTypeBase runtimeEntityType)
     {
         var runtimeComplexProperty = runtimeEntityType.AddComplexProperty(
             complexProperty.Name,
@@ -511,7 +524,9 @@ public class RuntimeModelConvention : IModelFinalizedConvention
             complexProperty.IsCollection,
             complexProperty.ComplexType.GetChangeTrackingStrategy(),
             complexProperty.ComplexType.FindIndexerPropertyInfo(),
-            complexProperty.ComplexType.IsPropertyBag);
+            complexProperty.ComplexType.IsPropertyBag,
+            propertyCount: complexProperty.ComplexType.GetDeclaredProperties().Count(),
+            complexPropertyCount: complexProperty.ComplexType.GetDeclaredComplexProperties().Count());
 
         var complexType = complexProperty.ComplexType;
         var runtimeComplexType = runtimeComplexProperty.ComplexType;
@@ -536,53 +551,6 @@ public class RuntimeModelConvention : IModelFinalizedConvention
         foreach (var property in complexType.GetComplexProperties())
         {
             var runtimeProperty = Create(property, runtimeComplexType);
-            CreateAnnotations(
-                property, runtimeProperty, static (convention, annotations, source, target, runtime) =>
-                    convention.ProcessComplexPropertyAnnotations(annotations, source, target, runtime));
-        }
-
-        return runtimeComplexProperty;
-    }
-
-    private RuntimeComplexProperty Create(IComplexProperty complexProperty, RuntimeComplexType runtimeComplexType)
-    {
-        var runtimeComplexProperty = runtimeComplexType.AddComplexProperty(
-            complexProperty.Name,
-            complexProperty.ClrType,
-            complexProperty.ComplexType.Name,
-            complexProperty.ComplexType.ClrType,
-            complexProperty.PropertyInfo,
-            complexProperty.FieldInfo,
-            complexProperty.GetPropertyAccessMode(),
-            complexProperty.IsNullable,
-            complexProperty.IsCollection,
-            complexProperty.ComplexType.GetChangeTrackingStrategy(),
-            complexProperty.ComplexType.FindIndexerPropertyInfo(),
-            complexProperty.ComplexType.IsPropertyBag);
-
-        var complexType = complexProperty.ComplexType;
-        var newRuntimeComplexType = runtimeComplexProperty.ComplexType;
-
-        foreach (var property in complexType.GetProperties())
-        {
-            var runtimeProperty = Create(property, newRuntimeComplexType);
-            CreateAnnotations(
-                property, runtimeProperty, static (convention, annotations, source, target, runtime) =>
-                    convention.ProcessPropertyAnnotations(annotations, source, target, runtime));
-
-            var elementType = property.GetElementType();
-            if (elementType != null)
-            {
-                var runtimeElementType = Create(runtimeProperty, elementType, property.IsPrimitiveCollection);
-                CreateAnnotations(
-                    elementType, runtimeElementType, static (convention, annotations, source, target, runtime) =>
-                        convention.ProcessElementTypeAnnotations(annotations, source, target, runtime));
-            }
-        }
-
-        foreach (var property in complexType.GetComplexProperties())
-        {
-            var runtimeProperty = Create(property, newRuntimeComplexType);
             CreateAnnotations(
                 property, runtimeProperty, static (convention, annotations, source, target, runtime) =>
                     convention.ProcessComplexPropertyAnnotations(annotations, source, target, runtime));

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -459,7 +459,7 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual Guid ModelId { get; } = Guid.NewGuid();
+    public virtual Guid ModelId { get; set; } = Guid.NewGuid();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1094,7 +1094,6 @@ public class Model : ConventionAnnotatable, IMutableModel, IConventionModel, IRu
         ConventionDispatcher.AssertNoScope();
 
         var finalizedModel = (IModel)ConventionDispatcher.OnModelFinalizing(Builder).Metadata;
-
         if (finalizedModel is Model model)
         {
             finalizedModel = model.MakeReadonly();

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -1308,7 +1308,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual IEnumerable<Key> GetContainingKeys()
-        => Keys ?? Enumerable.Empty<Key>();
+        => Keys?.OrderBy(k => k.Properties, PropertyListComparer.Instance) ?? Enumerable.Empty<Key>();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1334,7 +1334,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual IEnumerable<ForeignKey> GetContainingForeignKeys()
-        => ForeignKeys ?? Enumerable.Empty<ForeignKey>();
+        => ForeignKeys?.OrderBy(fk => fk.Properties, PropertyListComparer.Instance) ?? Enumerable.Empty<ForeignKey>();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1360,7 +1360,7 @@ public class Property : PropertyBase, IMutableProperty, IConventionProperty, IPr
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public virtual IEnumerable<Index> GetContainingIndexes()
-        => Indexes ?? Enumerable.Empty<Index>();
+        => Indexes?.OrderBy(i => i.Properties, PropertyListComparer.Instance) ?? Enumerable.Empty<Index>();
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/PropertyListComparer.cs
+++ b/src/EFCore/Metadata/Internal/PropertyListComparer.cs
@@ -49,7 +49,6 @@ public sealed class PropertyListComparer : IComparer<IReadOnlyList<IReadOnlyProp
         }
 
         var result = x.Count - y.Count;
-
         if (result != 0)
         {
             return result;

--- a/src/EFCore/Metadata/Internal/PropertyNameComparer.cs
+++ b/src/EFCore/Metadata/Internal/PropertyNameComparer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </summary>
-public sealed class PropertyNameComparer : IComparer<string>
+public sealed class PropertyNameComparer : IComparer<string>, IEqualityComparer<string>
 {
     private readonly IReadOnlyEntityType? _entityType;
 
@@ -76,4 +76,22 @@ public sealed class PropertyNameComparer : IComparer<string>
             ? -1
             : 1;
     }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public bool Equals(string? x, string? y)
+        => StringComparer.Ordinal.Equals(x, y);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public int GetHashCode(string obj)
+        => StringComparer.Ordinal.GetHashCode(obj);
 }

--- a/src/EFCore/Metadata/RuntimeAnnotatableBase.cs
+++ b/src/EFCore/Metadata/RuntimeAnnotatableBase.cs
@@ -1,0 +1,360 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure;
+
+/// <summary>
+///     <para>
+///         Base class for types that support reading and writing annotations.
+///     </para>
+///     <para>
+///         This type is typically used by database providers (and other extensions). It is generally
+///         not used in application code.
+///     </para>
+/// </summary>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-providers">Implementation of database providers and extensions</see>
+///     for more information and examples.
+/// </remarks>
+public class RuntimeAnnotatableBase : IAnnotatable
+{
+    private readonly Dictionary<string, Annotation> _annotations = new(StringComparer.Ordinal);
+    private ConcurrentDictionary<string, Annotation>? _runtimeAnnotations;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public RuntimeAnnotatableBase()
+    {
+    }
+
+    /// <summary>
+    ///     Adds an annotation to this object. Throws if an annotation with the specified name already exists.
+    /// </summary>
+    /// <param name="name">The key of the annotation to be added.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The newly added annotation.</returns>
+    public virtual Annotation AddAnnotation(string name, object? value)
+    {
+        Check.NotEmpty(name, nameof(name));
+
+        var annotation = CreateAnnotation(name, value);
+
+        if (FindAnnotation(name) != null)
+        {
+            throw new InvalidOperationException(CoreStrings.DuplicateAnnotation(name, ToString()));
+        }
+
+        SetAnnotation(name, annotation);
+
+        return annotation;
+    }
+
+    /// <summary>
+    ///     Adds annotations to this object overriding any existing annotations with the same name.
+    /// </summary>
+    /// <param name="annotations">The annotations to be added.</param>
+    public virtual void AddAnnotations(IEnumerable<IAnnotation> annotations)
+    {
+        foreach (var annotation in annotations)
+        {
+            SetAnnotation(annotation.Name, (annotation as Annotation) ?? CreateAnnotation(annotation.Name, annotation.Value));
+        }
+    }
+
+    /// <summary>
+    ///     Adds annotations to this object overriding any existing annotations with the same name.
+    /// </summary>
+    /// <param name="annotations">The annotations to be added.</param>
+    public virtual void AddAnnotations(IReadOnlyDictionary<string, object?> annotations)
+    {
+        foreach (var annotation in annotations)
+        {
+            SetAnnotation(annotation.Key, CreateAnnotation(annotation.Key, annotation.Value));
+        }
+    }
+
+    /// <summary>
+    ///     Sets the annotation stored under the given key. Overwrites the existing annotation if an
+    ///     annotation with the specified name already exists.
+    /// </summary>
+    /// <param name="name">The key of the annotation to be added.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    public virtual void SetAnnotation(string name, object? value)
+    {
+        var oldAnnotation = FindAnnotation(name);
+        if (oldAnnotation != null
+            && Equals(oldAnnotation.Value, value))
+        {
+            return;
+        }
+
+        SetAnnotation(name, CreateAnnotation(name, value));
+    }
+
+    private Annotation? SetAnnotation(
+        string name,
+        Annotation annotation)
+    {
+        _annotations[name] = annotation;
+
+        return annotation;
+    }
+
+    /// <summary>
+    ///     Gets the annotation with the given name, returning <see langword="null" /> if it does not exist.
+    /// </summary>
+    /// <param name="name">The key of the annotation to find.</param>
+    /// <returns>
+    ///     The existing annotation if an annotation with the specified name already exists. Otherwise, <see langword="null" />.
+    /// </returns>
+    public virtual Annotation? FindAnnotation(string name)
+    {
+        Check.NotEmpty(name, nameof(name));
+
+        return _annotations.TryGetValue(name, out var annotation)
+                ? annotation
+                : null;
+    }
+
+    /// <summary>
+    ///     Gets the annotation with the given name, throwing if it does not exist.
+    /// </summary>
+    /// <param name="annotationName">The key of the annotation to find.</param>
+    /// <returns>The annotation with the specified name.</returns>
+    public virtual Annotation GetAnnotation(string annotationName)
+    {
+        Check.NotEmpty(annotationName, nameof(annotationName));
+
+        var annotation = FindAnnotation(annotationName);
+        if (annotation == null)
+        {
+            throw new InvalidOperationException(CoreStrings.AnnotationNotFound(annotationName, ToString()));
+        }
+
+        return annotation;
+    }
+
+    /// <summary>
+    ///     Gets the value annotation with the given name, returning <see langword="null" /> if it does not exist.
+    /// </summary>
+    /// <param name="name">The key of the annotation to find.</param>
+    /// <returns>
+    ///     The value of the existing annotation if an annotation with the specified name already exists.
+    ///     Otherwise, <see langword="null" />.
+    /// </returns>
+    public virtual object? this[string name] => FindAnnotation(name)?.Value;
+
+    /// <summary>
+    ///     Creates a new annotation.
+    /// </summary>
+    /// <param name="name">The key of the annotation.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The newly created annotation.</returns>
+    protected virtual Annotation CreateAnnotation(string name, object? value)
+        => new(name, value);
+
+    /// <summary>
+    ///     Gets all runtime annotations on the current object.
+    /// </summary>
+    public virtual IEnumerable<Annotation> GetRuntimeAnnotations()
+        => _runtimeAnnotations?.OrderBy(p => p.Key, StringComparer.Ordinal).Select(p => p.Value)
+            ?? Enumerable.Empty<Annotation>();
+
+    /// <summary>
+    ///     Adds a runtime annotation to this object. Throws if an annotation with the specified name already exists.
+    /// </summary>
+    /// <param name="name">The key of the annotation to be added.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The newly added annotation.</returns>
+    public virtual Annotation AddRuntimeAnnotation(string name, object? value)
+    {
+        Check.NotEmpty(name, nameof(name));
+
+        var annotation = CreateRuntimeAnnotation(name, value);
+
+        return AddRuntimeAnnotation(name, annotation);
+    }
+
+    /// <summary>
+    ///     Adds a runtime annotation to this object. Throws if an annotation with the specified name already exists.
+    /// </summary>
+    /// <param name="name">The key of the annotation to be added.</param>
+    /// <param name="annotation">The annotation to be added.</param>
+    /// <returns>The added annotation.</returns>
+    protected virtual Annotation AddRuntimeAnnotation(string name, Annotation annotation)
+        => GetOrCreateRuntimeAnnotations().TryAdd(name, annotation)
+            ? annotation
+            : throw new InvalidOperationException(CoreStrings.DuplicateAnnotation(name, ToString()));
+
+    /// <summary>
+    ///     Adds runtime annotations to this object.
+    /// </summary>
+    /// <param name="annotations">The annotations to be added.</param>
+    public virtual void AddRuntimeAnnotations(IEnumerable<Annotation> annotations)
+    {
+        foreach (var annotation in annotations)
+        {
+            AddRuntimeAnnotation(annotation.Name, annotation);
+        }
+    }
+
+    /// <summary>
+    ///     Adds runtime annotations to this object.
+    /// </summary>
+    /// <param name="annotations">The annotations to be added.</param>
+    public virtual void AddRuntimeAnnotations(IReadOnlyDictionary<string, object?> annotations)
+    {
+        foreach (var annotation in annotations)
+        {
+            AddRuntimeAnnotation(annotation.Key, CreateRuntimeAnnotation(annotation.Key, annotation.Value));
+        }
+    }
+
+    /// <summary>
+    ///     Sets the runtime annotation stored under the given key. Overwrites the existing annotation if an
+    ///     annotation with the specified name already exists.
+    /// </summary>
+    /// <param name="name">The key of the annotation to be added.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    public virtual Annotation SetRuntimeAnnotation(string name, object? value)
+        => GetOrCreateRuntimeAnnotations().AddOrUpdate(
+            name,
+            static (n, a) => a.Annotatable.CreateRuntimeAnnotation(n, a.Value),
+            static (n, oldAnnotation, a) =>
+                !Equals(oldAnnotation.Value, a.Value) ? a.Annotatable.CreateRuntimeAnnotation(n, a.Value) : oldAnnotation,
+            (Value: value, Annotatable: this));
+
+    /// <summary>
+    ///     Sets the runtime annotation stored under the given key. Overwrites the existing annotation if an
+    ///     annotation with the specified name already exists.
+    /// </summary>
+    /// <param name="name">The key of the annotation to be added.</param>
+    /// <param name="annotation">The annotation to be set.</param>
+    /// <param name="oldAnnotation">The annotation being replaced.</param>
+    /// <returns>The annotation that was set.</returns>
+    protected virtual Annotation SetRuntimeAnnotation(
+        string name,
+        Annotation annotation,
+        Annotation? oldAnnotation)
+    {
+        GetOrCreateRuntimeAnnotations()[name] = annotation;
+
+        return annotation;
+    }
+
+    /// <summary>
+    ///     Gets the value of the runtime annotation with the given name, adding it if one does not exist.
+    /// </summary>
+    /// <param name="name">The name of the annotation.</param>
+    /// <param name="valueFactory">The factory used to create the value if the annotation doesn't exist.</param>
+    /// <param name="factoryArgument">An argument for the factory method.</param>
+    /// <returns>
+    ///     The value of the existing runtime annotation if an annotation with the specified name already exists.
+    ///     Otherwise a newly created value.
+    /// </returns>
+    public virtual TValue GetOrAddRuntimeAnnotationValue<TValue, TArg>(
+        string name,
+        Func<TArg?, TValue> valueFactory,
+        TArg? factoryArgument)
+        => (TValue)GetOrCreateRuntimeAnnotations().GetOrAdd(
+            name,
+            static (n, t) => t.Annotatable.CreateRuntimeAnnotation(n, t.CreateValue(t.Argument)),
+            (CreateValue: valueFactory, Argument: factoryArgument, Annotatable: this)).Value!;
+
+    /// <summary>
+    ///     Gets the runtime annotation with the given name, returning <see langword="null" /> if it does not exist.
+    /// </summary>
+    /// <param name="name">The key of the annotation to find.</param>
+    /// <returns>
+    ///     The existing annotation if an annotation with the specified name already exists. Otherwise, <see langword="null" />.
+    /// </returns>
+    public virtual Annotation? FindRuntimeAnnotation(string name)
+    {
+        Check.NotEmpty(name, nameof(name));
+
+        return _runtimeAnnotations == null
+            ? null
+            : _runtimeAnnotations.TryGetValue(name, out var annotation)
+                ? annotation
+                : null;
+    }
+
+    /// <summary>
+    ///     Removes the given runtime annotation from this object.
+    /// </summary>
+    /// <param name="name">The annotation to remove.</param>
+    /// <returns>The annotation that was removed.</returns>
+    public virtual Annotation? RemoveRuntimeAnnotation(string name)
+    {
+        Check.NotNull(name, nameof(name));
+
+        if (_runtimeAnnotations == null)
+        {
+            return null;
+        }
+
+        _runtimeAnnotations.Remove(name, out var annotation);
+
+        return annotation;
+    }
+
+    /// <summary>
+    ///     Creates a new runtime annotation.
+    /// </summary>
+    /// <param name="name">The key of the annotation.</param>
+    /// <param name="value">The value to be stored in the annotation.</param>
+    /// <returns>The newly created annotation.</returns>
+    protected virtual Annotation CreateRuntimeAnnotation(string name, object? value)
+        => new(name, value);
+
+    private ConcurrentDictionary<string, Annotation> GetOrCreateRuntimeAnnotations()
+        => NonCapturingLazyInitializer.EnsureInitialized(
+            ref _runtimeAnnotations, (object?)null, static _ => new ConcurrentDictionary<string, Annotation>());
+
+    /// <inheritdoc />
+    object? IReadOnlyAnnotatable.this[string name]
+    {
+        [DebuggerStepThrough]
+        get => this[name];
+    }
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IEnumerable<IAnnotation> IReadOnlyAnnotatable.GetAnnotations()
+        => _annotations.Values.OrderBy(a => a.Name, StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IAnnotation? IReadOnlyAnnotatable.FindAnnotation(string name)
+        => FindAnnotation(name);
+
+    /// <inheritdoc />
+    IEnumerable<IAnnotation> IAnnotatable.GetRuntimeAnnotations()
+        => GetRuntimeAnnotations();
+
+    /// <inheritdoc />
+    IAnnotation? IAnnotatable.FindRuntimeAnnotation(string name)
+        => FindRuntimeAnnotation(name);
+
+    /// <inheritdoc />
+    IAnnotation IAnnotatable.AddRuntimeAnnotation(string name, object? value)
+        => AddRuntimeAnnotation(name, value);
+
+    /// <inheritdoc />
+    IAnnotation? IAnnotatable.RemoveRuntimeAnnotation(string name)
+        => RemoveRuntimeAnnotation(name);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IAnnotation IAnnotatable.SetRuntimeAnnotation(string name, object? value)
+        => SetRuntimeAnnotation(name, value);
+}

--- a/src/EFCore/Metadata/RuntimeComplexProperty.cs
+++ b/src/EFCore/Metadata/RuntimeComplexProperty.cs
@@ -36,7 +36,9 @@ public class RuntimeComplexProperty : RuntimePropertyBase, IComplexProperty
         bool collection,
         ChangeTrackingStrategy changeTrackingStrategy,
         PropertyInfo? indexerPropertyInfo,
-        bool propertyBag)
+        bool propertyBag,
+        int propertyCount,
+        int complexPropertyCount)
         : base(name, propertyInfo, fieldInfo, propertyAccessMode)
     {
         DeclaringType = declaringType;
@@ -44,7 +46,9 @@ public class RuntimeComplexProperty : RuntimePropertyBase, IComplexProperty
         _isNullable = nullable;
         _isCollection = collection;
         ComplexType = new RuntimeComplexType(
-            targetTypeName, targetType, this, changeTrackingStrategy, indexerPropertyInfo, propertyBag);
+            targetTypeName, targetType, this, changeTrackingStrategy, indexerPropertyInfo, propertyBag,
+            propertyCount: propertyCount,
+            complexPropertyCount: complexPropertyCount);
     }
 
     /// <summary>

--- a/src/EFCore/Metadata/RuntimeComplexType.cs
+++ b/src/EFCore/Metadata/RuntimeComplexType.cs
@@ -33,8 +33,13 @@ public class RuntimeComplexType : RuntimeTypeBase, IRuntimeComplexType
         RuntimeComplexProperty complexProperty,
         ChangeTrackingStrategy changeTrackingStrategy,
         PropertyInfo? indexerPropertyInfo,
-        bool propertyBag)
-        : base(name, type, complexProperty.DeclaringType.Model, null, changeTrackingStrategy, indexerPropertyInfo, propertyBag)
+        bool propertyBag,
+        int propertyCount,
+        int complexPropertyCount)
+        : base(name, type, complexProperty.DeclaringType.Model, null, changeTrackingStrategy, indexerPropertyInfo, propertyBag,
+            derivedTypesCount: 0,
+            propertyCount: propertyCount,
+            complexPropertyCount: complexPropertyCount)
     {
         ComplexProperty = complexProperty;
         ContainingEntityType = complexProperty.DeclaringType switch

--- a/src/EFCore/Metadata/RuntimeElementType.cs
+++ b/src/EFCore/Metadata/RuntimeElementType.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
-public class RuntimeElementType : AnnotatableBase, IElementType
+public class RuntimeElementType : RuntimeAnnotatableBase, IElementType
 {
     private readonly bool _isNullable;
     private readonly ValueConverter? _valueConverter;

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -17,36 +17,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// </remarks>
 public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
 {
-    private readonly List<RuntimeForeignKey> _foreignKeys = new();
-
-    private readonly SortedDictionary<string, RuntimeNavigation> _navigations
-        = new(StringComparer.Ordinal);
-
-    private readonly SortedDictionary<string, RuntimeSkipNavigation> _skipNavigations
-        = new(StringComparer.Ordinal);
-
-    private readonly SortedDictionary<string, RuntimeServiceProperty> _serviceProperties
-        = new(StringComparer.Ordinal);
-
-    private readonly SortedDictionary<IReadOnlyList<IReadOnlyProperty>, RuntimeIndex> _unnamedIndexes
-        = new(PropertyListComparer.Instance);
-
-    private readonly SortedDictionary<string, RuntimeIndex> _namedIndexes
-        = new(StringComparer.Ordinal);
-
-    private readonly SortedDictionary<IReadOnlyList<IReadOnlyProperty>, RuntimeKey> _keys
-        = new(PropertyListComparer.Instance);
-
-    private readonly SortedDictionary<string, RuntimeTrigger> _triggers
-        = new(StringComparer.Ordinal);
-
-    private RuntimeKey? _primaryKey;
+    private readonly List<RuntimeForeignKey> _foreignKeys;
+    private readonly OrderedDictionary<string, RuntimeNavigation> _navigations;
+    private OrderedDictionary<string, RuntimeSkipNavigation>? _skipNavigations;
+    private OrderedDictionary<string, RuntimeServiceProperty>? _serviceProperties;
+    private readonly OrderedDictionary<IReadOnlyList<IReadOnlyProperty>, RuntimeIndex> _unnamedIndexes;
+    private OrderedDictionary<string, RuntimeIndex>? _namedIndexes;
+    private readonly OrderedDictionary<IReadOnlyList<IReadOnlyProperty>, RuntimeKey> _keys;
+    private OrderedDictionary<string, RuntimeTrigger>? _triggers;
+    private readonly object? _discriminatorValue;
     private readonly bool _hasSharedClrType;
-
+    private RuntimeKey? _primaryKey;
     private InstantiationBinding? _constructorBinding;
     private InstantiationBinding? _serviceOnlyConstructorBinding;
-    private readonly object? _discriminatorValue;
-    private bool _hasServiceProperties;
 
     // Warning: Never access these fields directly as access needs to be thread-safe
     private PropertyCounts? _counts;
@@ -79,13 +62,47 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
         ChangeTrackingStrategy changeTrackingStrategy,
         PropertyInfo? indexerPropertyInfo,
         bool propertyBag,
-        object? discriminatorValue)
-        : base(name, type, model, baseType, changeTrackingStrategy, indexerPropertyInfo, propertyBag)
+        object? discriminatorValue,
+        int derivedTypesCount,
+        int propertyCount,
+        int complexPropertyCount,
+        int foreignKeyCount,
+        int navigationCount,
+        int skipNavigationPropertyCount,
+        int servicePropertyCount,
+        int unnamedIndexCount,
+        int namedIndexCount,
+        int keyCount,
+        int triggerPropertyCount)
+        : base(name, type, model, baseType, changeTrackingStrategy, indexerPropertyInfo, propertyBag,
+            derivedTypesCount: derivedTypesCount,
+            propertyCount: propertyCount,
+            complexPropertyCount: complexPropertyCount)
     {
         _hasSharedClrType = sharedClrType;
 
         SetAnnotation(CoreAnnotationNames.DiscriminatorProperty, discriminatorProperty);
         _discriminatorValue = discriminatorValue;
+        _foreignKeys = new(foreignKeyCount);
+        _navigations = new(navigationCount, StringComparer.Ordinal);
+        if (skipNavigationPropertyCount > 0)
+        {
+            _skipNavigations = new(skipNavigationPropertyCount, StringComparer.Ordinal);
+        }
+        if (servicePropertyCount > 0)
+        {
+            _serviceProperties = new(servicePropertyCount, StringComparer.Ordinal);
+        }
+        _unnamedIndexes = new(unnamedIndexCount, PropertyListComparer.Instance);
+        if(namedIndexCount > 0)
+        {
+            _namedIndexes = new(namedIndexCount, StringComparer.Ordinal);
+        }
+        _keys = new(keyCount, PropertyListComparer.Instance);
+        if(triggerPropertyCount > 0)
+        {
+            _triggers = new(triggerPropertyCount, StringComparer.Ordinal);
+        }
     }
 
     private new RuntimeEntityType? BaseType
@@ -109,16 +126,10 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     {
         foreach (var property in key.Properties)
         {
-            Properties.Remove(property.Name);
             property.PrimaryKey = key;
         }
 
         _primaryKey = key;
-
-        foreach (var property in key.Properties)
-        {
-            Properties.Add(property.Name, property);
-        }
     }
 
     /// <summary>
@@ -258,7 +269,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
             ?? BaseType?.FindForeignKey(properties, principalKey, principalEntityType);
 
     private IEnumerable<RuntimeForeignKey> GetDerivedForeignKeys()
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeForeignKey>()
             : GetDerivedTypes().Cast<RuntimeEntityType>().SelectMany(et => et._foreignKeys);
 
@@ -342,7 +353,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
         var navigation = new RuntimeNavigation(
             name, clrType, propertyInfo, fieldInfo, foreignKey, propertyAccessMode, eagerLoaded, lazyLoadingEnabled);
 
-        _navigations.Add(name, navigation);
+        _navigations.Insert(name, navigation);
 
         foreignKey.AddNavigation(navigation, onDependent);
 
@@ -374,7 +385,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     {
         Check.NotNull(name, nameof(name));
 
-        return DirectlyDerivedTypes.Count == 0
+        return !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeNavigation>()
             : (IEnumerable<RuntimeNavigation>)GetDerivedTypes<RuntimeEntityType>()
                 .Select(et => et.FindDeclaredNavigation(name)).Where(n => n != null);
@@ -385,7 +396,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     /// </summary>
     /// <returns>Type navigations.</returns>
     public virtual IEnumerable<RuntimeNavigation> FindNavigationsInHierarchy(string name)
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? ToEnumerable(FindNavigation(name))
             : ToEnumerable(FindNavigation(name)).Concat(FindDerivedNavigations(name));
 
@@ -433,6 +444,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
             eagerLoaded,
             lazyLoadingEnabled);
 
+        _skipNavigations ??= new(StringComparer.Ordinal);
         _skipNavigations.Add(name, skipNavigation);
 
         return skipNavigation;
@@ -450,30 +462,30 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
         => FindSkipNavigation(memberInfo.GetSimpleMemberName());
 
     private RuntimeSkipNavigation? FindDeclaredSkipNavigation(string name)
-        => _skipNavigations.TryGetValue(name, out var navigation)
+        => _skipNavigations != null && _skipNavigations.TryGetValue(name, out var navigation)
             ? navigation
             : null;
 
     private IEnumerable<RuntimeSkipNavigation> GetDeclaredSkipNavigations()
-        => _skipNavigations.Values;
+        => _skipNavigations?.Values ?? Enumerable.Empty<RuntimeSkipNavigation>();
 
     private IEnumerable<RuntimeSkipNavigation> GetDerivedSkipNavigations()
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeSkipNavigation>()
             : GetDerivedTypes().Cast<RuntimeEntityType>().SelectMany(et => et.GetDeclaredSkipNavigations());
 
     private IEnumerable<RuntimeSkipNavigation> GetSkipNavigations()
         => BaseType != null
-            ? _skipNavigations.Count == 0
+            ? _skipNavigations == null
                 ? BaseType.GetSkipNavigations()
                 : BaseType.GetSkipNavigations().Concat(_skipNavigations.Values)
-            : _skipNavigations.Values;
+            : GetDeclaredSkipNavigations();
 
     private IEnumerable<RuntimeSkipNavigation> FindDerivedSkipNavigations(string name)
     {
         Check.NotNull(name, nameof(name));
 
-        return DirectlyDerivedTypes.Count == 0
+        return !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeSkipNavigation>()
             : (IEnumerable<RuntimeSkipNavigation>)GetDerivedTypes<RuntimeEntityType>()
                 .Select(et => et.FindDeclaredSkipNavigation(name)).Where(n => n != null);
@@ -484,7 +496,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     /// </summary>
     /// <returns>Type skip navigations.</returns>
     public virtual IEnumerable<RuntimeSkipNavigation> FindSkipNavigationsInHierarchy(string name)
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? ToEnumerable(FindSkipNavigation(name))
             : ToEnumerable(FindSkipNavigation(name)).Concat(FindDerivedSkipNavigations(name));
 
@@ -503,7 +515,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
         var index = new RuntimeIndex(properties, this, name, unique);
         if (name != null)
         {
-            _namedIndexes.Add(name, index);
+            (_namedIndexes ??= new(StringComparer.Ordinal)).Add(name, index);
         }
         else
         {
@@ -544,23 +556,23 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     /// <param name="name">The name of the index.</param>
     /// <returns>The index, or <see langword="null" /> if none is found.</returns>
     public virtual RuntimeIndex? FindIndex(string name)
-        => _namedIndexes.TryGetValue(name, out var index)
+        => _namedIndexes != null && _namedIndexes.TryGetValue(name, out var index)
             ? index
             : BaseType?.FindIndex(name);
 
     private IEnumerable<RuntimeIndex> GetDeclaredIndexes()
-        => _namedIndexes.Count == 0
+        => _namedIndexes == null
             ? _unnamedIndexes.Values
             : _unnamedIndexes.Values.Concat(_namedIndexes.Values);
 
     private IEnumerable<RuntimeIndex> GetDerivedIndexes()
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeIndex>()
             : GetDerivedTypes().Cast<RuntimeEntityType>().SelectMany(et => et.GetDeclaredIndexes());
 
     private IEnumerable<RuntimeIndex> GetIndexes()
         => BaseType != null
-            ? _namedIndexes.Count == 0 && _unnamedIndexes.Count == 0
+            ? _namedIndexes == null
                 ? BaseType.GetIndexes()
                 : BaseType.GetIndexes().Concat(GetDeclaredIndexes())
             : GetDeclaredIndexes();
@@ -589,8 +601,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
             this,
             propertyAccessMode);
 
-        _serviceProperties[serviceProperty.Name] = serviceProperty;
-        _hasServiceProperties = true;
+        (_serviceProperties ??= new(StringComparer.Ordinal))[serviceProperty.Name] = serviceProperty;
 
         return serviceProperty;
     }
@@ -608,25 +619,25 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
         => FindDeclaredServiceProperty(name) ?? BaseType?.FindServiceProperty(name);
 
     private RuntimeServiceProperty? FindDeclaredServiceProperty(string name)
-        => _serviceProperties.TryGetValue(name, out var property)
+        => _serviceProperties != null && _serviceProperties.TryGetValue(name, out var property)
             ? property
             : null;
 
     private bool HasServiceProperties()
-        => _hasServiceProperties || BaseType != null && BaseType.HasServiceProperties();
+        => _serviceProperties != null || BaseType != null && BaseType.HasServiceProperties();
 
     private IEnumerable<RuntimeServiceProperty> GetServiceProperties()
         => BaseType != null
-            ? _hasServiceProperties
+            ? _serviceProperties != null
                 ? BaseType.GetServiceProperties().Concat(_serviceProperties.Values)
                 : BaseType.GetServiceProperties()
-            : _serviceProperties.Values;
+            : GetDeclaredServiceProperties();
 
     private IEnumerable<RuntimeServiceProperty> GetDeclaredServiceProperties()
-        => _serviceProperties.Values;
+        => _serviceProperties?.Values ?? Enumerable.Empty<RuntimeServiceProperty>();
 
     private IEnumerable<RuntimeServiceProperty> GetDerivedServiceProperties()
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeServiceProperty>()
             : GetDerivedTypes().Cast<RuntimeEntityType>().SelectMany(et => et.GetDeclaredServiceProperties());
 
@@ -640,7 +651,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     {
         Check.NotNull(propertyName, nameof(propertyName));
 
-        return DirectlyDerivedTypes.Count == 0
+        return !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeServiceProperty>()
             : (IEnumerable<RuntimeServiceProperty>)GetDerivedTypes<RuntimeEntityType>()
                 .Select(et => et.FindDeclaredServiceProperty(propertyName))
@@ -652,7 +663,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     /// </summary>
     /// <returns>Type service properties.</returns>
     public virtual IEnumerable<RuntimeServiceProperty> FindServicePropertiesInHierarchy(string propertyName)
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? ToEnumerable(FindServiceProperty(propertyName))
             : ToEnumerable(FindServiceProperty(propertyName)).Concat(FindDerivedServiceProperties(propertyName));
 
@@ -718,7 +729,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     {
         var trigger = new RuntimeTrigger(this, modelName);
 
-        _triggers.Add(modelName, trigger);
+        (_triggers ??= new(StringComparer.Ordinal)).Add(modelName, trigger);
 
         return trigger;
     }
@@ -732,13 +743,13 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     {
         Check.NotEmpty(modelName, nameof(modelName));
 
-        return _triggers.TryGetValue(modelName, out var trigger)
+        return _triggers != null && _triggers.TryGetValue(modelName, out var trigger)
             ? trigger
             : null;
     }
 
     private IEnumerable<RuntimeTrigger> GetDeclaredTriggers()
-        => _triggers.Values;
+        => _triggers?.Values ?? Enumerable.Empty<RuntimeTrigger>();
 
     private IEnumerable<RuntimeTrigger> GetTriggers()
         => BaseType != null
@@ -762,13 +773,13 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     {
         get => !base.ClrType.IsAbstract
             ? NonCapturingLazyInitializer.EnsureInitialized(
-                ref _constructorBinding, this, (Action<RuntimeEntityType>)(entityType =>
+                ref _constructorBinding, this, entityType =>
                 {
                     ((IModel)entityType.Model).GetModelDependencies().ConstructorBindingFactory.GetBindings(
                         entityType,
                         out entityType._constructorBinding,
                         out entityType._serviceOnlyConstructorBinding);
-                }))
+                })
             : _constructorBinding;
 
         [DebuggerStepThrough]
@@ -943,7 +954,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
 
     /// <inheritdoc />
     IEnumerable<IReadOnlyEntityType> IReadOnlyEntityType.GetDerivedTypesInclusive()
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? new[] { this }
             : new[] { this }.Concat(GetDerivedTypes<RuntimeEntityType>());
 
@@ -1106,7 +1117,7 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
     /// <inheritdoc />
     [DebuggerStepThrough]
     IEnumerable<IReadOnlyNavigation> IReadOnlyEntityType.GetDerivedNavigations()
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeNavigation>()
             : GetDerivedTypes().Cast<RuntimeEntityType>().SelectMany(et => et.GetDeclaredNavigations());
 

--- a/src/EFCore/Metadata/RuntimeForeignKey.cs
+++ b/src/EFCore/Metadata/RuntimeForeignKey.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
-public class RuntimeForeignKey : AnnotatableBase, IRuntimeForeignKey
+public class RuntimeForeignKey : RuntimeAnnotatableBase, IRuntimeForeignKey
 {
     private readonly DeleteBehavior _deleteBehavior;
     private readonly bool _isUnique;

--- a/src/EFCore/Metadata/RuntimeIndex.cs
+++ b/src/EFCore/Metadata/RuntimeIndex.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
-public class RuntimeIndex : AnnotatableBase, IIndex
+public class RuntimeIndex : RuntimeAnnotatableBase, IIndex
 {
     private readonly bool _isUnique;
 
@@ -122,9 +122,5 @@ public class RuntimeIndex : AnnotatableBase, IIndex
     [DebuggerStepThrough]
     IDependentKeyValueFactory<TKey> IIndex.GetNullableValueFactory<TKey>()
         => (IDependentKeyValueFactory<TKey>)NonCapturingLazyInitializer.EnsureInitialized(
-            ref _nullableValueFactory, this, static index =>
-            {
-                index.EnsureReadOnly();
-                return new CompositeValueFactory(index.Properties);
-            });
+            ref _nullableValueFactory, this, static index => new CompositeValueFactory(index.Properties));
 }

--- a/src/EFCore/Metadata/RuntimeKey.cs
+++ b/src/EFCore/Metadata/RuntimeKey.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
-public class RuntimeKey : AnnotatableBase, IRuntimeKey
+public class RuntimeKey : RuntimeAnnotatableBase, IRuntimeKey
 {
     // Warning: Never access these fields directly as access needs to be thread-safe
     private Func<bool, IIdentityMap>? _identityMapFactory;
@@ -144,18 +144,10 @@ public class RuntimeKey : AnnotatableBase, IRuntimeKey
         .GetDeclaredMethod(nameof(CreatePrincipalKeyValueFactory))!;
 
     private IPrincipalKeyValueFactory<TKey> CreatePrincipalKeyValueFactory<TKey>()
-        where TKey : notnull
-    {
-        EnsureReadOnly();
-        return new KeyValueFactoryFactory().Create<TKey>(this);
-    }
+        where TKey : notnull => new KeyValueFactoryFactory().Create<TKey>(this);
 
     /// <inheritdoc />
     Func<bool, IIdentityMap> IRuntimeKey.GetIdentityMapFactory()
         => NonCapturingLazyInitializer.EnsureInitialized(
-            ref _identityMapFactory, this, static key =>
-            {
-                key.EnsureReadOnly();
-                return new IdentityMapFactoryFactory().Create(key);
-            });
+            ref _identityMapFactory, this, static key => new IdentityMapFactoryFactory().Create(key));
 }

--- a/src/EFCore/Metadata/RuntimeNavigation.cs
+++ b/src/EFCore/Metadata/RuntimeNavigation.cs
@@ -111,9 +111,5 @@ public class RuntimeNavigation : RuntimePropertyBase, INavigation
             ref _collectionAccessor,
             ref _collectionAccessorInitialized,
             this,
-            static navigation =>
-            {
-                navigation.EnsureReadOnly();
-                return new ClrCollectionAccessorFactory().Create(navigation);
-            });
+            static navigation => new ClrCollectionAccessorFactory().Create(navigation));
 }

--- a/src/EFCore/Metadata/RuntimePropertyBase.cs
+++ b/src/EFCore/Metadata/RuntimePropertyBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
-public abstract class RuntimePropertyBase : AnnotatableBase, IRuntimePropertyBase
+public abstract class RuntimePropertyBase : RuntimeAnnotatableBase, IRuntimePropertyBase
 {
     private readonly PropertyInfo? _propertyInfo;
     private readonly FieldInfo? _fieldInfo;

--- a/src/EFCore/Metadata/RuntimeSkipNavigation.cs
+++ b/src/EFCore/Metadata/RuntimeSkipNavigation.cs
@@ -170,18 +170,10 @@ public class RuntimeSkipNavigation : RuntimePropertyBase, IRuntimeSkipNavigation
             ref _collectionAccessor,
             ref _collectionAccessorInitialized,
             this,
-            static navigation =>
-            {
-                navigation.EnsureReadOnly();
-                return new ClrCollectionAccessorFactory().Create(navigation);
-            });
+            static navigation => new ClrCollectionAccessorFactory().Create(navigation));
 
     /// <inheritdoc />
     ICollectionLoader IRuntimeSkipNavigation.GetManyToManyLoader()
         => NonCapturingLazyInitializer.EnsureInitialized(
-            ref _manyToManyLoader, this, static navigation =>
-            {
-                navigation.EnsureReadOnly();
-                return new ManyToManyLoaderFactory().Create(navigation);
-            });
+            ref _manyToManyLoader, this, static navigation => new ManyToManyLoaderFactory().Create(navigation));
 }

--- a/src/EFCore/Metadata/RuntimeTrigger.cs
+++ b/src/EFCore/Metadata/RuntimeTrigger.cs
@@ -6,13 +6,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// <summary>
 ///     Represents a database trigger on a table.
 /// </summary>
-public class RuntimeTrigger : AnnotatableBase, ITrigger
+public class RuntimeTrigger : RuntimeAnnotatableBase, ITrigger
 {
     /// <summary>
-    ///     Initializes a new instance of the <see cref="RuntimeTrigger" /> class.
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    /// <param name="entityType">The entity type.</param>
-    /// <param name="modelName">The name in the model.</param>
+    [EntityFrameworkInternal]
     public RuntimeTrigger(
         RuntimeEntityType entityType,
         string modelName)

--- a/src/EFCore/Metadata/RuntimeTypeBase.cs
+++ b/src/EFCore/Metadata/RuntimeTypeBase.cs
@@ -14,15 +14,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
-public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
+public abstract class RuntimeTypeBase : RuntimeAnnotatableBase, IRuntimeTypeBase
 {
     private RuntimeModel _model;
     private readonly RuntimeTypeBase? _baseType;
-    private readonly SortedSet<RuntimeTypeBase> _directlyDerivedTypes = new(TypeBaseNameComparer.Instance);
-    private readonly SortedDictionary<string, RuntimeProperty> _properties;
-
-    private readonly SortedDictionary<string, RuntimeComplexProperty> _complexProperties = new(StringComparer.Ordinal);
-
+    private SortedSet<RuntimeTypeBase>? _directlyDerivedTypes;
+    private readonly OrderedDictionary<string, RuntimeProperty> _properties;
+    private OrderedDictionary<string, RuntimeComplexProperty>? _complexProperties;
     private readonly PropertyInfo? _indexerPropertyInfo;
     private readonly bool _isPropertyBag;
     private readonly ChangeTrackingStrategy _changeTrackingStrategy;
@@ -46,7 +44,10 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
         RuntimeTypeBase? baseType,
         ChangeTrackingStrategy changeTrackingStrategy,
         PropertyInfo? indexerPropertyInfo,
-        bool propertyBag)
+        bool propertyBag,
+        int derivedTypesCount,
+        int propertyCount,
+        int complexPropertyCount)
     {
         Name = name;
         ClrType = type;
@@ -54,13 +55,17 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
         if (baseType != null)
         {
             _baseType = baseType;
-            baseType._directlyDerivedTypes.Add(this);
+            (baseType._directlyDerivedTypes ??= new(TypeBaseNameComparer.Instance)).Add(this);
         }
 
         _changeTrackingStrategy = changeTrackingStrategy;
         _indexerPropertyInfo = indexerPropertyInfo;
         _isPropertyBag = propertyBag;
-        _properties = new SortedDictionary<string, RuntimeProperty>(new PropertyNameComparer(this));
+        _properties = new OrderedDictionary<string, RuntimeProperty>(propertyCount, new PropertyNameComparer(this));
+        if (complexPropertyCount > 0)
+        {
+            _complexProperties = new(complexPropertyCount, StringComparer.Ordinal);
+        }
     }
 
     /// <summary>
@@ -88,8 +93,20 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     ///     Gets all types in the model that directly derive from this type.
     /// </summary>
     /// <returns>The derived types.</returns>
-    public virtual SortedSet<RuntimeTypeBase> DirectlyDerivedTypes
-        => _directlyDerivedTypes;
+    [EntityFrameworkInternal]
+    protected virtual IEnumerable<RuntimeTypeBase> DirectlyDerivedTypes
+        => _directlyDerivedTypes ?? Enumerable.Empty<RuntimeTypeBase>();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    protected virtual bool HasDirectlyDerivedTypes
+        => _directlyDerivedTypes != null
+        && _directlyDerivedTypes.Count > 0;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -110,7 +127,7 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     protected virtual IEnumerable<T> GetDerivedTypes<T>()
         where T : RuntimeTypeBase
     {
-        if (DirectlyDerivedTypes.Count == 0)
+        if (!HasDirectlyDerivedTypes)
         {
             return Enumerable.Empty<T>();
         }
@@ -234,7 +251,7 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
         => _properties.TryGetValue(name, out var property)
             ? property
             : null;
-
+    
     /// <summary>
     ///     Gets all scalar properties declared on this type.
     /// </summary>
@@ -248,7 +265,7 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
         => _properties.Values;
 
     private IEnumerable<RuntimeProperty> GetDerivedProperties()
-        => _directlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeProperty>()
             : GetDerivedTypes().SelectMany(et => et.GetDeclaredProperties());
 
@@ -282,7 +299,7 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     /// </summary>
     /// <returns>Type properties.</returns>
     public virtual IEnumerable<RuntimeProperty> FindPropertiesInHierarchy(string propertyName)
-        => _directlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? ToEnumerable(FindProperty(propertyName))
             : ToEnumerable(FindProperty(propertyName)).Concat(FindDerivedProperties(propertyName));
 
@@ -290,7 +307,7 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     {
         Check.NotNull(propertyName, nameof(propertyName));
 
-        return _directlyDerivedTypes.Count == 0
+        return !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeProperty>()
             : (IEnumerable<RuntimeProperty>)GetDerivedTypes()
                 .Select(et => et.FindDeclaredProperty(propertyName)).Where(p => p != null);
@@ -307,16 +324,6 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
         => _baseType != null
             ? _baseType.GetProperties().Concat(_properties.Values)
             : _properties.Values;
-
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    protected virtual SortedDictionary<string, RuntimeProperty> Properties
-        => _properties;
 
     /// <inheritdoc />
     [DebuggerStepThrough]
@@ -351,6 +358,8 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     ///     A value indicating whether this entity type has an indexer which is able to contain arbitrary properties
     ///     and a method that can be used to determine whether a given indexer property contains a value.
     /// </param>
+    /// <param name="propertyCount">The expected number of declared properties for this complex type.</param>
+    /// <param name="complexPropertyCount">The expected number of declared complex properties for this complex type.</param>
     /// <returns>The newly created property.</returns>
     public virtual RuntimeComplexProperty AddComplexProperty(
         string name,
@@ -364,7 +373,9 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
         bool collection = false,
         ChangeTrackingStrategy changeTrackingStrategy = ChangeTrackingStrategy.Snapshot,
         PropertyInfo? indexerPropertyInfo = null,
-        bool propertyBag = false)
+        bool propertyBag = false,
+        int propertyCount = 0,
+        int complexPropertyCount = 0)
     {
         var property = new RuntimeComplexProperty(
             name,
@@ -379,8 +390,11 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
             collection,
             changeTrackingStrategy,
             indexerPropertyInfo,
-            propertyBag);
+            propertyBag,
+            propertyCount: propertyCount,
+            complexPropertyCount: complexPropertyCount);
 
+        _complexProperties ??= new(StringComparer.Ordinal);
         _complexProperties.Add(property.Name, property);
 
         return property;
@@ -395,7 +409,8 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
         => FindDeclaredComplexProperty(name) ?? BaseType?.FindComplexProperty(name);
 
     private RuntimeComplexProperty? FindDeclaredComplexProperty(string name)
-        => _complexProperties.TryGetValue(name, out var property)
+        => _complexProperties != null
+            && _complexProperties.TryGetValue(name, out var property)
             ? property
             : null;
 
@@ -404,10 +419,10 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     /// </summary>
     /// <returns>Declared complex properties.</returns>
     public virtual IEnumerable<RuntimeComplexProperty> GetDeclaredComplexProperties()
-        => _complexProperties.Values;
+        => _complexProperties?.Values ?? Enumerable.Empty<RuntimeComplexProperty>();
 
     private IEnumerable<RuntimeComplexProperty> GetDerivedComplexProperties()
-        => DirectlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeComplexProperty>()
             : GetDerivedTypes().Cast<RuntimeEntityType>().SelectMany(et => et.GetDeclaredComplexProperties());
 
@@ -420,15 +435,17 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     /// <returns>The complex properties defined on this type.</returns>
     public virtual IEnumerable<RuntimeComplexProperty> GetComplexProperties()
         => BaseType != null
-            ? BaseType.GetComplexProperties().Concat(_complexProperties.Values)
-            : _complexProperties.Values;
+            ? _complexProperties != null
+                ? BaseType.GetComplexProperties().Concat(_complexProperties.Values)
+                : BaseType.GetComplexProperties()
+            : GetDeclaredComplexProperties();
 
     /// <summary>
     ///     Gets the complex properties with the given name on this type, base types or derived types.
     /// </summary>
     /// <returns>Type complex properties.</returns>
     public virtual IEnumerable<RuntimeComplexProperty> FindComplexPropertiesInHierarchy(string propertyName)
-        => _directlyDerivedTypes.Count == 0
+        => !HasDirectlyDerivedTypes
             ? ToEnumerable(FindComplexProperty(propertyName))
             : ToEnumerable(FindComplexProperty(propertyName)).Concat(FindDerivedComplexProperties(propertyName));
 
@@ -436,7 +453,7 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     {
         Check.NotNull(propertyName, nameof(propertyName));
 
-        return _directlyDerivedTypes.Count == 0
+        return !HasDirectlyDerivedTypes
             ? Enumerable.Empty<RuntimeComplexProperty>()
             : (IEnumerable<RuntimeComplexProperty>)GetDerivedTypes()
                 .Select(et => et.FindDeclaredComplexProperty(propertyName)).Where(p => p != null);
@@ -564,6 +581,17 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public abstract IEnumerable<RuntimePropertyBase> GetSnapshottableMembers();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual void FinalizeType()
+    {
+    }
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/RuntimeTypeMappingConfiguration.cs
+++ b/src/EFCore/Metadata/RuntimeTypeMappingConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata;
 /// <remarks>
 ///     See <see href="https://aka.ms/efcore-docs-modeling">Modeling entity types and relationships</see> for more information and examples.
 /// </remarks>
-public sealed class RuntimeTypeMappingConfiguration : AnnotatableBase, ITypeMappingConfiguration
+public sealed class RuntimeTypeMappingConfiguration : RuntimeAnnotatableBase, ITypeMappingConfiguration
 {
     private readonly ValueConverter? _valueConverter;
 

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -87,10 +87,7 @@ public abstract class ExecutionStrategy : IExecutionStrategy
         int maxRetryCount,
         TimeSpan maxRetryDelay)
     {
-        if (maxRetryCount < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxRetryCount));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(maxRetryCount);
 
         if (maxRetryDelay.TotalMilliseconds < 0.0)
         {

--- a/src/Shared/HashHelpers.cs
+++ b/src/Shared/HashHelpers.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore.Utilities
+{
+    internal static partial class HashHelpers
+    {
+        internal static int PowerOf2(int v)
+        {
+            if ((v & (v - 1)) == 0)
+            {
+                return v;
+            }
+
+            var i = 2;
+            while (i < v)
+            {
+                i <<= 1;
+            }
+
+            return i;
+        }
+
+        // must never be written to
+        internal static readonly int[] SizeOneIntArray = new int[1];
+
+        public const int HashCollisionThreshold = 100;
+
+        // This is the maximum prime smaller than Array.MaxArrayLength
+        public const int MaxPrimeArrayLength = 0x7FEFFFFD;
+
+        public const int HashPrime = 101;
+
+        // Table of prime numbers to use as hash table sizes. 
+        // A typical resize algorithm would pick the smallest prime number in this array
+        // that is larger than twice the previous capacity. 
+        // Suppose our Hashtable currently has capacity x and enough elements are added 
+        // such that a resize needs to occur. Resizing first computes 2x then finds the 
+        // first prime in the table greater than 2x, i.e. if primes are ordered 
+        // p_1, p_2, ..., p_i, ..., it finds p_n such that p_n-1 < 2x < p_n. 
+        // Doubling is important for preserving the asymptotic complexity of the 
+        // hashtable operations such as add.  Having a prime guarantees that double 
+        // hashing does not lead to infinite loops.  IE, your hash function will be 
+        // h1(key) + i*h2(key), 0 <= i < size.  h2 and the size must be relatively prime.
+        // We prefer the low computation costs of higher prime numbers over the increased
+        // memory allocation of a fixed prime number i.e. when right sizing a HashSet.
+        public static readonly int[] primes = {
+            3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
+            1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
+            17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
+            187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
+            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369 };
+
+        public static bool IsPrime(int candidate)
+        {
+            if ((candidate & 1) != 0)
+            {
+                var limit = (int)Math.Sqrt(candidate);
+                for (var divisor = 3; divisor <= limit; divisor += 2)
+                {
+                    if ((candidate % divisor) == 0)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return candidate == 2;
+        }
+
+        public static int GetPrime(int min)
+        {
+            if (min < 0)
+            {
+                throw new ArgumentException("Hashtable's capacity overflowed and went negative. Check load factor, capacity and the current size of the table.");
+            }
+
+            for (var i = 0; i < primes.Length; i++)
+            {
+                var prime = primes[i];
+                if (prime >= min)
+                {
+                    return prime;
+                }
+            }
+
+            //outside of our predefined table. 
+            //compute the hard way. 
+            for (var i = (min | 1); i < int.MaxValue; i += 2)
+            {
+                if (IsPrime(i) && ((i - 1) % HashPrime != 0))
+                {
+                    return i;
+                }
+            }
+            return min;
+        }
+
+        // Returns size of hashtable to grow to.
+        public static int ExpandPrime(int oldSize)
+        {
+            var newSize = 2 * oldSize;
+
+            // Allow the hashtables to grow to maximum possible size (~2G elements) before encountering capacity overflow.
+            // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
+            if ((uint)newSize > MaxPrimeArrayLength && MaxPrimeArrayLength > oldSize)
+            {
+                Debug.Assert(MaxPrimeArrayLength == GetPrime(MaxPrimeArrayLength), "Invalid MaxPrimeArrayLength");
+                return MaxPrimeArrayLength;
+            }
+
+            return GetPrime(newSize);
+        }
+    }
+}

--- a/src/Shared/IDictionaryDebugView.cs
+++ b/src/Shared/IDictionaryDebugView.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore.Utilities
+{
+    internal sealed class IDictionaryDebugView<TKey, TValue>
+    {
+        private readonly IDictionary<TKey, TValue> _dict;
+
+        public IDictionaryDebugView(IDictionary<TKey, TValue> dictionary)
+        {
+            _dict = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<TKey, TValue>[] Items
+        {
+            get
+            {
+                var items = new KeyValuePair<TKey, TValue>[_dict.Count];
+                _dict.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+
+    internal sealed class DictionaryKeyCollectionDebugView<TKey, TValue>
+    {
+        private readonly ICollection<TKey> _collection;
+
+        public DictionaryKeyCollectionDebugView(ICollection<TKey> collection)
+        {
+            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TKey[] Items
+        {
+            get
+            {
+                var items = new TKey[_collection.Count];
+                _collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+
+    internal sealed class DictionaryValueCollectionDebugView<TKey, TValue>
+    {
+        private readonly ICollection<TValue> _collection;
+
+        public DictionaryValueCollectionDebugView(ICollection<TValue> collection)
+        {
+            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TValue[] Items
+        {
+            get
+            {
+                var items = new TValue[_collection.Count];
+                _collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }
+}

--- a/src/Shared/OrderedDictionary.KeyCollection.cs
+++ b/src/Shared/OrderedDictionary.KeyCollection.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections;
+
+namespace Microsoft.EntityFrameworkCore.Utilities
+{
+    internal partial class OrderedDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// Represents the collection of keys in a <see cref="OrderedDictionary{TKey, TValue}" />. This class cannot be inherited.
+        /// </summary>
+        [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
+        [DebuggerDisplay("Count = {Count}")]
+        internal sealed class KeyCollection : IList<TKey>, IReadOnlyList<TKey>
+        {
+            private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+
+            /// <summary>
+            /// Gets the number of elements contained in the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.
+            /// </summary>
+            /// <returns>The number of elements contained in the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.</returns>
+            public int Count => _orderedDictionary.Count;
+
+            /// <summary>
+            /// Gets the key at the specified index as an O(1) operation.
+            /// </summary>
+            /// <param name="index">The zero-based index of the key to get.</param>
+            /// <returns>The key at the specified index.</returns>
+            /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.KeyCollection.Count" />.</exception>
+            public TKey this[int index] => ((IList<KeyValuePair<TKey, TValue>>)_orderedDictionary)[index].Key;
+
+            TKey IList<TKey>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException();
+            }
+
+            bool ICollection<TKey>.IsReadOnly => true;
+
+            internal KeyCollection(OrderedDictionary<TKey, TValue> orderedDictionary)
+            {
+                _orderedDictionary = orderedDictionary;
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.
+            /// </summary>
+            /// <returns>A <see cref="OrderedDictionary{TKey, TValue}.KeyCollection.Enumerator" /> for the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.</returns>
+            public Enumerator GetEnumerator() => new Enumerator(_orderedDictionary);
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            int IList<TKey>.IndexOf(TKey item) => _orderedDictionary.IndexOf(item);
+
+            void IList<TKey>.Insert(int index, TKey item) => throw new NotSupportedException();
+
+            void IList<TKey>.RemoveAt(int index) => throw new NotSupportedException();
+
+            void ICollection<TKey>.Add(TKey item) => throw new NotSupportedException();
+
+            void ICollection<TKey>.Clear() => throw new NotSupportedException();
+
+            bool ICollection<TKey>.Contains(TKey item) => _orderedDictionary.ContainsKey(item);
+
+            void ICollection<TKey>.CopyTo(TKey[] array, int arrayIndex)
+            {
+                ArgumentNullException.ThrowIfNull(array);
+                if ((uint)arrayIndex > (uint)array.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+                }
+                var count = Count;
+                if (array.Length - arrayIndex < count)
+                {
+                    throw new ArgumentException();
+                }
+
+                var entries = _orderedDictionary._entries;
+                for (var i = 0; i < count; ++i)
+                {
+                    array[i + arrayIndex] = entries[i].Key;
+                }
+            }
+
+            bool ICollection<TKey>.Remove(TKey item) => throw new NotSupportedException();
+
+            /// <summary>
+            /// Enumerates the elements of a <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.
+            /// </summary>
+            public struct Enumerator : IEnumerator<TKey>
+            {
+                private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+                private readonly int _version;
+                private int _index;
+                private TKey _current;
+
+                /// <summary>
+                /// Gets the element at the current position of the enumerator.
+                /// </summary>
+                /// <returns>The element in the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" /> at the current position of the enumerator.</returns>
+                public readonly TKey Current => _current;
+
+                readonly object? IEnumerator.Current => _current;
+
+                internal Enumerator(OrderedDictionary<TKey, TValue> orderedDictionary)
+                {
+                    _orderedDictionary = orderedDictionary;
+                    _version = orderedDictionary._version;
+                    _index = 0;
+                    _current = default!;
+                }
+
+                /// <summary>
+                /// Releases all resources used by the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection.Enumerator" />.
+                /// </summary>
+                public void Dispose()
+                {
+                }
+
+                /// <summary>
+                /// Advances the enumerator to the next element of the <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" />.
+                /// </summary>
+                /// <returns>true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.</returns>
+                /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+                public bool MoveNext()
+                {
+                    if (_version != _orderedDictionary._version)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    if (_index < _orderedDictionary.Count)
+                    {
+                        _current = _orderedDictionary._entries[_index].Key;
+                        ++_index;
+                        return true;
+                    }
+                    _current = default!;
+                    return false;
+                }
+
+                void IEnumerator.Reset()
+                {
+                    if (_version != _orderedDictionary._version)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    _index = 0;
+                    _current = default!;
+                }
+            }
+        }
+    }
+}

--- a/src/Shared/OrderedDictionary.ValueCollection.cs
+++ b/src/Shared/OrderedDictionary.ValueCollection.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections;
+
+namespace Microsoft.EntityFrameworkCore.Utilities
+{
+    internal partial class OrderedDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// Represents the collection of values in a <see cref="OrderedDictionary{TKey, TValue}" />. This class cannot be inherited.
+        /// </summary>
+        [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
+        [DebuggerDisplay("Count = {Count}")]
+        public sealed class ValueCollection : IList<TValue>, IReadOnlyList<TValue>
+        {
+            private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+
+            /// <summary>
+            /// Gets the number of elements contained in the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.
+            /// </summary>
+            /// <returns>The number of elements contained in the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.</returns>
+            public int Count => _orderedDictionary.Count;
+
+            /// <summary>
+            /// Gets the value at the specified index as an O(1) operation.
+            /// </summary>
+            /// <param name="index">The zero-based index of the value to get.</param>
+            /// <returns>The value at the specified index.</returns>
+            /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.ValueCollection.Count" />.</exception>
+            public TValue this[int index] => _orderedDictionary[index];
+
+            TValue IList<TValue>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotSupportedException();
+            }
+
+            bool ICollection<TValue>.IsReadOnly => true;
+
+            internal ValueCollection(OrderedDictionary<TKey, TValue> orderedDictionary)
+            {
+                _orderedDictionary = orderedDictionary;
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.
+            /// </summary>
+            /// <returns>A <see cref="OrderedDictionary{TKey, TValue}.ValueCollection.Enumerator" /> for the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.</returns>
+            public Enumerator GetEnumerator() => new Enumerator(_orderedDictionary);
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            int IList<TValue>.IndexOf(TValue item)
+            {
+                var comparer = EqualityComparer<TValue>.Default;
+                var entries = _orderedDictionary._entries;
+                var count = Count;
+                for (var i = 0; i < count; ++i)
+                {
+                    if (comparer.Equals(entries[i].Value, item))
+                    {
+                        return i;
+                    }
+                }
+                return -1;
+            }
+
+            void IList<TValue>.Insert(int index, TValue item) => throw new NotSupportedException();
+
+            void IList<TValue>.RemoveAt(int index) => throw new NotSupportedException();
+
+            void ICollection<TValue>.Add(TValue item) => throw new NotSupportedException();
+
+            void ICollection<TValue>.Clear() => throw new NotSupportedException();
+
+            bool ICollection<TValue>.Contains(TValue item) => ((IList<TValue>)this).IndexOf(item) >= 0;
+
+            void ICollection<TValue>.CopyTo(TValue[] array, int arrayIndex)
+            {
+                ArgumentNullException.ThrowIfNull(array);
+
+                if ((uint)arrayIndex > (uint)array.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+                }
+                var count = Count;
+                if (array.Length - arrayIndex < count)
+                {
+                    throw new ArgumentException();
+                }
+
+                var entries = _orderedDictionary._entries;
+                for (var i = 0; i < count; ++i)
+                {
+                    array[i + arrayIndex] = entries[i].Value;
+                }
+            }
+
+            bool ICollection<TValue>.Remove(TValue item) => throw new NotSupportedException();
+
+            /// <summary>
+            /// Enumerates the elements of a <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.
+            /// </summary>
+            public struct Enumerator : IEnumerator<TValue>
+            {
+                private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+                private readonly int _version;
+                private int _index;
+                private TValue _current;
+
+                /// <summary>
+                /// Gets the element at the current position of the enumerator.
+                /// </summary>
+                /// <returns>The element in the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" /> at the current position of the enumerator.</returns>
+                public TValue Current => _current;
+
+                object? IEnumerator.Current => _current;
+
+                internal Enumerator(OrderedDictionary<TKey, TValue> orderedDictionary)
+                {
+                    _orderedDictionary = orderedDictionary;
+                    _version = orderedDictionary._version;
+                    _index = 0;
+                    _current = default!;
+                }
+
+                /// <summary>
+                /// Releases all resources used by the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection.Enumerator" />.
+                /// </summary>
+                public void Dispose()
+                {
+                }
+
+                /// <summary>
+                /// Advances the enumerator to the next element of the <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" />.
+                /// </summary>
+                /// <returns>true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.</returns>
+                /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+                public bool MoveNext()
+                {
+                    if (_version != _orderedDictionary._version)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    if (_index < _orderedDictionary.Count)
+                    {
+                        _current = _orderedDictionary._entries[_index].Value;
+                        ++_index;
+                        return true;
+                    }
+                    _current = default!;
+                    return false;
+                }
+
+                void IEnumerator.Reset()
+                {
+                    if (_version != _orderedDictionary._version)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    _index = 0;
+                    _current = default!;
+                }
+            }
+        }
+    }
+}

--- a/src/Shared/OrderedDictionary.cs
+++ b/src/Shared/OrderedDictionary.cs
@@ -1,0 +1,893 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections;
+
+namespace Microsoft.EntityFrameworkCore.Utilities
+{
+    internal enum InsertionBehavior
+    {
+        None = 0,
+        OverwriteExisting = 1,
+        ThrowOnExisting = 2
+    }
+
+    /// <summary>
+    /// Represents an ordered collection of keys and values with the same performance as <see cref="Dictionary{TKey, TValue}"/> with O(1) lookups and adds but with O(n) inserts and removes.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+    [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}")]
+    internal sealed partial class OrderedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>, IList<KeyValuePair<TKey, TValue>>, IReadOnlyList<KeyValuePair<TKey, TValue>>
+    {
+        private struct Entry
+        {
+            public uint HashCode;
+            public TKey Key;
+            public TValue Value;
+            public int Next; // the index of the next item in the same bucket, -1 if last
+        }
+
+        // We want to initialize without allocating arrays. We also want to avoid null checks.
+        // Array.Empty would give divide by zero in modulo operation. So we use static one element arrays.
+        // The first add will cause a resize replacing these with real arrays of three elements.
+        // Arrays are wrapped in a class to avoid being duplicated for each <TKey, TValue>
+        private static readonly Entry[] InitialEntries = new Entry[1];
+        // 1-based index into _entries; 0 means empty
+        private int[] _buckets = HashHelpers.SizeOneIntArray;
+        // remains contiguous and maintains order
+        private Entry[] _entries = InitialEntries;
+        private int _count;
+        private int _version;
+        // is null when comparer is EqualityComparer<TKey>.Default so that the GetHashCode method is used explicitly on the object
+        private readonly IEqualityComparer<TKey>? _comparer;
+        private KeyCollection? _keys;
+        private ValueCollection? _values;
+
+        /// <summary>
+        /// Gets the number of key/value pairs contained in the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        /// <returns>The number of key/value pairs contained in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        public int Count => _count;
+
+        /// <summary>
+        /// Gets the <see cref="IEqualityComparer{TKey}" /> that is used to determine equality of keys for the dictionary.
+        /// </summary>
+        /// <returns>The <see cref="IEqualityComparer{TKey}" /> generic interface implementation that is used to determine equality of keys for the current <see cref="OrderedDictionary{TKey, TValue}" /> and to provide hash values for the keys.</returns>
+        public IEqualityComparer<TKey> Comparer => _comparer ?? EqualityComparer<TKey>.Default;
+
+        /// <summary>
+        /// Gets a collection containing the keys in the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        /// <returns>An <see cref="OrderedDictionary{TKey, TValue}.KeyCollection" /> containing the keys in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        public KeyCollection Keys => _keys ??= new KeyCollection(this);
+
+        /// <summary>
+        /// Gets a collection containing the values in the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        /// <returns>An <see cref="OrderedDictionary{TKey, TValue}.ValueCollection" /> containing the values in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        public ValueCollection Values => _values ??= new ValueCollection(this);
+
+        /// <summary>
+        /// Gets or sets the value associated with the specified key as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the value to get or set.</param>
+        /// <returns>The value associated with the specified key. If the specified key is not found, a get operation throws a <see cref="KeyNotFoundException" />, and a set operation creates a new element with the specified key.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        /// <exception cref="KeyNotFoundException">The property is retrieved and <paramref name="key" /> does not exist in the collection.</exception>
+        public TValue this[TKey key]
+        {
+            get
+            {
+                var index = IndexOf(key);
+                return index < 0
+                    ? throw new KeyNotFoundException($"Key {key} not found in the dictionary")
+                    : _entries[index].Value;
+            }
+            set => TryInsert(null, key, value, InsertionBehavior.OverwriteExisting);
+        }
+
+        /// <summary>
+        /// Gets or sets the value at the specified index as an O(1) operation.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get or set.</param>
+        /// <returns>The value at the specified index.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public TValue this[int index]
+        {
+            get
+            {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
+                return _entries[index].Value;
+            }
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
+                _entries[index].Value = value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that is empty, has the default initial capacity, and uses the default equality comparer for the key type.
+        /// </summary>
+        public OrderedDictionary()
+            : this(0, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that is empty, has the specified initial capacity, and uses the default equality comparer for the key type.
+        /// </summary>
+        /// <param name="capacity">The initial number of elements that the <see cref="OrderedDictionary{TKey, TValue}" /> can contain.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0.</exception>
+        public OrderedDictionary(int capacity)
+            : this(capacity, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that is empty, has the default initial capacity, and uses the specified <see cref="IEqualityComparer{T}" />.
+        /// </summary>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing keys, or null to use the default <see cref="EqualityComparer{T}" /> for the type of the key.</param>
+        public OrderedDictionary(IEqualityComparer<TKey> comparer)
+            : this(0, comparer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that is empty, has the specified initial capacity, and uses the specified <see cref="IEqualityComparer{T}" />.
+        /// </summary>
+        /// <param name="capacity">The initial number of elements that the <see cref="OrderedDictionary{TKey, TValue}" /> can contain.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}" /> implementation to use when comparing keys, or null to use the default <see cref="EqualityComparer{T}" /> for the type of the key.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0.</exception>
+        public OrderedDictionary(int capacity, IEqualityComparer<TKey>? comparer)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(capacity);
+
+            if (capacity > 0)
+            {
+                var newSize = HashHelpers.GetPrime(capacity);
+                _buckets = new int[newSize];
+                _entries = new Entry[newSize];
+            }
+
+            if (comparer != EqualityComparer<TKey>.Default)
+            {
+                _comparer = comparer;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that contains elements copied from the specified <see cref="IEnumerable{T}" /> and uses the default equality comparer for the key type.
+        /// </summary>
+        /// <param name="collection">The <see cref="IEnumerable{T}" /> whose elements are copied to the new <see cref="OrderedDictionary{TKey, TValue}" />.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="collection" /> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="collection" /> contains one or more duplicate keys.</exception>
+        public OrderedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection)
+            : this(collection, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderedDictionary{TKey, TValue}" /> class that contains elements copied from the specified <see cref="IEnumerable{T}" /> and uses the specified <see cref="IEqualityComparer{TKey}" />.
+        /// </summary>
+        /// <param name="collection">The <see cref="IEnumerable{T}" /> whose elements are copied to the new <see cref="OrderedDictionary{TKey, TValue}" />.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{TKey}" /> implementation to use when comparing keys, or null to use the default <see cref="EqualityComparer{TKey}" /> for the type of the key.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="collection" /> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="collection" /> contains one or more duplicate keys.</exception>
+        public OrderedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer)
+            : this((collection as ICollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0, comparer)
+        {
+            ArgumentNullException.ThrowIfNull(collection);
+
+            foreach (var pair in collection)
+            {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
+        /// <summary>
+        /// Adds the specified key and value to the dictionary as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value of the element to add. The value can be null for reference types.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        /// <exception cref="ArgumentException">An element with the same key already exists in the <see cref="OrderedDictionary{TKey, TValue}" />.</exception>
+        public void Add(TKey key, TValue value) => TryInsert(null, key, value, InsertionBehavior.ThrowOnExisting);
+
+        /// <summary>
+        /// Removes all keys and values from the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        public void Clear()
+        {
+            if (_count > 0)
+            {
+                Array.Clear(_buckets, 0, _buckets.Length);
+                Array.Clear(_entries, 0, _count);
+                _count = 0;
+                ++_version;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the <see cref="OrderedDictionary{TKey, TValue}" /> contains the specified key as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key to locate in the <see cref="OrderedDictionary{TKey, TValue}" />.</param>
+        /// <returns>true if the <see cref="OrderedDictionary{TKey, TValue}" /> contains an element with the specified key; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool ContainsKey(TKey key) => IndexOf(key) >= 0;
+
+        /// <summary>
+        /// Resizes the internal data structure if necessary to ensure no additional resizing to support the specified capacity.
+        /// </summary>
+        /// <param name="capacity">The number of elements that the <see cref="OrderedDictionary{TKey, TValue}" /> must be able to contain.</param>
+        /// <returns>The capacity of the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity" /> is less than 0.</exception>
+        public int EnsureCapacity(int capacity)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(capacity);
+
+            if (_entries.Length >= capacity)
+            {
+                return _entries.Length;
+            }
+            var newSize = HashHelpers.GetPrime(capacity);
+            Resize(newSize);
+            ++_version;
+            return newSize;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        /// <returns>An <see cref="OrderedDictionary{TKey, TValue}.Enumerator" /> structure for the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="OrderedDictionary{TKey, TValue}" /> if the key does not already exist as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value to be added, if the key does not already exist.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already in the dictionary, or the new value if the key was not in the dictionary.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public TValue GetOrAdd(TKey key, TValue value) => GetOrAdd(key, () => value);
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="OrderedDictionary{TKey, TValue}" /> by using the specified function, if the key does not already exist as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The function used to generate a value for the key.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already in the dictionary, or the new value for the key as returned by valueFactory if the key was not in the dictionary.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.-or-<paramref name="valueFactory"/> is null.</exception>
+        public TValue GetOrAdd(TKey key, Func<TValue> valueFactory)
+        {
+            ArgumentNullException.ThrowIfNull(valueFactory);
+
+            var index = IndexOf(key, out var hashCode);
+            TValue value;
+            if (index < 0)
+            {
+                value = valueFactory();
+                AddInternal(null, key, value, hashCode);
+            }
+            else
+            {
+                value = _entries[index].Value;
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Returns the zero-based index of the element with the specified key within the <see cref="OrderedDictionary{TKey, TValue}" /> as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to locate.</param>
+        /// <returns>The zero-based index of the element with the specified key within the <see cref="OrderedDictionary{TKey, TValue}" />, if found; otherwise, -1.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public int IndexOf(TKey key) => IndexOf(key, out _);
+
+        /// <summary>
+        /// Inserts the specified key/value pair into the <see cref="OrderedDictionary{TKey, TValue}" /> at the specified index as an O(n) operation.
+        /// </summary>
+        /// <param name="index">The zero-based index of the key/value pair to insert.</param>
+        /// <param name="key">The key of the element to insert.</param>
+        /// <param name="value">The value of the element to insert.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        /// <exception cref="ArgumentException">An element with the same key already exists in the <see cref="OrderedDictionary{TKey, TValue}" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public void Insert(int index, TKey key, TValue value)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, Count);
+
+            TryInsert(index, key, value, InsertionBehavior.ThrowOnExisting);
+        }
+
+        /// <summary>
+        /// Inserts the element in this sorted dictionary to the corresponding index using the default comparer.
+        /// </summary>
+        /// <param name="key">The key of the element to insert.</param>
+        /// <param name="value">The value of the element to insert.</param>
+        public void Insert(TKey key, TValue value)
+        {
+            var existingIndex = IndexOf(key, out var hashCode);
+            if (existingIndex >= 0)
+            {
+                throw new ArgumentException($"Key {key} is already present");
+            }
+
+            var comparer = Comparer<TKey>.Default;
+            for (var i = _count - 1; i >= 0; i--)
+            {
+                if (comparer.Compare(key, _entries[i].Key) >= 0)
+                {
+                    AddInternal(i + 1, key, value, hashCode);
+                    return;
+                }
+            }
+
+            AddInternal(0, key, value, hashCode);
+        }
+
+        /// <summary>
+        /// Moves the element at the specified fromIndex to the specified toIndex while re-arranging the elements in between.
+        /// </summary>
+        /// <param name="fromIndex">The zero-based index of the element to move.</param>
+        /// <param name="toIndex">The zero-based index to move the element to.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="fromIndex"/> is less than 0.
+        /// -or-
+        /// <paramref name="fromIndex"/> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />
+        /// -or-
+        /// <paramref name="toIndex"/> is less than 0.
+        /// -or-
+        /// <paramref name="toIndex"/> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />
+        /// </exception>
+        public void Move(int fromIndex, int toIndex)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(fromIndex, Count);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(toIndex, Count);
+
+            if (fromIndex == toIndex)
+            {
+                return;
+            }
+
+            var entries = _entries;
+            var temp = entries[fromIndex];
+            RemoveEntryFromBucket(fromIndex);
+            var direction = fromIndex < toIndex ? 1 : -1;
+            for (var i = fromIndex; i != toIndex; i += direction)
+            {
+                entries[i] = entries[i + direction];
+                UpdateBucketIndex(i + direction, -direction);
+            }
+            AddEntryToBucket(ref temp, toIndex, _buckets);
+            entries[toIndex] = temp;
+            ++_version;
+        }
+
+        /// <summary>
+        /// Moves the specified number of elements at the specified fromIndex to the specified toIndex while re-arranging the elements in between.
+        /// </summary>
+        /// <param name="fromIndex">The zero-based index of the elements to move.</param>
+        /// <param name="toIndex">The zero-based index to move the elements to.</param>
+        /// <param name="count">The number of elements to move.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="fromIndex"/> is less than 0.
+        /// -or-
+        /// <paramref name="fromIndex"/> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.
+        /// -or-
+        /// <paramref name="toIndex"/> is less than 0.
+        /// -or-
+        /// <paramref name="toIndex"/> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.
+        /// -or-
+        /// <paramref name="count"/> is less than 0.</exception>
+        /// <exception cref="ArgumentException"><paramref name="fromIndex"/> + <paramref name="count"/> is greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.
+        /// -or-
+        /// <paramref name="toIndex"/> + <paramref name="count"/> is greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public void MoveRange(int fromIndex, int toIndex, int count)
+        {
+            if (count == 1)
+            {
+                Move(fromIndex, toIndex);
+                return;
+            }
+
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(fromIndex, Count);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(toIndex, Count);
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(fromIndex + count, Count, nameof(fromIndex));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(toIndex + count, Count, nameof(toIndex));
+
+            if (fromIndex == toIndex || count == 0)
+            {
+                return;
+            }
+
+            var entries = _entries;
+            // Make a copy of the entries to move. Consider using ArrayPool instead to avoid allocations?
+            var entriesToMove = new Entry[count];
+            for (var i = 0; i < count; ++i)
+            {
+                entriesToMove[i] = entries[fromIndex + i];
+                RemoveEntryFromBucket(fromIndex + i);
+            }
+
+            // Move entries in between
+            var direction = 1;
+            var amount = count;
+            var start = fromIndex;
+            var end = toIndex;
+            if (fromIndex > toIndex)
+            {
+                direction = -1;
+                amount = -count;
+                start = fromIndex + count - 1;
+                end = toIndex + count - 1;
+            }
+            for (var i = start; i != end; i += direction)
+            {
+                entries[i] = entries[i + amount];
+                UpdateBucketIndex(i + amount, -amount);
+            }
+
+            var buckets = _buckets;
+            // Copy entries to destination
+            for (var i = 0; i < count; ++i)
+            {
+                var temp = entriesToMove[i];
+                AddEntryToBucket(ref temp, toIndex + i, buckets);
+                entries[toIndex + i] = temp;
+            }
+            ++_version;
+        }
+
+        /// <summary>
+        /// Removes the value with the specified key from the <see cref="OrderedDictionary{TKey, TValue}" /> as an O(n) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <returns>true if the element is successfully found and removed; otherwise, false. This method returns false if <paramref name="key" /> is not found in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool Remove(TKey key) => Remove(key, out _);
+
+        /// <summary>
+        /// Removes the value with the specified key from the <see cref="OrderedDictionary{TKey, TValue}" /> and returns the value as an O(n) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <param name="value">When this method returns, contains the value associated with the specified key, if the key is found; otherwise, the default value for the type of the <paramref name="value" /> parameter. This parameter is passed uninitialized.</param>
+        /// <returns>true if the element is successfully found and removed; otherwise, false. This method returns false if <paramref name="key" /> is not found in the <see cref="OrderedDictionary{TKey, TValue}" />.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool Remove(TKey key, out TValue value)
+        {
+            var index = IndexOf(key);
+            if (index >= 0)
+            {
+                value = _entries[index].Value;
+                RemoveAt(index);
+                return true;
+            }
+            value = default!;
+            return false;
+        }
+
+        /// <summary>
+        /// Removes the value at the specified index from the <see cref="OrderedDictionary{TKey, TValue}" /> as an O(n) operation.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> is less than 0.-or-<paramref name="index" /> is equal to or greater than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public void RemoveAt(int index)
+        {
+            var count = Count;
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, count);
+
+            // Remove the entry from the bucket
+            RemoveEntryFromBucket(index);
+
+            // Decrement the indices > index
+            var entries = _entries;
+            for (var i = index + 1; i < count; ++i)
+            {
+                entries[i - 1] = entries[i];
+                UpdateBucketIndex(i, incrementAmount: -1);
+            }
+            --_count;
+            entries[_count] = default;
+            ++_version;
+        }
+
+        /// <summary>
+        /// Sets the capacity of an <see cref="OrderedDictionary{TKey, TValue}" /> object to the actual number of elements it contains, rounded up to a nearby, implementation-specific value.
+        /// </summary>
+        public void TrimExcess() => TrimExcess(Count);
+
+        /// <summary>
+        /// Sets the capacity of an <see cref="OrderedDictionary{TKey, TValue}" /> object to the specified capacity, rounded up to a nearby, implementation-specific value.
+        /// </summary>
+        /// <param name="capacity">The number of elements that the <see cref="OrderedDictionary{TKey, TValue}" /> must be able to contain.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than <see cref="OrderedDictionary{TKey, TValue}.Count" />.</exception>
+        public void TrimExcess(int capacity)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(capacity, Count);
+
+            var newSize = HashHelpers.GetPrime(capacity);
+            if (newSize < _entries.Length)
+            {
+                Resize(newSize);
+                ++_version;
+            }
+        }
+
+        /// <summary>
+        /// Tries to add the specified key and value to the dictionary as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value of the element to add. The value can be null for reference types.</param>
+        /// <returns>true if the element was added to the <see cref="OrderedDictionary{TKey, TValue}" />; false if the <see cref="OrderedDictionary{TKey, TValue}" /> already contained an element with the specified key.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool TryAdd(TKey key, TValue value) => TryInsert(null, key, value, InsertionBehavior.None);
+
+        /// <summary>
+        /// Gets the value associated with the specified key as an O(1) operation.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <param name="value">When this method returns, contains the value associated with the specified key, if the key is found; otherwise, the default value for the type of the <paramref name="value" /> parameter. This parameter is passed uninitialized.</param>
+        /// <returns>true if the <see cref="OrderedDictionary{TKey, TValue}" /> contains an element with the specified key; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is null.</exception>
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            var index = IndexOf(key);
+            if (index >= 0)
+            {
+                value = _entries[index].Value;
+                return true;
+            }
+            value = default!;
+            return false;
+        }
+
+        #region Explicit Interface Implementation
+        KeyValuePair<TKey, TValue> IList<KeyValuePair<TKey, TValue>>.this[int index]
+        {
+            get
+            {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
+                var entry = _entries[index];
+                return new KeyValuePair<TKey, TValue>(entry.Key, entry.Value);
+            }
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
+                var key = value.Key;
+                var foundIndex = IndexOf(key, out var hashCode);
+                // key does not exist in dictionary thus replace entry at index
+                if (foundIndex < 0)
+                {
+                    RemoveEntryFromBucket(index);
+                    var entry = new Entry { HashCode = hashCode, Key = key, Value = value.Value };
+                    AddEntryToBucket(ref entry, index, _buckets);
+                    _entries[index] = entry;
+                    ++_version;
+                }
+                // key already exists in dictionary at the specified index thus just replace the key and value as hashCode remains the same
+                else if (foundIndex == index)
+                {
+                    ref var entry = ref _entries[index];
+                    entry.Key = key;
+                    entry.Value = value.Value;
+                }
+                // key already exists in dictionary but not at the specified index thus throw exception as this method shouldn't affect the indices of other entries
+                else
+                {
+                    throw new ArgumentException($"Key {key} already exists in dictionary but not at the specified index {index}");
+                }
+            }
+        }
+
+        KeyValuePair<TKey, TValue> IReadOnlyList<KeyValuePair<TKey, TValue>>.this[int index] => ((IList<KeyValuePair<TKey, TValue>>)this)[index];
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item) => Add(item.Key, item.Value);
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item) => TryGetValue(item.Key, out var value) && EqualityComparer<TValue>.Default.Equals(value, item.Value);
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ArgumentNullException.ThrowIfNull(array);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length);
+            var count = Count;
+            ArgumentOutOfRangeException.ThrowIfLessThan(array.Length - arrayIndex, count);
+
+            var entries = _entries;
+            for (var i = 0; i < count; ++i)
+            {
+                var entry = entries[i];
+                array[i + arrayIndex] = new KeyValuePair<TKey, TValue>(entry.Key, entry.Value);
+            }
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+        {
+            var index = IndexOf(item.Key);
+            if (index >= 0 && EqualityComparer<TValue>.Default.Equals(_entries[index].Value, item.Value))
+            {
+                RemoveAt(index);
+                return true;
+            }
+            return false;
+        }
+
+        int IList<KeyValuePair<TKey, TValue>>.IndexOf(KeyValuePair<TKey, TValue> item)
+        {
+            var index = IndexOf(item.Key);
+            if (index >= 0 && !EqualityComparer<TValue>.Default.Equals(_entries[index].Value, item.Value))
+            {
+                index = -1;
+            }
+            return index;
+        }
+
+        void IList<KeyValuePair<TKey, TValue>>.Insert(int index, KeyValuePair<TKey, TValue> item) => Insert(index, item.Key, item.Value);
+        #endregion
+
+        private Entry[] Resize(int newSize)
+        {
+            var newBuckets = new int[newSize];
+            var newEntries = new Entry[newSize];
+
+            var count = Count;
+            Array.Copy(_entries, newEntries, count);
+            for (var i = 0; i < count; ++i)
+            {
+                AddEntryToBucket(ref newEntries[i], i, newBuckets);
+            }
+
+            _buckets = newBuckets;
+            _entries = newEntries;
+            return newEntries;
+        }
+
+        private int IndexOf(TKey key, out uint hashCode)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            var comparer = _comparer;
+            hashCode = (uint)(comparer?.GetHashCode(key) ?? key.GetHashCode());
+            var index = _buckets[(int)(hashCode % (uint)_buckets.Length)] - 1;
+            if (index >= 0)
+            {
+                comparer ??= EqualityComparer<TKey>.Default;
+                var entries = _entries;
+                var collisionCount = 0;
+                do
+                {
+                    var entry = entries[index];
+                    if (entry.HashCode == hashCode && comparer.Equals(entry.Key, key))
+                    {
+                        break;
+                    }
+                    index = entry.Next;
+                    if (collisionCount >= entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        throw new InvalidOperationException("Concurrent update detected");
+                    }
+                    ++collisionCount;
+                } while (index >= 0);
+            }
+            return index;
+        }
+
+        private bool TryInsert(int? index, TKey key, TValue value, InsertionBehavior behavior)
+        {
+            var i = IndexOf(key, out var hashCode);
+            if (i >= 0)
+            {
+                switch (behavior)
+                {
+                    case InsertionBehavior.OverwriteExisting:
+                        _entries[i].Value = value;
+                        return true;
+                    case InsertionBehavior.ThrowOnExisting:
+                        throw new ArgumentException($"Key {key} is already present");
+                    default:
+                        return false;
+                }
+            }
+
+            AddInternal(index, key, value, hashCode);
+            return true;
+        }
+
+        private int AddInternal(int? index, TKey key, TValue value, uint hashCode)
+        {
+            var entries = _entries;
+            // Check if resize is needed
+            var count = Count;
+            if (entries.Length == count || entries.Length == 1)
+            {
+                entries = Resize(HashHelpers.ExpandPrime(entries.Length));
+            }
+
+            // Increment indices >= index;
+            var actualIndex = index ?? count;
+            for (var i = count - 1; i >= actualIndex; --i)
+            {
+                entries[i + 1] = entries[i];
+                UpdateBucketIndex(i, incrementAmount: 1);
+            }
+
+            ref var entry = ref entries[actualIndex];
+            entry.HashCode = hashCode;
+            entry.Key = key;
+            entry.Value = value;
+            AddEntryToBucket(ref entry, actualIndex, _buckets);
+            ++_count;
+            ++_version;
+            return actualIndex;
+        }
+
+        // Returns the index of the next entry in the bucket
+        private void AddEntryToBucket(ref Entry entry, int entryIndex, int[] buckets)
+        {
+            ref var b = ref buckets[(int)(entry.HashCode % (uint)buckets.Length)];
+            entry.Next = b - 1;
+            b = entryIndex + 1;
+        }
+
+        private void RemoveEntryFromBucket(int entryIndex)
+        {
+            var entries = _entries;
+            var entry = entries[entryIndex];
+            ref var b = ref _buckets[(int)(entry.HashCode % (uint)_buckets.Length)];
+            // Bucket was pointing to removed entry. Update it to point to the next in the chain
+            if (b == entryIndex + 1)
+            {
+                b = entry.Next + 1;
+            }
+            else
+            {
+                // Start at the entry the bucket points to, and walk the chain until we find the entry with the index we want to remove, then fix the chain
+                var i = b - 1;
+                var collisionCount = 0;
+                while (true)
+                {
+                    ref var e = ref entries[i];
+                    if (e.Next == entryIndex)
+                    {
+                        e.Next = entry.Next;
+                        return;
+                    }
+                    i = e.Next;
+                    if (collisionCount >= entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        throw new InvalidOperationException("Concurrent update detected");
+                    }
+                    ++collisionCount;
+                }
+            }
+        }
+
+        private void UpdateBucketIndex(int entryIndex, int incrementAmount)
+        {
+            var entries = _entries;
+            var entry = entries[entryIndex];
+            ref var b = ref _buckets[(int)(entry.HashCode % (uint)_buckets.Length)];
+            // Bucket was pointing to entry. Increment the index by incrementAmount.
+            if (b == entryIndex + 1)
+            {
+                b += incrementAmount;
+            }
+            else
+            {
+                // Start at the entry the bucket points to, and walk the chain until we find the entry with the index we want to increment.
+                var i = b - 1;
+                var collisionCount = 0;
+                while (true)
+                {
+                    ref var e = ref entries[i];
+                    if (e.Next == entryIndex)
+                    {
+                        e.Next += incrementAmount;
+                        return;
+                    }
+                    i = e.Next;
+                    if (collisionCount >= entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        throw new InvalidOperationException("Concurrent update detected");
+                    }
+                    ++collisionCount;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Enumerates the elements of a <see cref="OrderedDictionary{TKey, TValue}" />.
+        /// </summary>
+        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
+        {
+            private readonly OrderedDictionary<TKey, TValue> _orderedDictionary;
+            private readonly int _version;
+            private int _index;
+            private KeyValuePair<TKey, TValue> _current;
+
+            /// <summary>
+            /// Gets the element at the current position of the enumerator.
+            /// </summary>
+            /// <returns>The element in the <see cref="OrderedDictionary{TKey, TValue}" /> at the current position of the enumerator.</returns>
+            public KeyValuePair<TKey, TValue> Current => _current;
+
+            object IEnumerator.Current => _current;
+
+            internal Enumerator(OrderedDictionary<TKey, TValue> orderedDictionary)
+            {
+                _orderedDictionary = orderedDictionary;
+                _version = orderedDictionary._version;
+                _index = 0;
+            }
+
+            /// <summary>
+            /// Releases all resources used by the <see cref="OrderedDictionary{TKey, TValue}.Enumerator" />.
+            /// </summary>
+            public void Dispose()
+            {
+            }
+
+            /// <summary>
+            /// Advances the enumerator to the next element of the <see cref="OrderedDictionary{TKey, TValue}" />.
+            /// </summary>
+            /// <returns>true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.</returns>
+            /// <exception cref="InvalidOperationException">The collection was modified after the enumerator was created.</exception>
+            public bool MoveNext()
+            {
+                if (_version != _orderedDictionary._version)
+                {
+                    throw new InvalidOperationException("The dictionary has been modified during enumeration");
+                }
+
+                if (_index < _orderedDictionary.Count)
+                {
+                    var entry = _orderedDictionary._entries[_index];
+                    _current = new KeyValuePair<TKey, TValue>(entry.Key, entry.Value);
+                    ++_index;
+                    return true;
+                }
+                _current = default;
+                return false;
+            }
+
+            void IEnumerator.Reset()
+            {
+                if (_version != _orderedDictionary._version)
+                {
+                    throw new InvalidOperationException("The dictionary has been modified during enumeration");
+                }
+
+                _index = 0;
+                _current = default;
+            }
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -609,7 +609,7 @@ namespace MyNamespace
 
         var modelBuilder = SqlServerTestHelpers.Instance.CreateConventionBuilder(configureConventions: c => c.RemoveAllConventions());
         modelBuilder.HasAnnotation("Some:EnumValue", RegexOptions.Multiline);
-        modelBuilder.HasAnnotation(RelationalAnnotationNames.DbFunctions, new SortedDictionary<string, IDbFunction>());
+        modelBuilder.HasAnnotation(RelationalAnnotationNames.DbFunctions, new Dictionary<string, IDbFunction>());
         modelBuilder.Entity(
             "T1", eb =>
             {

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -85,6 +85,8 @@ public class MigrationsScaffolderTest
                         TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
                     new MigrationsAnnotationProvider(
                         new MigrationsAnnotationProviderDependencies()),
+                    new RelationalAnnotationProvider(
+                        new RelationalAnnotationProviderDependencies()),
                     services.GetRequiredService<IRowIdentityMapFactory>(),
                     services.GetRequiredService<CommandBatchPreparerDependencies>()),
                 idGenerator,

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -124,6 +124,8 @@ public abstract class MigrationsModelDifferTestBase
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
             new MigrationsAnnotationProvider(
                 new MigrationsAnnotationProviderDependencies()),
+            new RelationalAnnotationProvider(
+                new RelationalAnnotationProviderDependencies()),
             TestServiceFactory.Instance.Create<IRowIdentityMapFactory>(),
             TestHelpers.CreateContext(options).GetService<CommandBatchPreparerDependencies>());
 }

--- a/test/EFCore.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
@@ -41,8 +41,13 @@ public class SqlServerOptionsExtensionTest
     {
         static EmptyContextModel()
         {
-            var model = new EmptyContextModel();
+            var model = new EmptyContextModel(false, Guid.NewGuid(), 0, 0);
             _instance = model;
+        }
+
+        public EmptyContextModel(bool skipDetectChanges, Guid modelId, int entityTypeCount, int typeConfigurationCount)
+            : base(skipDetectChanges, modelId, entityTypeCount, typeConfigurationCount)
+        {
         }
 
         private static readonly EmptyContextModel _instance;

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -263,7 +263,7 @@ public class InternalEntryEntrySubscriberTest
         entity.NotifyChanging(null);
 
         Assert.Equal(
-            new[] { "Name", "RelatedCollection" },
+            ["Name", "RelatedCollection"],
             testListener.Changing.Select(e => e.Item2.Name).OrderBy(e => e).ToArray());
 
         Assert.Empty(testListener.Changed);
@@ -271,7 +271,7 @@ public class InternalEntryEntrySubscriberTest
         entity.NotifyChanged("");
 
         Assert.Equal(
-            new[] { "Name", "RelatedCollection" },
+            ["Name", "RelatedCollection"],
             testListener.Changed.Select(e => e.Item2.Name).OrderBy(e => e).ToArray());
     }
 

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -403,14 +403,14 @@ public partial class EntityTypeTest
 
         Assert.True(((Key)key1).IsInModel);
         Assert.True(((Key)key2).IsInModel);
-        Assert.Equal(new[] { key2, key1 }, entityType.GetKeys().ToArray());
+        Assert.Equal(new[] { key2, key1 }, entityType.GetKeys());
         Assert.True(idProperty.IsKey());
-        Assert.Equal(new[] { key1, key2 }, idProperty.GetContainingKeys().ToArray());
+        Assert.Equal(new[] { key2, key1 }, idProperty.GetContainingKeys());
 
         Assert.Same(key1, entityType.RemoveKey(key1.Properties));
         Assert.Null(entityType.RemoveKey(key1.Properties));
 
-        Assert.Equal(new[] { key2 }, entityType.GetKeys().ToArray());
+        Assert.Equal(new[] { key2 }, entityType.GetKeys());
 
         Assert.Same(key2, entityType.RemoveKey(new[] { idProperty }));
 


### PR DESCRIPTION
Fixes #31142
Fixes #19361

Implementation copied from https://github.com/dotnet/corefxlab/blob/archive/src/Microsoft.Experimental.Collections/Microsoft/Collections/Extensions/OrderedDictionary.cs until it's included in the framework.

For reference, these are its perf characteristics:


Operation | Dictionary<K,V> | SortedDictionary<K,V> | SortedList<K,V> | OrderedDictionary<K,V>
-- | -- | -- | -- | --
this[key] | O(1) | O(log n) | O(log n) or O(n) | O(1)
this[index] | n/a | n/a | n/a | O(1)
Add(key,value) | O(1) | O(log n) | O(n) | O(1)
Remove(key) | O(1) | O(log n) | O(n) | O(n)
RemoveAt(index) | n/a | n/a | n/a | O(n)
ContainsKey(key) | O(1) | O(log n) | O(log n) | O(1)
ContainsValue(value) | O(n) | O(n) | O(n) | O(n)
IndexOf(key) | n/a | n/a | n/a | O(1)
Insert(index,key,value) | n/a | n/a | n/a | O(n)
Space efficiency | good | worst | medium | good
Insert/Remove sorted data | n/a | O(log n) | O(n) | n/a
From sorted data | n/a | ? | better? | n/a