### PR TITLE
[release/8.0] Fix to #32235 - Buffering error in JSON deserialization with junk data

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1176,14 +1176,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("JsonQueryLinqOperatorsNotSupported");
 
         /// <summary>
-        ///     Invalid token type: '{tokenType}'.
-        /// </summary>
-        public static string JsonReaderInvalidTokenType(object? tokenType)
-            => string.Format(
-                GetString("JsonReaderInvalidTokenType", nameof(tokenType)),
-                tokenType);
-
-        /// <summary>
         ///     Entity {entity} is required but the JSON element containing it is null.
         /// </summary>
         public static string JsonRequiredEntityWithNullJson(object? entity)
@@ -2062,7 +2054,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 nodeType, expressionType);
 
         /// <summary>
-        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'. 
+        ///     No relational type mapping can be found for property '{entity}.{property}' and the current provider doesn't specify a default store type for the properties of type '{clrType}'.
         /// </summary>
         public static string UnsupportedPropertyType(object? entity, object? property, object? clrType)
             => string.Format(

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -561,9 +561,6 @@
   </data>
   <data name="JsonQueryLinqOperatorsNotSupported" xml:space="preserve">
     <value>Composing LINQ operators over collections inside JSON documents isn't supported or hasn't been implemented by your EF provider.</value>
-  </data>
-  <data name="JsonReaderInvalidTokenType" xml:space="preserve">
-    <value>Invalid token type: '{tokenType}'.</value>
   </data>
   <data name="JsonRequiredEntityWithNullJson" xml:space="preserve">
     <value>Entity {entity} is required but the JSON element containing it is null.</value>

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -955,6 +955,11 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                     tokenType = manager.MoveNext();
                 }
+                else if (!UseOldBehavior32235)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                }
             }
 
             manager.CaptureState();
@@ -1042,6 +1047,11 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     }
 
                     tokenType = manager.MoveNext();
+                }
+                else if (!UseOldBehavior32235)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
                 }
             }
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -891,7 +891,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             if (tokenType != JsonTokenType.StartObject)
             {
                 throw new InvalidOperationException(
-                    RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                    CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
             }
 
             manager.CaptureState();
@@ -924,7 +924,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             if (tokenType != JsonTokenType.StartArray)
             {
                 throw new InvalidOperationException(
-                    RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                    CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
             }
 
             var collectionAccessor = navigation.GetCollectionAccessor();
@@ -950,7 +950,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     if (manager.CurrentReader.TokenType != JsonTokenType.EndObject)
                     {
                         throw new InvalidOperationException(
-                            RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                            CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
                     }
 
                     tokenType = manager.MoveNext();
@@ -958,7 +958,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 else if (!UseOldBehavior32235)
                 {
                     throw new InvalidOperationException(
-                        RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
                 }
             }
 
@@ -1014,7 +1014,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
             if (tokenType != JsonTokenType.StartArray)
             {
                 throw new InvalidOperationException(
-                    RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                    CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
             }
 
             getOrCreateCollectionObject(entity);
@@ -1043,7 +1043,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                     if (manager.CurrentReader.TokenType != JsonTokenType.EndObject)
                     {
                         throw new InvalidOperationException(
-                            RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                            CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
                     }
 
                     tokenType = manager.MoveNext();
@@ -1051,7 +1051,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                 else if (!UseOldBehavior32235)
                 {
                     throw new InvalidOperationException(
-                        RelationalStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
                 }
             }
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.ClientMethods.cs
@@ -955,7 +955,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                     tokenType = manager.MoveNext();
                 }
-                else if (!UseOldBehavior32235)
+                else if (!Utf8JsonReaderManager.UseOldBehavior32235)
                 {
                     throw new InvalidOperationException(
                         CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
@@ -1048,7 +1048,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 
                     tokenType = manager.MoveNext();
                 }
-                else if (!UseOldBehavior32235)
+                else if (!Utf8JsonReaderManager.UseOldBehavior32235)
                 {
                     throw new InvalidOperationException(
                         CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -14,15 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Query;
 
 public partial class RelationalShapedQueryCompilingExpressionVisitor
 {
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public static readonly bool UseOldBehavior32235 =
-        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32235", out var enabled32235) && enabled32235;
-
     private sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
     {
         /// <summary>
@@ -1842,7 +1833,7 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                         Switch(
                             tokenTypeVariable,
                             Block(
-                                UseOldBehavior32235
+                                Utf8JsonReaderManager.UseOldBehavior32235
                                     ? Call(
                                         Field(managerVariable, Utf8JsonReaderManagerCurrentReaderField),
                                         Utf8JsonReaderTrySkipMethod)

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1622,6 +1622,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("IQueryableProviderNotAsync");
 
         /// <summary>
+        ///     Invalid token type: '{tokenType}'.
+        /// </summary>
+        public static string JsonReaderInvalidTokenType(object? tokenType)
+            => string.Format(
+                GetString("JsonReaderInvalidTokenType", nameof(tokenType)),
+                tokenType);
+
+        /// <summary>
         ///     The derived type '{derivedType}' cannot have the [Key] attribute on property '{property}' since primary keys may only be declared on the root type. Move the property '{property}' to '{rootType}' or remove '{rootType}' from the model by using [NotMapped] attribute or calling 'EntityTypeBuilder.Ignore' on the base type in 'OnModelCreating'.
         /// </summary>
         public static string KeyAttributeOnDerivedEntity(object? derivedType, object? property, object? rootType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -726,6 +726,9 @@
   </data>
   <data name="IQueryableProviderNotAsync" xml:space="preserve">
     <value>The provider for the source 'IQueryable' doesn't implement 'IAsyncQueryProvider'. Only providers that implement 'IAsyncQueryProvider' can be used for Entity Framework asynchronous operations.</value>
+  </data>
+  <data name="JsonReaderInvalidTokenType" xml:space="preserve">
+    <value>Invalid token type: '{tokenType}'.</value>
   </data>
   <data name="KeyAttributeOnDerivedEntity" xml:space="preserve">
     <value>The derived type '{derivedType}' cannot have the [Key] attribute on property '{property}' since primary keys may only be declared on the root type. Move the property '{property}' to '{rootType}' or remove '{rootType}' from the model by using [NotMapped] attribute or calling 'EntityTypeBuilder.Ignore' on the base type in 'OnModelCreating'.</value>

--- a/src/EFCore/Storage/Json/JsonCollectionReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCollectionReaderWriter.cs
@@ -46,11 +46,24 @@ public class JsonCollectionReaderWriter<TCollection, TConcreteCollection, TEleme
             collection.Clear();
         }
 
-        while (manager.CurrentReader.TokenType != JsonTokenType.EndArray)
+        if (manager.CurrentReader.TokenType == JsonTokenType.None)
         {
             manager.MoveNext();
+        }
 
-            switch (manager.CurrentReader.TokenType)
+        var tokenType = manager.CurrentReader.TokenType;
+        if (tokenType != JsonTokenType.StartArray)
+        {
+            throw new InvalidOperationException(
+                CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+        }
+
+        while (tokenType != JsonTokenType.EndArray)
+        {
+            manager.MoveNext();
+            tokenType = manager.CurrentReader.TokenType;
+
+            switch (tokenType)
             {
                 case JsonTokenType.String:
                 case JsonTokenType.Number:
@@ -60,6 +73,16 @@ public class JsonCollectionReaderWriter<TCollection, TConcreteCollection, TEleme
                     break;
                 case JsonTokenType.Null:
                     collection.Add(default);
+                    break;
+                case JsonTokenType.None:
+                case JsonTokenType.StartObject:
+                case JsonTokenType.EndObject:
+                case JsonTokenType.StartArray:
+                case JsonTokenType.PropertyName:
+                    throw new InvalidOperationException(
+                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                case JsonTokenType.Comment:
+                default:
                     break;
             }
         }

--- a/src/EFCore/Storage/Json/JsonCollectionReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCollectionReaderWriter.cs
@@ -74,16 +74,16 @@ public class JsonCollectionReaderWriter<TCollection, TConcreteCollection, TEleme
                 case JsonTokenType.Null:
                     collection.Add(default);
                     break;
-                case JsonTokenType.None:
+                case JsonTokenType.Comment:
+                    break;
+                case JsonTokenType.None: // Explicitly listing all states that we throw for
                 case JsonTokenType.StartObject:
                 case JsonTokenType.EndObject:
                 case JsonTokenType.StartArray:
                 case JsonTokenType.PropertyName:
+                default:
                     throw new InvalidOperationException(
                         CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
-                case JsonTokenType.Comment:
-                default:
-                    break;
             }
         }
 

--- a/src/EFCore/Storage/Json/JsonCollectionReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonCollectionReaderWriter.cs
@@ -46,44 +46,68 @@ public class JsonCollectionReaderWriter<TCollection, TConcreteCollection, TEleme
             collection.Clear();
         }
 
-        if (manager.CurrentReader.TokenType == JsonTokenType.None)
+        if (Utf8JsonReaderManager.UseOldBehavior32235)
         {
-            manager.MoveNext();
-        }
-
-        var tokenType = manager.CurrentReader.TokenType;
-        if (tokenType != JsonTokenType.StartArray)
-        {
-            throw new InvalidOperationException(
-                CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
-        }
-
-        while (tokenType != JsonTokenType.EndArray)
-        {
-            manager.MoveNext();
-            tokenType = manager.CurrentReader.TokenType;
-
-            switch (tokenType)
+            while (manager.CurrentReader.TokenType != JsonTokenType.EndArray)
             {
-                case JsonTokenType.String:
-                case JsonTokenType.Number:
-                case JsonTokenType.True:
-                case JsonTokenType.False:
-                    collection.Add(_elementReaderWriter.FromJsonTyped(ref manager));
-                    break;
-                case JsonTokenType.Null:
-                    collection.Add(default);
-                    break;
-                case JsonTokenType.Comment:
-                    break;
-                case JsonTokenType.None: // Explicitly listing all states that we throw for
-                case JsonTokenType.StartObject:
-                case JsonTokenType.EndObject:
-                case JsonTokenType.StartArray:
-                case JsonTokenType.PropertyName:
-                default:
-                    throw new InvalidOperationException(
-                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                manager.MoveNext();
+
+                switch (manager.CurrentReader.TokenType)
+                {
+                    case JsonTokenType.String:
+                    case JsonTokenType.Number:
+                    case JsonTokenType.True:
+                    case JsonTokenType.False:
+                        collection.Add(_elementReaderWriter.FromJsonTyped(ref manager));
+                        break;
+                    case JsonTokenType.Null:
+                        collection.Add(default);
+                        break;
+                }
+            }
+        }
+        else
+        {
+            if (manager.CurrentReader.TokenType == JsonTokenType.None)
+            {
+                manager.MoveNext();
+            }
+
+            var tokenType = manager.CurrentReader.TokenType;
+            if (tokenType != JsonTokenType.StartArray)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+            }
+
+            while (tokenType != JsonTokenType.EndArray)
+            {
+                manager.MoveNext();
+                tokenType = manager.CurrentReader.TokenType;
+
+                switch (tokenType)
+                {
+                    case JsonTokenType.String:
+                    case JsonTokenType.Number:
+                    case JsonTokenType.True:
+                    case JsonTokenType.False:
+                        collection.Add(_elementReaderWriter.FromJsonTyped(ref manager));
+                        break;
+                    case JsonTokenType.Null:
+                        collection.Add(default);
+                        break;
+                    case JsonTokenType.Comment:
+                    case JsonTokenType.EndArray:
+                        break;
+                    case JsonTokenType.None: // Explicitly listing all states that we throw for
+                    case JsonTokenType.StartObject:
+                    case JsonTokenType.EndObject:
+                    case JsonTokenType.StartArray:
+                    case JsonTokenType.PropertyName:
+                    default:
+                        throw new InvalidOperationException(
+                            CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                }
             }
         }
 

--- a/src/EFCore/Storage/Json/JsonNullableStructCollectionReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonNullableStructCollectionReaderWriter.cs
@@ -75,16 +75,16 @@ public class JsonNullableStructCollectionReaderWriter<TCollection, TConcreteColl
                 case JsonTokenType.Null:
                     collection.Add(null);
                     break;
-                case JsonTokenType.None:
+                case JsonTokenType.Comment:
+                    break;
+                case JsonTokenType.None: // Explicitly listing all states that we throw for
                 case JsonTokenType.StartObject:
                 case JsonTokenType.EndObject:
                 case JsonTokenType.StartArray:
                 case JsonTokenType.PropertyName:
+                default:
                     throw new InvalidOperationException(
                         CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
-                case JsonTokenType.Comment:
-                default:
-                    break;
             }
         }
 

--- a/src/EFCore/Storage/Json/JsonNullableStructCollectionReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonNullableStructCollectionReaderWriter.cs
@@ -47,44 +47,68 @@ public class JsonNullableStructCollectionReaderWriter<TCollection, TConcreteColl
             collection.Clear();
         }
 
-        if (manager.CurrentReader.TokenType == JsonTokenType.None)
+        if (Utf8JsonReaderManager.UseOldBehavior32235)
         {
-            manager.MoveNext();
-        }
-
-        var tokenType = manager.CurrentReader.TokenType;
-        if (tokenType != JsonTokenType.StartArray)
-        {
-            throw new InvalidOperationException(
-                CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
-        }
-
-        while (tokenType != JsonTokenType.EndArray)
-        {
-            manager.MoveNext();
-            tokenType = manager.CurrentReader.TokenType;
-
-            switch (tokenType)
+            while (manager.CurrentReader.TokenType != JsonTokenType.EndArray)
             {
-                case JsonTokenType.String:
-                case JsonTokenType.Number:
-                case JsonTokenType.True:
-                case JsonTokenType.False:
-                    collection.Add(_elementReaderWriter.FromJsonTyped(ref manager));
-                    break;
-                case JsonTokenType.Null:
-                    collection.Add(null);
-                    break;
-                case JsonTokenType.Comment:
-                    break;
-                case JsonTokenType.None: // Explicitly listing all states that we throw for
-                case JsonTokenType.StartObject:
-                case JsonTokenType.EndObject:
-                case JsonTokenType.StartArray:
-                case JsonTokenType.PropertyName:
-                default:
-                    throw new InvalidOperationException(
-                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                manager.MoveNext();
+
+                switch (manager.CurrentReader.TokenType)
+                {
+                    case JsonTokenType.String:
+                    case JsonTokenType.Number:
+                    case JsonTokenType.True:
+                    case JsonTokenType.False:
+                        collection.Add(_elementReaderWriter.FromJsonTyped(ref manager));
+                        break;
+                    case JsonTokenType.Null:
+                        collection.Add(null);
+                        break;
+                }
+            }
+        }
+        else
+        {
+            if (manager.CurrentReader.TokenType == JsonTokenType.None)
+            {
+                manager.MoveNext();
+            }
+
+            var tokenType = manager.CurrentReader.TokenType;
+            if (tokenType != JsonTokenType.StartArray)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+            }
+
+            while (tokenType != JsonTokenType.EndArray)
+            {
+                manager.MoveNext();
+                tokenType = manager.CurrentReader.TokenType;
+
+                switch (tokenType)
+                {
+                    case JsonTokenType.String:
+                    case JsonTokenType.Number:
+                    case JsonTokenType.True:
+                    case JsonTokenType.False:
+                        collection.Add(_elementReaderWriter.FromJsonTyped(ref manager));
+                        break;
+                    case JsonTokenType.Null:
+                        collection.Add(null);
+                        break;
+                    case JsonTokenType.EndArray:
+                    case JsonTokenType.Comment:
+                        break;
+                    case JsonTokenType.None: // Explicitly listing all states that we throw for
+                    case JsonTokenType.StartObject:
+                    case JsonTokenType.EndObject:
+                    case JsonTokenType.StartArray:
+                    case JsonTokenType.PropertyName:
+                    default:
+                        throw new InvalidOperationException(
+                            CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                }
             }
         }
 

--- a/src/EFCore/Storage/Json/JsonNullableStructCollectionReaderWriter.cs
+++ b/src/EFCore/Storage/Json/JsonNullableStructCollectionReaderWriter.cs
@@ -47,11 +47,24 @@ public class JsonNullableStructCollectionReaderWriter<TCollection, TConcreteColl
             collection.Clear();
         }
 
-        while (manager.CurrentReader.TokenType != JsonTokenType.EndArray)
+        if (manager.CurrentReader.TokenType == JsonTokenType.None)
         {
             manager.MoveNext();
+        }
 
-            switch (manager.CurrentReader.TokenType)
+        var tokenType = manager.CurrentReader.TokenType;
+        if (tokenType != JsonTokenType.StartArray)
+        {
+            throw new InvalidOperationException(
+                CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+        }
+
+        while (tokenType != JsonTokenType.EndArray)
+        {
+            manager.MoveNext();
+            tokenType = manager.CurrentReader.TokenType;
+
+            switch (tokenType)
             {
                 case JsonTokenType.String:
                 case JsonTokenType.Number:
@@ -61,6 +74,16 @@ public class JsonNullableStructCollectionReaderWriter<TCollection, TConcreteColl
                     break;
                 case JsonTokenType.Null:
                     collection.Add(null);
+                    break;
+                case JsonTokenType.None:
+                case JsonTokenType.StartObject:
+                case JsonTokenType.EndObject:
+                case JsonTokenType.StartArray:
+                case JsonTokenType.PropertyName:
+                    throw new InvalidOperationException(
+                        CoreStrings.JsonReaderInvalidTokenType(tokenType.ToString()));
+                case JsonTokenType.Comment:
+                default:
                     break;
             }
         }

--- a/src/EFCore/Storage/Json/JsonReaderData.cs
+++ b/src/EFCore/Storage/Json/JsonReaderData.cs
@@ -56,28 +56,35 @@ public class JsonReaderData
     /// <returns>The new <see cref="Utf8JsonReader" />, having read my bytes from the stream.</returns>
     public virtual Utf8JsonReader ReadBytes(int bytesConsumed, JsonReaderState state)
     {
-        Check.DebugAssert(_stream != null, "Only needed when buffer doesn't contain full JSON document.");
-
-        var buffer = _buffer;
-        var totalConsumed = bytesConsumed + _positionInBuffer;
-        if (_bytesAvailable != 0 && totalConsumed < buffer.Length)
+        if (_stream == null)
         {
-            var leftover = buffer.AsSpan(totalConsumed);
-
-            if (leftover.Length == buffer.Length)
-            {
-                Array.Resize(ref buffer, buffer.Length * 2);
-            }
-
-            leftover.CopyTo(buffer);
-            _bytesAvailable = _stream.Read(buffer.AsSpan(leftover.Length)) + leftover.Length;
+            _bytesAvailable = 0;
         }
         else
         {
-            _bytesAvailable = _stream.Read(buffer);
+
+            var buffer = _buffer;
+            var totalConsumed = bytesConsumed + _positionInBuffer;
+            if (_bytesAvailable != 0 && totalConsumed < buffer.Length)
+            {
+                var leftover = buffer.AsSpan(totalConsumed);
+
+                if (leftover.Length == buffer.Length)
+                {
+                    Array.Resize(ref buffer, buffer.Length * 2);
+                }
+
+                leftover.CopyTo(buffer);
+                _bytesAvailable = _stream.Read(buffer.AsSpan(leftover.Length)) + leftover.Length;
+            }
+            else
+            {
+                _bytesAvailable = _stream.Read(buffer);
+            }
+
+            _buffer = buffer;
         }
 
-        _buffer = buffer;
         _positionInBuffer = 0;
         _readerState = state;
 

--- a/src/EFCore/Storage/Json/Utf8JsonReaderManager.cs
+++ b/src/EFCore/Storage/Json/Utf8JsonReaderManager.cs
@@ -56,6 +56,18 @@ public ref struct Utf8JsonReaderManager
     }
 
     /// <summary>
+    ///     Skips the children of the current JSON token, which may involve reading more data from the stream and creating a new <see cref="Utf8JsonReader " />
+    ///     instance in <see cref="CurrentReader" />.
+    /// </summary>
+    public void Skip()
+    {
+        while (!CurrentReader.TrySkip())
+        {
+            CurrentReader = Data.ReadBytes((int)CurrentReader.BytesConsumed, CurrentReader.CurrentState);
+        }
+    }
+
+    /// <summary>
     ///     Called to capture the state of this <see cref="Utf8JsonReaderManager" /> into the associated <see cref="JsonReaderData" /> so
     ///     that a new <see cref="Utf8JsonReaderManager" /> can later be created to pick up at the same position in the JSON document.
     /// </summary>

--- a/src/EFCore/Storage/Json/Utf8JsonReaderManager.cs
+++ b/src/EFCore/Storage/Json/Utf8JsonReaderManager.cs
@@ -15,6 +15,15 @@ namespace Microsoft.EntityFrameworkCore.Storage.Json;
 public ref struct Utf8JsonReaderManager
 {
     /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static readonly bool UseOldBehavior32235 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32235", out var enabled32235) && enabled32235;
+
+    /// <summary>
     ///     Tracks state and underlying stream or buffer of UTF8 bytes.
     /// </summary>
     public readonly JsonReaderData Data;

--- a/test/EFCore.InMemory.FunctionalTests/BadDataJsonDeserializationInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/BadDataJsonDeserializationInMemoryTest.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class BadDataJsonDeserializationInMemoryTest : BadDataJsonDeserializationTestBase
+{
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => base.OnConfiguring(optionsBuilder.UseInMemoryDatabase("X"));
+}

--- a/test/EFCore.Specification.Tests/BadDataJsonDeserializationTestBase.cs
+++ b/test/EFCore.Specification.Tests/BadDataJsonDeserializationTestBase.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Storage.Json;
+using NetTopologySuite.Geometries;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public abstract class BadDataJsonDeserializationTestBase
+{
+    [ConditionalTheory]
+    [InlineData("""{"Prop"}""")]
+    [InlineData("""{"Prop"}:127}""")]
+    [InlineData("""{"Prop":"X"}""")]
+    [InlineData("""{"Prop":}""")]
+    public virtual void Throws_for_bad_sbyte_JSON_values(string json)
+        => Throws_for_bad_JSON_value<Int8Type, sbyte>(nameof(Int8Type.Int8), json);
+
+    protected class Int8Type
+    {
+        public sbyte Int8 { get; set; }
+    }
+
+    [ConditionalTheory]
+    [InlineData("""{"Prop"}""")]
+    [InlineData("""{"Prop"}:127}""")]
+    [InlineData("""{"Prop":"X"}""")]
+    [InlineData("""{"Prop":}""")]
+    public virtual void Throws_for_bad_nullable_long_JSON_values(string json)
+        => Throws_for_bad_JSON_value<NullableInt64Type, long?>(nameof(NullableInt64Type.Int64), json);
+
+    protected class NullableInt64Type
+    {
+        public long? Int64 { get; set; }
+    }
+
+    [ConditionalTheory]
+    [InlineData("""{"Prop":{"type""Point","coordinates":[2.0,4.0]}}""")]
+    [InlineData("""{"Prop":{"type":["Point","coordinates":[2.0,4.0]}}""")]
+    [InlineData("""{"Prop":{"type":"Point","coordinates":[2.0,,4.0]}}""")]
+    [InlineData("""{"Prop":[{"type":"Point","coordinates":[2.0,4.0]}]}""")]
+    [InlineData("""{"Prop":1}""")]
+    [InlineData("""{"Prop":true}""")]
+    [InlineData("""{"Prop":false}""")]
+    [InlineData("""{"Prop":"X"}""")]
+    public virtual void Throws_for_bad_point_as_GeoJson(string json)
+        => Throws_for_bad_JSON_property_value<PointType, Point>(
+            b => b.Metadata.SetJsonValueReaderWriterType(typeof(JsonTypesTestBase.JsonGeoJsonReaderWriter)),
+            nameof(PointType.Point),
+            json);
+
+    public class PointType
+    {
+        public Point? Point { get; set; }
+    }
+
+    [ConditionalTheory]
+    [InlineData("""{"Prop":[-128,[0,127]]}""")]
+    [InlineData("""{"Prop":[-128,{"P":127}]}""")]
+    [InlineData("""{"Prop":[-128,],23]}""")]
+    [InlineData("""{"Prop":[-128,},23]}""")]
+    [InlineData("""{"Prop":[-128,,23]}""")]
+    [InlineData("""{"Prop":[-128,,23]}""")]
+    public virtual void Throws_for_bad_collection_of_sbyte_JSON_values(string json)
+        => Throws_for_bad_JSON_value<Int8CollectionType, List<sbyte>>(
+            nameof(Int8CollectionType.Int8),
+            json,
+            mappedCollection: true);
+
+    protected class Int8CollectionType
+    {
+        public sbyte[] Int8 { get; set; } = null!;
+    }
+
+    [ConditionalTheory]
+    [InlineData("""{"Prop":[-128,[0,127]]}""")]
+    [InlineData("""{"Prop":[-128,{"P":127}]}""")]
+    [InlineData("""{"Prop":[-128,],23]}""")]
+    [InlineData("""{"Prop":[-128,},23]}""")]
+    [InlineData("""{"Prop":[-128,,23]}""")]
+    [InlineData("""{"Prop":[-128,,23]}""")]
+    public virtual void Throws_for_bad_collection_of_nullable_long_JSON_values(string json)
+        => Throws_for_bad_JSON_value<NullableInt64CollectionType, List<long?>>(
+            nameof(NullableInt64CollectionType.Int64),
+            json,
+            mappedCollection: true);
+
+    protected class NullableInt64CollectionType
+    {
+        public IList<long?> Int64 { get; set; } = null!;
+    }
+
+    protected virtual void Throws_for_bad_JSON_value<TEntity, TModel>(
+        string propertyName,
+        string json,
+        bool mappedCollection = false,
+        object? existingObject = null)
+        where TEntity : class
+    {
+        if (mappedCollection)
+        {
+            Throws_for_bad_JSON_value<TEntity, TModel>(
+                b => b.Entity<TEntity>().HasNoKey().PrimitiveCollection(propertyName),
+                null,
+                propertyName,
+                json,
+                mappedCollection,
+                existingObject);
+        }
+        else
+        {
+            Throws_for_bad_JSON_value<TEntity, TModel>(
+                b => b.Entity<TEntity>().HasNoKey().Property(propertyName),
+                null,
+                propertyName,
+                json,
+                mappedCollection,
+                existingObject);
+        }
+    }
+
+    protected virtual void Throws_for_bad_JSON_property_value<TEntity, TModel>(
+        Action<PropertyBuilder> buildProperty,
+        string propertyName,
+        string json,
+        object? existingObject = null)
+        where TEntity : class
+        => Throws_for_bad_JSON_value<TEntity, TModel>(
+            b => buildProperty(b.Entity<TEntity>().HasNoKey().Property(propertyName)),
+            null,
+            propertyName,
+            json,
+            mappedCollection: false,
+            existingObject);
+
+    protected virtual void Throws_for_bad_JSON_value<TEntity, TModel>(
+        Action<ModelBuilder> buildModel,
+        Action<ModelConfigurationBuilder>? configureConventions,
+        string propertyName,
+        string json,
+        bool mappedCollection = false,
+        object? existingObject = null)
+        where TEntity : class
+    {
+        using var context = new SingleTypeDbContext(OnConfiguring, buildModel, configureConventions);
+        var property = context.Model.FindEntityType(typeof(TEntity))!.GetProperty(propertyName);
+
+        var jsonReaderWriter = property.GetJsonValueReaderWriter()
+            ?? property.GetTypeMapping().JsonValueReaderWriter!;
+
+        var buffer = Encoding.UTF8.GetBytes(json);
+        var readerManager = new Utf8JsonReaderManager(new JsonReaderData(buffer), null);
+
+        try
+        {
+            Assert.Equal(JsonTokenType.StartObject, readerManager.MoveNext());
+            Assert.Equal(JsonTokenType.PropertyName, readerManager.MoveNext());
+            readerManager.MoveNext();
+            jsonReaderWriter.FromJson(ref readerManager, existingObject);
+            Assert.Fail("Expected JSON deserialization to throw.");
+        }
+        catch (Exception e)
+        {
+            Assert.True(e is InvalidOperationException || e is JsonException || e is Newtonsoft.Json.JsonException);
+        }
+    }
+
+    protected class SingleTypeDbContext(
+            Action<DbContextOptionsBuilder> buildOptions,
+            Action<ModelBuilder> buildModel,
+            Action<ModelConfigurationBuilder>? configureConventions = null)
+        : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => buildOptions(optionsBuilder.ReplaceService<IModelCacheKeyFactory, DegenerateCacheKeyFactory>());
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => buildModel(modelBuilder);
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+            => configureConventions?.Invoke(configurationBuilder);
+
+        private class DegenerateCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _value;
+
+            public object Create(DbContext context, bool designTime)
+                => _value++;
+        }
+    }
+
+    protected virtual void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.ConfigureWarnings(
+            w => w.Ignore(
+                CoreEventId.MappedEntityTypeIgnoredWarning,
+                CoreEventId.MappedPropertyIgnoredWarning,
+                CoreEventId.MappedNavigationIgnoredWarning));
+}

--- a/test/EFCore.Specification.Tests/BadDataJsonDeserializationTestBase.cs
+++ b/test/EFCore.Specification.Tests/BadDataJsonDeserializationTestBase.cs
@@ -63,7 +63,6 @@ public abstract class BadDataJsonDeserializationTestBase
     [InlineData("""{"Prop":[-128,],23]}""")]
     [InlineData("""{"Prop":[-128,},23]}""")]
     [InlineData("""{"Prop":[-128,,23]}""")]
-    [InlineData("""{"Prop":[-128,,23]}""")]
     public virtual void Throws_for_bad_collection_of_sbyte_JSON_values(string json)
         => Throws_for_bad_JSON_value<Int8CollectionType, List<sbyte>>(
             nameof(Int8CollectionType.Int8),
@@ -80,7 +79,6 @@ public abstract class BadDataJsonDeserializationTestBase
     [InlineData("""{"Prop":[-128,{"P":127}]}""")]
     [InlineData("""{"Prop":[-128,],23]}""")]
     [InlineData("""{"Prop":[-128,},23]}""")]
-    [InlineData("""{"Prop":[-128,,23]}""")]
     [InlineData("""{"Prop":[-128,,23]}""")]
     public virtual void Throws_for_bad_collection_of_nullable_long_JSON_values(string json)
         => Throws_for_bad_JSON_value<NullableInt64CollectionType, List<long?>>(

--- a/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
@@ -452,7 +452,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableInt8Type
     {
-        public sbyte Int8 { get; set; }
+        public sbyte? Int8 { get; set; }
     }
 
     [ConditionalTheory]
@@ -466,7 +466,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableInt16Type
     {
-        public short Int16 { get; set; }
+        public short? Int16 { get; set; }
     }
 
     [ConditionalTheory]
@@ -480,7 +480,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableInt32Type
     {
-        public int Int32 { get; set; }
+        public int? Int32 { get; set; }
     }
 
     [ConditionalTheory]
@@ -494,7 +494,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableInt64Type
     {
-        public long Int64 { get; set; }
+        public long? Int64 { get; set; }
     }
 
     [ConditionalTheory]
@@ -507,7 +507,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableUInt8Type
     {
-        public byte UInt8 { get; set; }
+        public byte? UInt8 { get; set; }
     }
 
     [ConditionalTheory]
@@ -520,7 +520,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableUInt16Type
     {
-        public ushort UInt16 { get; set; }
+        public ushort? UInt16 { get; set; }
     }
 
     [ConditionalTheory]
@@ -533,7 +533,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableUInt32Type
     {
-        public uint UInt32 { get; set; }
+        public uint? UInt32 { get; set; }
     }
 
     [ConditionalTheory]
@@ -546,7 +546,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableUInt64Type
     {
-        public ulong UInt64 { get; set; }
+        public ulong? UInt64 { get; set; }
     }
 
     [ConditionalTheory]
@@ -560,7 +560,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableFloatType
     {
-        public float Float { get; set; }
+        public float? Float { get; set; }
     }
 
     [ConditionalTheory]
@@ -574,7 +574,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableDoubleType
     {
-        public double Double { get; set; }
+        public double? Double { get; set; }
     }
 
     [ConditionalTheory]
@@ -590,7 +590,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableDecimalType
     {
-        public decimal Decimal { get; set; }
+        public decimal? Decimal { get; set; }
     }
 
     [ConditionalTheory]
@@ -605,7 +605,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableDateOnlyType
     {
-        public DateOnly DateOnly { get; set; }
+        public DateOnly? DateOnly { get; set; }
     }
 
     [ConditionalTheory]
@@ -620,7 +620,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableTimeOnlyType
     {
-        public TimeOnly TimeOnly { get; set; }
+        public TimeOnly? TimeOnly { get; set; }
     }
 
     [ConditionalTheory]
@@ -635,7 +635,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableDateTimeType
     {
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
     }
 
     [ConditionalTheory]
@@ -651,7 +651,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableDateTimeOffsetType
     {
-        public DateTimeOffset DateTimeOffset { get; set; }
+        public DateTimeOffset? DateTimeOffset { get; set; }
     }
 
     [ConditionalTheory]
@@ -667,7 +667,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableTimeSpanType
     {
-        public TimeSpan TimeSpan { get; set; }
+        public TimeSpan? TimeSpan { get; set; }
     }
 
     [ConditionalTheory]
@@ -679,7 +679,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableBooleanType
     {
-        public bool Boolean { get; set; }
+        public bool? Boolean { get; set; }
     }
 
     [ConditionalTheory]
@@ -693,7 +693,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableCharacterType
     {
-        public char Character { get; set; }
+        public char? Character { get; set; }
     }
 
     [ConditionalTheory]
@@ -708,7 +708,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableGuidType
     {
-        public Guid Guid { get; set; }
+        public Guid? Guid { get; set; }
     }
 
     [ConditionalTheory]
@@ -794,7 +794,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullablePhysicalAddressType
     {
-        public PhysicalAddress PhysicalAddress { get; set; } = null!;
+        public PhysicalAddress? PhysicalAddress { get; set; } = null!;
     }
 
     [ConditionalTheory]
@@ -810,7 +810,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableEnum8Type
     {
-        public Enum8 Enum8 { get; set; }
+        public Enum8? Enum8 { get; set; }
     }
 
     [ConditionalTheory]
@@ -826,7 +826,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableEnum16Type
     {
-        public Enum16 Enum16 { get; set; }
+        public Enum16? Enum16 { get; set; }
     }
 
     [ConditionalTheory]
@@ -842,7 +842,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableEnum32Type
     {
-        public Enum32 Enum32 { get; set; }
+        public Enum32? Enum32 { get; set; }
     }
 
     [ConditionalTheory]
@@ -858,7 +858,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableEnum64Type
     {
-        public Enum64 Enum64 { get; set; }
+        public Enum64? Enum64 { get; set; }
     }
 
     [ConditionalTheory]
@@ -873,7 +873,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableEnumU8Type
     {
-        public EnumU8 EnumU8 { get; set; }
+        public EnumU8? EnumU8 { get; set; }
     }
 
     [ConditionalTheory]
@@ -888,7 +888,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableEnumU16Type
     {
-        public EnumU16 EnumU16 { get; set; }
+        public EnumU16? EnumU16 { get; set; }
     }
 
     [ConditionalTheory]
@@ -903,7 +903,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableEnumU32Type
     {
-        public EnumU32 EnumU32 { get; set; }
+        public EnumU32? EnumU32 { get; set; }
     }
 
     [ConditionalTheory]
@@ -918,7 +918,7 @@ public abstract class JsonTypesTestBase
 
     protected class NullableEnumU64Type
     {
-        public EnumU64 EnumU64 { get; set; }
+        public EnumU64? EnumU64 { get; set; }
     }
 
     [ConditionalTheory]
@@ -3725,13 +3725,11 @@ public abstract class JsonTypesTestBase
 
         public override Geometry FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
         {
-            var builder = new StringBuilder("{");
-            var depth = 1;
+            var builder = new StringBuilder();
+            var depth = 0;
             var comma = false;
-            while (depth > 0)
+            do
             {
-                manager.MoveNext();
-
                 switch (manager.CurrentReader.TokenType)
                 {
                     case JsonTokenType.EndObject:
@@ -3783,7 +3781,10 @@ public abstract class JsonTypesTestBase
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
+
+                manager.MoveNext();
             }
+            while (depth > 0);
 
             var serializer = GeoJsonSerializer.Create();
             using var stringReader = new StringReader(builder.ToString());

--- a/test/EFCore.SqlServer.FunctionalTests/BadDataJsonDeserializationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BadDataJsonDeserializationSqlServerTest.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class BadDataJsonDeserializationSqlServerTest : BadDataJsonDeserializationTestBase
+{
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => base.OnConfiguring(optionsBuilder.UseSqlServer(b => b.UseNetTopologySuite()));
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryAdHocSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryAdHocSqlServerTest.cs
@@ -128,6 +128,14 @@ N'{{""Name"":""r1"",""JunkCollection"":[{{""Foo"":""junk value""}}],""JunkRefere
 N'{{""MyBool"":true,""JunkCollection"":[{{""Foo"":""junk value""}}],""Name"":""r1 ctor"",""JunkReference"":{{""Something"":""SomeValue"" }},""NestedCollection"":[{{""DoB"":""2001-02-01T00:00:00""}},{{""DoB"":""2001-02-02T00:00:00""}}],""NestedReference"":{{""JunkCollection"":[{{""Foo"":""junk value""}}],""DoB"":""2001-01-01T00:00:00""}}}}',
 1)");
 
+    protected override void SeedTrickyBuffering(MyContextTrickyBuffering ctx)
+        => ctx.Database.ExecuteSqlRaw(
+"""
+INSERT INTO [Entities] ([Reference], [Id])
+VALUES(
+N'{{"Name": "r1", "Number": 7, "JunkReference":{{"Something": "SomeValue" }}, "JunkCollection": [{{"Foo": "junk value"}}], "NestedReference": {{"DoB": "2000-01-01T00:00:00"}}, "NestedCollection": [{{"DoB": "2000-02-01T00:00:00", "JunkReference": {{"Something": "SomeValue"}}}}, {{"DoB": "2000-02-02T00:00:00"}}]}}',1)
+""");
+
     protected override void SeedShadowProperties(MyContextShadowProperties ctx)
         => ctx.Database.ExecuteSqlRaw(
             @"INSERT INTO [Entities] ([Collection], [CollectionWithCtor], [Reference], [ReferenceWithCtor], [Id], [Name])

--- a/test/EFCore.Sqlite.FunctionalTests/BadDataJsonDeserializationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BadDataJsonDeserializationSqliteTest.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore;
+
+public class BadDataJsonDeserializationSqliteTest : BadDataJsonDeserializationTestBase
+{
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => base.OnConfiguring(optionsBuilder.UseSqlite(b => b.UseNetTopologySuite()));
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/JsonQueryAdHocSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/JsonQueryAdHocSqliteTest.cs
@@ -124,6 +124,14 @@ VALUES(
 '{{""MyBool"":true,""JunkCollection"":[{{""Foo"":""junk value""}}],""Name"":""r1 ctor"",""JunkReference"":{{""Something"":""SomeValue"" }},""NestedCollection"":[{{""DoB"":""2001-02-01T00:00:00""}},{{""DoB"":""2001-02-02T00:00:00""}}],""NestedReference"":{{""JunkCollection"":[{{""Foo"":""junk value""}}],""DoB"":""2001-01-01T00:00:00""}}}}',
 1)");
 
+    protected override void SeedTrickyBuffering(MyContextTrickyBuffering ctx)
+        => ctx.Database.ExecuteSqlRaw(
+"""
+INSERT INTO "Entities" ("Reference", "Id")
+VALUES(
+'{{"Name": "r1", "Number": 7, "JunkReference":{{"Something": "SomeValue" }}, "JunkCollection": [{{"Foo": "junk value"}}], "NestedReference": {{"DoB": "2000-01-01T00:00:00"}}, "NestedCollection": [{{"DoB": "2000-02-01T00:00:00", "JunkReference": {{"Something": "SomeValue"}}}}, {{"DoB": "2000-02-02T00:00:00"}}]}}',1)
+""");
+
     protected override void SeedShadowProperties(MyContextShadowProperties ctx)
         => ctx.Database.ExecuteSqlRaw(
             @"INSERT INTO ""Entities"" (""Collection"", ""CollectionWithCtor"", ""Reference"", ""ReferenceWithCtor"", ""Id"", ""Name"")


### PR DESCRIPTION
Fixes #32235
Fixes #32194

**Description**
When skipping unmapped json property make sure we skip it correctly (i.e. entire property is in the buffer), otherwise expand the buffer, read more and try again. Also, when materializing json collections, throw when unexpected token is encountered.

**Customer impact**
This can cause bugs when materializing entities mapped to JSON, if the JSON contains unmapped properties (junk data). Because we incorrectly skip those in some cases, we may end up in invalid state when streaming the results.

**How found**
Found by EF Core team member when implementing support for postgres.

**Regression**
Yes.

**Testing**
Added tests.

**Risk**
Low: we use the same mechanism for skipping as we do for regular reads and that works without issue. Also improved robustness of the code in other places, by throwing exceptions if somehow we end up in bad state regardless. Added quirk just in case.