### PR TITLE
Refactor queryable collection support for non-relational providers

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryRootProcessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryRootProcessor.cs
@@ -28,7 +28,7 @@ public class RelationalQueryRootProcessor : QueryRootProcessor
 
     /// <summary>
     ///     Indicates that a <see cref="ConstantExpression" /> can be converted to a <see cref="InlineQueryRootExpression" />;
-    ///     the latter will end up in <see cref="RelationalQueryableMethodTranslatingExpressionVisitor.VisitInlineQueryRoot" /> for
+    ///     the latter will end up in <see cref="RelationalQueryableMethodTranslatingExpressionVisitor.TranslateInlineQueryRoot" /> for
     ///     translation to a SQL <see cref="ValuesExpression" />.
     /// </summary>
     protected override bool ShouldConvertToInlineQueryRoot(NewArrayExpression newArrayExpression)

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -760,38 +760,6 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
             ? sqlConstantExpression
             : QueryCompilationContext.NotTranslatedExpression;
 
-    /// <summary>
-    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-    ///     any release. You should only use it directly in your code with extreme caution and knowing that
-    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-    /// </summary>
-    [EntityFrameworkInternal]
-    public virtual bool TryTranslatePropertyAccess(
-        Expression expression,
-        [NotNullWhen(true)] out Expression? translatedExpression,
-        [NotNullWhen(true)] out IPropertyBase? property)
-    {
-        if (expression is MethodCallExpression methodCallExpression)
-        {
-            if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName)
-                && TryBindMember(Visit(source), MemberIdentity.Create(propertyName), out translatedExpression, out property))
-            {
-                return true;
-            }
-
-            if (methodCallExpression.TryGetIndexerArguments(_model, out source, out propertyName)
-                && TryBindMember(Visit(source), MemberIdentity.Create(propertyName), out translatedExpression, out property))
-            {
-                return true;
-            }
-        }
-
-        translatedExpression = null;
-        property = null;
-        return false;
-    }
-
     /// <inheritdoc />
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
@@ -1258,7 +1226,14 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         [NotNullWhen(true)] out Expression? expression)
         => TryBindMember(source, member, out expression, out _);
 
-    private bool TryBindMember(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    public virtual bool TryBindMember(
         Expression? source,
         MemberIdentity member,
         [NotNullWhen(true)] out Expression? expression,

--- a/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/PrimitiveCollectionsQueryTestBase.cs
@@ -512,6 +512,13 @@ public abstract class PrimitiveCollectionsQueryTestBase<TFixture> : QueryTestBas
             async,
             ss => ss.Set<PrimitiveCollectionsEntity>().Where(c => c.Ints.Distinct().Count() == 3));
 
+    [ConditionalTheory] // #32505
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Column_collection_SelectMany(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<PrimitiveCollectionsEntity>().SelectMany(c => c.Ints));
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Column_collection_projection_from_top_level(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQueryOldSqlServerTest.cs
@@ -505,6 +505,9 @@ WHERE (
     public override Task Column_collection_Distinct(bool async)
         => AssertTranslationFailed(() => base.Column_collection_Distinct(async));
 
+    public override Task Column_collection_SelectMany(bool async)
+        => AssertTranslationFailed(() => base.Column_collection_SelectMany(async));
+
     public override async Task Column_collection_projection_from_top_level(bool async)
     {
         await base.Column_collection_projection_from_top_level(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrimitiveCollectionsQuerySqlServerTest.cs
@@ -811,6 +811,18 @@ WHERE (
 """);
     }
 
+    public override async Task Column_collection_SelectMany(bool async)
+    {
+        await base.Column_collection_SelectMany(async);
+
+        AssertSql(
+            """
+SELECT [i].[value]
+FROM [PrimitiveCollectionsEntity] AS [p]
+CROSS APPLY OPENJSON([p].[Ints]) WITH ([value] int '$') AS [i]
+""");
+    }
+
     public override async Task Column_collection_projection_from_top_level(bool async)
     {
         await base.Column_collection_projection_from_top_level(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/PrimitiveCollectionsQuerySqliteTest.cs
@@ -790,6 +790,12 @@ WHERE (
 """);
     }
 
+    public override async Task Column_collection_SelectMany(bool async)
+        => Assert.Equal(
+            SqliteStrings.ApplyNotSupported,
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Column_collection_SelectMany(async))).Message);
+
     public override async Task Column_collection_projection_from_top_level(bool async)
     {
         await base.Column_collection_projection_from_top_level(async);


### PR DESCRIPTION
Pretty straightforward refactor that moves some basic queryable collection support from relational to core; this will make it easier to implement e.g. primitive collection support for non-relational providers.

This also fixes exception ordering issue which caused SelectMany over primitive collection properties to fail.

Fixes #32505
