### PR TITLE
[release/7.0] Fix to #31448 Use token for NonQueryResultAsync (#31449)

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -200,7 +200,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                                 state.commandSource),
                             cancellationToken);
                     },
-                    null);
+                    null,
+                    relationalQueryContext.CancellationToken);
             }
             finally
             {


### PR DESCRIPTION
Fixes #31448, backports #31449

**Description**
The user-provided cancellation token was not being flown down for ExecuteUpdate/Delete operations.

**Customer impact**
When using ExecuteUpdate/Delete, triggering the cancellation token wouldn't affect the operation at all. This means that the program could hang indefinitely, e.g. in case of a network partition.

**How found**
Found by a customer.

**Regression**
No.

**Testing**
None.

**Risk**
Extremely low, just flows the cancellation token through.