### PR TITLE
[release/8.0] Don't throw when attempting to load from a newly Added entity with unknown FK values

### DIFF
--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -715,7 +715,7 @@ public class EntityFinder<TEntity> : IEntityFinder<TEntity>
         for (var i = 0; i < values.Length; i++)
         {
             var property = properties[i];
-            if (property.IsShadowProperty() && (detached || entry.IsUnknown(property)))
+            if (property.IsShadowProperty() && (detached || (entry.EntityState != EntityState.Added && entry.IsUnknown(property))))
             {
                 throw new InvalidOperationException(
                     CoreStrings.CannotLoadDetachedShadow(navigation.Name, entry.EntityType.DisplayName()));

--- a/test/EFCore.Specification.Tests/LazyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadTestBase.cs
@@ -2006,7 +2006,8 @@ public abstract partial class LoadTestBase<TFixture>
 
         if (LazyLoadingEnabled)
         {
-            if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+            if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                || state == EntityState.Added && queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
             {
                 Assert.Null(child.Parent); // Explicitly detached
             }
@@ -2094,7 +2095,8 @@ public abstract partial class LoadTestBase<TFixture>
 
         if (LazyLoadingEnabled)
         {
-            if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll)
+            if (state == EntityState.Detached && queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                || state == EntityState.Added && queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
             {
                 Assert.Null(single.Parent); // Explicitly detached
             }
@@ -2258,7 +2260,8 @@ public abstract partial class LoadTestBase<TFixture>
             {
                 Assert.Null(child.Parent); // Explicitly detached
             }
-            else if (queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
+            else if (queryTrackingBehavior != QueryTrackingBehavior.TrackAll
+                     && state != EntityState.Added)
             {
                 Assert.Equal(
                     CoreStrings.CannotLoadDetachedShadow("Parent", "ChildShadowFk"),
@@ -2327,7 +2330,8 @@ public abstract partial class LoadTestBase<TFixture>
             {
                 Assert.Null(single.Parent);
             }
-            else if (queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
+            else if (queryTrackingBehavior != QueryTrackingBehavior.TrackAll
+                     && state != EntityState.Added)
             {
                 Assert.Equal(
                     CoreStrings.CannotLoadDetachedShadow("Parent", "SingleShadowFk"),


### PR DESCRIPTION
Port of #32343
Fixes #32314

### Description

EF8 contains a new feature allowing lazy-loading from detached entities. This brought up a case where lazy-loading would be wrong because shadow FK values are not known. We throw an exception for this case in EF8, but this regressed a valid scenario where the key values are not known because the entity instance is new.

### Customer impact

Exception when accessing a lazy-loading enabled navigation backed by a shadow foreign key on an entity in the Added state.

### How found

Customer reported on 8.0

### Regression

Yes

### Testing

Added regression test.

### Risk

Low and quirked.