### PR TITLE
Fix to #29902 - Renaming PeriodStart and PeriodEnd columns of a temporal table causes them to be swapped

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -8429,7 +8429,7 @@ EXEC sp_rename N'[CustomersHistory]', N'HistoryTable';
 """);
     }
 
-    [ConditionalFact(Skip = "issue #29902")]
+    [ConditionalFact]
     public virtual async Task Change_names_of_period_columns_in_temporal_table()
     {
         await Test(


### PR DESCRIPTION
Problem was that migration model differ was too lax with pairing up columns. Fix is to add more predicates - one that matches annotations+values and one that just matches annotations, ignoring the values, before we fallback to simple column definition. Now that we reworked temporal annotations, this actually gives clean match for the period start and period end column. Moreover, this change could improve matching in other, non-temporal scenarios.

Fixes #29902