### PR TITLE
[release/8.0] Visit arguments in QueryableMethodNormalizingExpressionVisitor after converting List.Contains (#32219)

### DIFF
--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -807,12 +807,26 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
             },
             assertOrder: true);
 
-    [ConditionalTheory] // #32208
+    [ConditionalTheory] // #32208, #32215
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_contains_with_Lists_and_no_inferred_type_mapping(bool async)
     {
         var ints = new List<int> { 1, 2, 3 };
         var strings = new List<string> { "one", "two", "three" };
+
+        // Note that in this query, the outer Contains really has no type mapping, neither for its source (collection parameter), nor
+        // for its item (the conditional expression returns constants). The default type mapping must be applied.
+        return AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(e => strings.Contains(ints.Contains(e.Int) ? "one" : "two")));
+    }
+
+    [ConditionalTheory] // #32208, #32215
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Nested_contains_with_arrays_and_no_inferred_type_mapping(bool async)
+    {
+        var ints = new[] { 1, 2, 3 };
+        var strings = new[] { "one", "two", "three" };
 
         // Note that in this query, the outer Contains really has no type mapping, neither for its source (collection parameter), nor
         // for its item (the conditional expression returns constants). The default type mapping must be applied.

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -625,6 +625,21 @@ END IN (N'one', N'two', N'three')
 """);
     }
 
+    public override async Task Nested_contains_with_arrays_and_no_inferred_type_mapping(bool async)
+    {
+        await base.Nested_contains_with_arrays_and_no_inferred_type_mapping(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE CASE
+    WHEN [p].[Int] IN (1, 2, 3) THEN N'one'
+    ELSE N'two'
+END IN (N'one', N'two', N'three')
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -1233,12 +1233,40 @@ ORDER BY [p].[Id]
 
         AssertSql(
             """
+@__ints_1='[1,2,3]' (Size = 4000)
 @__strings_0='["one","two","three"]' (Size = 4000)
 
 SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
 FROM [PrimitiveCollectionsEntity] AS [p]
 WHERE CASE
-    WHEN [p].[Int] IN (1, 2, 3) THEN N'one'
+    WHEN [p].[Int] IN (
+        SELECT [i].[value]
+        FROM OPENJSON(@__ints_1) WITH ([value] int '$') AS [i]
+    ) THEN N'one'
+    ELSE N'two'
+END IN (
+    SELECT [s].[value]
+    FROM OPENJSON(@__strings_0) WITH ([value] nvarchar(max) '$') AS [s]
+)
+""");
+    }
+
+    public override async Task Nested_contains_with_arrays_and_no_inferred_type_mapping(bool async)
+    {
+        await base.Nested_contains_with_arrays_and_no_inferred_type_mapping(async);
+
+        AssertSql(
+            """
+@__ints_1='[1,2,3]' (Size = 4000)
+@__strings_0='["one","two","three"]' (Size = 4000)
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE CASE
+    WHEN [p].[Int] IN (
+        SELECT [i].[value]
+        FROM OPENJSON(@__ints_1) WITH ([value] int '$') AS [i]
+    ) THEN N'one'
     ELSE N'two'
 END IN (
     SELECT [s].[value]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3982,13 +3982,17 @@ WHERE [r].[MyTime] IN (
 
             AssertSql(
                 """
+@__todoTypes_1='[0]' (Size = 4000)
 @__key_2='5f221fb9-66f4-442a-92c9-d97ed5989cc7'
 @__keys_0='["0a47bcb7-a1cb-4345-8944-c58f82d6aac7","5f221fb9-66f4-442a-92c9-d97ed5989cc7"]' (Size = 4000)
 
 SELECT [t].[Id], [t].[Type]
 FROM [Todos] AS [t]
 WHERE CASE
-    WHEN [t].[Type] = 0 THEN @__key_2
+    WHEN [t].[Type] IN (
+        SELECT [t0].[value]
+        FROM OPENJSON(@__todoTypes_1) WITH ([value] int '$') AS [t0]
+    ) THEN @__key_2
     ELSE @__key_2
 END IN (
     SELECT [k].[value]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -1115,12 +1115,40 @@ ORDER BY "p"."Id"
 
         AssertSql(
             """
+@__ints_1='[1,2,3]' (Size = 7)
 @__strings_0='["one","two","three"]' (Size = 21)
 
 SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
 FROM "PrimitiveCollectionsEntity" AS "p"
 WHERE CASE
-    WHEN "p"."Int" IN (1, 2, 3) THEN 'one'
+    WHEN "p"."Int" IN (
+        SELECT "i"."value"
+        FROM json_each(@__ints_1) AS "i"
+    ) THEN 'one'
+    ELSE 'two'
+END IN (
+    SELECT "s"."value"
+    FROM json_each(@__strings_0) AS "s"
+)
+""");
+    }
+
+    public override async Task Nested_contains_with_arrays_and_no_inferred_type_mapping(bool async)
+    {
+        await base.Nested_contains_with_arrays_and_no_inferred_type_mapping(async);
+
+        AssertSql(
+            """
+@__ints_1='[1,2,3]' (Size = 7)
+@__strings_0='["one","two","three"]' (Size = 21)
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE CASE
+    WHEN "p"."Int" IN (
+        SELECT "i"."value"
+        FROM json_each(@__ints_1) AS "i"
+    ) THEN 'one'
     ELSE 'two'
 END IN (
     SELECT "s"."value"


### PR DESCRIPTION
Fixes #32215 and #32218, backports #32219

(cherry picked from commit 08ee676693bcc5910fc5f632f15704fc974ced3b)

### Description

1. When converting List.Contains() to Queryable.Contains() in preprocessing, QueryableMethodNormalizingExpressionVisitor does not visit into the instance/arguments of the expressions. As a result, normalization does not happen recursively.
2. When identifying Contains for legacy pre-8.0-style translation (expansion of parameter list to constants in SQL), if AsQueryable() as composed over the parameter list, the construct isn't identified and translation fails.

The two bugs are fixed in the same PR as fixing the 1st exposes the 2nd.

### Customer impact

The 1st bug can affect any LINQ query containins List.Contains(); if either the instance or the argument requires normalization, that normalization won't occur and query translation will likely fail. This can affect an unknown number of queries.

### How found

Customer reported on 8.0

### Regression

Yes.

### Testing

Added tests.

### Risk

Very low; separate quirks for both bugs have been added.