### PR TITLE
Fix to #27844 - EF Core 6.0 temporal table migration when altering computed column not generating correct script

### DIFF
--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -298,6 +298,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 entityType, propertyName);
 
         /// <summary>
+        ///     Modifying SQL of a computed column '{columnName}' on a temporal table '{tableName}' is not supported by migrations.
+        /// </summary>
+        public static string TemporalMigrationModifyingComputedColumnNotSupported(object? columnName, object? tableName)
+            => string.Format(
+                GetString("TemporalMigrationModifyingComputedColumnNotSupported", nameof(columnName), nameof(tableName)),
+                columnName, tableName);
+
+        /// <summary>
         ///     Entity type '{entityType}' mapped to temporal table must have a period start and a period end property.
         /// </summary>
         public static string TemporalMustDefinePeriodProperties(object? entityType)

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -320,6 +320,9 @@
   <data name="TemporalExpectedPeriodPropertyNotFound" xml:space="preserve">
     <value>Entity type '{entityType}' mapped to temporal table does not contain the expected period property: '{propertyName}'.</value>
   </data>
+  <data name="TemporalMigrationModifyingComputedColumnNotSupported" xml:space="preserve">
+    <value>Modifying SQL of a computed column '{columnName}' on a temporal table '{tableName}' is not supported by migrations.</value>
+  </data>
   <data name="TemporalMustDefinePeriodProperties" xml:space="preserve">
     <value>Entity type '{entityType}' mapped to temporal table must have a period start and a period end property.</value>
   </data>


### PR DESCRIPTION
Working with computed column on a temporal table requires special processing - we need to disable the versioning, add the computed column to regular table and a column with the same name/type/position to the history table, but as a regular column. After all is done we re-enable versioning. Historical information on the computed column will be copied to the counterpart column in history table without issue.

One thing that we can't do is modifying computed column SQL when table is temporal. What happens in case of CCSQL modification, we drop the column and create a new one with new CCSQL. This is not an issue for regular table, because the value is computed anyway, so old value is useless. But when we drop-create column, that column gets created at the last position in the table, and so the table no longer matches it's history table exactly (positions of columns may differ). We would have to drop+recreate column on a history table, but that results in losing historical data of that column. And that is valuable data, unlike for regular table. We could enable that scenario once/if we support table rebuilds.

Fixes #27844