### PR TITLE
[release/8.0] Stop throwing for complex type properties when sensitive data logging is on

### DIFF
--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -2143,7 +2143,7 @@ public static class CoreLoggerExtensions
                 property.Name,
                 oldValue,
                 newValue,
-                internalEntityEntry.BuildCurrentValuesString(((IEntityType)property.DeclaringType).FindPrimaryKey()!.Properties));
+                internalEntityEntry.BuildCurrentValuesString(property.DeclaringType.ContainingEntityType.FindPrimaryKey()!.Properties));
         }
 
         if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -2170,7 +2170,7 @@ public static class CoreLoggerExtensions
             p.OldValue,
             p.NewValue,
             p.EntityEntry.GetInfrastructure().BuildCurrentValuesString(
-                ((IEntityType)p.Property.DeclaringType).FindPrimaryKey()!.Properties));
+                p.Property.DeclaringType.ContainingEntityType.FindPrimaryKey()!.Properties));
     }
 
     /// <summary>
@@ -2246,7 +2246,7 @@ public static class CoreLoggerExtensions
                 property.Name,
                 oldValue,
                 newValue,
-                internalEntityEntry.BuildCurrentValuesString(((IEntityType)property.DeclaringType).FindPrimaryKey()!.Properties));
+                internalEntityEntry.BuildCurrentValuesString(property.DeclaringType.ContainingEntityType.FindPrimaryKey()!.Properties));
         }
 
         if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -2273,7 +2273,7 @@ public static class CoreLoggerExtensions
             p.OldValue,
             p.NewValue,
             p.EntityEntry.GetInfrastructure().BuildCurrentValuesString(
-                ((IEntityType)p.Property.DeclaringType).FindPrimaryKey()!.Properties));
+                p.Property.DeclaringType.ContainingEntityType.FindPrimaryKey()!.Properties));
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/32198

### Description

Property instances can now belong to complex types, which is a new feature in 8.0. However, logging of a change made to such a property incorrectly assumes the property must be on an entity type.

### Customer impact

Exception when using new feature in 8.0 when sensitive data logging is turned on, which is common.

### How found

Customer reported on 8.0 RC

### Regression

No; complex types are a new feature in 8.0

### Testing

Added tests.

### Risk

Very low; fixing an invalid cast.