### PR TITLE
[release/8.0] Add method postfix when rewriting parameters for StartsWith/EndsWith/Contains

### DIFF
--- a/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
@@ -542,6 +542,21 @@ public abstract class FunkyDataQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 AssertEqual(e.last, a.last);
             });
 
+
+    [ConditionalTheory] // #32432
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task String_Contains_and_StartsWith_with_same_parameter(bool async)
+    {
+        var s = "B";
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<FunkyCustomer>().Where(
+                c => c.FirstName.Contains(s) || c.LastName.StartsWith(s)),
+            ss => ss.Set<FunkyCustomer>().Where(
+                c => c.FirstName.MaybeScalar(f => f.Contains(s)) == true || c.LastName.MaybeScalar(l => l.StartsWith(s)) == true));
+    }
+
     protected FunkyDataContext CreateContext()
         => Fixture.CreateContext();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -78,19 +78,19 @@ FROM [FunkyCustomers] AS [f]
 
         AssertSql(
             """
-@__prm1_0_rewritten='%\%B%' (Size = 4000)
+@__prm1_0_contains='%\%B%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm1_0_contains ESCAPE N'\'
 """,
             //
             """
-@__prm2_0_rewritten='%a\_%' (Size = 4000)
+@__prm2_0_contains='%a\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm2_0_contains ESCAPE N'\'
 """,
             //
             """
@@ -100,35 +100,35 @@ WHERE 0 = 1
 """,
             //
             """
-@__prm4_0_rewritten='%' (Size = 4000)
+@__prm4_0_contains='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm4_0_contains ESCAPE N'\'
 """,
             //
             """
-@__prm5_0_rewritten='%\_Ba\_%' (Size = 4000)
+@__prm5_0_contains='%\_Ba\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm5_0_contains ESCAPE N'\'
 """,
             //
             """
-@__prm6_0_rewritten='%\%B\%a\%r%' (Size = 4000)
+@__prm6_0_contains='%\%B\%a\%r%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @__prm6_0_contains ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
             """
-@__prm7_0_rewritten='%' (Size = 4000)
+@__prm7_0_contains='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @__prm7_0_contains ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
             //
             """
@@ -221,61 +221,61 @@ FROM [FunkyCustomers] AS [f]
         await base.String_starts_with_on_argument_with_wildcard_parameter(async);
 
         AssertSql(
-"""
-@__prm1_0_rewritten='\%B%' (Size = 4000)
+            """
+@__prm1_0_startswith='\%B%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm1_0_startswith ESCAPE N'\'
 """,
-                //
-                """
-@__prm2_0_rewritten='\_B%' (Size = 4000)
+            //
+            """
+@__prm2_0_startswith='\_B%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm2_0_startswith ESCAPE N'\'
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-                //
-                """
-@__prm4_0_rewritten='%' (Size = 4000)
+            //
+            """
+@__prm4_0_startswith='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm4_0_startswith ESCAPE N'\'
 """,
-                //
-                """
-@__prm5_0_rewritten='\_Ba\_%' (Size = 4000)
+            //
+            """
+@__prm5_0_startswith='\_Ba\_%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm5_0_startswith ESCAPE N'\'
 """,
-                //
-                """
-@__prm6_0_rewritten='\%B\%a\%r%' (Size = 4000)
+            //
+            """
+@__prm6_0_startswith='\%B\%a\%r%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @__prm6_0_startswith ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
-                //
-                """
-@__prm7_0_rewritten='%' (Size = 4000)
+            //
+            """
+@__prm7_0_startswith='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @__prm7_0_startswith ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -305,27 +305,27 @@ WHERE [f].[FirstName] LIKE N'B\[\[a^%' ESCAPE N'\'
 """,
             //
             """
-@__prm1_0_rewritten='\[%' (Size = 4000)
+@__prm1_0_startswith='\[%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm1_0_startswith ESCAPE N'\'
 """,
             //
             """
-@__prm2_0_rewritten='B\[%' (Size = 4000)
+@__prm2_0_startswith='B\[%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm2_0_startswith ESCAPE N'\'
 """,
             //
             """
-@__prm3_0_rewritten='B\[\[a^%' (Size = 4000)
+@__prm3_0_startswith='B\[\[a^%' (Size = 4000)
 
 SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm3_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm3_0_startswith ESCAPE N'\'
 """,
             //
             """
@@ -419,61 +419,61 @@ FROM [FunkyCustomers] AS [f]
         await base.String_ends_with_on_argument_with_wildcard_parameter(async);
 
         AssertSql(
-"""
-@__prm1_0_rewritten='%\%r' (Size = 4000)
+            """
+@__prm1_0_endswith='%\%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm1_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm1_0_endswith ESCAPE N'\'
 """,
-                //
-                """
-@__prm2_0_rewritten='%r\_' (Size = 4000)
+            //
+            """
+@__prm2_0_endswith='%r\_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm2_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm2_0_endswith ESCAPE N'\'
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 WHERE 0 = 1
 """,
-                //
-                """
-@__prm4_0_rewritten='%' (Size = 4000)
+            //
+            """
+@__prm4_0_endswith='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm4_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm4_0_endswith ESCAPE N'\'
 """,
-                //
-                """
-@__prm5_0_rewritten='%\_r\_' (Size = 4000)
+            //
+            """
+@__prm5_0_endswith='%\_r\_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] LIKE @__prm5_0_rewritten ESCAPE N'\'
+WHERE [f].[FirstName] LIKE @__prm5_0_endswith ESCAPE N'\'
 """,
-                //
-                """
-@__prm6_0_rewritten='%a\%r\%' (Size = 4000)
+            //
+            """
+@__prm6_0_endswith='%a\%r\%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm6_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @__prm6_0_endswith ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
-                //
-                """
-@__prm7_0_rewritten='%' (Size = 4000)
+            //
+            """
+@__prm7_0_endswith='%' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE [f].[FirstName] NOT LIKE @__prm7_0_rewritten ESCAPE N'\' OR [f].[FirstName] IS NULL
+WHERE [f].[FirstName] NOT LIKE @__prm7_0_endswith ESCAPE N'\' OR [f].[FirstName] IS NULL
 """,
-                //
-                """
+            //
+            """
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
 """);
@@ -578,6 +578,21 @@ END <> [f].[NullableBool] OR [f].[NullableBool] IS NULL
 SELECT SUBSTRING([f].[FirstName], 1, 1) AS [first], SUBSTRING([f].[FirstName], LEN([f].[FirstName]), 1) AS [last]
 FROM [FunkyCustomers] AS [f]
 ORDER BY [f].[Id]
+""");
+    }
+
+    public override async Task String_Contains_and_StartsWith_with_same_parameter(bool async)
+    {
+        await base.String_Contains_and_StartsWith_with_same_parameter(async);
+
+        AssertSql(
+            """
+@__s_0_contains='%B%' (Size = 4000)
+@__s_0_startswith='B%' (Size = 4000)
+
+SELECT [f].[Id], [f].[FirstName], [f].[LastName], [f].[NullableBool]
+FROM [FunkyCustomers] AS [f]
+WHERE [f].[FirstName] LIKE @__s_0_contains ESCAPE N'\' OR [f].[LastName] LIKE @__s_0_startswith ESCAPE N'\'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -96,11 +96,11 @@ WHERE [c].[ContactName] LIKE N'M%'
 
         AssertSql(
             """
-@__pattern_0_rewritten='M%' (Size = 30)
+@__pattern_0_startswith='M%' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_rewritten ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @__pattern_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -158,11 +158,11 @@ WHERE [c].[ContactName] LIKE N'%b'
 
         AssertSql(
             """
-@__pattern_0_rewritten='%b' (Size = 30)
+@__pattern_0_endswith='%b' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_rewritten ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @__pattern_0_endswith ESCAPE N'\'
 """);
     }
 
@@ -259,11 +259,11 @@ WHERE [c].[ContactName] LIKE N'%     %'
 
         AssertSql(
             """
-@__pattern_0_rewritten='%     %' (Size = 30)
+@__pattern_0_contains='%     %' (Size = 30)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__pattern_0_rewritten ESCAPE N'\'
+WHERE [c].[ContactName] LIKE @__pattern_0_contains ESCAPE N'\'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -3042,12 +3042,12 @@ WHERE [o].[OrderDate] > @__p_0
 
         AssertSql(
             """
-@__NewLine_0_rewritten='%
+@__NewLine_0_contains='%
 %' (Size = 5)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE @__NewLine_0_rewritten ESCAPE N'\'
+WHERE [c].[CustomerID] LIKE @__NewLine_0_contains ESCAPE N'\'
 """);
     }
 
@@ -4787,11 +4787,11 @@ FROM (
 
         AssertSql(
             """
-@__prefix_0_rewritten='A%' (Size = 5)
+@__prefix_0_startswith='A%' (Size = 5)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE @__prefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CustomerID] LIKE @__prefix_0_startswith ESCAPE N'\'
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -27,11 +27,11 @@ public class NorthwindQueryFiltersQuerySqlServerTest : NorthwindQueryFiltersQuer
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -41,11 +41,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -55,12 +55,12 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 @__p_0='ALFKI' (Size = 5) (DbType = StringFixedLength)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' AND [c].[CustomerID] = @__p_0
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\' AND [c].[CustomerID] = @__p_0
 """);
     }
 
@@ -70,11 +70,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' 
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='F%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='F%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -84,19 +84,19 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """,
             //
             """
-@__ef_filter__TenantPrefix_0_rewritten='T%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='T%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -106,11 +106,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='F%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='F%' (Size = 40)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -120,11 +120,11 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -134,7 +134,7 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t0].[CustomerID0]
 FROM [Customers] AS [c]
@@ -144,11 +144,11 @@ LEFT JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE [c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+        WHERE [c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 ORDER BY [c].[CustomerID], [t0].[OrderID]
 """);
     }
@@ -172,14 +172,14 @@ ORDER BY [c].[CustomerID]
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);
@@ -191,7 +191,7 @@ WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_1_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_1_startswith='B%' (Size = 40)
 @__ef_filter___quantity_0='50'
 
 SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
@@ -202,7 +202,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c].[CustomerID], [c].[CompanyName]
         FROM [Customers] AS [c]
-        WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_1_rewritten ESCAPE N'\'
+        WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_1_startswith ESCAPE N'\'
     ) AS [t] ON [o0].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
@@ -216,7 +216,7 @@ WHERE [o].[Quantity] > @__ef_filter___quantity_0
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 @__ef_filter___quantity_1='50'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -227,7 +227,7 @@ INNER JOIN (
     LEFT JOIN (
         SELECT [c0].[CustomerID], [c0].[CompanyName]
         FROM [Customers] AS [c0]
-        WHERE [c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+        WHERE [c0].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
     ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
@@ -240,13 +240,13 @@ INNER JOIN (
         LEFT JOIN (
             SELECT [c1].[CustomerID], [c1].[CompanyName]
             FROM [Customers] AS [c1]
-            WHERE [c1].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+            WHERE [c1].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
         ) AS [t3] ON [o1].[CustomerID] = [t3].[CustomerID]
         WHERE [t3].[CustomerID] IS NOT NULL AND [t3].[CompanyName] IS NOT NULL
     ) AS [t2] ON [o0].[OrderID] = [t2].[OrderID]
     WHERE [o0].[Quantity] > @__ef_filter___quantity_1
 ) AS [t1] ON [t0].[OrderID] = [t1].[OrderID]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' AND [t1].[Discount] < CAST(10 AS real)
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\' AND [t1].[Discount] < CAST(10 AS real)
 """);
     }
 
@@ -262,13 +262,13 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' 
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [m].[CustomerID], [m].[Address], [m].[City], [m].[CompanyName], [m].[ContactName], [m].[ContactTitle], [m].[Country], [m].[Fax], [m].[Phone], [m].[PostalCode], [m].[Region]
 FROM (
     select * from Customers
 ) AS [m]
-WHERE [m].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+WHERE [m].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 """);
     }
 
@@ -284,7 +284,7 @@ WHERE [m].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [m].[OrderID], [m].[CustomerID], [m].[EmployeeID], [m].[OrderDate]
 FROM (
@@ -293,7 +293,7 @@ FROM (
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 ) AS [t] ON [m].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);
@@ -305,21 +305,21 @@ WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 @__customerID='BERGS' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' AND [c].[CustomerID] = @__customerID
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\' AND [c].[CustomerID] = @__customerID
 """,
             //
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 @__customerID='BLAUS' (Size = 5) (DbType = StringFixedLength)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' AND [c].[CustomerID] = @__customerID
+WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\' AND [c].[CustomerID] = @__customerID
 """);
     }
 
@@ -329,14 +329,14 @@ WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\' 
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[CompanyName]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);
@@ -355,14 +355,14 @@ WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 40)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 40)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
-    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE N'\'
+    WHERE [c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE N'\'
 ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
 WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 """);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -712,11 +712,11 @@ WHERE "c"."ContactName" LIKE 'M%'
 
         AssertSql(
             """
-@__pattern_0_rewritten='M%' (Size = 2)
+@__pattern_0_startswith='M%' (Size = 2)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" LIKE @__pattern_0_rewritten ESCAPE '\'
+WHERE "c"."ContactName" LIKE @__pattern_0_startswith ESCAPE '\'
 """);
     }
 
@@ -774,11 +774,11 @@ WHERE "c"."ContactName" LIKE '%b'
 
         AssertSql(
             """
-@__pattern_0_rewritten='%b' (Size = 2)
+@__pattern_0_endswith='%b' (Size = 2)
 
 SELECT "c"."CustomerID", "c"."Address", "c"."City", "c"."CompanyName", "c"."ContactName", "c"."ContactTitle", "c"."Country", "c"."Fax", "c"."Phone", "c"."PostalCode", "c"."Region"
 FROM "Customers" AS "c"
-WHERE "c"."ContactName" LIKE @__pattern_0_rewritten ESCAPE '\'
+WHERE "c"."ContactName" LIKE @__pattern_0_endswith ESCAPE '\'
 """);
     }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQueryFiltersQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQueryFiltersQuerySqliteTest.cs
@@ -21,11 +21,11 @@ public class NorthwindQueryFiltersQuerySqliteTest : NorthwindQueryFiltersQueryTe
 
         AssertSql(
             """
-@__ef_filter__TenantPrefix_0_rewritten='B%' (Size = 2)
+@__ef_filter__TenantPrefix_0_startswith='B%' (Size = 2)
 
 SELECT COUNT(*)
 FROM "Customers" AS "c"
-WHERE "c"."CompanyName" LIKE @__ef_filter__TenantPrefix_0_rewritten ESCAPE '\'
+WHERE "c"."CompanyName" LIKE @__ef_filter__TenantPrefix_0_startswith ESCAPE '\'
 """);
     }
 


### PR DESCRIPTION
Fixes #32432, backports #32433.

### Description

EF 8.0 optimizes the translations of string.StartsWith/EndsWith/Contains for when the pattern is a parameter:

```c#
var pattern = "foo";
var blogs = context.Blogs.Where(b => b.Name.StartsWith(pattern)...
```

Unfortunately, if the same pattern parameter is used for two different methods in the same query (i.e. Contains and StartsWith), only one parameter is sent to the database, with whatever pattern comes last (i.e. `%foo%` for Contains, `foo%` for StartsWith).

### Customer impact

When using the same pattern parameter for two different methods in the same query, the query is translated incorrectly and the user may receive incorrect results (data corruption bug).

### How found

Customer reported on 8.0

### Regression

Yes

### Testing

Added.

### Risk

Very low; quirk added.
