### PR TITLE
[release/8.0] Visit inside InlineQueryRootExpression in nav expansion

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -15,23 +15,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal;
 /// </summary>
 public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
 {
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public static readonly bool UseOldBehavior32217 =
+    private static readonly bool UseOldBehavior32217 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32217", out var enabled32217) && enabled32217;
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    public static readonly bool UseOldBehavior32312 =
+    private static readonly bool UseOldBehavior32312 =
         AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32312", out var enabled32312) && enabled32312;
+
+    private static readonly bool UseOldBehavior32331 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32331", out var enabled32331) && enabled32331;
 
     private static readonly PropertyInfo QueryContextContextPropertyInfo
         = typeof(QueryContext).GetTypeInfo().GetDeclaredProperty(nameof(QueryContext.Context))!;
@@ -249,11 +240,23 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
 
                 return ApplyQueryFilter(entityType, navigationExpansionExpression);
 
+            // Inline query roots can contain arbitrary expressions, including subqueries with navigations; visit inside to process those.
+            case InlineQueryRootExpression inlineQueryRootExpression when !UseOldBehavior32331:
+            {
+                var visited = inlineQueryRootExpression.Update(this.VisitAndConvert(inlineQueryRootExpression.Values));
+                var currentTree = new NavigationTreeExpression(Expression.Default(inlineQueryRootExpression.ElementType));
+                var parameterName = GetParameterName("e");
+
+                return new NavigationExpansionExpression(visited, currentTree, currentTree, parameterName);
+            }
+
             case QueryRootExpression queryRootExpression:
+            {
                 var currentTree = new NavigationTreeExpression(Expression.Default(queryRootExpression.ElementType));
                 var parameterName = GetParameterName("e");
 
                 return new NavigationExpansionExpression(queryRootExpression, currentTree, currentTree, parameterName);
+            }
 
             case NavigationExpansionExpression:
             case OwnedNavigationReference:

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4670,6 +4670,14 @@ WHERE ((c["Discriminator"] = "Customer") AND @__Contains_0)
 """);
     }
 
+    public override async Task Subquery_with_navigation_inside_inline_collection(bool async)
+    {
+        await AssertTranslationFailed(
+            () => base.Subquery_with_navigation_inside_inline_collection(async));
+
+        AssertSql();
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5709,4 +5709,11 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
             async,
             ss => ss.Set<Order>().Where(o => data.Contains(o.CustomerID + o.Customer.CustomerID)));
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Subquery_with_navigation_inside_inline_collection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(c => new[] { 100, c.Orders.Count }.Sum() > 101));
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -7344,6 +7344,23 @@ WHERE @__Contains_0 = CAST(1 AS bit)
 """);
     }
 
+    public override async Task Subquery_with_navigation_inside_inline_collection(bool async)
+    {
+        await base.Subquery_with_navigation_inside_inline_collection(async);
+
+        AssertSql(
+            """
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT COALESCE(SUM([v].[Value]), 0)
+    FROM (VALUES (CAST(100 AS int)), ((
+        SELECT COUNT(*)
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]))) AS [v]([Value])) > 101
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Fixes #32331, backports #32460.

### Description

As part of the primitive collection work for EF 8, the new InlineCollectionQueryRoot expression type was introduced to represent collections which are inline in the LINQ query (e.g. `Where(b => new[] { 1, 3 }.Where(...)`). However, our navigation expansion visitor, which is responsible for processing navigations, was not modified to visit inside this new expression type; as a result, navigations inside subqueries within InlineCollectionQueryRoot do not work.

### Customer impact

Queries which include navigations inside an inline collection fail to execute, e.g.:

```c#
_ = context.Blogs
    .Select(b => new[] { b.Updated, b.Posts.Max(p => p.Updated) }.Max())
    .ToList();
```

Such queries used to work in 7.0, if the code in question was in the top-level Select (and got client-evaluated).

### How found

Customers reported on 8.0

### Regression

Yes

### Testing

Added.

### Risk

Low - very targeted and single, simple fix (but in the query pipeline, which is never zero-risk). Quirk added.
