### PR TITLE
Allow specifying Assembly for migrations

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
@@ -97,6 +97,17 @@ public abstract class RelationalDbContextOptionsBuilder<TBuilder, TExtension> : 
         => WithOption(e => (TExtension)e.WithMigrationsAssembly(Check.NullButNotEmpty(assemblyName, nameof(assemblyName))));
 
     /// <summary>
+    ///     Configures the assembly where migrations are maintained for this context.
+    /// </summary>
+    /// <remarks>
+    ///     See <see href="https://aka.ms/efcore-docs-migrations">Database migrations</see> for more information and examples.
+    /// </remarks>
+    /// <param name="assembly">The <see cref="Assembly"/> where the migrations are located.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public virtual TBuilder MigrationsAssembly(Assembly assembly)
+        => WithOption(e => (TExtension)e.WithMigrationsAssembly(assembly));
+
+    /// <summary>
     ///     Configures the name of the table used to record which migrations have been applied to the database.
     /// </summary>
     /// <remarks>

--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -32,6 +32,8 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
     private bool _useRelationalNulls;
     private QuerySplittingBehavior? _querySplittingBehavior;
     private string? _migrationsAssembly;
+    private Assembly? _migrationsAssemblyObject;
+
     private string? _migrationsHistoryTableName;
     private string? _migrationsHistoryTableSchema;
     private Func<ExecutionStrategyDependencies, IExecutionStrategy>? _executionStrategyFactory;
@@ -271,6 +273,12 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
         => _migrationsAssembly;
 
     /// <summary>
+    ///     The Assembly that contains migrations, or <see langword="null" /> if none has been set.
+    /// </summary>
+    public virtual Assembly? MigrationsAssemblyObject
+        => _migrationsAssemblyObject;
+
+    /// <summary>
     ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
     ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
     /// </summary>
@@ -281,6 +289,21 @@ public abstract class RelationalOptionsExtension : IDbContextOptionsExtension
         var clone = Clone();
 
         clone._migrationsAssembly = migrationsAssembly;
+
+        return clone;
+    }
+
+    /// <summary>
+    ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
+    ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
+    /// </summary>
+    /// <param name="migrationsAssembly">The option to change.</param>
+    /// <returns>A new instance with the option changed.</returns>
+    public virtual RelationalOptionsExtension WithMigrationsAssembly(Assembly migrationsAssembly)
+    {
+        var clone = Clone();
+
+        clone._migrationsAssemblyObject = migrationsAssembly;
 
         return clone;
     }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsAssembly.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsAssembly.cs
@@ -32,9 +32,11 @@ public class MigrationsAssembly : IMigrationsAssembly
         _contextType = currentContext.Context.GetType();
 
         var assemblyName = RelationalOptionsExtension.Extract(options).MigrationsAssembly;
+        var assemblyObject = RelationalOptionsExtension.Extract(options).MigrationsAssemblyObject;
+
         Assembly = assemblyName == null
-            ? _contextType.Assembly
-            : Assembly.Load(new AssemblyName(assemblyName));
+            ?   assemblyObject ?? _contextType.Assembly
+            :   Assembly.Load(new AssemblyName(assemblyName));
 
         _idGenerator = idGenerator;
         _logger = logger;


### PR DESCRIPTION
        - Allow to specify a migrations assembly using an Assembly type apart from an assemlyName

 Fixes #32461

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

