### PR TITLE
[release/8.0] Cosmos: Generate ordinal values for key properties that used not to be persisted.

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
@@ -34,8 +34,8 @@ public static class CosmosPropertyExtensions
         {
             var pk = property.FindContainingPrimaryKey();
             if (pk != null
-                && (property.ClrType == typeof(int) || ownership.Properties.Contains(property))
-                && property.IsShadowProperty()
+                && ((property.ClrType == typeof(int) && property.IsShadowProperty())
+                    || ownership.Properties.Contains(property))
                 && pk.Properties.Count == ownership.Properties.Count + (ownership.IsUnique ? 0 : 1)
                 && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
             {

--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyExtensions.cs
@@ -15,6 +15,12 @@ namespace Microsoft.EntityFrameworkCore;
 /// </remarks>
 public static class CosmosPropertyExtensions
 {
+    private static readonly bool _useOldBehavior31664 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue31664", out var enabled31664) && enabled31664;
+
+    private static readonly bool _useOldBehavior32363 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32363", out var enabled32363) && enabled32363;
+
     /// <summary>
     ///     Returns the property name that the property is mapped to when targeting Cosmos.
     /// </summary>
@@ -34,8 +40,10 @@ public static class CosmosPropertyExtensions
         {
             var pk = property.FindContainingPrimaryKey();
             if (pk != null
-                && ((property.ClrType == typeof(int) && property.IsShadowProperty())
+                && ((property.ClrType == typeof(int)
+                    && (property.IsShadowProperty() || _useOldBehavior32363 || _useOldBehavior31664))
                     || ownership.Properties.Contains(property))
+                && (property.IsShadowProperty() || !_useOldBehavior32363 || _useOldBehavior31664)
                 && pk.Properties.Count == ownership.Properties.Count + (ownership.IsUnique ? 0 : 1)
                 && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
             {

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosValueGenerationConvention.cs
@@ -27,6 +27,9 @@ public class CosmosValueGenerationConvention :
     {
     }
 
+    private static readonly bool _useOldBehavior31664 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue31664", out var enabled31664) && enabled31664;
+
     /// <summary>
     ///     Called after an annotation is changed on an entity type.
     /// </summary>
@@ -80,7 +83,7 @@ public class CosmosValueGenerationConvention :
                 if (pk != null
                     && !property.IsForeignKey()
                     && pk.Properties.Count == ownership.Properties.Count + 1
-                    && property.IsShadowProperty()
+                    && (property.IsShadowProperty() || _useOldBehavior31664)
                     && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
                 {
                     return ValueGenerated.OnAddOrUpdate;

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -596,25 +596,27 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 return _projectionBindings[jObjectExpression];
             }
 
+            var entityType = property.DeclaringType as IEntityType;
+            var ownership = entityType?.FindOwnership();
             var storeName = property.GetJsonPropertyName();
             if (storeName.Length == 0)
             {
-                var entityType = property.DeclaringType as IEntityType;
                 if (entityType == null
                     || !entityType.IsDocumentRoot())
                 {
-                    var ownership = entityType?.FindOwnership();
                     if (ownership != null
-                        && !ownership.IsUnique
-                        && property.IsOrdinalKeyProperty())
+                        && !ownership.IsUnique)
                     {
-                        var readExpression = _ordinalParameterBindings[jObjectExpression];
-                        if (readExpression.Type != type)
+                        if (property.IsOrdinalKeyProperty())
                         {
-                            readExpression = Convert(readExpression, type);
-                        }
+                            var ordinalExpression = _ordinalParameterBindings[jObjectExpression];
+                            if (ordinalExpression.Type != type)
+                            {
+                                ordinalExpression = Convert(ordinalExpression, type);
+                            }
 
-                        return readExpression;
+                            return ordinalExpression;
+                        }
                     }
 
                     var principalProperty = property.FindFirstPrincipal();
@@ -646,6 +648,37 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
                 }
 
                 return Default(type);
+            }
+
+            // Workaround for old databases that didn't store the key property
+            if (ownership != null
+                && !ownership.IsUnique
+                && !entityType.IsDocumentRoot()
+                && property.ClrType == typeof(int)
+                && !property.IsForeignKey()
+                && property.FindContainingPrimaryKey() is { Properties.Count: > 1 }
+                && property.GetJsonPropertyName().Length != 0
+                && !property.IsShadowProperty())
+            {
+                var readExpression = CreateGetValueExpression(
+                    jObjectExpression, storeName, type.MakeNullable(), property.GetTypeMapping());
+
+                var nonNullReadExpression = readExpression;
+                if (nonNullReadExpression.Type != type)
+                {
+                    nonNullReadExpression = Convert(nonNullReadExpression, type);
+                }
+
+                var ordinalExpression = _ordinalParameterBindings[jObjectExpression];
+                if (ordinalExpression.Type != type)
+                {
+                    ordinalExpression = Convert(ordinalExpression, type);
+                }
+
+                return Condition(
+                    Equal(readExpression, Constant(null, readExpression.Type)),
+                    ordinalExpression,
+                    nonNullReadExpression);
             }
 
             return Convert(

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -15,6 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 
 public partial class CosmosShapedQueryCompilingExpressionVisitor
 {
+    private static readonly bool _useOldBehavior32363 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32363", out var enabled32363) && enabled32363;
+
     private abstract class CosmosProjectionBindingRemovingExpressionVisitorBase : ExpressionVisitor
     {
         private static readonly MethodInfo GetItemMethodInfo
@@ -651,7 +654,8 @@ public partial class CosmosShapedQueryCompilingExpressionVisitor
             }
 
             // Workaround for old databases that didn't store the key property
-            if (ownership != null
+            if (!_useOldBehavior32363
+                && ownership != null
                 && !ownership.IsUnique
                 && !entityType.IsDocumentRoot()
                 && property.ClrType == typeof(int)


### PR DESCRIPTION
Port of #32469
Fixes #32363
Fixes #32410

### Description

We fixed #31664 for 8.0 RTM. It was a known breaking change, but had bigger impact then initially thought for existing databases. With that fix the nested entities fail to load when queried as the now required key value is missing. The new fix is to use a generated ordinal value in this case (this is the same value that the property would have had in 8.0.0-rc2 and previous versions).

### Customer impact

Users with an existing database that use a model with nested owned collections where the entity type has an `int` property that matches our key convention (e.g. named `Id`) are either getting an exception during query execution or the nested collection is silently lost.

### How found

Customers reported on 8.0

### Regression

Yes

### Testing

Added.

### Risk

Low, reverses some of the behavior changed in a previous fix. Added a quirk for this fix and also for #31664 in case there are more scenarios not covered by the current fix.
