### PR TITLE
[release/8.0] Create correct JSON reader/writer for double nested value conversions

### DIFF
--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -24,6 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Storage;
 /// </remarks>
 public abstract class CoreTypeMapping
 {
+    private static readonly bool UseOldBehavior32376 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32376", out var enabled32376) && enabled32376;
+
     /// <summary>
     ///     Parameter object for use in the <see cref="CoreTypeMapping" /> hierarchy.
     /// </summary>
@@ -145,7 +148,8 @@ public abstract class CoreTypeMapping
                     throw new InvalidOperationException(CoreStrings.NativeAotNoCompiledModel);
                 }
 
-                if (readerWriter is IJsonConvertedValueReaderWriter convertedValueReaderWriter)
+                if (!UseOldBehavior32376
+                    && readerWriter is IJsonConvertedValueReaderWriter convertedValueReaderWriter)
                 {
                     readerWriter = convertedValueReaderWriter.InnerReaderWriter;
                 }


### PR DESCRIPTION
Port of #32444
Fixes #32376

## Description

When a custom converter is applied over an existing built-in converter, then the wrong JSON reader/writer can be used.

## Customer impact

Exception thrown when translating a previously working Contains query.

## How found

Customer reported on 8.0

## Regression

Yes

## Testing

Added.

## Risk

Very low; quirk added.