### PR TITLE
Make SQL CLR optional for running EF tests

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2915,6 +2915,7 @@ WHERE [m].[Timeline] = '1902-01-02T10:00:00.1234567+01:30'
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    [SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
     public virtual async Task Where_AtTimeZone_datetime_constant(bool async)
     {
         using var context = CreateContext();
@@ -2938,6 +2939,7 @@ WHERE [m].[Timeline] = CAST('0010-05-03T12:00:00.0000000' AS datetime2) AT TIME 
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    [SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
     public virtual async Task Where_AtTimeZone_datetime_parameter(bool async)
     {
         using var context = CreateContext();
@@ -2966,6 +2968,7 @@ WHERE [m].[Timeline] = @__dateTime_1 AT TIME ZONE @__timeZone_2
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    [SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
     public virtual async Task Where_AtTimeZone_datetime_column(bool async)
     {
         using var context = CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OperatorsQuerySqlServerTest.cs
@@ -134,6 +134,7 @@ WHERE N'Foo' + JSON_VALUE([o].[Owned], '$.SomeProperty') = N'FooBar'
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    [SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
     public virtual async Task Where_AtTimeZone_datetimeoffset_constant(bool async)
     {
         var contextFactory = await InitializeAsync<OperatorsContext>(seed: Seed);
@@ -163,6 +164,7 @@ WHERE [o].[Value] AT TIME ZONE 'UTC' = '2000-01-01T18:00:00.0000000+00:00'
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    [SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
     public virtual async Task Where_AtTimeZone_datetimeoffset_parameter(bool async)
     {
         var contextFactory = await InitializeAsync<OperatorsContext>(seed: Seed);
@@ -198,6 +200,7 @@ WHERE [o].[Value] AT TIME ZONE @__timeZone_1 = @__dateTime_2
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    [SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
     public virtual async Task Where_AtTimeZone_datetimeoffset_column(bool async)
     {
         var contextFactory = await InitializeAsync<OperatorsContext>(seed: Seed);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -8937,6 +8937,7 @@ WHERE [e].[Id] NOT IN (
     #region Issue23282
 
     [ConditionalFact]
+    [SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
     public virtual async Task Can_query_point_with_buffered_data_reader()
     {
         var contextFactory = await InitializeAsync<MyContext23282>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -7,6 +7,7 @@ using NetTopologySuite.IO;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
+[SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
 public class SpatialQuerySqlServerGeographyTest : SpatialQueryRelationalTestBase<SpatialQuerySqlServerGeographyFixture>
 {
     public SpatialQuerySqlServerGeographyTest(SpatialQuerySqlServerGeographyFixture fixture, ITestOutputHelper testOutputHelper)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -6,6 +6,7 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
+[SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
 public class SpatialQuerySqlServerGeometryTest : SpatialQueryRelationalTestBase<SpatialQuerySqlServerGeometryFixture>
 {
     public SpatialQuerySqlServerGeometryTest(SpatialQuerySqlServerGeometryFixture fixture, ITestOutputHelper testOutputHelper)

--- a/test/EFCore.SqlServer.FunctionalTests/SpatialSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SpatialSqlServerTest.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
+[SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
 public class SpatialSqlServerTest : SpatialTestBase<SpatialSqlServerFixture>
 {
     public SpatialSqlServerTest(SpatialSqlServerFixture fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerSentinelValueGenerationScenariosTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerSentinelValueGenerationScenariosTest.cs
@@ -54,9 +54,16 @@ public class SqlServerSentinelValueGenerationScenariosTest : SqlServerValueGener
                 b.Property(e => e.Id).HasSentinel(IntSentinel);
                 b.Property(e => e.Name).HasSentinel(StringSentinel);
                 b.Property(e => e.CreatedOn).HasSentinel(DateTimeSentinel);
-                b.Property(e => e.GeometryCollection).HasSentinel(GeometryCollectionSentinel);
                 b.Property(e => e.OtherId).HasSentinel(NullableIntSentinel);
                 b.Property(e => e.NeedsConverter).HasSentinel(new NeedsConverter(IntSentinel));
+            });
+
+        modelBuilder.Entity<BlogWithSpatial>(
+            b =>
+            {
+                b.Property(e => e.Id).HasSentinel(IntSentinel);
+                b.Property(e => e.Name).HasSentinel(StringSentinel);
+                b.Property(e => e.GeometryCollection).HasSentinel(GeometryCollectionSentinel);
             });
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
@@ -19,4 +19,5 @@ public enum SqlServerCondition
     SupportsFunctions2019 = 1 << 10,
     SupportsFunctions2017 = 1 << 11,
     SupportsJsonPathExpressions = 1 << 12,
+    SupportsSqlClr = 1 << 13,
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
@@ -87,6 +87,11 @@ public sealed class SqlServerConditionAttribute : Attribute, ITestCondition
             isMet &= TestEnvironment.SupportsJsonPathExpressions;
         }
 
+        if (Conditions.HasFlag(SqlServerCondition.SupportsSqlClr))
+        {
+            isMet &= TestEnvironment.IsSqlClrSupported;
+        }
+
         return ValueTask.FromResult(isMet);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -31,6 +31,8 @@ public static class TestEnvironment
 
     private static bool? _supportsHiddenColumns;
 
+    private static bool? _supportsSqlClr;
+
     private static bool? _supportsOnlineIndexing;
 
     private static bool? _supportsMemoryOptimizedTables;
@@ -65,9 +67,7 @@ public static class TestEnvironment
 
             try
             {
-                _engineEdition = GetEngineEdition();
-
-                _isAzureSqlDb = _engineEdition is 5 or 8;
+                _isAzureSqlDb = GetEngineEdition() is 5 or 8;
             }
             catch (PlatformNotSupportedException)
             {
@@ -130,10 +130,7 @@ public static class TestEnvironment
 
             try
             {
-                _engineEdition = GetEngineEdition();
-                _productMajorVersion = GetProductMajorVersion();
-
-                _supportsHiddenColumns = (_productMajorVersion >= 13 && _engineEdition != 6) || IsSqlAzure;
+                _supportsHiddenColumns = (GetProductMajorVersion() >= 13 && GetEngineEdition() != 6) || IsSqlAzure;
             }
             catch (PlatformNotSupportedException)
             {
@@ -141,6 +138,33 @@ public static class TestEnvironment
             }
 
             return _supportsHiddenColumns.Value;
+        }
+    }
+
+    public static bool IsSqlClrSupported
+    {
+        get
+        {
+            if (!IsConfigured)
+            {
+                return false;
+            }
+
+            if (_supportsSqlClr.HasValue)
+            {
+                return _supportsSqlClr.Value;
+            }
+
+            try
+            {
+                _supportsSqlClr = GetEngineEdition() != 9;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                _supportsSqlClr = false;
+            }
+
+            return _supportsSqlClr.Value;
         }
     }
 
@@ -160,9 +184,7 @@ public static class TestEnvironment
 
             try
             {
-                _engineEdition = GetEngineEdition();
-
-                _supportsOnlineIndexing = _engineEdition == 3 || IsSqlAzure;
+                _supportsOnlineIndexing = GetEngineEdition() == 3 || IsSqlAzure;
             }
             catch (PlatformNotSupportedException)
             {
@@ -228,10 +250,7 @@ public static class TestEnvironment
 
             try
             {
-                _engineEdition = GetEngineEdition();
-                _productMajorVersion = GetProductMajorVersion();
-
-                _supportsTemporalTablesCascadeDelete = (_productMajorVersion >= 14 /* && _engineEdition != 6*/) || IsSqlAzure;
+                _supportsTemporalTablesCascadeDelete = (GetProductMajorVersion() >= 14 /* && GetEngineEdition() != 6*/) || IsSqlAzure;
             }
             catch (PlatformNotSupportedException)
             {
@@ -258,9 +277,7 @@ public static class TestEnvironment
 
             try
             {
-                _productMajorVersion = GetProductMajorVersion();
-
-                _supportsUtf8 = _productMajorVersion >= 15 || IsSqlAzure;
+                _supportsUtf8 = GetProductMajorVersion() >= 15 || IsSqlAzure;
             }
             catch (PlatformNotSupportedException)
             {
@@ -287,9 +304,7 @@ public static class TestEnvironment
 
             try
             {
-                _productMajorVersion = GetProductMajorVersion();
-
-                _supportsFunctions2017 = _productMajorVersion >= 14 || IsSqlAzure;
+                _supportsFunctions2017 = GetProductMajorVersion() >= 14 || IsSqlAzure;
             }
             catch (PlatformNotSupportedException)
             {
@@ -316,9 +331,7 @@ public static class TestEnvironment
 
             try
             {
-                _productMajorVersion = GetProductMajorVersion();
-
-                _supportsFunctions2019 = _productMajorVersion >= 15 || IsSqlAzure;
+                _supportsFunctions2019 = GetProductMajorVersion() >= 15 || IsSqlAzure;
             }
             catch (PlatformNotSupportedException)
             {
@@ -345,9 +358,7 @@ public static class TestEnvironment
 
             try
             {
-                _productMajorVersion = GetProductMajorVersion();
-
-                _supportsJsonPathExpressions = _productMajorVersion >= 14 || IsSqlAzure;
+                _supportsJsonPathExpressions = GetProductMajorVersion() >= 14 || IsSqlAzure;
             }
             catch (PlatformNotSupportedException)
             {

--- a/test/EFCore.SqlServer.HierarchyId.Tests/QueryTests.cs
+++ b/test/EFCore.SqlServer.HierarchyId.Tests/QueryTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer;
 
-[SqlServerConfiguredCondition]
+[SqlServerCondition(SqlServerCondition.SupportsSqlClr)]
 public class QueryTests : IDisposable
 {
     private readonly AbrahamicContext _db;


### PR DESCRIPTION
Allows running tests against SQL Edge on ARM64, which doesn't support CLR types in the engine.

