### PR TITLE
[release/8.0] Fix expression cloning when table changes in SelectExpression.VisitChildren

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4678,6 +4678,14 @@ WHERE ((c["Discriminator"] = "Customer") AND @__Contains_0)
         AssertSql();
     }
 
+    public override async Task Parameter_collection_Contains_with_projection_and_ordering(bool async)
+    {
+        await AssertTranslationFailed(
+            () => base.Parameter_collection_Contains_with_projection_and_ordering(async));
+
+        AssertSql();
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5716,4 +5716,20 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture> : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => new[] { 100, c.Orders.Count }.Sum() > 101));
+
+    [ConditionalTheory] // #32234
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Parameter_collection_Contains_with_projection_and_ordering(bool async)
+    {
+        var ids = new[] { 10248, 10249 };
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>()
+                .Where(e => ids.Contains(e.OrderID))
+                .GroupBy(e => e.Quantity)
+                .Select(g => new { g.Key, MaxTimestamp = g.Select(e => e.Order.OrderDate).Max() })
+                .OrderBy(x => x.MaxTimestamp)
+                .Select(x => x));
+    }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -438,6 +438,19 @@ FROM "Orders" AS "o"
     public override Task Max_on_empty_sequence_throws(bool async)
         => Assert.ThrowsAsync<InvalidOperationException>(() => base.Max_on_empty_sequence_throws(async));
 
+    public override async Task Parameter_collection_Contains_with_projection_and_ordering(bool async)
+    {
+#if DEBUG
+        // GroupBy debug assert. Issue #26104.
+        Assert.StartsWith(
+            "Missing alias in the list",
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Parameter_collection_Contains_with_projection_and_ordering(async))).Message);
+#else
+        await base.Parameter_collection_Contains_with_projection_and_ordering(async);
+#endif
+    }
+
     [ConditionalFact]
     public async Task Single_Predicate_Cancellation()
         => await Assert.ThrowsAnyAsync<OperationCanceledException>(


### PR DESCRIPTION
Fixes #32234, backports #32456.

### Description

The primitive collection work in 8.0 caused the query tree shape to change, introducing a subquery where previously a simpler construct existed (`WHERE x IN (...)`). This exposed a latent bug in the query pipeline around the cloning of SelectExpressions which causes us to lose referential integrity and generate incorrect SQL.

### Customer impact

Queries where the same subquery ends up duplicated twice - which used to work on EF 7 - now produce invalid SQL. For example:

```c#
_ = await context.IterationValues
    .Where(r => ids.Contains(r.IterationId))
    .GroupBy(x => x.IterationId)
    .Select(x => new
    {
        x.Key,
        MaxTimestamp = x.Select(x => x.Iteration.Timestamp).Max(),
    })
    .OrderBy(x => x.MaxTimestamp)
    .ToListAsync();
```

### How found

Customers reported on 8.0

### Regression

Yes

### Testing

Added.

### Risk

Medium. The fix is quite minimal/safe, but is in an area in the query pipeline which is a bit risky. Quirk added to revert to the previous behavior.
