### PR TITLE
Remove no-longer-needed unwrapping of AsQueryable

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -288,7 +288,7 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
             // Server), we need to fall back to the previous IN translation.
             if (method.IsGenericMethod
                 && method.GetGenericMethodDefinition() == QueryableMethods.Contains
-                && UnwrapAsQueryable(methodCallExpression.Arguments[0]) is ParameterQueryRootExpression parameterSource
+                && methodCallExpression.Arguments[0] is ParameterQueryRootExpression parameterSource
                 && TranslateExpression(methodCallExpression.Arguments[1]) is SqlExpression item
                 && _sqlTranslator.Visit(parameterSource.ParameterExpression) is SqlParameterExpression sqlParameterExpression)
             {
@@ -300,12 +300,6 @@ public class RelationalQueryableMethodTranslatingExpressionVisitor : QueryableMe
                     .UpdateResultCardinality(ResultCardinality.Single);
                 return shapedQueryExpression;
             }
-
-            static Expression UnwrapAsQueryable(Expression expression)
-                => expression is MethodCallExpression { Method: { IsGenericMethod: true } method } methodCall
-                    && method.GetGenericMethodDefinition() == QueryableMethods.AsQueryable
-                        ? methodCall.Arguments[0]
-                        : expression;
         }
 
         return translated;


### PR DESCRIPTION
#32219 added special unwrapping of AsQueryable() for handling legacy Contains as a workaround for #32217 (nav expansion not visiting inside Contains); but since #32217 has been fixed, this workaround can now be removed.