### PR TITLE
Scaffolding: Handle unknown computed column SQL in model factory

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <DefaultNetCoreTargetFramework>net8.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -466,7 +466,14 @@ public class RelationalScaffoldingModelFactory : IScaffoldingModelFactory
 
         if (column.ComputedColumnSql != null)
         {
-            property.HasComputedColumnSql(column.ComputedColumnSql, column.IsStored);
+            if (column.ComputedColumnSql.Length == 0)
+            {
+                property.HasComputedColumnSql();
+            }
+            else
+            {
+                property.HasComputedColumnSql(column.ComputedColumnSql, column.IsStored);
+            }
         }
 
         if (column.Comment != null)

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -3072,4 +3072,36 @@ public class RelationalScaffoldingModelFactoryTest
                 }
             );
     }
+
+    [ConditionalFact]
+    public void Computed_column_when_sql_unknown()
+    {
+        var database = new DatabaseModel
+        {
+            Tables =
+            {
+                new DatabaseTable
+                {
+                    Database = Database,
+                    Name = "Table",
+                    Columns =
+                    {
+                        IdColumn,
+                        new DatabaseColumn
+                        {
+                            Table = Table,
+                            Name = "Column",
+                            StoreType = "int",
+                            ComputedColumnSql = string.Empty
+                        }
+                    }
+                }
+            }
+        };
+
+        var model = _factory.Create(database, new ModelReverseEngineerOptions());
+
+        var column = model.FindEntityType("Table").GetProperty("Column");
+        Assert.Empty(column.GetComputedColumnSql());
+    }
 }


### PR DESCRIPTION
Fixes #32179

Manually verified end-to-end that this fixes the issue:

```cs
entity.Property(e => e.Id)
    .HasComputedColumnSql();
```