### PR TITLE
Fix expression cloning when table changes in SelectExpression.VisitChildren

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4614,6 +4614,14 @@ WHERE (c["Discriminator"] = "Customer")
         AssertSql();
     }
 
+    public override async Task Parameter_collection_Contains_with_projection_and_ordering(bool async)
+    {
+        await AssertTranslationFailed(
+            () => base.Parameter_collection_Contains_with_projection_and_ordering(async));
+
+        AssertSql();
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5659,4 +5659,20 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => new[] { 100, c.Orders.Count }.Sum() > 101));
+
+    [ConditionalTheory] // #32234
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Parameter_collection_Contains_with_projection_and_ordering(bool async)
+    {
+        var ids = new[] { 10248, 10249 };
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>()
+                .Where(e => ids.Contains(e.OrderID))
+                .GroupBy(e => e.Quantity)
+                .Select(g => new { g.Key, MaxTimestamp = g.Select(e => e.Order.OrderDate).Max() })
+                .OrderBy(x => x.MaxTimestamp)
+                .Select(x => x));
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -7277,6 +7277,47 @@ WHERE (
 """);
     }
 
+    public override async Task Parameter_collection_Contains_with_projection_and_ordering(bool async)
+    {
+#if DEBUG
+        // GroupBy debug assert. Issue #26104.
+        Assert.StartsWith(
+            "Missing alias in the list",
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Parameter_collection_Contains_with_projection_and_ordering(async))).Message);
+#else
+        await base.Parameter_collection_Contains_with_projection_and_ordering(async);
+
+        AssertSql(
+            """
+@__ids_0='[10248,10249]' (Size = 4000)
+
+SELECT [o].[Quantity] AS [Key], (
+    SELECT MAX([o3].[OrderDate])
+    FROM [Order Details] AS [o2]
+    INNER JOIN [Orders] AS [o3] ON [o2].[OrderID] = [o3].[OrderID]
+    WHERE [o2].[OrderID] IN (
+        SELECT [i1].[value]
+        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i1]
+    ) AND [o].[Quantity] = [o2].[Quantity]) AS [MaxTimestamp]
+FROM [Order Details] AS [o]
+WHERE [o].[OrderID] IN (
+    SELECT [i].[value]
+    FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i]
+)
+GROUP BY [o].[Quantity]
+ORDER BY (
+    SELECT MAX([o3].[OrderDate])
+    FROM [Order Details] AS [o2]
+    INNER JOIN [Orders] AS [o3] ON [o2].[OrderID] = [o3].[OrderID]
+    WHERE [o2].[OrderID] IN (
+        SELECT [i0].[value]
+        FROM OPENJSON(@__ids_0) WITH ([value] int '$') AS [i0]
+    ) AND [o].[Quantity] = [o2].[Quantity])
+""");
+#endif
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -438,6 +438,19 @@ FROM "Orders" AS "o"
     public override Task Max_on_empty_sequence_throws(bool async)
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Max_on_empty_sequence_throws(async));
 
+    public override async Task Parameter_collection_Contains_with_projection_and_ordering(bool async)
+    {
+#if DEBUG
+        // GroupBy debug assert. Issue #26104.
+        Assert.StartsWith(
+            "Missing alias in the list",
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Parameter_collection_Contains_with_projection_and_ordering(async))).Message);
+#else
+        await base.Parameter_collection_Contains_with_projection_and_ordering(async);
+#endif
+    }
+
     [ConditionalFact]
     public async Task Single_Predicate_Cancellation()
         => await Assert.ThrowsAnyAsync<OperationCanceledException>(


### PR DESCRIPTION
When a table is changed in SelectExpression.VisitChildren() (on an immutable SelectExpression), visit the entire SelectExpression and replace ColumnExpressions to have them properly point to the new SelectExpression, without sharing TableReferenceExpression. This allows us to mutate the TableReferenceExpression later (i.e. alias uniquification) without affecting two queries in the tree.

There's a bit of added complexity here to prevent infinite recursion where the new ColumnTableReferenceUpdater that we call also uses SelectExpression.VisitChildren, but we don't want/need that to go into ColumnTableReferenceUpdater again.

This should be a temporary fix; I believe we should revisit the general design around tables, ColumnExpression and TableReferenceExpression.

Finally, this isn't a super trivial fix - would appreciate a deep review (especially as we may consider this for patching).

Fixes #32234

Note that I ran into #26104 as well while testing this, which is a debug-only issue that's very related to this one (same SelectExpression instance referenced from multiple parts of the query).