### PR TITLE
Temporal table migrations refactor.

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
@@ -84,11 +84,8 @@ public class SqlServerCSharpRuntimeAnnotationCodeGenerator : RelationalCSharpRun
             var annotations = parameters.Annotations;
             annotations.Remove(SqlServerAnnotationNames.Identity);
             annotations.Remove(SqlServerAnnotationNames.Sparse);
-            annotations.Remove(SqlServerAnnotationNames.IsTemporal);
-            annotations.Remove(SqlServerAnnotationNames.TemporalHistoryTableName);
-            annotations.Remove(SqlServerAnnotationNames.TemporalHistoryTableSchema);
-            annotations.Remove(SqlServerAnnotationNames.TemporalPeriodStartColumnName);
-            annotations.Remove(SqlServerAnnotationNames.TemporalPeriodEndColumnName);
+            annotations.Remove(SqlServerAnnotationNames.TemporalIsPeriodStartColumn);
+            annotations.Remove(SqlServerAnnotationNames.TemporalIsPeriodEndColumn);
         }
 
         base.Generate(column, parameters);

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
@@ -282,4 +282,20 @@ public static class SqlServerAnnotationNames
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public const string UseSqlOutputClause = Prefix + "UseSqlOutputClause";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public const string TemporalIsPeriodStartColumn = Prefix + "TemporalIsPeriodStartColumn";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public const string TemporalIsPeriodEndColumn = Prefix + "TemporalIsPeriodEndColumn";
 }

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -99,7 +99,7 @@ public class SqlServerAnnotationProvider : RelationalAnnotationProvider
             yield return new Annotation(SqlServerAnnotationNames.MemoryOptimized, true);
         }
 
-        if (entityType.IsTemporal() && designTime)
+        if (entityType.IsTemporal())
         {
             yield return new Annotation(SqlServerAnnotationNames.IsTemporal, true);
             yield return new Annotation(SqlServerAnnotationNames.TemporalHistoryTableName, entityType.GetHistoryTableName());
@@ -253,7 +253,7 @@ public class SqlServerAnnotationProvider : RelationalAnnotationProvider
         }
 
         var entityType = (IEntityType)column.Table.EntityTypeMappings.First().TypeBase;
-        if (entityType.IsTemporal() && designTime)
+        if (entityType.IsTemporal())
         {
             var periodStartPropertyName = entityType.GetPeriodStartPropertyName();
             var periodEndPropertyName = entityType.GetPeriodEndPropertyName();
@@ -275,12 +275,14 @@ public class SqlServerAnnotationProvider : RelationalAnnotationProvider
                 ? periodEndProperty.GetColumnName(storeObjectIdentifier)
                 : periodEndPropertyName;
 
-            // TODO: issue #27459 - we want to avoid having those annotations on every column
-            yield return new Annotation(SqlServerAnnotationNames.IsTemporal, true);
-            yield return new Annotation(SqlServerAnnotationNames.TemporalHistoryTableName, entityType.GetHistoryTableName());
-            yield return new Annotation(SqlServerAnnotationNames.TemporalHistoryTableSchema, entityType.GetHistoryTableSchema());
-            yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodStartColumnName, periodStartColumnName);
-            yield return new Annotation(SqlServerAnnotationNames.TemporalPeriodEndColumnName, periodEndColumnName);
+            if (column.Name == periodStartColumnName)
+            {
+                yield return new Annotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn, true);
+            }
+            else if (column.Name == periodEndColumnName)
+            {
+                yield return new Annotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn, true);
+            }
         }
     }
 }

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -33,57 +33,18 @@ public class SqlServerMigrationsAnnotationProvider : MigrationsAnnotationProvide
         => table.GetAnnotations();
 
     /// <inheritdoc />
-    public override IEnumerable<IAnnotation> ForRemove(IUniqueConstraint constraint)
-    {
-        if (constraint.Table[SqlServerAnnotationNames.IsTemporal] as bool? == true)
-        {
-            yield return new Annotation(SqlServerAnnotationNames.IsTemporal, true);
-
-            yield return new Annotation(
-                SqlServerAnnotationNames.TemporalPeriodStartColumnName,
-                constraint.Table[SqlServerAnnotationNames.TemporalPeriodStartColumnName]);
-
-            yield return new Annotation(
-                SqlServerAnnotationNames.TemporalPeriodEndColumnName,
-                constraint.Table[SqlServerAnnotationNames.TemporalPeriodEndColumnName]);
-
-            yield return new Annotation(
-                SqlServerAnnotationNames.TemporalHistoryTableName,
-                constraint.Table[SqlServerAnnotationNames.TemporalHistoryTableName]);
-
-            yield return new Annotation(
-                SqlServerAnnotationNames.TemporalHistoryTableSchema,
-                constraint.Table[SqlServerAnnotationNames.TemporalHistoryTableSchema]);
-        }
-    }
-
-    /// <inheritdoc />
     public override IEnumerable<IAnnotation> ForRemove(IColumn column)
     {
         if (column.Table[SqlServerAnnotationNames.IsTemporal] as bool? == true)
         {
-            yield return new Annotation(SqlServerAnnotationNames.IsTemporal, true);
-
-            yield return new Annotation(
-                SqlServerAnnotationNames.TemporalHistoryTableName,
-                column.Table[SqlServerAnnotationNames.TemporalHistoryTableName]);
-
-            yield return new Annotation(
-                SqlServerAnnotationNames.TemporalHistoryTableSchema,
-                column.Table[SqlServerAnnotationNames.TemporalHistoryTableSchema]);
-
-            if (column[SqlServerAnnotationNames.TemporalPeriodStartColumnName] is string periodStartColumnName)
+            if (column[SqlServerAnnotationNames.TemporalIsPeriodStartColumn] as bool? == true)
             {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.TemporalPeriodStartColumnName,
-                    periodStartColumnName);
+                yield return new Annotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn, true);
             }
 
-            if (column[SqlServerAnnotationNames.TemporalPeriodEndColumnName] is string periodEndColumnName)
+            if (column[SqlServerAnnotationNames.TemporalIsPeriodEndColumn] as bool? == true)
             {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.TemporalPeriodEndColumnName,
-                    periodEndColumnName);
+                yield return new Annotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn, true);
             }
         }
     }
@@ -102,37 +63,28 @@ public class SqlServerMigrationsAnnotationProvider : MigrationsAnnotationProvide
             yield return new Annotation(
                 SqlServerAnnotationNames.TemporalHistoryTableSchema,
                 table[SqlServerAnnotationNames.TemporalHistoryTableSchema]);
+
+            yield return new Annotation(
+                SqlServerAnnotationNames.TemporalPeriodStartColumnName,
+                table[SqlServerAnnotationNames.TemporalPeriodStartColumnName]);
+
+            yield return new Annotation(
+                SqlServerAnnotationNames.TemporalPeriodEndColumnName,
+                table[SqlServerAnnotationNames.TemporalPeriodEndColumnName]);
         }
     }
 
     /// <inheritdoc />
     public override IEnumerable<IAnnotation> ForRename(IColumn column)
     {
-        if (column.Table[SqlServerAnnotationNames.IsTemporal] as bool? == true)
+        if (column[SqlServerAnnotationNames.TemporalIsPeriodStartColumn] as bool? == true)
         {
-            yield return new Annotation(SqlServerAnnotationNames.IsTemporal, true);
+            yield return new Annotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn, true);
+        }
 
-            yield return new Annotation(
-                SqlServerAnnotationNames.TemporalHistoryTableName,
-                column.Table[SqlServerAnnotationNames.TemporalHistoryTableName]);
-
-            yield return new Annotation(
-                SqlServerAnnotationNames.TemporalHistoryTableSchema,
-                column.Table[SqlServerAnnotationNames.TemporalHistoryTableSchema]);
-
-            if (column[SqlServerAnnotationNames.TemporalPeriodStartColumnName] is string periodStartColumnName)
-            {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.TemporalPeriodStartColumnName,
-                    periodStartColumnName);
-            }
-
-            if (column[SqlServerAnnotationNames.TemporalPeriodEndColumnName] is string periodEndColumnName)
-            {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.TemporalPeriodEndColumnName,
-                    periodEndColumnName);
-            }
+        if (column[SqlServerAnnotationNames.TemporalIsPeriodEndColumn] as bool? == true)
+        {
+            yield return new Annotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn, true);
         }
     }
 }

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -792,18 +792,6 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Name));
         }
-
-        if (operation[SqlServerAnnotationNames.IsTemporal] as bool? == true)
-        {
-            var schema = operation.Schema ?? model?[RelationalAnnotationNames.DefaultSchema] as string;
-            var historyTableSchema = operation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string ?? schema;
-            if (operation[SqlServerAnnotationNames.TemporalHistoryTableName] is string historyTableName)
-            {
-                var dropHistoryTableOperation = new DropTableOperation { Name = historyTableName, Schema = historyTableSchema };
-
-                Generate(dropHistoryTableOperation, model, builder, terminate);
-            }
-        }
     }
 
     /// <summary>
@@ -1346,31 +1334,6 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
-
-        if (operation[SqlServerAnnotationNames.IsTemporal] as bool? == true)
-        {
-            var historyTableName = operation[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
-            var historyTableSchema = operation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
-                ?? operation.Schema ?? model?.GetDefaultSchema();
-            var periodStartColumnName = operation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
-            var periodEndColumnName = operation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
-
-            // when dropping column, we only need to drop the column from history table as well if that column is not part of the period
-            // for columns that are part of the period - if we are removing them from the temporal table, it means
-            // that we are converting back to a regular table, and the history table will be removed anyway
-            // so we don't need to keep it in sync
-            if (operation.Name != periodStartColumnName
-                && operation.Name != periodEndColumnName)
-            {
-                Generate(
-                    new DropColumnOperation
-                    {
-                        Name = operation.Name,
-                        Table = historyTableName!,
-                        Schema = historyTableSchema
-                    }, model, builder, terminate);
-            }
-        }
     }
 
     /// <summary>
@@ -1613,14 +1576,24 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             builder.Append(" SPARSE");
         }
 
-        var periodStartColumnName = operation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
-        var periodEndColumnName = operation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
+        var isPeriodStartColumn = operation[SqlServerAnnotationNames.TemporalIsPeriodStartColumn] as bool? == true;
+        var isPeriodEndColumn = operation[SqlServerAnnotationNames.TemporalIsPeriodEndColumn] as bool? == true;
 
-        if (name == periodStartColumnName
-            || name == periodEndColumnName)
+        // falling back to legacy annotations, in case the migration was generated using pre-9.0 bits
+        if (!isPeriodStartColumn && !isPeriodEndColumn)
+        {
+            if (operation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] is string periodStartColumnName
+                && operation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] is string periodEndColumnName)
+            {
+                isPeriodStartColumn = operation.Name == periodStartColumnName;
+                isPeriodEndColumn = operation.Name == periodEndColumnName;
+            }
+        }
+
+        if (isPeriodStartColumn || isPeriodEndColumn)
         {
             builder.Append(" GENERATED ALWAYS AS ROW ");
-            builder.Append(name == periodStartColumnName ? "START" : "END");
+            builder.Append(isPeriodStartColumn ? "START" : "END");
             builder.Append(" HIDDEN");
         }
 
@@ -2347,11 +2320,143 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
         MigrationsSqlGenerationOptions options)
     {
         var operations = new List<MigrationOperation>();
-
-        var versioningMap = new Dictionary<(string?, string?), (string, string?, bool)>();
-        var periodMap = new Dictionary<(string?, string?), (string, string, bool)>();
         var availableSchemas = new List<string>();
 
+        // we need to know temporal information for all the tables involved in the migration
+        // problem is, the temporal information is stored only on table operations and not column operations
+        // if migration operation doesn't contain the table operation, or the table operation comes later
+        // we don't know what we should do
+        // to fix that, we loop through all the operations and extract initial temporal state for relevant tables
+        // if we don't encounter any table operations, then we can take information from the model
+        // since migration hasn't changed it at all - be we can only know that after looping though all ops
+        // once we have the initial state of the table, we can update it each time we encounter a table operation
+        // and we can use what we stored when dealing with all other operations (that don't contain temporal annotations themselves)
+        var temporalTableInformationMap = new Dictionary<(string TableName, string? Schema), TemporalOperationInformation>();
+        var missingTemporalTableInformation = new List<(string TableName, string? Schema)>();
+
+        foreach (var operation in migrationOperations)
+        {
+            switch (operation)
+            {
+                case CreateTableOperation createTableOperation:
+                {
+                    var tableName = createTableOperation.Name;
+                    var rawSchema = createTableOperation.Schema;
+                    var schema = rawSchema ?? model?.GetDefaultSchema();
+                    if (!temporalTableInformationMap.ContainsKey((tableName, rawSchema)))
+                    {
+                        var temporalTableInformation = BuildTemporalInformationFromMigrationOperation(schema, createTableOperation);
+                        temporalTableInformationMap[(tableName, rawSchema)] = temporalTableInformation;
+                    }
+                    // no need to remove from missingTemporalTableInformation - CreateTable should be first operation for this table
+                    // so there can't be entry for it in missingTemporalTableInformation (they are added by other/earlier operations on that table)
+                    // the only possibility is that we had a table before, dropped it and now creating a new table with the same name
+                    // but in this case we would have generated the necessary information from the DropTableOperation
+                    // and also removed the missingTemporalTableInformation entry if there was one before
+                    break;
+                }
+
+                case DropTableOperation dropTableOperation:
+                {
+                    var tableName = dropTableOperation.Name;
+                    var rawSchema = dropTableOperation.Schema;
+                    var schema = rawSchema ?? model?.GetDefaultSchema();
+                    if (!temporalTableInformationMap.ContainsKey((tableName, rawSchema)))
+                    {
+                        var temporalTableInformation = BuildTemporalInformationFromMigrationOperation(schema, dropTableOperation);
+                        temporalTableInformationMap[(tableName, rawSchema)] = temporalTableInformation;
+                    }
+
+                    missingTemporalTableInformation.Remove((tableName, rawSchema));
+                    break;
+                }
+
+                case RenameTableOperation renameTableOperation:
+                {
+                    var tableName = renameTableOperation.Name;
+                    var rawSchema = renameTableOperation.Schema;
+                    var schema = rawSchema ?? model?.GetDefaultSchema();
+                    var newTableName = renameTableOperation.NewName!;
+                    var newRawSchema = renameTableOperation.NewSchema;
+                    var newSchema = newRawSchema ?? model?.GetDefaultSchema();
+
+                    if (!temporalTableInformationMap.ContainsKey((tableName, rawSchema)))
+                    {
+                        var temporalTableInformation = BuildTemporalInformationFromMigrationOperation(schema, renameTableOperation);
+                        temporalTableInformationMap[(tableName, rawSchema)] = temporalTableInformation;
+                        temporalTableInformationMap[(newTableName, newRawSchema)] = temporalTableInformation;
+                    }
+
+                    missingTemporalTableInformation.Remove((tableName, rawSchema));
+                    missingTemporalTableInformation.Remove((newTableName, newRawSchema));
+
+                    break;
+                }
+
+                case AlterTableOperation alterTableOperation:
+                {
+                    var tableName = alterTableOperation.Name;
+                    var rawSchema = alterTableOperation.Schema;
+                    var schema = rawSchema ?? model?.GetDefaultSchema();
+                    if (!temporalTableInformationMap.ContainsKey((tableName, rawSchema)))
+                    {
+                        // we create the temporal info based on the OLD table here - we want the initial state
+                        var temporalTableInformation = BuildTemporalInformationFromMigrationOperation(schema, alterTableOperation.OldTable);
+                        temporalTableInformationMap[(tableName, rawSchema)] = temporalTableInformation;
+                    }
+
+                    missingTemporalTableInformation.Remove((tableName, schema));
+                    break;
+                }
+
+                default:
+                {
+                    if (operation is ITableMigrationOperation tableMigrationOperation)
+                    {
+                        var tableName = tableMigrationOperation.Table;
+                        var rawSchema = tableMigrationOperation.Schema;
+                        if (!temporalTableInformationMap.ContainsKey((tableName, rawSchema))
+                            && !missingTemporalTableInformation.Contains((tableName, rawSchema)))
+                        {
+                            missingTemporalTableInformation.Add((tableName, rawSchema));
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        // fill the missing temporal information from Relational Model - it's the second best source we have
+        // if we can't figure out proper temporal info from table annotations,
+        // and we don't have it in relational model (for whatever reason) we assume table is not temporal
+        // this last step is purely defensive and shouldn't happen in real situations
+        foreach (var missingInfo in missingTemporalTableInformation)
+        {
+            var table = model?.GetRelationalModel().FindTable(missingInfo.TableName, missingInfo.Schema)!;
+            if (table != null)
+            {
+                var schema = missingInfo.Schema ?? model?.GetDefaultSchema();
+
+                var temporalTableInformation = BuildTemporalInformationFromMigrationOperation(schema, table);
+                temporalTableInformationMap[(missingInfo.TableName, missingInfo.Schema)] = temporalTableInformation;
+            }
+            else
+            {
+                temporalTableInformationMap[(missingInfo.TableName, missingInfo.Schema)] = new TemporalOperationInformation
+                {
+                    IsTemporalTable = false,
+                    HistoryTableName = null,
+                    HistoryTableSchema = null,
+                    PeriodStartColumnName = null,
+                    PeriodEndColumnName = null
+                };
+            }
+        }
+
+        // now we do proper processing - for table operations we look at the annotations on them
+        // and continuously update the stored temporal info as the table is being modified
+        // for column (and other) operations we don't have annotations on them, so we look into the
+        // information we stored in the initial pass and updated in when processing table ops that happened earlier
         foreach (var operation in migrationOperations)
         {
             if (operation is EnsureSchemaOperation ensureSchemaOperation)
@@ -2359,86 +2464,144 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 availableSchemas.Add(ensureSchemaOperation.Name);
             }
 
-            var isTemporal = operation[SqlServerAnnotationNames.IsTemporal] as bool? == true;
-            if (isTemporal)
+            if (operation is not ITableMigrationOperation tableMigrationOperation)
             {
-                string? table = null;
-                string? schema = null;
+                operations.Add(operation);
+                continue;
+            }
 
-                if (operation is ITableMigrationOperation tableMigrationOperation)
+            var tableName = tableMigrationOperation.Table;
+            var rawSchema = tableMigrationOperation.Schema;
+
+            var suppressTransaction = IsMemoryOptimized(operation, model, rawSchema, tableName);
+
+            var schema = rawSchema ?? model?.GetDefaultSchema();
+
+            // we are guaranteed to find entry here - we looped through all the operations earlier,
+            // info missing from operations we got from the model
+            // and in case of no/incomplete model we created dummy (non-temporal) entries
+            var temporalInformation = temporalTableInformationMap[(tableName, rawSchema)];
+
+            switch (operation)
+            {
+                case CreateTableOperation createTableOperation:
                 {
-                    table = tableMigrationOperation.Table;
-                    schema = tableMigrationOperation.Schema;
+                    // for create table we always generate new temporal information from the operation itself
+                    // just in case there was a table with that name before that got deleted/renamed
+                    // this shouldn't happen as we re-use existin tables rather than drop/recreate
+                    // but we are being extra defensive here 
+                    // and also, temporal state (disabled versioning etc.) should always reset when creating a table
+                    temporalInformation = BuildTemporalInformationFromMigrationOperation(schema, createTableOperation);
+
+                    if (temporalInformation.IsTemporalTable
+                        && temporalInformation.HistoryTableSchema != schema
+                        && temporalInformation.HistoryTableSchema != null
+                        && !availableSchemas.Contains(temporalInformation.HistoryTableSchema))
+                    {
+                        operations.Add(new EnsureSchemaOperation { Name = temporalInformation.HistoryTableSchema });
+                        availableSchemas.Add(temporalInformation.HistoryTableSchema);
+                    }
+
+                    operations.Add(operation);
+
+                    break;
                 }
 
-                var suppressTransaction = table is not null && IsMemoryOptimized(operation, model, schema, table);
-
-                schema ??= model?.GetDefaultSchema();
-                var historyTableName = operation[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
-                var historyTableSchema = operation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
-                    ?? schema;
-                var periodStartColumnName = operation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
-                var periodEndColumnName = operation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
-
-                switch (operation)
+                case DropTableOperation dropTableOperation:
                 {
-                    case CreateTableOperation createTableOperation:
-                        if (historyTableSchema != createTableOperation.Schema
-                            && historyTableSchema != null
-                            && !availableSchemas.Contains(historyTableSchema))
+                    var isTemporalTable = dropTableOperation[SqlServerAnnotationNames.IsTemporal] as bool? == true;
+                    if (isTemporalTable)
+                    {
+                        // if we don't have temporal information, but we know table is temporal
+                        // (based on the annotation found on the operation itself)
+                        // we assume that versioning must be disabled, if we have temporal info we can check properly
+                        if (temporalInformation is null || !temporalInformation.DisabledVersioning)
                         {
-                            operations.Add(new EnsureSchemaOperation { Name = historyTableSchema });
-                            availableSchemas.Add(historyTableSchema);
+                            AddDisableVersioningOperation(tableName, schema, suppressTransaction);
+                        }
+
+                        if (temporalInformation is not null)
+                        {
+                            temporalInformation.ShouldEnableVersioning = false;
+                            temporalInformation.ShouldEnablePeriod = false;
                         }
 
                         operations.Add(operation);
-                        break;
 
-                    case DropTableOperation:
-                        DisableVersioning(table!, schema, historyTableName!, historyTableSchema, suppressTransaction);
+                        var historyTableName = dropTableOperation[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
+                        var historyTableSchema = dropTableOperation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string ?? schema;
+                        var dropHistoryTableOperation = new DropTableOperation { Name = historyTableName!, Schema = historyTableSchema };
+                        operations.Add(dropHistoryTableOperation);
+                    }
+                    else
+                    {
                         operations.Add(operation);
+                    }
 
-                        versioningMap.Remove((table, schema));
-                        periodMap.Remove((table, schema));
-                        break;
+                    // we removed the table, so we no longer need it's temporal information
+                    // there will be no more operations involving this table
+                    temporalTableInformationMap.Remove((tableName, schema));
 
-                    case RenameTableOperation renameTableOperation:
-                        DisableVersioning(table!, schema, historyTableName!, historyTableSchema, suppressTransaction);
-                        operations.Add(operation);
+                    break;
+                }
 
-                        // since table was renamed, remove old entry and add new entry
-                        // marked as versioning disabled, so we enable it in the end for the new table
-                        versioningMap.Remove((table, schema));
-                        versioningMap[(renameTableOperation.NewName, renameTableOperation.NewSchema)] =
-                            (historyTableName!, historyTableSchema, suppressTransaction);
+                case RenameTableOperation renameTableOperation:
+                {
+                    if (temporalInformation is null)
+                    {
+                        temporalInformation = BuildTemporalInformationFromMigrationOperation(schema, renameTableOperation);
+                    }
 
-                        // same thing for disabled system period - remove one associated with old table and add one for the new table
-                        if (periodMap.TryGetValue((table, schema), out var result))
+                    var isTemporalTable = renameTableOperation[SqlServerAnnotationNames.IsTemporal] as bool? == true;
+                    if (isTemporalTable &&
+                        !temporalInformation.DisabledVersioning &&
+                        !temporalInformation.ShouldEnableVersioning)
+                    {
+                        DisableVersioning(
+                            tableName,
+                            schema,
+                            temporalInformation,
+                            suppressTransaction,
+                            shouldEnableVersioning: true);
+                    }
+
+                    operations.Add(operation);
+
+                    // since table was renamed, update entry in the temporal info map
+                    temporalTableInformationMap[(renameTableOperation.NewName!, renameTableOperation.NewSchema)] = temporalInformation;
+                    temporalTableInformationMap.Remove((tableName, schema));
+
+                    break;
+                }
+
+                case AlterTableOperation alterTableOperation:
+                {
+                    var isTemporalTable = alterTableOperation[SqlServerAnnotationNames.IsTemporal] as bool? == true;
+                    var historyTableName = alterTableOperation[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
+                    var historyTableSchema = alterTableOperation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string ?? schema;
+                    var periodStartColumnName = alterTableOperation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
+                    var periodEndColumnName = alterTableOperation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
+
+                    var oldIsTemporalTable = alterTableOperation.OldTable[SqlServerAnnotationNames.IsTemporal] as bool? == true;
+                    var oldHistoryTableName =
+                        alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
+                    var oldHistoryTableSchema =
+                        alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
+                        ?? alterTableOperation.OldTable.Schema
+                        ?? model?[RelationalAnnotationNames.DefaultSchema] as string;
+
+                    if (isTemporalTable)
+                    {
+                        if (!oldIsTemporalTable)
                         {
-                            periodMap.Remove((table, schema));
-                            periodMap[(renameTableOperation.NewName, renameTableOperation.NewSchema)] = result;
-                        }
-
-                        break;
-
-                    case AlterTableOperation alterTableOperation:
-                        var oldIsTemporal = alterTableOperation.OldTable[SqlServerAnnotationNames.IsTemporal] as bool? == true;
-                        if (!oldIsTemporal)
-                        {
-                            periodMap[(alterTableOperation.Name, alterTableOperation.Schema)] =
-                                (periodStartColumnName!, periodEndColumnName!, suppressTransaction);
-                            versioningMap[(alterTableOperation.Name, alterTableOperation.Schema)] =
-                                (historyTableName!, historyTableSchema, suppressTransaction);
+                            // converting from regular table to temporal table - enable period and versioning at the end
+                            // other temporal information (history table, period columns etc) is added below
+                            temporalInformation.ShouldEnablePeriod = true;
+                            temporalInformation.ShouldEnableVersioning = true;
                         }
                         else
                         {
-                            var oldHistoryTableName =
-                                alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
-                            var oldHistoryTableSchema =
-                                alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
-                                ?? alterTableOperation.OldTable.Schema
-                                ?? model?[RelationalAnnotationNames.DefaultSchema] as string;
-
+                            // changing something within temporal table
                             if (oldHistoryTableName != historyTableName
                                 || oldHistoryTableSchema != historyTableSchema)
                             {
@@ -2458,244 +2621,322 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                                         NewSchema = historyTableSchema
                                     });
 
-                                if (versioningMap.ContainsKey((alterTableOperation.Name, alterTableOperation.Schema)))
-                                {
-                                    versioningMap[(alterTableOperation.Name, alterTableOperation.Schema)] =
-                                        (historyTableName!, historyTableSchema, suppressTransaction);
-                                }
+                                temporalInformation.HistoryTableName = historyTableName;
+                                temporalInformation.HistoryTableSchema = historyTableSchema;
                             }
                         }
-
-                        operations.Add(operation);
-                        break;
-
-                    case AlterColumnOperation alterColumnOperation:
-                        // if only difference is in temporal annotations being removed or history table changed etc - we can ignore this operation
-                        if (!CanSkipAlterColumnOperation(alterColumnOperation.OldColumn, alterColumnOperation))
-                        {
-                            // for alter column operation converting column from nullable to non-nullable in the temporal table
-                            // we must disable versioning in order to properly handle it
-                            // specifically, for null -> non-null, switching values in history table from
-                            // null to the default value for the non-nullable column
-                            if (alterColumnOperation.OldColumn.IsNullable && !alterColumnOperation.IsNullable)
-                            {
-                                DisableVersioning(table!, schema, historyTableName!, historyTableSchema, suppressTransaction);
-                            }
-
-                            operations.Add(operation);
-
-                            // when modifying a period column, we need to perform the operations as a normal column first, and only later enable period
-                            // removing the period information now, so that when we generate SQL that modifies the column we won't be making them auto generated as period
-                            // (making column auto generated is not allowed in ALTER COLUMN statement)
-                            // in later operation we enable the period and the period columns get set to auto generated automatically
-                            //
-                            // if the column is not period we just remove temporal information - it's no longer needed and could affect the generated sql
-                            // we will generate all the necessary operations involved with temporal tables here
-                            alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.IsTemporal);
-                            alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalPeriodStartColumnName);
-                            alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalPeriodEndColumnName);
-                            alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalHistoryTableName);
-                            alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalHistoryTableSchema);
-
-                            // this is the case where we are not converting from normal table to temporal
-                            // just a normal modification to a column on a temporal table
-                            // in that case we need to double check if we need have disabled versioning earlier in this migration
-                            // if so, we need to mirror the operation to the history table
-                            if (alterColumnOperation.OldColumn[SqlServerAnnotationNames.IsTemporal] as bool? == true)
-                            {
-                                alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.IsTemporal);
-                                alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.TemporalPeriodStartColumnName);
-                                alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.TemporalPeriodEndColumnName);
-                                alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.TemporalHistoryTableName);
-                                alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.TemporalHistoryTableSchema);
-
-                                if (versioningMap.ContainsKey((table, schema)))
-                                {
-                                    var alterHistoryTableColumn = CopyColumnOperation<AlterColumnOperation>(alterColumnOperation);
-                                    alterHistoryTableColumn.Table = historyTableName!;
-                                    alterHistoryTableColumn.Schema = historyTableSchema;
-                                    alterHistoryTableColumn.OldColumn =
-                                        CopyColumnOperation<AddColumnOperation>(alterColumnOperation.OldColumn);
-                                    alterHistoryTableColumn.OldColumn.Table = historyTableName!;
-                                    alterHistoryTableColumn.OldColumn.Schema = historyTableSchema;
-
-                                    operations.Add(alterHistoryTableColumn);
-                                }
-
-                                // TODO: test what happens if default value just changes (from temporal to temporal)
-                            }
-                        }
-
-                        break;
-
-                    case DropPrimaryKeyOperation:
-                    case AddPrimaryKeyOperation:
-                        DisableVersioning(table!, schema, historyTableName!, historyTableSchema, suppressTransaction);
-                        operations.Add(operation);
-                        break;
-
-                    case DropColumnOperation dropColumnOperation:
-                        DisableVersioning(table!, schema, historyTableName!, historyTableSchema, suppressTransaction);
-                        if (dropColumnOperation.Name == periodStartColumnName
-                            || dropColumnOperation.Name == periodEndColumnName)
-                        {
-                            // period columns can be null here - it doesn't really matter since we are never enabling the period back
-                            // if we remove the period columns, it means we will be dropping the table also or at least convert it back to
-                            // regular which will clear the entry in the periodMap for this table
-                            DisablePeriod(table!, schema, periodStartColumnName!, periodEndColumnName!, suppressTransaction);
-                        }
-
-                        operations.Add(operation);
-
-                        break;
-
-                    case AddColumnOperation addColumnOperation:
-                        operations.Add(addColumnOperation);
-
-                        // when adding a period column, we need to add it as a normal column first, and only later enable period
-                        // removing the period information now, so that when we generate SQL that adds the column we won't be making them
-                        // auto generated as period it won't work, unless period is enabled but we can't enable period without adding the
-                        // columns first - chicken and egg
-                        if (addColumnOperation[SqlServerAnnotationNames.IsTemporal] as bool? == true)
-                        {
-                            addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.IsTemporal);
-                            addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalHistoryTableName);
-                            addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalHistoryTableSchema);
-                            addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalPeriodStartColumnName);
-                            addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalPeriodEndColumnName);
-
-                            // model differ adds default value, but for period end we need to replace it with the correct one -
-                            // DateTime.MaxValue
-                            if (addColumnOperation.Name == periodEndColumnName)
-                            {
-                                addColumnOperation.DefaultValue = DateTime.MaxValue;
-                            }
-
-                            // when adding (non-period) column to an exisiting temporal table we need to check if we have disabled the period
-                            // due to some other operations in the same migration (e.g. delete column)
-                            // if so, we need to also add the same column to history table
-                            if (addColumnOperation.Name != periodStartColumnName
-                                && addColumnOperation.Name != periodEndColumnName)
-                            {
-                                if (versioningMap.ContainsKey((table, schema)))
-                                {
-                                    var addHistoryTableColumnOperation = CopyColumnOperation<AddColumnOperation>(addColumnOperation);
-                                    addHistoryTableColumnOperation.Table = historyTableName!;
-                                    addHistoryTableColumnOperation.Schema = historyTableSchema;
-
-                                    operations.Add(addHistoryTableColumnOperation);
-                                }
-                            }
-                        }
-
-                        break;
-
-                    case RenameColumnOperation renameColumnOperation:
-                        operations.Add(renameColumnOperation);
-
-                        // if we disabled period for the temporal table and now we are renaming the column,
-                        // we need to also rename this same column in history table
-                        if (versioningMap.ContainsKey((table, schema)))
-                        {
-                            var renameHistoryTableColumnOperation = new RenameColumnOperation
-                            {
-                                IsDestructiveChange = renameColumnOperation.IsDestructiveChange,
-                                Name = renameColumnOperation.Name,
-                                NewName = renameColumnOperation.NewName,
-                                Table = historyTableName!,
-                                Schema = historyTableSchema
-                            };
-
-                            operations.Add(renameHistoryTableColumnOperation);
-                        }
-
-                        break;
-
-                    default:
-                        operations.Add(operation);
-                        break;
-                }
-            }
-            else
-            {
-                if (operation is AlterTableOperation alterTableOperation
-                    && alterTableOperation.OldTable[SqlServerAnnotationNames.IsTemporal] as bool? == true)
-                {
-                    var historyTableName = alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
-                    var historyTableSchema = alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
-                        ?? alterTableOperation.OldTable.Schema
-                        ?? model?[RelationalAnnotationNames.DefaultSchema] as string;
-
-                    var periodStartColumnName =
-                        alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
-                    var periodEndColumnName =
-                        alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
-                    var suppressTransaction = IsMemoryOptimized(operation, model, alterTableOperation.Schema, alterTableOperation.Name);
-
-                    DisableVersioning(
-                        alterTableOperation.Name, alterTableOperation.Schema, historyTableName!, historyTableSchema, suppressTransaction);
-                    DisablePeriod(
-                        alterTableOperation.Name, alterTableOperation.Schema, periodStartColumnName!, periodEndColumnName!,
-                        suppressTransaction);
-
-                    if (historyTableName != null)
+                    }
+                    else
                     {
-                        operations.Add(
-                            new DropTableOperation { Name = historyTableName, Schema = historyTableSchema });
+                        if (oldIsTemporalTable)
+                        {
+                            // converting from temporal table to regular table
+                            var oldPeriodStartColumnName =
+                                alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
+                            var oldPeriodEndColumnName =
+                                alterTableOperation.OldTable[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
+
+                            if (!temporalInformation.DisabledVersioning
+                                && !temporalInformation.ShouldEnableVersioning)
+                            {
+                                DisableVersioning(
+                                    tableName,
+                                    schema,
+                                    temporalInformation,
+                                    suppressTransaction,
+                                    shouldEnableVersioning: null);
+                            }
+
+                            if (!temporalInformation.DisabledPeriod)
+                            {
+                                DisablePeriod(tableName, schema, temporalInformation, suppressTransaction);
+                            }
+
+                            if (oldHistoryTableName != null)
+                            {
+                                operations.Add(new DropTableOperation { Name = oldHistoryTableName, Schema = oldHistoryTableSchema });
+                            }
+
+                            // also clear any pending versioning/period, that would be switched on at the end
+                            // we don't need it now that the table is no longer temporal
+                            temporalInformation.ShouldEnableVersioning = false;
+                            temporalInformation.ShouldEnablePeriod = false;
+                        }
                     }
 
-                    operations.Add(operation);
+                    temporalInformation.IsTemporalTable = isTemporalTable;
+                    temporalInformation.HistoryTableName = historyTableName;
+                    temporalInformation.HistoryTableSchema = historyTableSchema;
+                    temporalInformation.PeriodStartColumnName = periodStartColumnName;
+                    temporalInformation.PeriodEndColumnName = periodEndColumnName;
 
-                    // when we disable versioning and period earlier, we marked it to be re-enabled
-                    // since table is no longer temporal we don't need to do that anymore
-                    versioningMap.Remove((alterTableOperation.Name, alterTableOperation.Schema));
-                    periodMap.Remove((alterTableOperation.Name, alterTableOperation.Schema));
+                    operations.Add(operation);
+                    break;
                 }
-                else if (operation is AlterColumnOperation alterColumnOperation)
+
+                case AddColumnOperation addColumnOperation:
                 {
-                    // if only difference is in temporal annotations being removed or history table changed etc - we can ignore this operation
-                    if (alterColumnOperation.OldColumn?[SqlServerAnnotationNames.IsTemporal] as bool? != true
-                        || !CanSkipAlterColumnOperation(alterColumnOperation.OldColumn, alterColumnOperation))
+                    operations.Add(addColumnOperation);
+
+                    // when adding a period column, we need to add it as a normal column first, and only later enable period
+                    // removing the period information now, so that when we generate SQL that adds the column we won't be making them
+                    // auto generated as period it won't work, unless period is enabled but we can't enable period without adding the
+                    // columns first - chicken and egg
+                    if (temporalInformation.IsTemporalTable)
+                    {
+                        addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn);
+                        addColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn);
+
+                        // model differ adds default value, but for period end we need to replace it with the correct one -
+                        // DateTime.MaxValue
+                        if (addColumnOperation.Name == temporalInformation.PeriodEndColumnName)
+                        {
+                            addColumnOperation.DefaultValue = DateTime.MaxValue;
+                        }
+
+                        // when adding (non-period) column to an existing temporal table we need to check if we have disabled versioning
+                        // due to some other operations in the same migration (e.g. delete column)
+                        // if so, we need to also add the same column to history table
+                        if (addColumnOperation.Name != temporalInformation.PeriodStartColumnName
+                            && addColumnOperation.Name != temporalInformation.PeriodEndColumnName
+                            && temporalInformation.DisabledVersioning)
+                        {
+                            var addHistoryTableColumnOperation = CopyColumnOperation<AddColumnOperation>(addColumnOperation);
+                            addHistoryTableColumnOperation.Table = temporalInformation.HistoryTableName!;
+                            addHistoryTableColumnOperation.Schema = temporalInformation.HistoryTableSchema;
+                            operations.Add(addHistoryTableColumnOperation);
+                        }
+                    }
+
+                    break;
+                }
+
+                case DropColumnOperation dropColumnOperation:
+                {
+                    if (temporalInformation.IsTemporalTable)
+                    {
+                        var droppingPeriodColumn = dropColumnOperation.Name == temporalInformation.PeriodStartColumnName
+                            || dropColumnOperation.Name == temporalInformation.PeriodEndColumnName;
+
+                        if (!temporalInformation.DisabledVersioning
+                            && !temporalInformation.ShouldEnableVersioning)
+                        {
+                            // if we are dropping non-period column, we should enable versioning at the end.
+                            // When dropping period column there is no need - we are removing the versioning for this table altogether
+                            DisableVersioning(
+                                tableName,
+                                schema,
+                                temporalInformation,
+                                suppressTransaction,
+                                shouldEnableVersioning: droppingPeriodColumn ? null : true);
+                        }
+
+                        if (droppingPeriodColumn && !temporalInformation.DisabledPeriod)
+                        {
+                            DisablePeriod(tableName, schema, temporalInformation, suppressTransaction);
+
+                            // if we remove the period columns, it means we will be dropping the table
+                            // also or at least convert it back to regular - no need to enable period later
+                            temporalInformation.ShouldEnablePeriod = false;
+                        }
+
+                        operations.Add(operation);
+
+                        if (!droppingPeriodColumn)
+                        {
+                            operations.Add(new DropColumnOperation
+                            {
+                                Name = dropColumnOperation.Name,
+                                Table = temporalInformation.HistoryTableName!,
+                                Schema = temporalInformation.HistoryTableSchema
+                            });
+                        }
+                    }
+                    else
                     {
                         operations.Add(operation);
                     }
+                    break;
                 }
-                else
+
+                case RenameColumnOperation renameColumnOperation:
                 {
-                    operations.Add(operation);
+                    operations.Add(renameColumnOperation);
+
+                    // if we disabled period for the temporal table and now we are renaming the column,
+                    // we need to also rename this same column in history table
+                    if (temporalInformation.IsTemporalTable
+                        && temporalInformation.DisabledVersioning
+                        && temporalInformation.ShouldEnableVersioning)
+                    {
+                        var renameHistoryTableColumnOperation = new RenameColumnOperation
+                        {
+                            IsDestructiveChange = renameColumnOperation.IsDestructiveChange,
+                            Name = renameColumnOperation.Name,
+                            NewName = renameColumnOperation.NewName,
+                            Table = temporalInformation.HistoryTableName!,
+                            Schema = temporalInformation.HistoryTableSchema
+                        };
+
+                        operations.Add(renameHistoryTableColumnOperation);
+                    }
+
+                    break;
                 }
+
+                case AlterColumnOperation alterColumnOperation:
+                {
+                    // we can remove temporal annotations, they don't make a difference when it comes to
+                    // generating ALTER COLUMN operations and could just muddy the waters
+                    alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn);
+                    alterColumnOperation.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn);
+                    alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodStartColumn);
+                    alterColumnOperation.OldColumn.RemoveAnnotation(SqlServerAnnotationNames.TemporalIsPeriodEndColumn);
+
+                    if (temporalInformation.IsTemporalTable)
+                    {
+                        // for alter column operation converting column from nullable to non-nullable in the temporal table
+                        // we must disable versioning in order to properly handle it
+                        // specifically, switching values in history table from null to the default value
+                        if (alterColumnOperation.OldColumn.IsNullable
+                            && !alterColumnOperation.IsNullable
+                            && !temporalInformation.DisabledVersioning
+                            && !temporalInformation.ShouldEnableVersioning)
+                        {
+                            DisableVersioning(
+                                tableName!,
+                                schema,
+                                temporalInformation,
+                                suppressTransaction,
+                                shouldEnableVersioning: true);
+                        }
+
+                        operations.Add(alterColumnOperation);
+
+                        // when modifying a period column, we need to perform the operations as a normal column first, and only later enable period
+                        // removing the period information now, so that when we generate SQL that modifies the column we won't be making them auto generated as period
+                        // (making column auto generated is not allowed in ALTER COLUMN statement)
+                        // in later operation we enable the period and the period columns get set to auto generated automatically
+                        //
+                        // if the column is not period we just remove temporal information - it's no longer needed and could affect the generated sql
+                        // we will generate all the necessary operations involved with temporal tables here
+                        if (temporalInformation.DisabledVersioning && temporalInformation.ShouldEnableVersioning)
+                        {
+                            var alterHistoryTableColumn = CopyColumnOperation<AlterColumnOperation>(alterColumnOperation);
+                            alterHistoryTableColumn.Table = temporalInformation.HistoryTableName!;
+                            alterHistoryTableColumn.Schema = temporalInformation.HistoryTableSchema;
+                            alterHistoryTableColumn.OldColumn = CopyColumnOperation<AddColumnOperation>(alterColumnOperation.OldColumn);
+                            alterHistoryTableColumn.OldColumn.Table = temporalInformation.HistoryTableName!;
+                            alterHistoryTableColumn.OldColumn.Schema = temporalInformation.HistoryTableSchema;
+
+                            operations.Add(alterHistoryTableColumn);
+                        }
+                    }
+                    else
+                    {
+                        operations.Add(alterColumnOperation);
+                    }
+                    break;
+                }
+
+                case DropPrimaryKeyOperation:
+                case AddPrimaryKeyOperation:
+                    if (temporalInformation.IsTemporalTable
+                        && !temporalInformation.DisabledVersioning
+                        && !temporalInformation.ShouldEnableVersioning)
+                    {
+                        DisableVersioning(
+                            tableName!,
+                            schema,
+                            temporalInformation,
+                            suppressTransaction,
+                            shouldEnableVersioning: true);
+                    }
+
+                    operations.Add(operation);
+                    break;
+
+                default:
+                    operations.Add(operation);
+                    break;
             }
         }
 
-        foreach (var ((table, schema), (periodStartColumnName, periodEndColumnName, suppressTransaction)) in periodMap)
+        foreach (var temporalInformation in temporalTableInformationMap.Where(x => x.Value.ShouldEnablePeriod))
         {
-            EnablePeriod(table!, schema, periodStartColumnName, periodEndColumnName, suppressTransaction);
+            EnablePeriod(
+                temporalInformation.Key.TableName,
+                temporalInformation.Key.Schema,
+                temporalInformation.Value.PeriodStartColumnName!,
+                temporalInformation.Value.PeriodEndColumnName!,
+                temporalInformation.Value.SuppressTransaction);
         }
 
-        foreach (var ((table, schema), (historyTableName, historyTableSchema, suppressTransaction)) in versioningMap)
+        foreach (var temporalInformation in temporalTableInformationMap.Where(x => x.Value.ShouldEnableVersioning))
         {
-            EnableVersioning(table!, schema, historyTableName, historyTableSchema, suppressTransaction);
+            EnableVersioning(
+                temporalInformation.Key.TableName,
+                temporalInformation.Key.Schema,
+                temporalInformation.Value.HistoryTableName!,
+                temporalInformation.Value.HistoryTableSchema,
+                temporalInformation.Value.SuppressTransaction);
         }
 
         return operations;
 
-        void DisableVersioning(string table, string? schema, string historyTableName, string? historyTableSchema, bool suppressTransaction)
+        static TemporalOperationInformation BuildTemporalInformationFromMigrationOperation(
+            string? schema,
+            IAnnotatable operation)
         {
-            if (!versioningMap.TryGetValue((table, schema), out _))
-            {
-                versioningMap[(table, schema)] = (historyTableName, historyTableSchema, suppressTransaction);
+            var isTemporalTable = operation[SqlServerAnnotationNames.IsTemporal] as bool? == true;
+            var historyTableName = operation[SqlServerAnnotationNames.TemporalHistoryTableName] as string;
+            var historyTableSchema = operation[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string ?? schema;
+            var periodStartColumnName = operation[SqlServerAnnotationNames.TemporalPeriodStartColumnName] as string;
+            var periodEndColumnName = operation[SqlServerAnnotationNames.TemporalPeriodEndColumnName] as string;
 
-                operations.Add(
-                    new SqlOperation
-                    {
-                        Sql = new StringBuilder()
-                            .Append("ALTER TABLE ")
-                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
-                            .AppendLine(" SET (SYSTEM_VERSIONING = OFF)")
-                            .ToString(),
-                        SuppressTransaction = suppressTransaction
-                    });
+            return new TemporalOperationInformation
+            {
+                IsTemporalTable = isTemporalTable,
+                HistoryTableName = historyTableName,
+                HistoryTableSchema = historyTableSchema,
+                PeriodStartColumnName = periodStartColumnName,
+                PeriodEndColumnName = periodEndColumnName
+            };
+        }
+
+        void DisableVersioning(
+            string tableName,
+            string? schema,
+            TemporalOperationInformation temporalInformation,
+            bool suppressTransaction,
+            bool? shouldEnableVersioning)
+        {
+            temporalInformation.DisabledVersioning = true;
+
+            AddDisableVersioningOperation(tableName, schema, suppressTransaction);
+
+            if (shouldEnableVersioning != null)
+            {
+                temporalInformation.ShouldEnableVersioning = shouldEnableVersioning.Value;
+                if (shouldEnableVersioning.Value)
+                {
+                    temporalInformation.SuppressTransaction = suppressTransaction;
+                }
             }
+        }
+
+        void AddDisableVersioningOperation(string tableName, string? schema, bool suppressTransaction)
+        {
+            operations.Add(
+                new SqlOperation
+                {
+                    Sql = new StringBuilder()
+                        .Append("ALTER TABLE ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(tableName, schema))
+                        .AppendLine(" SET (SYSTEM_VERSIONING = OFF)")
+                        .ToString(),
+                    SuppressTransaction = suppressTransaction
+                });
         }
 
         void EnableVersioning(string table, string? schema, string historyTableName, string? historyTableSchema, bool suppressTransaction)
@@ -2731,23 +2972,24 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 new SqlOperation { Sql = stringBuilder.ToString(), SuppressTransaction = suppressTransaction });
         }
 
-        void DisablePeriod(string table, string? schema, string periodStartColumnName, string periodEndColumnName, bool suppressTransaction)
+        void DisablePeriod(
+            string table,
+            string? schema,
+            TemporalOperationInformation temporalInformation,
+            bool suppressTransaction)
         {
-            if (!periodMap.TryGetValue((table, schema), out _))
-            {
-                periodMap[(table, schema)] = (periodStartColumnName, periodEndColumnName, suppressTransaction);
+            temporalInformation.DisabledPeriod = true;
 
-                operations.Add(
-                    new SqlOperation
-                    {
-                        Sql = new StringBuilder()
-                            .Append("ALTER TABLE ")
-                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
-                            .AppendLine(" DROP PERIOD FOR SYSTEM_TIME")
-                            .ToString(),
-                        SuppressTransaction = suppressTransaction
-                    });
-            }
+            operations.Add(
+                new SqlOperation
+                {
+                    Sql = new StringBuilder()
+                        .Append("ALTER TABLE ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
+                        .AppendLine(" DROP PERIOD FOR SYSTEM_TIME")
+                        .ToString(),
+                    SuppressTransaction = suppressTransaction
+                });
         }
 
         void EnablePeriod(string table, string? schema, string periodStartColumnName, string periodEndColumnName, bool suppressTransaction)
@@ -2801,57 +3043,6 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                 });
         }
 
-        static bool CanSkipAlterColumnOperation(ColumnOperation first, ColumnOperation second)
-            => ColumnPropertiesAreTheSame(first, second)
-                && ColumnOperationsOnlyDifferByTemporalTableAnnotation(first, second)
-                && ColumnOperationsOnlyDifferByTemporalTableAnnotation(second, first);
-
-        // don't compare name, table or schema - they are not being set in the model differ (since they should always be the same)
-        static bool ColumnPropertiesAreTheSame(ColumnOperation first, ColumnOperation second)
-            => first.ClrType == second.ClrType
-                && first.Collation == second.Collation
-                && first.ColumnType == second.ColumnType
-                && first.Comment == second.Comment
-                && first.ComputedColumnSql == second.ComputedColumnSql
-                && Equals(first.DefaultValue, second.DefaultValue)
-                && first.DefaultValueSql == second.DefaultValueSql
-                && first.IsDestructiveChange == second.IsDestructiveChange
-                && first.IsFixedLength == second.IsFixedLength
-                && first.IsNullable == second.IsNullable
-                && first.IsReadOnly == second.IsReadOnly
-                && first.IsRowVersion == second.IsRowVersion
-                && first.IsStored == second.IsStored
-                && first.IsUnicode == second.IsUnicode
-                && first.MaxLength == second.MaxLength
-                && first.Precision == second.Precision
-                && first.Scale == second.Scale;
-
-        static bool ColumnOperationsOnlyDifferByTemporalTableAnnotation(ColumnOperation first, ColumnOperation second)
-        {
-            var unmatched = first.GetAnnotations().ToList();
-            foreach (var annotation in second.GetAnnotations())
-            {
-                var index = unmatched.FindIndex(
-                    a => a.Name == annotation.Name
-                        && StructuralComparisons.StructuralEqualityComparer.Equals(a.Value, annotation.Value));
-                if (index == -1)
-                {
-                    continue;
-                }
-
-                unmatched.RemoveAt(index);
-            }
-
-            return unmatched.All(
-                a => a.Name is SqlServerAnnotationNames.IsTemporal
-                    or SqlServerAnnotationNames.TemporalHistoryTableName
-                    or SqlServerAnnotationNames.TemporalHistoryTableSchema
-                    or SqlServerAnnotationNames.TemporalPeriodStartPropertyName
-                    or SqlServerAnnotationNames.TemporalPeriodEndPropertyName
-                    or SqlServerAnnotationNames.TemporalPeriodStartColumnName
-                    or SqlServerAnnotationNames.TemporalPeriodEndColumnName);
-        }
-
         static TOperation CopyColumnOperation<TOperation>(ColumnOperation source)
             where TOperation : ColumnOperation, new()
         {
@@ -2885,5 +3076,21 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 
             return result;
         }
+    }
+
+    private sealed class TemporalOperationInformation
+    {
+        public bool IsTemporalTable { get; set; }
+        public string? HistoryTableName { get; set; }
+        public string? HistoryTableSchema { get; set; }
+        public string? PeriodStartColumnName { get; set; }
+        public string? PeriodEndColumnName { get; set; }
+
+        public bool DisabledVersioning { get; set; } = false;
+        public bool DisabledPeriod { get; set; } = false;
+
+        public bool ShouldEnableVersioning { get; set; } = false;
+        public bool ShouldEnablePeriod { get; set; } = false;
+        public bool SuppressTransaction { get; set; } = false;
     }
 }


### PR DESCRIPTION
Before we used to put temporal annotations on temporal tables and all their columns, so that it's easier to process. Problem was that this would generate very noisy migrations when converting from regular table to temporal and vice versa. Every column would have an AlterColumn operation (which we would ignore during processing, but they were nonetheless generated in migration files). Also, we were using relatively simple logic to track state of our temporal tables. Some operations require temporary disabling of the versioning/period, and we need to keep track of that so that we don't try to disable period twice, or forget to enable it later. The way we did it could lead to invalid SQL in some non-trivial scenarios (e.g. converting table to temporal and adding a new column at the same time)

The new approach is to only put temporal annotations on the table itself, and the period columns. Regular columns of the temporal table don't have any temporal annotations on them anymore and we reason about temporal information based on other table-based migration operation in the batch and, if need be, on the relational model. We also keep track of the actual temporal information for every operation (rather than keeping global dictionaries of period/version), so that complex migrations, involving multiple operations are more robust. To achieve that we compute the initial (temporal) state of all the tables involved in the migration. We scan all the table operations, and if some info is missing we get it from relational model. Then we do the proper processing of the migration operations - when we encounter table operation, we update the temporal information for that table (since table operations contain relevant temporal annotations). For all other operations we extract the current temporal state for the table involved, and reason based on that info.

Fixes #27459 - SQL Server Migrations: Review temporal table annotations 
Fixes #29536 - EF Core IsTemporal() creates huge migration 
Fixes #29799 - EF7 SqlServer Migration is trying to update columns on History table before creating the History table if any new columns are added in the same migration
