### PR TITLE
Fix Contains within SQL Server aggregate functions

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1423,7 +1423,14 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         }
     }
 
-    private bool TryTranslateAggregateMethodCall(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    protected virtual bool TryTranslateAggregateMethodCall(
         MethodCallExpression methodCallExpression,
         [NotNullWhen(true)] out SqlExpression? translation)
     {

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
@@ -39,4 +39,16 @@ public class SqlServerQueryCompilationContext : RelationalQueryCompilationContex
         => base.IsBuffering
             || (QuerySplittingBehavior == EntityFrameworkCore.QuerySplittingBehavior.SplitQuery
                 && !_multipleActiveResultSetsEnabled);
+
+    /// <summary>
+    ///     Tracks whether translation is currently within the argument of an aggregate method (e.g. MAX, COUNT); SQL Server does not
+    ///     allow subqueries and aggregates in that context.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual bool InAggregateFunction { get; set; }
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQueryableMethodTranslatingExpressionVisitor
 {
-    private readonly QueryCompilationContext _queryCompilationContext;
+    private readonly SqlServerQueryCompilationContext _queryCompilationContext;
     private readonly IRelationalTypeMappingSource _typeMappingSource;
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
     private readonly int _sqlServerCompatibilityLevel;
@@ -34,7 +34,7 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     public SqlServerQueryableMethodTranslatingExpressionVisitor(
         QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
         RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies,
-        QueryCompilationContext queryCompilationContext,
+        SqlServerQueryCompilationContext queryCompilationContext,
         ISqlServerSingletonOptions sqlServerSingletonOptions)
         : base(dependencies, relationalDependencies, queryCompilationContext)
     {
@@ -120,6 +120,103 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
 
         return base.VisitExtension(extensionExpression);
     }
+
+    #region Aggregate functions
+
+    // We override these for SQL Server to add tracking whether we're inside an aggregate function context, since SQL Server doesn't
+    // support subqueries (or aggregates) within them.
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateAverage(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
+    {
+        var previousInAggregateFunction = _queryCompilationContext.InAggregateFunction;
+        _queryCompilationContext.InAggregateFunction = true;
+        var result = base.TranslateAverage(source, selector, resultType);
+        _queryCompilationContext.InAggregateFunction = previousInAggregateFunction;
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateSum(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
+    {
+        var previousInAggregateFunction = _queryCompilationContext.InAggregateFunction;
+        _queryCompilationContext.InAggregateFunction = true;
+        var result = base.TranslateSum(source, selector, resultType);
+        _queryCompilationContext.InAggregateFunction = previousInAggregateFunction;
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateCount(ShapedQueryExpression source, LambdaExpression? predicate)
+    {
+        var previousInAggregateFunction = _queryCompilationContext.InAggregateFunction;
+        _queryCompilationContext.InAggregateFunction = true;
+        var result = base.TranslateCount(source, predicate);
+        _queryCompilationContext.InAggregateFunction = previousInAggregateFunction;
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateLongCount(ShapedQueryExpression source, LambdaExpression? predicate)
+    {
+        var previousInAggregateFunction = _queryCompilationContext.InAggregateFunction;
+        _queryCompilationContext.InAggregateFunction = true;
+        var result = base.TranslateLongCount(source, predicate);
+        _queryCompilationContext.InAggregateFunction = previousInAggregateFunction;
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateMax(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
+    {
+        var previousInAggregateFunction = _queryCompilationContext.InAggregateFunction;
+        _queryCompilationContext.InAggregateFunction = true;
+        var result = base.TranslateMax(source, selector, resultType);
+        _queryCompilationContext.InAggregateFunction = previousInAggregateFunction;
+        return result;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateMin(ShapedQueryExpression source, LambdaExpression? selector, Type resultType)
+    {
+        var previousInAggregateFunction = _queryCompilationContext.InAggregateFunction;
+        _queryCompilationContext.InAggregateFunction = true;
+        var result = base.TranslateMin(source, selector, resultType);
+        _queryCompilationContext.InAggregateFunction = previousInAggregateFunction;
+        return result;
+    }
+
+    #endregion Aggregate functions
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -321,6 +418,47 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    protected override ShapedQueryExpression? TranslateContains(ShapedQueryExpression source, Expression item)
+    {
+        var translatedSource = base.TranslateContains(source, item);
+
+        // SQL Server does not support subqueries inside aggregate functions (e.g. COUNT(SELECT * FROM OPENJSON(@p)...)).
+        // As a result, we track whether we're within an aggregate function; if we are, and we see the regular Contains translation
+        // (which uses IN with an OPENJSON subquery - incompatible), we transform it to the old-style IN+constants translation (as if a
+        // low SQL Server compatibility level were defined)
+        if (_queryCompilationContext.InAggregateFunction
+            && translatedSource is not null
+            && TryGetProjection(translatedSource, out var projection)
+            && projection is InExpression
+            {
+                Item: var translatedItem,
+                Subquery:
+                {
+                    Tables: [SqlServerOpenJsonExpression { Arguments: [SqlParameterExpression parameter] } openJsonExpression],
+                    GroupBy: [],
+                    Having: null,
+                    IsDistinct: false,
+                    Limit: null,
+                    Offset: null,
+                    Orderings: [],
+                    Projection: [{ Expression: ColumnExpression { Name: "value", Table: var projectionColumnTable } }]
+                }
+            }
+            && projectionColumnTable == openJsonExpression)
+        {
+            var newInExpression = _sqlExpressionFactory.In(translatedItem, parameter);
+            return source.UpdateQueryExpression(_sqlExpressionFactory.Select(newInExpression));
+        }
+
+        return translatedSource;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     protected override ShapedQueryExpression? TranslateElementAtOrDefault(
         ShapedQueryExpression source,
         Expression index,
@@ -501,6 +639,29 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitor : RelationalQu
         }
 
         tableExpression = null;
+        return false;
+    }
+
+    private bool TryGetProjection(ShapedQueryExpression shapedQueryExpression, [NotNullWhen(true)] out SqlExpression? projection)
+    {
+        var shaperExpression = shapedQueryExpression.ShaperExpression;
+        // No need to check ConvertChecked since this is convert node which we may have added during projection
+        if (shaperExpression is UnaryExpression { NodeType: ExpressionType.Convert } unaryExpression
+            && unaryExpression.Operand.Type.IsNullableType()
+            && unaryExpression.Operand.Type.UnwrapNullableType() == unaryExpression.Type)
+        {
+            shaperExpression = unaryExpression.Operand;
+        }
+
+        if (shapedQueryExpression.QueryExpression is SelectExpression selectExpression
+            && shaperExpression is ProjectionBindingExpression projectionBindingExpression
+            && selectExpression.GetProjection(projectionBindingExpression) is SqlExpression sqlExpression)
+        {
+            projection = sqlExpression;
+            return true;
+        }
+
+        projection = null;
         return false;
     }
 

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -49,5 +49,5 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitorFactory : IQuer
     /// </summary>
     public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new SqlServerQueryableMethodTranslatingExpressionVisitor(
-            Dependencies, RelationalDependencies, queryCompilationContext, _sqlServerSingletonOptions);
+            Dependencies, RelationalDependencies, (SqlServerQueryCompilationContext)queryCompilationContext, _sqlServerSingletonOptions);
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExpressionVisitor
 {
-    private readonly QueryCompilationContext _queryCompilationContext;
+    private readonly SqlServerQueryCompilationContext _queryCompilationContext;
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
     private static readonly HashSet<string> DateTimeDataTypes
@@ -73,7 +73,7 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
     /// </summary>
     public SqlServerSqlTranslatingExpressionVisitor(
         RelationalSqlTranslatingExpressionVisitorDependencies dependencies,
-        QueryCompilationContext queryCompilationContext,
+        SqlServerQueryCompilationContext queryCompilationContext,
         QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
         : base(dependencies, queryCompilationContext, queryableMethodTranslatingExpressionVisitor)
     {
@@ -430,6 +430,28 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
         }
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override bool TryTranslateAggregateMethodCall(
+        MethodCallExpression methodCallExpression,
+        [NotNullWhen(true)] out SqlExpression? translation)
+    {
+        var previousInAggregateFunction = _queryCompilationContext.InAggregateFunction;
+        _queryCompilationContext.InAggregateFunction = true;
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var result = base.TryTranslateAggregateMethodCall(methodCallExpression, out translation);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        _queryCompilationContext.InAggregateFunction = previousInAggregateFunction;
+
+        return result;
     }
 
     private Expression TranslateByteArrayElementAccess(Expression array, Expression index, Type resultType)

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitorFactory.cs
@@ -39,6 +39,6 @@ public class SqlServerSqlTranslatingExpressionVisitorFactory : IRelationalSqlTra
         QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
         => new SqlServerSqlTranslatingExpressionVisitor(
             Dependencies,
-            queryCompilationContext,
+            (SqlServerQueryCompilationContext)queryCompilationContext,
             queryableMethodTranslatingExpressionVisitor);
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -2249,6 +2249,86 @@ WHERE (c["Discriminator"] = "Customer")
         AssertSql();
     }
 
+    public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
+    {
+        // GroupBy. Issue #17313.
+        await AssertTranslationFailed(() => base.Contains_inside_aggregate_function_with_GroupBy(async));
+
+        AssertSql();
+    }
+
+    public override async Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Average_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT AVG((c["City"] IN ("London", "Berlin") ? 1.0 : 0.0)) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
+    public override async Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Sum_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT SUM((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
+    public override async Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Count_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT(1) AS c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["City"] IN ("London", "Berlin"))
+""");
+    }
+
+    public override async Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_LongCount_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT(1) AS c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["City"] IN ("London", "Berlin"))
+""");
+    }
+
+    public override async Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Max_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT MAX((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
+    public override async Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Min_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT MIN((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -1923,4 +1923,89 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => !c.Orders.Any(o => false)).Select(c => c.CustomerID));
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_aggregate_function_with_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>()
+                .GroupBy(c => c.Country)
+                .Select(g => g.Count(c => cities.Contains(c.City))));
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertAverage(
+            async,
+            ss => ss.Set<Customer>(),
+            selector: c => cities.Contains(c.City) ? 1.0 : 0.0);
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertSum(
+            async,
+            ss => ss.Set<Customer>(),
+            selector: c => cities.Contains(c.City) ? 1 : 0);
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertCount(
+            async,
+            ss => ss.Set<Customer>(),
+            predicate: c => cities.Contains(c.City));
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertLongCount(
+            async,
+            ss => ss.Set<Customer>(),
+            predicate: c => cities.Contains(c.City));
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertMax(
+            async,
+            ss => ss.Set<Customer>(),
+            selector: c => cities.Contains(c.City) ? 1 : 0);
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertMin(
+            async,
+            ss => ss.Set<Customer>(),
+            selector: c => cities.Contains(c.City) ? 1 : 0);
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -2902,6 +2902,100 @@ FROM [Customers] AS [c]
 """);
     }
 
+    public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
+    {
+        await base.Contains_inside_aggregate_function_with_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1
+END)
+FROM [Customers] AS [c]
+GROUP BY [c].[Country]
+""");
+    }
+
+    public override async Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Average_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT AVG(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1.0E0
+    ELSE 0.0E0
+END)
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Sum_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COALESCE(SUM(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1
+    ELSE 0
+END), 0)
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Count_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT(*)
+FROM [Customers] AS [c]
+WHERE [c].[City] IN (N'London', N'Berlin')
+""");
+    }
+
+    public override async Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_LongCount_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT_BIG(*)
+FROM [Customers] AS [c]
+WHERE [c].[City] IN (N'London', N'Berlin')
+""");
+    }
+
+    public override async Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Max_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT MAX(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1
+    ELSE 0
+END)
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Min_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT MIN(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1
+    ELSE 0
+END)
+FROM [Customers] AS [c]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -71,4 +71,139 @@ public class NorthwindAggregateOperatorsQuerySqliteTest : NorthwindAggregateOper
 
     public override async Task Contains_with_local_tuple_array_closure(bool async)
         => await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
+
+    public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
+    {
+        await base.Contains_inside_aggregate_function_with_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT COUNT(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+END)
+FROM "Customers" AS "c"
+GROUP BY "c"."Country"
+""");
+    }
+
+    public override async Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Average_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT AVG(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1.0
+    ELSE 0.0
+END)
+FROM "Customers" AS "c"
+""");
+    }
+
+    public override async Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Sum_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT COALESCE(SUM(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ELSE 0
+END), 0)
+FROM "Customers" AS "c"
+""");
+    }
+
+    public override async Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Count_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT COUNT(*)
+FROM "Customers" AS "c"
+WHERE EXISTS (
+    SELECT 1
+    FROM json_each(@__cities_0) AS "c0"
+    WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL))
+""");
+    }
+
+    public override async Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_LongCount_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT COUNT(*)
+FROM "Customers" AS "c"
+WHERE EXISTS (
+    SELECT 1
+    FROM json_each(@__cities_0) AS "c0"
+    WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL))
+""");
+    }
+
+    public override async Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Max_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT MAX(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ELSE 0
+END)
+FROM "Customers" AS "c"
+""");
+    }
+
+    public override async Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Min_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT MIN(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ELSE 0
+END)
+FROM "Customers" AS "c"
+""");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    protected override void ClearLog()
+        => Fixture.TestSqlLoggerFactory.Clear();
 }


### PR DESCRIPTION
This:

* Adds tracking in SQL Server for when we're inside an aggregate method (Count, Max...). The flag was introduced on SqlServerQueryCompilationContext.
    * This maybe isn't the ideal place, because the flag is only temporary translation state, and does not apply to all of compilation.
    * But it's currently the only place shared across SqlServerQueryableMethodTranslatingExpressionVisitor and SqlServerSqlTranslatingExpressionVisitor. We can think about a better way to preserve state data across the different visitors during the translation process.
* Then, if the flag is on and we see the new OPENJSON-based subquery translation for Contains, we convert it to the old IN+constants translations, as if the SQL Server compatibility level were too low.

One note: we could instead refrain from producing the OPENJSON translation altogether (return null from TranslatePrimitiveCollection), and let the general relational fallback produce the old IN+constants translation. But this would block simplifications that pattern-match on top of the OPENJSON translation (currently we only have TranslateElementOrDefault which does that for SQL Server).

Fixes #32374