### PR TITLE
[release/8.0] Revert binary breaking change on IEntityType

### DIFF
--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -418,6 +418,99 @@ public interface IEntityType : IReadOnlyEntityType, ITypeBase
     /// <returns>The indexes defined on this entity type.</returns>
     new IEnumerable<IIndex> GetIndexes();
 
+    // The following methods are needed for binary compatibility
+    #region DO NOT DELETE
+
+    /// <summary>
+    ///     Gets a property on the given entity type. Returns <see langword="null" /> if no property is found.
+    /// </summary>
+    /// <remarks>
+    ///     This API only finds scalar properties and does not find navigation properties. Use
+    ///     <see cref="FindNavigation(MemberInfo)" /> to find a navigation property.
+    /// </remarks>
+    /// <param name="memberInfo">The property on the entity class.</param>
+    /// <returns>The property, or <see langword="null" /> if none is found.</returns>
+    new IProperty? FindProperty(MemberInfo memberInfo)
+        => (IProperty?)((IReadOnlyEntityType)this).FindProperty(memberInfo);
+
+    /// <summary>
+    ///     Gets the property with a given name. Returns <see langword="null" /> if no property with the given name is defined.
+    /// </summary>
+    /// <remarks>
+    ///     This API only finds scalar properties and does not find navigation properties. Use
+    ///     <see cref="FindNavigation(string)" /> to find a navigation property.
+    /// </remarks>
+    /// <param name="name">The name of the property.</param>
+    /// <returns>The property, or <see langword="null" /> if none is found.</returns>
+    new IProperty? FindProperty(string name);
+
+    /// <summary>
+    ///     Finds matching properties on the given entity type. Returns <see langword="null" /> if any property is not found.
+    /// </summary>
+    /// <remarks>
+    ///     This API only finds scalar properties and does not find navigation properties.
+    /// </remarks>
+    /// <param name="propertyNames">The property names.</param>
+    /// <returns>The properties, or <see langword="null" /> if any property is not found.</returns>
+    new IReadOnlyList<IProperty>? FindProperties(
+        IReadOnlyList<string> propertyNames)
+        => (IReadOnlyList<IProperty>?)((IReadOnlyEntityType)this).FindProperties(propertyNames);
+
+    /// <summary>
+    ///     Gets a property with the given name.
+    /// </summary>
+    /// <remarks>
+    ///     This API only finds scalar properties and does not find navigation properties. Use
+    ///     <see cref="FindNavigation(string)" /> to find a navigation property.
+    /// </remarks>
+    /// <param name="name">The property name.</param>
+    /// <returns>The property.</returns>
+    new IProperty GetProperty(string name)
+        => (IProperty)((IReadOnlyEntityType)this).GetProperty(name);
+
+    /// <summary>
+    ///     Finds a property declared on the type with the given name.
+    ///     Does not return properties defined on a base type.
+    /// </summary>
+    /// <param name="name">The property name.</param>
+    /// <returns>The property, or <see langword="null" /> if none is found.</returns>
+    new IProperty? FindDeclaredProperty(string name);
+
+    /// <summary>
+    ///     Gets all non-navigation properties declared on the given <see cref="IEntityType" />.
+    /// </summary>
+    /// <remarks>
+    ///     This method does not return properties declared on base types.
+    ///     It is useful when iterating over all entity types to avoid processing the same property more than once.
+    ///     Use <see cref="GetProperties" /> to also return properties declared on base types.
+    /// </remarks>
+    /// <returns>Declared non-navigation properties.</returns>
+    new IEnumerable<IProperty> GetDeclaredProperties();
+
+    /// <summary>
+    ///     Gets all non-navigation properties declared on the types derived from this entity type.
+    /// </summary>
+    /// <remarks>
+    ///     This method does not return properties declared on the given entity type itself.
+    ///     Use <see cref="GetProperties" /> to return properties declared on this
+    ///     and base entity typed types.
+    /// </remarks>
+    /// <returns>Derived non-navigation properties.</returns>
+    new IEnumerable<IProperty> GetDerivedProperties()
+        => ((IReadOnlyEntityType)this).GetDerivedProperties().Cast<IProperty>();
+
+    /// <summary>
+    ///     Gets the properties defined on this entity type.
+    /// </summary>
+    /// <remarks>
+    ///     This API only returns scalar properties and does not return navigation properties. Use
+    ///     <see cref="GetNavigations()" /> to get navigation properties.
+    /// </remarks>
+    /// <returns>The properties defined on this entity type.</returns>
+    new IEnumerable<IProperty> GetProperties();
+
+    #endregion
+
     /// <summary>
     ///     Returns the properties contained in foreign keys.
     /// </summary>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -4111,6 +4111,42 @@ public class EntityType : TypeBase, IMutableEntityType, IConventionEntityType, I
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [DebuggerStepThrough]
+    IProperty? IEntityType.FindProperty(string name) => FindProperty(name);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
+    IProperty? IEntityType.FindDeclaredProperty(string name) => FindDeclaredProperty(name);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
+    IEnumerable<IProperty> IEntityType.GetDeclaredProperties() => GetDeclaredProperties();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
+    IEnumerable<IProperty> IEntityType.GetProperties() => GetProperties();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [DebuggerStepThrough]
     IMutableIndex IMutableEntityType.AddIndex(IReadOnlyList<IMutableProperty> properties)
         => AddIndex(properties as IReadOnlyList<Property> ?? properties.Cast<Property>().ToList(), ConfigurationSource.Explicit)!;
 

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -1260,6 +1260,27 @@ public class RuntimeEntityType : RuntimeTypeBase, IRuntimeEntityType
 
     /// <inheritdoc />
     [DebuggerStepThrough]
+    IProperty? IEntityType.FindProperty(string name) => FindProperty(name);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IReadOnlyList<IProperty>? IEntityType.FindProperties(IReadOnlyList<string> propertyNames)
+        => FindProperties(propertyNames);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IProperty? IEntityType.FindDeclaredProperty(string name) => FindDeclaredProperty(name);
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IEnumerable<IProperty> IEntityType.GetDeclaredProperties() => GetDeclaredProperties();
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
+    IEnumerable<IProperty> IEntityType.GetProperties() => GetProperties();
+
+    /// <inheritdoc />
+    [DebuggerStepThrough]
     IEnumerable<IProperty> IEntityType.GetForeignKeyProperties()
         => NonCapturingLazyInitializer.EnsureInitialized(
             ref _foreignKeyProperties, this,

--- a/src/EFCore/Metadata/RuntimeTypeBase.cs
+++ b/src/EFCore/Metadata/RuntimeTypeBase.cs
@@ -230,7 +230,14 @@ public abstract class RuntimeTypeBase : AnnotatableBase, IRuntimeTypeBase
     public virtual RuntimeProperty? FindProperty(string name)
         => FindDeclaredProperty(name) ?? _baseType?.FindProperty(name);
 
-    private RuntimeProperty? FindDeclaredProperty(string name)
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    protected virtual RuntimeProperty? FindDeclaredProperty(string name)
         => _properties.TryGetValue(name, out var property)
             ? property
             : null;


### PR DESCRIPTION
Fixes #32105

### Description

When adding support for complex types we moved some methods from `IEntityType` to the base type - `ITypeBase`. This breaks libraries calling these methods directly.

### Customer impact

MissingMethodException thrown when using affected libraries.

### How found

Customer reported on RC2

### Regression

Yes, from preview 6.

### Testing

Verified manually.

### Risk

Low. 
