### PR TITLE
[release/8.0] Do extra processing for init-only fields (#32342)

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -2063,7 +2063,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     OrElse(
                                         ReferenceEqual(currentVariable, Constant(null)),
                                         ReferenceEqual(parameter, Constant(null))),
-                                    MakeBinary(node.NodeType, node.Left, parameter),
+                                    node is { NodeType: ExpressionType.Assign, Left: MemberExpression leftMemberExpression }
+                                        ? leftMemberExpression.Assign(parameter)
+                                        : MakeBinary(node.NodeType, node.Left, parameter),
                                     Call(
                                         PopulateListMethod.MakeGenericMethod(property.ClrType.TryGetElementType(typeof(IEnumerable<>))!),
                                         parameter,

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -16,6 +16,9 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
 {
     private sealed partial class ShaperProcessingExpressionVisitor : ExpressionVisitor
     {
+        public static readonly bool UseOldBehavior32310 =
+            AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32310", out var enabled32310) && enabled32310;
+
         /// <summary>
         ///     Reading database values
         /// </summary>
@@ -2063,7 +2066,8 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor
                                     OrElse(
                                         ReferenceEqual(currentVariable, Constant(null)),
                                         ReferenceEqual(parameter, Constant(null))),
-                                    node is { NodeType: ExpressionType.Assign, Left: MemberExpression leftMemberExpression }
+                                    !UseOldBehavior32310
+                                    && node is { NodeType: ExpressionType.Assign, Left: MemberExpression leftMemberExpression }
                                         ? leftMemberExpression.Assign(parameter)
                                         : MakeBinary(node.NodeType, node.Left, parameter),
                                     Call(


### PR DESCRIPTION
Port of #32342
Fixes #32310

Description

When processing queries with nested binary expressions, we missed one path where we need to do extra work for init-only properties.

Customer impact

Crash when running queries with nested binary expressions.

How found

Customer reported on 8.0

Regression

Yes

Testing

Added regression test.

Risk

Low and quirked.
