### PR TITLE
Work on LEAST/GREATEST, Math.Min/Max

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDbFunctionsExtensions.cs
@@ -36,4 +36,24 @@ public static class RelationalDbFunctionsExtensions
         TProperty operand,
         [NotParameterized] string collation)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Collate)));
+
+    /// <summary>
+    ///     Returns the smallest value from the given list of values. Usually corresponds to the <c>LEAST</c> SQL function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The list of values from which return the smallest value.</param>
+    public static T Least<T>(
+        this DbFunctions _,
+        [NotParameterized] params T[] values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Least)));
+
+    /// <summary>
+    ///     Returns the greatest value from the given list of values. Usually corresponds to the <c>GREATEST</c> SQL function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The list of values from which return the greatest value.</param>
+    public static T Greatest<T>(
+        this DbFunctions _,
+        [NotParameterized] params T[] values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Greatest)));
 }

--- a/src/EFCore.Relational/Query/ExpressionExtensions.cs
+++ b/src/EFCore.Relational/Query/ExpressionExtensions.cs
@@ -34,4 +34,23 @@ public static class ExpressionExtensions
 
         return null;
     }
+
+    /// <summary>
+    ///     Infers type mapping from given <see cref="SqlExpression" />s.
+    /// </summary>
+    /// <param name="expressions">Expressions to search for to find the type mapping.</param>
+    /// <returns>A relational type mapping inferred from the expressions.</returns>
+    public static RelationalTypeMapping? InferTypeMapping(IReadOnlyList<SqlExpression> expressions)
+    {
+        for (var i = 0; i < expressions.Count; i++)
+        {
+            var sql = expressions[i];
+            if (sql.TypeMapping != null)
+            {
+                return sql.TypeMapping;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -483,4 +483,30 @@ public interface ISqlExpressionFactory
     /// <param name="tableExpressionBase">A table source to project from.</param>
     /// <returns>An expression representing a SELECT in a SQL tree.</returns>
     SelectExpression Select(IEntityType entityType, TableExpressionBase tableExpressionBase);
+
+    /// <summary>
+    ///     Attempts to creates a new expression that returns the smallest value from a list of expressions, e.g. an invocation of the
+    ///     <c>LEAST</c> SQL function.
+    /// </summary>
+    /// <param name="expressions">An entity type to project.</param>
+    /// <param name="resultType">The result CLR type for the returned expression.</param>
+    /// <param name="leastExpression">The expression which computes the smallest value.</param>
+    /// <returns><see langword="true" /> if the expression could be created, <see langword="false" /> otherwise.</returns>
+    bool TryCreateLeast(
+        IReadOnlyList<SqlExpression> expressions,
+        Type resultType,
+        [NotNullWhen(true)] out SqlExpression? leastExpression);
+
+    /// <summary>
+    ///     Attempts to creates a new expression that returns the greatest value from a list of expressions, e.g. an invocation of the
+    ///     <c>GREATEST</c> SQL function.
+    /// </summary>
+    /// <param name="expressions">An entity type to project.</param>
+    /// <param name="resultType">The result CLR type for the returned expression.</param>
+    /// <param name="greatestExpression">The expression which computes the greatest value.</param>
+    /// <returns><see langword="true" /> if the expression could be created, <see langword="false" /> otherwise.</returns>
+    bool TryCreateGreatest(
+        IReadOnlyList<SqlExpression> expressions,
+        Type resultType,
+        [NotNullWhen(true)] out SqlExpression? greatestExpression);
 }

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -675,6 +675,30 @@ public class SqlExpressionFactory : ISqlExpressionFactory
         return selectExpression;
     }
 
+    /// <inheritdoc />
+    public virtual bool TryCreateLeast(
+        IReadOnlyList<SqlExpression> expressions,
+        Type resultType,
+        [NotNullWhen(true)] out SqlExpression? leastExpression)
+    {
+        var resultTypeMapping = ExpressionExtensions.InferTypeMapping(expressions);
+        leastExpression = Function(
+            "LEAST", expressions, nullable: true, Enumerable.Repeat(true, expressions.Count), resultType, resultTypeMapping);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public virtual bool TryCreateGreatest(
+        IReadOnlyList<SqlExpression> expressions,
+        Type resultType,
+        [NotNullWhen(true)] out SqlExpression? greatestExpression)
+    {
+        var resultTypeMapping = ExpressionExtensions.InferTypeMapping(expressions);
+        greatestExpression = Function(
+            "GREATEST", expressions, nullable: true, Enumerable.Repeat(true, expressions.Count), resultType, resultTypeMapping);
+        return true;
+    }
+
     /***
      * We need to add additional conditions on basic SelectExpression for certain cases
      * - If we are selecting from TPH then we need to add condition for discriminator if mapping is incomplete

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -148,6 +148,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 key1, entityType1, key2, entityType2, table, keyName);
 
         /// <summary>
+        ///     This usage of Math.Min or Math.Max requires SQL Server functions LEAST and GREATEST, which require compatibility level 160.
+        /// </summary>
+        public static string LeastGreatestCompatibilityLevelTooLow
+            => GetString("LeastGreatestCompatibilityLevelTooLow");
+
+        /// <summary>
         ///     Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.
         /// </summary>
         public static string IdentityBadType(object? property, object? entityType, object? propertyType)

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -165,6 +165,9 @@
   <data name="DuplicateKeyMismatchedClustering" xml:space="preserve">
     <value>The keys {key1} on '{entityType1}' and {key2} on '{entityType2}' are both mapped to '{table}.{keyName}', but have different clustering configurations.</value>
   </data>
+  <data name="LeastGreatestCompatibilityLevelTooLow" xml:space="preserve">
+    <value>This usage of Math.Min or Math.Max requires SQL Server functions LEAST and GREATEST, which require compatibility level 160.</value>
+  </data>
   <data name="IdentityBadType" xml:space="preserve">
     <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.</value>
   </data>

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMathTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMathTranslator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using ExpressionExtensions = Microsoft.EntityFrameworkCore.Query.ExpressionExtensions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
@@ -184,6 +186,31 @@ public class SqlServerMathTranslator : IMethodCallTranslator
             }
 
             return _sqlExpressionFactory.ApplyTypeMapping(result, argument.TypeMapping);
+        }
+
+        if (method.DeclaringType == typeof(Math))
+        {
+            if (method.Name == nameof(Math.Min))
+            {
+                if (_sqlExpressionFactory.TryCreateLeast(
+                        new[] { arguments[0], arguments[1] }, method.ReturnType, out var leastExpression))
+                {
+                    return leastExpression;
+                }
+
+                throw new InvalidOperationException(SqlServerStrings.LeastGreatestCompatibilityLevelTooLow);
+            }
+
+            if (method.Name == nameof(Math.Max))
+            {
+                if (_sqlExpressionFactory.TryCreateGreatest(
+                        new[] { arguments[0], arguments[1] }, method.ReturnType, out var leastExpression))
+                {
+                    return leastExpression;
+                }
+
+                throw new InvalidOperationException(SqlServerStrings.LeastGreatestCompatibilityLevelTooLow);
+            }
         }
 
         return null;

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteMathTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteMathTranslator.cs
@@ -37,24 +37,6 @@ public class SqliteMathTranslator : IMethodCallTranslator
         { typeof(Math).GetMethod(nameof(Math.Log), new[] { typeof(double) })!, "ln" },
         { typeof(Math).GetMethod(nameof(Math.Log2), new[] { typeof(double) })!, "log2" },
         { typeof(Math).GetMethod(nameof(Math.Log10), new[] { typeof(double) })!, "log10" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(byte), typeof(byte) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(double), typeof(double) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(float), typeof(float) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(int), typeof(int) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(long), typeof(long) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(sbyte), typeof(sbyte) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(short), typeof(short) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(uint), typeof(uint) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(ushort), typeof(ushort) })!, "max" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(byte), typeof(byte) })!, "min" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(double), typeof(double) })!, "min" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(float), typeof(float) })!, "min" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(int), typeof(int) })!, "min" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(long), typeof(long) })!, "min" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(sbyte), typeof(sbyte) })!, "min" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(short), typeof(short) })!, "min" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(uint), typeof(uint) })!, "min" },
-        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(ushort), typeof(ushort) })!, "min" },
         { typeof(Math).GetMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) })!, "pow" },
         { typeof(Math).GetMethod(nameof(Math.Round), new[] { typeof(double) })!, "round" },
         { typeof(Math).GetMethod(nameof(Math.Sign), new[] { typeof(double) })!, "sign" },
@@ -177,6 +159,25 @@ public class SqliteMathTranslator : IMethodCallTranslator
                 argumentsPropagateNullability: new[] { true, true },
                 method.ReturnType,
                 typeMapping);
+        }
+
+        if (method.DeclaringType == typeof(Math))
+        {
+            if (method.Name == nameof(Math.Min))
+            {
+                var success = _sqlExpressionFactory.TryCreateLeast(
+                    new[] { arguments[0], arguments[1] }, method.ReturnType, out var leastExpression);
+                Check.DebugAssert(success, "Couldn't generate min");
+                return leastExpression;
+            }
+
+            if (method.Name == nameof(Math.Max))
+            {
+                var success = _sqlExpressionFactory.TryCreateGreatest(
+                    new[] { arguments[0], arguments[1] }, method.ReturnType, out var leastExpression);
+                Check.DebugAssert(success, "Couldn't generate max");
+                return leastExpression;
+            }
         }
 
         return null;

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlExpressionFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlExpressionFactory.cs
@@ -184,4 +184,28 @@ public class SqliteSqlExpressionFactory : SqlExpressionFactory
             ? new RegexpExpression(match, pattern, _boolTypeMapping)
             : regexpExpression;
     }
+
+    /// <inheritdoc />
+    public override bool TryCreateLeast(
+        IReadOnlyList<SqlExpression> expressions,
+        Type resultType,
+        [NotNullWhen(true)] out SqlExpression? leastExpression)
+    {
+        var resultTypeMapping = ExpressionExtensions.InferTypeMapping(expressions);
+        leastExpression = Function(
+            "min", expressions, nullable: true, Enumerable.Repeat(true, expressions.Count), resultType, resultTypeMapping);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool TryCreateGreatest(
+        IReadOnlyList<SqlExpression> expressions,
+        Type resultType,
+        [NotNullWhen(true)] out SqlExpression? greatestExpression)
+    {
+        var resultTypeMapping = ExpressionExtensions.InferTypeMapping(expressions);
+        greatestExpression = Function(
+            "max", expressions, nullable: true, Enumerable.Repeat(true, expressions.Count), resultType, resultTypeMapping);
+        return true;
+    }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -593,7 +593,39 @@ WHERE (((c["Discriminator"] = "OrderDetail") AND (c["OrderID"] = 11077)) AND (SI
         AssertSql();
     }
 
+    public override async Task Where_math_min_nested(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_min(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_math_min_nested_twice(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_min(async));
+
+        AssertSql();
+    }
+
     public override async Task Where_math_max(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_max(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_math_max_nested(bool async)
+    {
+        // Cosmos client evaluation. Issue #17246.
+        await AssertTranslationFailed(() => base.Where_math_max(async));
+
+        AssertSql();
+    }
+
+    public override async Task Where_math_max_nested_twice(bool async)
     {
         // Cosmos client evaluation. Issue #17246.
         await AssertTranslationFailed(() => base.Where_math_max(async));

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindFunctionsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindFunctionsQueryRelationalTestBase.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class NorthwindFunctionsQueryRelationalTestBase<TFixture> : NorthwindFunctionsQueryTestBase<TFixture>

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalNorthwindDbFunctionsQueryTestBase.cs
@@ -50,6 +50,48 @@ public abstract class NorthwindDbFunctionsQueryRelationalTestBase<TFixture> : No
             c => c.ContactName == EF.Functions.Collate("maria anders", CaseSensitiveCollation),
             c => c.ContactName.Equals("maria anders", StringComparison.Ordinal));
 
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Least(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>().Where(od => EF.Functions.Least(od.OrderID, 10251) == 10251),
+            ss => ss.Set<OrderDetail>().Where(od => Math.Min(od.OrderID, 10251) == 10251));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Greatest(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>().Where(od => EF.Functions.Greatest(od.OrderID, 10251) == 10251),
+            ss => ss.Set<OrderDetail>().Where(od => Math.Max(od.OrderID, 10251) == 10251));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Least_with_parameter_array_is_not_supported(bool async)
+    {
+        var arr = new[] { 1, 2 };
+
+        await AssertTranslationFailed(
+            () =>
+                AssertQuery(
+                    async,
+                    ss => ss.Set<OrderDetail>().Where(od => EF.Functions.Least(arr) == 10251)));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Greatest_with_parameter_array_is_not_supported(bool async)
+    {
+        var arr = new[] { 1, 2 };
+
+        await AssertTranslationFailed(
+            () =>
+                AssertQuery(
+                    async,
+                    ss => ss.Set<OrderDetail>().Where(od => EF.Functions.Greatest(arr) == 10251)));
+    }
+
     protected abstract string CaseInsensitiveCollation { get; }
     protected abstract string CaseSensitiveCollation { get; }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -1027,11 +1027,43 @@ public abstract class NorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual Task Where_math_max_nested(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID == 11077)
+                .Where(od => Math.Max(od.OrderID, Math.Max(od.ProductID, 1)) == od.OrderID));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Where_math_max_nested_twice(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID == 11077)
+                .Where(od => Math.Max(Math.Max(1, Math.Max(od.OrderID, 2)), od.ProductID) == od.OrderID));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Where_math_min(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<OrderDetail>().Where(od => od.OrderID == 11077)
                 .Where(od => Math.Min(od.OrderID, od.ProductID) == od.ProductID));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Where_math_min_nested(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID == 11077)
+                .Where(od => Math.Min(od.OrderID, Math.Min(od.ProductID, 99999)) == od.ProductID));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Where_math_min_nested_twice(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID == 11077)
+                .Where(od => Math.Min(Math.Min(99999, Math.Min(od.OrderID, 99998)), od.ProductID) == od.ProductID));
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -156,6 +156,42 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Inline_collection_Min_with_two_values(bool async)
+        => await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 30, c.Int }.Min() == 30));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Inline_collection_Max_with_two_values(bool async)
+        => await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 30, c.Int }.Max() == 30));
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Inline_collection_Min_with_three_values(bool async)
+    {
+        var i = 25;
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 30, c.Int, i }.Min() == 25));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Inline_collection_Max_with_three_values(bool async)
+    {
+        var i = 35;
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => new[] { 30, c.Int, i }.Max() == 35));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public virtual Task Parameter_collection_Count(bool async)
     {
         var ids = new[] { 2, 999 };

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3061,13 +3061,14 @@ ORDER BY [i].[Id], [i0].[Id], [i1].[Id], [i2].[Id], [t].[Id], [t].[Id0]
 """);
     }
 
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
     public override async Task Nav_rewrite_doesnt_apply_null_protection_for_function_arguments(bool async)
     {
         await base.Nav_rewrite_doesnt_apply_null_protection_for_function_arguments(async);
 
         AssertSql(
             """
-SELECT [l0].[Level1_Required_Id]
+SELECT GREATEST([l0].[Level1_Required_Id], 7)
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToOne_Optional_PK_Inverse2Id]
 WHERE [l0].[Id] IS NOT NULL

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -6461,13 +6461,14 @@ WHERE (
 """);
     }
 
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
     public override async Task Nav_rewrite_doesnt_apply_null_protection_for_function_arguments(bool async)
     {
         await base.Nav_rewrite_doesnt_apply_null_protection_for_function_arguments(async);
 
         AssertSql(
             """
-SELECT [t].[Level1_Required_Id]
+SELECT GREATEST([t].[Level1_Required_Id], 7)
 FROM [Level1] AS [l]
 LEFT JOIN (
     SELECT [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Required_Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
@@ -119,6 +119,46 @@ WHERE [c].[ContactName] = N'maria anders' COLLATE Latin1_General_CS_AS
 """);
     }
 
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Least(bool async)
+    {
+        await base.Least(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE LEAST([o].[OrderID], 10251) = 10251
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Greatest(bool async)
+    {
+        await base.Greatest(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE GREATEST([o].[OrderID], 10251) = 10251
+""");
+    }
+
+    public override async Task Least_with_parameter_array_is_not_supported(bool async)
+    {
+        await base.Least_with_parameter_array_is_not_supported(async);
+
+        AssertSql();
+    }
+
+    public override async Task Greatest_with_parameter_array_is_not_supported(bool async)
+    {
+        await base.Greatest_with_parameter_array_is_not_supported(async);
+
+        AssertSql();
+    }
+
     protected override string CaseInsensitiveCollation
         => "Latin1_General_CI_AI";
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1333,20 +1333,30 @@ WHERE [o].[OrderID] = 11077 AND SIGN([o].[Discount]) > 0
 """);
     }
 
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
     public override async Task Where_math_min(bool async)
     {
-        // Translate Math.Min.
-        await AssertTranslationFailed(() => base.Where_math_min(async));
+        await base.Where_math_min(async);
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE [o].[OrderID] = 11077 AND LEAST([o].[OrderID], [o].[ProductID]) = [o].[ProductID]
+""");
     }
 
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
     public override async Task Where_math_max(bool async)
     {
-        // Translate Math.Max.
-        await AssertTranslationFailed(() => base.Where_math_max(async));
+        await base.Where_math_max(async);
 
-        AssertSql();
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE [o].[OrderID] = 11077 AND GREATEST([o].[OrderID], [o].[ProductID]) = [o].[OrderID]
+""");
     }
 
     public override async Task Where_math_degrees(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1347,6 +1347,32 @@ WHERE [o].[OrderID] = 11077 AND LEAST([o].[OrderID], [o].[ProductID]) = [o].[Pro
     }
 
     [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Where_math_min_nested(bool async)
+    {
+        await base.Where_math_min_nested(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE [o].[OrderID] = 11077 AND LEAST([o].[OrderID], [o].[ProductID], 99999) = [o].[ProductID]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Where_math_min_nested_twice(bool async)
+    {
+        await base.Where_math_min_nested_twice(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE [o].[OrderID] = 11077 AND LEAST(99999, [o].[OrderID], 99998, [o].[ProductID]) = [o].[ProductID]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
     public override async Task Where_math_max(bool async)
     {
         await base.Where_math_max(async);
@@ -1356,6 +1382,32 @@ WHERE [o].[OrderID] = 11077 AND LEAST([o].[OrderID], [o].[ProductID]) = [o].[Pro
 SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
 WHERE [o].[OrderID] = 11077 AND GREATEST([o].[OrderID], [o].[ProductID]) = [o].[OrderID]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Where_math_max_nested(bool async)
+    {
+        await base.Where_math_max_nested(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE [o].[OrderID] = 11077 AND GREATEST([o].[OrderID], [o].[ProductID], 1) = [o].[OrderID]
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Where_math_max_nested_twice(bool async)
+    {
+        await base.Where_math_max_nested_twice(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE [o].[OrderID] = 11077 AND GREATEST(1, [o].[OrderID], 2, [o].[ProductID]) = [o].[OrderID]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -238,6 +238,66 @@ WHERE [p].[Id] NOT IN (2, 999)
 """);
     }
 
+    public override async Task Inline_collection_Min_with_two_values(bool async)
+    {
+        await base.Inline_collection_Min_with_two_values(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT MIN([v].[Value])
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int])) AS [v]([Value])) = 30
+""");
+    }
+
+    public override async Task Inline_collection_Max_with_two_values(bool async)
+    {
+        await base.Inline_collection_Max_with_two_values(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT MAX([v].[Value])
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int])) AS [v]([Value])) = 30
+""");
+    }
+
+    public override async Task Inline_collection_Min_with_three_values(bool async)
+    {
+        await base.Inline_collection_Min_with_three_values(async);
+
+        AssertSql(
+            """
+@__i_0='25'
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT MIN([v].[Value])
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 25
+""");
+    }
+
+    public override async Task Inline_collection_Max_with_three_values(bool async)
+    {
+        await base.Inline_collection_Max_with_three_values(async);
+
+        AssertSql(
+            """
+@__i_0='35'
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE (
+    SELECT MAX([v].[Value])
+    FROM (VALUES (CAST(30 AS int)), ([p].[Int]), (@__i_0)) AS [v]([Value])) = 35
+""");
+    }
+
     public override Task Parameter_collection_Count(bool async)
         => AssertCompatibilityLevelTooLow(() => base.Parameter_collection_Count(async));
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -230,6 +230,62 @@ WHERE [p].[Id] NOT IN (2, 999)
 """);
     }
 
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Inline_collection_Min_with_two_values(bool async)
+    {
+        await base.Inline_collection_Min_with_two_values(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE LEAST(30, [p].[Int]) = 30
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Inline_collection_Max_with_two_values(bool async)
+    {
+        await base.Inline_collection_Max_with_two_values(async);
+
+        AssertSql(
+            """
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE GREATEST(30, [p].[Int]) = 30
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Inline_collection_Min_with_three_values(bool async)
+    {
+        await base.Inline_collection_Min_with_three_values(async);
+
+        AssertSql(
+            """
+@__i_0='25'
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE LEAST(30, [p].[Int], @__i_0) = 25
+""");
+    }
+
+    [SqlServerCondition(SqlServerCondition.SupportsFunctions2022)]
+    public override async Task Inline_collection_Max_with_three_values(bool async)
+    {
+        await base.Inline_collection_Max_with_three_values(async);
+
+        AssertSql(
+            """
+@__i_0='35'
+
+SELECT [p].[Id], [p].[Bool], [p].[Bools], [p].[DateTime], [p].[DateTimes], [p].[Enum], [p].[Enums], [p].[Int], [p].[Ints], [p].[NullableInt], [p].[NullableInts], [p].[NullableString], [p].[NullableStrings], [p].[String], [p].[Strings]
+FROM [PrimitiveCollectionsEntity] AS [p]
+WHERE GREATEST(30, [p].[Int], @__i_0) = 35
+""");
+    }
+
     public override async Task Parameter_collection_Count(bool async)
     {
         await base.Parameter_collection_Count(async);

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
@@ -16,8 +16,9 @@ public enum SqlServerCondition
     SupportsOnlineIndexes = 1 << 7,
     SupportsTemporalTablesCascadeDelete = 1 << 8,
     SupportsUtf8 = 1 << 9,
-    SupportsFunctions2019 = 1 << 10,
-    SupportsFunctions2017 = 1 << 11,
-    SupportsJsonPathExpressions = 1 << 12,
-    SupportsSqlClr = 1 << 13,
+    SupportsJsonPathExpressions = 1 << 10,
+    SupportsSqlClr = 1 << 11,
+    SupportsFunctions2017 = 1 << 12,
+    SupportsFunctions2019 = 1 << 13,
+    SupportsFunctions2022 = 1 << 14,
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
@@ -72,16 +72,6 @@ public sealed class SqlServerConditionAttribute : Attribute, ITestCondition
             isMet &= TestEnvironment.IsUtf8Supported;
         }
 
-        if (Conditions.HasFlag(SqlServerCondition.SupportsFunctions2019))
-        {
-            isMet &= TestEnvironment.IsFunctions2019Supported;
-        }
-
-        if (Conditions.HasFlag(SqlServerCondition.SupportsFunctions2017))
-        {
-            isMet &= TestEnvironment.IsFunctions2017Supported;
-        }
-
         if (Conditions.HasFlag(SqlServerCondition.SupportsJsonPathExpressions))
         {
             isMet &= TestEnvironment.SupportsJsonPathExpressions;
@@ -90,6 +80,21 @@ public sealed class SqlServerConditionAttribute : Attribute, ITestCondition
         if (Conditions.HasFlag(SqlServerCondition.SupportsSqlClr))
         {
             isMet &= TestEnvironment.IsSqlClrSupported;
+        }
+
+        if (Conditions.HasFlag(SqlServerCondition.SupportsFunctions2017))
+        {
+            isMet &= TestEnvironment.IsFunctions2017Supported;
+        }
+
+        if (Conditions.HasFlag(SqlServerCondition.SupportsFunctions2019))
+        {
+            isMet &= TestEnvironment.IsFunctions2019Supported;
+        }
+
+        if (Conditions.HasFlag(SqlServerCondition.SupportsFunctions2022))
+        {
+            isMet &= TestEnvironment.IsFunctions2022Supported;
         }
 
         return ValueTask.FromResult(isMet);

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -41,11 +41,13 @@ public static class TestEnvironment
 
     private static bool? _supportsUtf8;
 
+    private static bool? _supportsJsonPathExpressions;
+
     private static bool? _supportsFunctions2017;
 
     private static bool? _supportsFunctions2019;
 
-    private static bool? _supportsJsonPathExpressions;
+    private static bool? _supportsFunctions2022;
 
     private static byte? _productMajorVersion;
 
@@ -288,6 +290,33 @@ public static class TestEnvironment
         }
     }
 
+    public static bool SupportsJsonPathExpressions
+    {
+        get
+        {
+            if (!IsConfigured)
+            {
+                return false;
+            }
+
+            if (_supportsJsonPathExpressions.HasValue)
+            {
+                return _supportsJsonPathExpressions.Value;
+            }
+
+            try
+            {
+                _supportsJsonPathExpressions = GetProductMajorVersion() >= 14 || IsSqlAzure;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                _supportsJsonPathExpressions = false;
+            }
+
+            return _supportsJsonPathExpressions.Value;
+        }
+    }
+
     public static bool IsFunctions2017Supported
     {
         get
@@ -342,7 +371,7 @@ public static class TestEnvironment
         }
     }
 
-    public static bool SupportsJsonPathExpressions
+    public static bool IsFunctions2022Supported
     {
         get
         {
@@ -351,21 +380,21 @@ public static class TestEnvironment
                 return false;
             }
 
-            if (_supportsJsonPathExpressions.HasValue)
+            if (_supportsFunctions2022.HasValue)
             {
-                return _supportsJsonPathExpressions.Value;
+                return _supportsFunctions2022.Value;
             }
 
             try
             {
-                _supportsJsonPathExpressions = GetProductMajorVersion() >= 14 || IsSqlAzure;
+                _supportsFunctions2022 = GetProductMajorVersion() >= 16 || IsSqlAzure;
             }
             catch (PlatformNotSupportedException)
             {
-                _supportsJsonPathExpressions = false;
+                _supportsFunctions2022 = false;
             }
 
-            return _supportsJsonPathExpressions.Value;
+            return _supportsFunctions2022.Value;
         }
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -1196,6 +1196,30 @@ WHERE "o"."OrderID" = 11077 AND min("o"."OrderID", "o"."ProductID") = "o"."Produ
 """);
     }
 
+    public override async Task Where_math_min_nested(bool async)
+    {
+        await base.Where_math_min_nested(async);
+
+        AssertSql(
+            """
+SELECT "o"."OrderID", "o"."ProductID", "o"."Discount", "o"."Quantity", "o"."UnitPrice"
+FROM "Order Details" AS "o"
+WHERE "o"."OrderID" = 11077 AND min("o"."OrderID", "o"."ProductID", 99999) = "o"."ProductID"
+""");
+    }
+
+    public override async Task Where_math_min_nested_twice(bool async)
+    {
+        await base.Where_math_min_nested_twice(async);
+
+        AssertSql(
+            """
+SELECT "o"."OrderID", "o"."ProductID", "o"."Discount", "o"."Quantity", "o"."UnitPrice"
+FROM "Order Details" AS "o"
+WHERE "o"."OrderID" = 11077 AND min(99999, "o"."OrderID", 99998, "o"."ProductID") = "o"."ProductID"
+""");
+    }
+
     public override async Task Where_math_max(bool async)
     {
         await base.Where_math_max(async);
@@ -1205,6 +1229,30 @@ WHERE "o"."OrderID" = 11077 AND min("o"."OrderID", "o"."ProductID") = "o"."Produ
 SELECT "o"."OrderID", "o"."ProductID", "o"."Discount", "o"."Quantity", "o"."UnitPrice"
 FROM "Order Details" AS "o"
 WHERE "o"."OrderID" = 11077 AND max("o"."OrderID", "o"."ProductID") = "o"."OrderID"
+""");
+    }
+
+    public override async Task Where_math_max_nested(bool async)
+    {
+        await base.Where_math_max_nested(async);
+
+        AssertSql(
+            """
+SELECT "o"."OrderID", "o"."ProductID", "o"."Discount", "o"."Quantity", "o"."UnitPrice"
+FROM "Order Details" AS "o"
+WHERE "o"."OrderID" = 11077 AND max("o"."OrderID", "o"."ProductID", 1) = "o"."OrderID"
+""");
+    }
+
+    public override async Task Where_math_max_nested_twice(bool async)
+    {
+        await base.Where_math_max_nested_twice(async);
+
+        AssertSql(
+            """
+SELECT "o"."OrderID", "o"."ProductID", "o"."Discount", "o"."Quantity", "o"."UnitPrice"
+FROM "Order Details" AS "o"
+WHERE "o"."OrderID" = 11077 AND max(1, "o"."OrderID", 2, "o"."ProductID") = "o"."OrderID"
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -231,6 +231,58 @@ WHERE "p"."Id" NOT IN (2, 999)
 """);
     }
 
+    public override async Task Inline_collection_Min_with_two_values(bool async)
+    {
+        await base.Inline_collection_Min_with_two_values(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE min(30, "p"."Int") = 30
+""");
+    }
+
+    public override async Task Inline_collection_Max_with_two_values(bool async)
+    {
+        await base.Inline_collection_Max_with_two_values(async);
+
+        AssertSql(
+            """
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE max(30, "p"."Int") = 30
+""");
+    }
+
+    public override async Task Inline_collection_Min_with_three_values(bool async)
+    {
+        await base.Inline_collection_Min_with_three_values(async);
+
+        AssertSql(
+            """
+@__i_0='25'
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE min(30, "p"."Int", @__i_0) = 25
+""");
+    }
+
+    public override async Task Inline_collection_Max_with_three_values(bool async)
+    {
+        await base.Inline_collection_Max_with_three_values(async);
+
+        AssertSql(
+            """
+@__i_0='35'
+
+SELECT "p"."Id", "p"."Bool", "p"."Bools", "p"."DateTime", "p"."DateTimes", "p"."Enum", "p"."Enums", "p"."Int", "p"."Ints", "p"."NullableInt", "p"."NullableInts", "p"."NullableString", "p"."NullableStrings", "p"."String", "p"."Strings"
+FROM "PrimitiveCollectionsEntity" AS "p"
+WHERE max(30, "p"."Int", @__i_0) = 35
+""");
+    }
+
     public override async Task Parameter_collection_Count(bool async)
     {
         await base.Parameter_collection_Count(async);


### PR DESCRIPTION
This PR:

1. Adds translations for Math.Min/Max in non-aggregate context ([#27794](https://github.com/dotnet/efcore/issues/27794)), using the SQL Server 2022 LEAST/GREATEST functions.
2. Adds EF.Functions.Least/Greatest at the relational level ([#31681](https://github.com/dotnet/efcore/issues/31681)), to allow invoking them directly; this is for types which don't have Math.Min/Max overloads (dates, strings...), and also to specify arbitrary-length lists without having to nest Math.Min/Max invocations
3. Pattern matches for Math.Min/Max over an inline primitive collection (`new[] { 1, 2 }.Max()`), simplifying the translation via LEAST/GREATEST ([#32332](https://github.com/dotnet/efcore/issues/32332)). This is done conditional on the SQL Server compatibility level.

Design notes:

* LEAST/GREATEST require SQL Server 2022; when introducing the SQL Server compatibility level, we decided to make it 2022 by default. This means that this PR breaks users of older databases who don't have their compatibility level set explicitly (change 3 specifically). We may want to revisit the default.
* In SQLite, EF.Functions.Least/Greatest translate to MIN/MAX, though we usually try to have EF.Functions method names correpond to the actual SQL function invoked. However, it's good to have these methods at the relational level, and all databases except for SQLite have LEAST/GREATEST.

Closes #27794
Closes #31681
Closes #32332
