### PR TITLE
Don't consider a generated value stable just because it was explicitly set

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -116,15 +116,6 @@ public class ValueGenerationManager : IValueGenerationManager
             var generatedValue = valueGenerator.Next(entityEntry);
             var temporary = valueGenerator.GeneratesTemporaryValues;
 
-            if (valueGenerator.GeneratesStableValues)
-            {
-                hasStableValues = true;
-            }
-            else
-            {
-                hasNonStableValues = true;
-            }
-
             Log(entry, property, generatedValue, temporary);
 
             SetGeneratedValue(entry, property, generatedValue, temporary);
@@ -163,17 +154,7 @@ public class ValueGenerationManager : IValueGenerationManager
         var hasNonStableValues = false;
         foreach (var property in entry.EntityType.GetValueGeneratingProperties())
         {
-            if (entry.HasExplicitValue(property)
-                || (!includePrimaryKey
-                    && property.IsPrimaryKey()))
-            {
-                continue;
-            }
-
             var valueGenerator = GetValueGenerator(property);
-            var generatedValue = await valueGenerator.NextAsync(entityEntry, cancellationToken).ConfigureAwait(false);
-            var temporary = valueGenerator.GeneratesTemporaryValues;
-
             if (valueGenerator.GeneratesStableValues)
             {
                 hasStableValues = true;
@@ -182,6 +163,16 @@ public class ValueGenerationManager : IValueGenerationManager
             {
                 hasNonStableValues = true;
             }
+
+            if (entry.HasExplicitValue(property)
+                || (!includePrimaryKey
+                    && property.IsPrimaryKey()))
+            {
+                continue;
+            }
+
+            var generatedValue = await valueGenerator.NextAsync(entityEntry, cancellationToken).ConfigureAwait(false);
+            var temporary = valueGenerator.GeneratesTemporaryValues;
 
             Log(entry, property, generatedValue, temporary);
 

--- a/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -96,14 +96,22 @@ public class ValueGenerationManager : IValueGenerationManager
         //TODO: Handle complex properties
         foreach (var property in entry.EntityType.GetValueGeneratingProperties())
         {
+            var valueGenerator = GetValueGenerator(property);
+            if (valueGenerator.GeneratesStableValues)
+            {
+                hasStableValues = true;
+            }
+            else
+            {
+                hasNonStableValues = true;
+            }
+
             if (entry.HasExplicitValue(property)
                 || (!includePrimaryKey
                     && property.IsPrimaryKey()))
             {
                 continue;
             }
-
-            var valueGenerator = GetValueGenerator(property);
 
             var generatedValue = valueGenerator.Next(entityEntry);
             var temporary = valueGenerator.GeneratesTemporaryValues;

--- a/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -167,6 +167,7 @@ public class ModificationCommandComparerTest
 
         var keyProperty = entityType.AddProperty("Id", typeof(T));
         keyProperty.IsNullable = false;
+        keyProperty.ValueGenerated = ValueGenerated.Never;
         entityType.SetPrimaryKey(keyProperty);
 
         var model = modelBuilder.FinalizeModel();

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -586,6 +586,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture> : IClassFixture<TFi
                     b.OwnsMany(e => e.OptionalChildren).OwnsMany(e => e.Children);
                     b.OwnsMany(e => e.RequiredChildren).OwnsMany(e => e.Children);
                 });
+
+            modelBuilder.Entity<ParentEntity32084>().HasOne(x => x.Child)
+                .WithOne()
+                .HasForeignKey<ChildBaseEntity32084>(x => x.ParentId);
+
+            modelBuilder.Entity<ChildEntity32084>();
         }
 
         protected virtual object CreateFullGraph()
@@ -4339,6 +4345,53 @@ public abstract partial class GraphUpdatesTestBase<TFixture> : IClassFixture<TFi
 
     protected class Beetroot2 : Parsnip2
     {
+    }
+
+    protected class ParentEntity32084 : NotifyingEntity
+    {
+        private Guid _id;
+        private ChildBaseEntity32084 _child;
+
+        public Guid Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public ChildBaseEntity32084 Child
+        {
+            get => _child;
+            set => SetWithNotify(value, ref _child);
+        }
+    }
+
+    protected abstract class ChildBaseEntity32084 : NotifyingEntity
+    {
+        private Guid _id;
+        private Guid _parentId;
+
+        public Guid Id
+        {
+            get => _id;
+            set => SetWithNotify(value, ref _id);
+        }
+
+        public Guid ParentId
+        {
+            get => _parentId;
+            set => SetWithNotify(value, ref _parentId);
+        }
+    }
+
+    protected class ChildEntity32084 : ChildBaseEntity32084
+    {
+        private string _childValue;
+
+        public string ChildValue
+        {
+            get => _childValue;
+            set => SetWithNotify(value, ref _childValue);
+        }
     }
 
     protected class NotifyingEntity : INotifyPropertyChanging, INotifyPropertyChanged

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -15,6 +15,10 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
         => Task.CompletedTask;
 
     // No owned types
+    public override Task Mark_explicitly_set_dependent_appropriately_with_any_inheritance_and_stable_generator(bool async)
+        => Task.CompletedTask;
+
+    // No owned types
     public override Task Update_root_by_collection_replacement_of_deleted_first_level(bool async)
         => Task.CompletedTask;
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerOwnedTest.cs
@@ -15,7 +15,15 @@ public class GraphUpdatesSqlServerOwnedTest : GraphUpdatesSqlServerTestBase<Grap
         => Task.CompletedTask;
 
     // No owned types
-    public override Task Mark_explicitly_set_dependent_appropriately_with_any_inheritance_and_stable_generator(bool async)
+    public override Task Mark_explicitly_set_dependent_appropriately_with_any_inheritance_and_stable_generator(bool async, bool useAdd)
+        => Task.CompletedTask;
+
+    // No owned types
+    public override Task Mark_explicitly_set_stable_dependent_appropriately(bool async, bool useAdd)
+        => Task.CompletedTask;
+
+    // No owned types
+    public override Task Mark_explicitly_set_stable_dependent_appropriately_when_deep_in_graph(bool async, bool useAdd)
         => Task.CompletedTask;
 
     // No owned types

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTptIdentityTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTptIdentityTest.cs
@@ -73,6 +73,9 @@ public class GraphUpdatesSqlServerTptIdentityTest : GraphUpdatesSqlServerTestBas
             modelBuilder.Entity<Poost>().ToTable(nameof(Poost));
             modelBuilder.Entity<Bloog>().ToTable(nameof(Bloog));
             modelBuilder.Entity<Produce>().ToTable(nameof(Produce));
+            modelBuilder.Entity<ParentEntity32084>().ToTable(nameof(ParentEntity32084));
+            modelBuilder.Entity<ChildBaseEntity32084>().ToTable(nameof(ChildBaseEntity32084));
+            modelBuilder.Entity<ChildEntity32084>().ToTable(nameof(ChildEntity32084));
         }
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -2299,17 +2299,17 @@ public class ChangeTrackerTest
             modelBuilder
                 .Entity<Cat>()
                 .Property(e => e.Id)
-                .HasValueGenerator<InMemoryIntegerValueGenerator<int>>();
+                .HasValueGenerator((_, __) => new ResettableValueGenerator());
 
             modelBuilder
                 .Entity<Hat>()
                 .Property(e => e.Id)
-                .HasValueGenerator<InMemoryIntegerValueGenerator<int>>();
+                .HasValueGenerator((_, __) => new ResettableValueGenerator());
 
             modelBuilder.Entity<Mat>(
                 b =>
                 {
-                    b.Property(e => e.Id).HasValueGenerator<InMemoryIntegerValueGenerator<int>>();
+                    b.Property(e => e.Id).HasValueGenerator((_, __) => new ResettableValueGenerator());
                     b.HasMany(e => e.Cats)
                         .WithMany(e => e.Mats)
                         .UsingEntity<CatMat>(


### PR DESCRIPTION
Fixes #32084
