### PR TITLE
Add DbContextOptions composibility support

### DIFF
--- a/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
@@ -6,14 +6,27 @@ using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization;
 
 [DisplayName("InitializationTests")]
 public abstract class InitializationTests
 {
+    private ServiceProvider _serviceProvider;
+    private ServiceProvider _pooledServiceProvider;
+
     protected abstract AdventureWorksContextBase CreateContext();
     protected abstract ConventionSet CreateConventionSet();
+    protected abstract IServiceCollection AddContext(IServiceCollection services);
+    protected abstract IServiceCollection AddContextPool(IServiceCollection services);
+
+    [GlobalSetup]
+    public virtual void Initialize()
+    {
+        _serviceProvider = AddContext(new ServiceCollection()).BuildServiceProvider();
+        _pooledServiceProvider = AddContextPool(new ServiceCollection()).BuildServiceProvider();
+    }
 
     [Benchmark]
     public virtual void CreateAndDisposeUnusedContext()
@@ -21,9 +34,49 @@ public abstract class InitializationTests
         for (var i = 0; i < 10000; i++)
         {
             // ReSharper disable once UnusedVariable
-            using (var context = CreateContext())
-            {
-            }
+            using var context = CreateContext();
+        }
+    }
+
+    [Benchmark]
+    public virtual void CreateAndDisposeUnusedContextFromDi()
+    {
+        for (var i = 0; i < 10000; i++)
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var context = scope.ServiceProvider.GetService<AdventureWorksContextBase>();
+        }
+    }
+
+    [Benchmark]
+    public virtual void CreateAndDisposeUnusedContextFromDiFactory()
+    {
+        var factory = _serviceProvider.GetService<IDbContextFactory<AdventureWorksContextBase>>();
+        for (var i = 0; i < 10000; i++)
+        {
+            using var _ = factory.CreateDbContext();
+        }
+    }
+
+    [Benchmark]
+    public virtual void CreateAndDisposePooledContextFromDi()
+    {
+        for (var i = 0; i < 10000; i++)
+        {
+            using var scope = _pooledServiceProvider.CreateScope();
+            var context = (AdventureWorksContextBase)scope.ServiceProvider.GetService(typeof(AdventureWorksContextBase));
+            var _ = context.Model;
+        }
+    }
+
+    [Benchmark]
+    public virtual void CreateAndDisposePooledContextFromDiFactory()
+    {
+        var factory = _pooledServiceProvider.GetService<IDbContextFactory<AdventureWorksContextBase>>();
+        for (var i = 0; i < 10000; i++)
+        {
+            using var context = factory.CreateDbContext();
+            var _ = context.Model;
         }
     }
 

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/AdventureWorksContextBase.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/AdventureWorksContextBase.cs
@@ -5,6 +5,15 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 
 public abstract class AdventureWorksContextBase : DbContext
 {
+    public AdventureWorksContextBase()
+    {
+    }
+
+    public AdventureWorksContextBase(DbContextOptions options)
+        : base(options)
+    {
+    }
+
     public virtual DbSet<Address> Address { get; set; }
     public virtual DbSet<AddressType> AddressType { get; set; }
     public virtual DbSet<BillOfMaterials> BillOfMaterials { get; set; }

--- a/benchmark/EFCore.SqlServer.Benchmarks/Initialization/InitializationSqlServerTests.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Initialization/InitializationSqlServerTests.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization;
 
@@ -13,4 +15,37 @@ public class InitializationSqlServerTests : InitializationTests
 
     protected override ConventionSet CreateConventionSet()
         => SqlServerConventionSetBuilder.Build();
+
+    protected override IServiceCollection AddContext(IServiceCollection services)
+    {
+        services.AddDbContext<AdventureWorksContextBase, AdventureWorksSqlServerContext>()
+                .AddDbContextFactory<AdventureWorksSqlServerContext>()
+                .TryAddSingleton<IDbContextFactory<AdventureWorksContextBase>,
+                    AdventureWorksSqlServerContextFactory<AdventureWorksSqlServerContext>>();
+
+        return services;
+    }
+
+    protected override IServiceCollection AddContextPool(IServiceCollection services)
+    {
+        services.AddDbContextPool<AdventureWorksContextBase, AdventureWorksPoolableSqlServerContext>(
+            AdventureWorksSqlServerFixture.ConfigureOptions)
+                .AddPooledDbContextFactory<AdventureWorksPoolableSqlServerContext>(AdventureWorksSqlServerFixture.ConfigureOptions)
+                .TryAddSingleton<IDbContextFactory<AdventureWorksContextBase>,
+                    AdventureWorksSqlServerContextFactory<AdventureWorksPoolableSqlServerContext>>();
+
+        return services;
+    }
+
+    private class AdventureWorksSqlServerContextFactory<T> : IDbContextFactory<AdventureWorksContextBase>
+        where T : AdventureWorksContextBase
+    {
+        private readonly IDbContextFactory<T> _factory;
+
+        public AdventureWorksSqlServerContextFactory(IDbContextFactory<T> factory)
+            => _factory = factory;
+
+        public AdventureWorksContextBase CreateDbContext()
+            => _factory.CreateDbContext();
+    }
 }

--- a/benchmark/EFCore.SqlServer.Benchmarks/Models/AdventureWorks/AdventureWorksPoolableSqlServerContext.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Models/AdventureWorks/AdventureWorksPoolableSqlServerContext.cs
@@ -3,8 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 
-public class AdventureWorksSqliteContext : AdventureWorksContextBase
+public class AdventureWorksPoolableSqlServerContext : AdventureWorksContextBase
 {
+    public AdventureWorksPoolableSqlServerContext(DbContextOptions<AdventureWorksPoolableSqlServerContext> options)
+        : base(options)
+    {
+    }
+
     protected override void ConfigureProvider(DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.UseSqlite(AdventureWorksSqliteFixture.ConnectionString);
+    {
+    }
 }

--- a/benchmark/EFCore.SqlServer.Benchmarks/Models/AdventureWorks/AdventureWorksSqlServerContext.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Models/AdventureWorks/AdventureWorksSqlServerContext.cs
@@ -5,13 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 
 public class AdventureWorksSqlServerContext : AdventureWorksContextBase
 {
-    private readonly string _connectionString;
-
-    public AdventureWorksSqlServerContext(string connectionString)
-    {
-        _connectionString = connectionString;
-    }
-
     protected override void ConfigureProvider(DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.UseSqlServer(_connectionString);
+        => optionsBuilder.UseSqlServer(AdventureWorksSqlServerFixture.ConnectionString);
 }

--- a/benchmark/EFCore.SqlServer.Benchmarks/Models/AdventureWorks/AdventureWorksSqlServerFixture.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Models/AdventureWorks/AdventureWorksSqlServerFixture.cs
@@ -5,9 +5,12 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 
 public static class AdventureWorksSqlServerFixture
 {
-    private static readonly string _connectionString = SqlServerBenchmarkEnvironment.CreateConnectionString("AdventureWorks2014");
+    public static string ConnectionString { get; } = SqlServerBenchmarkEnvironment.CreateConnectionString("AdventureWorks2014");
 
     // This method is called from timed code, be careful when changing it
     public static AdventureWorksContextBase CreateContext()
-        => new AdventureWorksSqlServerContext(_connectionString);
+        => new AdventureWorksSqlServerContext();
+
+    public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlServer(ConnectionString);
 }

--- a/benchmark/EFCore.Sqlite.Benchmarks/Initialization/InitializationSqliteTests.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Initialization/InitializationSqliteTests.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization;
 
@@ -13,4 +15,37 @@ public class InitializationSqliteTests : InitializationTests
 
     protected override ConventionSet CreateConventionSet()
         => SqliteConventionSetBuilder.Build();
+
+    protected override IServiceCollection AddContext(IServiceCollection services)
+    {
+        services.AddDbContext<AdventureWorksContextBase, AdventureWorksSqliteContext>()
+                .AddDbContextFactory<AdventureWorksSqliteContext>()
+                .TryAddSingleton<IDbContextFactory<AdventureWorksContextBase>,
+                    AdventureWorksSqliteContextFactory<AdventureWorksSqliteContext>>();
+
+        return services;
+    }
+
+    protected override IServiceCollection AddContextPool(IServiceCollection services)
+    {
+        services.AddDbContextPool<AdventureWorksContextBase, AdventureWorksPoolableSqliteContext>(
+            AdventureWorksSqliteFixture.ConfigureOptions)
+                .AddPooledDbContextFactory<AdventureWorksPoolableSqliteContext>(AdventureWorksSqliteFixture.ConfigureOptions)
+                .TryAddSingleton<IDbContextFactory<AdventureWorksContextBase>,
+                    AdventureWorksSqliteContextFactory<AdventureWorksPoolableSqliteContext>>();
+
+        return services;
+    }
+
+    private class AdventureWorksSqliteContextFactory<T> : IDbContextFactory<AdventureWorksContextBase>
+        where T : AdventureWorksContextBase
+    {
+        private readonly IDbContextFactory<T> _factory;
+
+        public AdventureWorksSqliteContextFactory(IDbContextFactory<T> factory)
+            => _factory = factory;
+
+        public AdventureWorksContextBase CreateDbContext()
+            => _factory.CreateDbContext();
+    }
 }

--- a/benchmark/EFCore.Sqlite.Benchmarks/Models/AdventureWorks/AdventureWorksPoolableSqliteContext.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Models/AdventureWorks/AdventureWorksPoolableSqliteContext.cs
@@ -3,8 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 
-public class AdventureWorksSqliteContext : AdventureWorksContextBase
+public class AdventureWorksPoolableSqliteContext : AdventureWorksContextBase
 {
+    public AdventureWorksPoolableSqliteContext(DbContextOptions<AdventureWorksPoolableSqliteContext> options)
+        : base(options)
+    {
+    }
+
     protected override void ConfigureProvider(DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.UseSqlite(AdventureWorksSqliteFixture.ConnectionString);
+    {
+    }
 }

--- a/benchmark/EFCore.Sqlite.Benchmarks/Models/AdventureWorks/AdventureWorksSqliteFixture.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Models/AdventureWorks/AdventureWorksSqliteFixture.cs
@@ -10,10 +10,12 @@ public static class AdventureWorksSqliteFixture
     private static readonly string _baseDirectory
         = Path.GetDirectoryName(typeof(AdventureWorksSqliteFixture).Assembly.Location);
 
-    private static readonly string _connectionString
-        = $"Data Source={Path.Combine(_baseDirectory, "AdventureWorks2014.db")}";
+    public static string ConnectionString { get; } = $"Data Source={Path.Combine(_baseDirectory, "AdventureWorks2014.db")}";
 
     // This method is called from timed code, be careful when changing it
     public static AdventureWorksContextBase CreateContext()
-        => new AdventureWorksSqliteContext(_connectionString);
+        => new AdventureWorksSqliteContext();
+
+    public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlite(ConnectionString);
 }

--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -1034,6 +1035,86 @@ public static class EntityFrameworkServiceCollectionExtensions
         return serviceCollection;
     }
 
+    /// <summary>
+    ///     Configures the given context type in the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="AddDbContext{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)" />,
+    ///         <see cref="AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />, 
+    ///         <see cref="AddDbContextFactory{TContext, TFactory}(IServiceCollection,Action{DbContextOptionsBuilder}?,ServiceLifetime)" /> or
+    ///         <see cref="AddPooledDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />
+    ///         must also be called for the specified configuration to take effect.
+    ///         Calling this method after any of the above will ovewrite conflicting configuration.
+    ///         For non-pooled contexts <see cref="DbContext.OnConfiguring" /> configuration will be applied
+    ///         in addition to configuration performed here.
+    ///     </para>
+    ///     <para>
+    ///         This method can be invoked multiple times and the configuration will be applied in the given order.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-di">Using DbContext with dependency injection</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TContext">The type of context to be registered.</typeparam>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection" /> to add services to.</param>
+    /// <param name="optionsAction">An action to configure the <see cref="DbContextOptions" /> for the context.</param>
+    /// <param name="optionsLifetime">
+    ///     The lifetime with which the <see cref="DbContextOptions" /> service will be registered in the container.
+    /// </param>
+    /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    public static IServiceCollection ConfigureDbContext
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<DbContextOptionsBuilder> optionsAction,
+            ServiceLifetime optionsLifetime = ServiceLifetime.Singleton)
+        where TContext : DbContext
+        => ConfigureDbContext<TContext>(serviceCollection, (_, b) => optionsAction(b), optionsLifetime);
+
+    /// <summary>
+    ///     Configures the given context type in the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="AddDbContext{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)" />,
+    ///         <see cref="AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />, 
+    ///         <see cref="AddDbContextFactory{TContext, TFactory}(IServiceCollection,Action{DbContextOptionsBuilder}?,ServiceLifetime)" /> or
+    ///         <see cref="AddPooledDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />
+    ///         must also be called for the specified configuration to take effect.
+    ///         Calling this method after any of the above will ovewrite conflicting configuration.
+    ///         For non-pooled contexts <see cref="DbContext.OnConfiguring" /> configuration will be applied
+    ///         in addition to configuration performed here.
+    ///     </para>
+    ///     <para>
+    ///         This method can be invoked multiple times and the configuration will be applied in the given order.
+    ///     </para>
+    ///     <para>
+    ///         See <see href="https://aka.ms/efcore-docs-di">Using DbContext with dependency injection</see> for more information and examples.
+    ///     </para>
+    /// </remarks>
+    /// <typeparam name="TContext">The type of context to be registered.</typeparam>
+    /// <param name="serviceCollection">The <see cref="IServiceCollection" /> to add services to.</param>
+    /// <param name="optionsAction">An action to configure the <see cref="DbContextOptions" /> for the context.</param>
+    /// <param name="optionsLifetime">
+    ///     The lifetime with which the <see cref="DbContextOptions" /> service will be registered in the container.
+    /// </param>
+    /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    public static IServiceCollection ConfigureDbContext
+        <[DynamicallyAccessedMembers(DbContext.DynamicallyAccessedMemberTypes)] TContext>(
+            this IServiceCollection serviceCollection,
+            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            ServiceLifetime optionsLifetime = ServiceLifetime.Singleton)
+        where TContext : DbContext
+    {
+        serviceCollection.Add(
+            new ServiceDescriptor(
+                typeof(IDbContextOptionsConfiguration<TContext>),
+                p => new DbContextOptionsConfiguration<TContext>(optionsAction),
+                optionsLifetime));
+
+        return serviceCollection;
+    }
+
     private static void AddCoreServices<TContextImplementation>(
         IServiceCollection serviceCollection,
         Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction,
@@ -1042,22 +1123,26 @@ public static class EntityFrameworkServiceCollectionExtensions
     {
         serviceCollection.TryAddSingleton<ServiceProviderAccessor>();
 
+        if (optionsAction != null)
+        {
+            serviceCollection.ConfigureDbContext<TContextImplementation>(optionsAction, optionsLifetime);
+        }
+
         serviceCollection.TryAdd(
             new ServiceDescriptor(
                 typeof(DbContextOptions<TContextImplementation>),
-                p => CreateDbContextOptions<TContextImplementation>(p, optionsAction),
+                CreateDbContextOptions<TContextImplementation>,
                 optionsLifetime));
 
-        serviceCollection.Add(
+        serviceCollection.TryAdd(
             new ServiceDescriptor(
                 typeof(DbContextOptions),
-                p => p.GetRequiredService<DbContextOptions<TContextImplementation>>(),
+                CreateDbContextOptions<TContextImplementation>,
                 optionsLifetime));
     }
 
     private static DbContextOptions<TContext> CreateDbContextOptions<TContext>(
-        IServiceProvider applicationServiceProvider,
-        Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction)
+        IServiceProvider applicationServiceProvider)
         where TContext : DbContext
     {
         var builder = new DbContextOptionsBuilder<TContext>(
@@ -1065,7 +1150,10 @@ public static class EntityFrameworkServiceCollectionExtensions
 
         builder.UseApplicationServiceProvider(applicationServiceProvider);
 
-        optionsAction?.Invoke(applicationServiceProvider, builder);
+        foreach (var configuration in applicationServiceProvider.GetServices<IDbContextOptionsConfiguration<TContext>>())
+        {
+            configuration.Configure(applicationServiceProvider, builder);
+        }
 
         return builder.Options;
     }

--- a/src/EFCore/Infrastructure/IDbContextOptionsConfiguration.cs
+++ b/src/EFCore/Infrastructure/IDbContextOptionsConfiguration.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure;
+
+/// <summary>
+///     Configures the options to be used by a <see cref="DbContext" />. You normally call
+///     <see cref="EntityFrameworkServiceCollectionExtensions.ConfigureDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}, ServiceLifetime)" />
+///     to register this class, it is not designed to be directly constructed in your application code.
+/// </summary>
+/// <typeparam name="TContext">The type of the context these options apply to.</typeparam>
+/// <remarks>
+///     See <see href="https://aka.ms/efcore-docs-di">Using DbContext with dependency injection</see> for more information and examples.
+/// </remarks>
+public interface IDbContextOptionsConfiguration<TContext>
+    where TContext : DbContext
+{
+    /// <summary>
+    ///     Applies the specified configuration.
+    /// </summary>
+    /// <param name="serviceProvider">The application's <see cref="IServiceProvider" /> that can be used to resolve services.</param>
+    /// <param name="optionsBuilder">The options being configured.</param>
+    void Configure(IServiceProvider serviceProvider, DbContextOptionsBuilder optionsBuilder);
+}

--- a/src/EFCore/Infrastructure/Internal/DbContextOptionsConfiguration.cs
+++ b/src/EFCore/Infrastructure/Internal/DbContextOptionsConfiguration.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class DbContextOptionsConfiguration<TContext> : IDbContextOptionsConfiguration<TContext>
+    where TContext : DbContext
+{
+    private readonly Action<IServiceProvider, DbContextOptionsBuilder> _configure;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public DbContextOptionsConfiguration(Action<IServiceProvider, DbContextOptionsBuilder> configure)
+    {
+        _configure = configure;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual void Configure(IServiceProvider serviceProvider, DbContextOptionsBuilder optionsBuilder)
+        => _configure(serviceProvider, optionsBuilder);
+}

--- a/test/EFCore.Specification.Tests/TestUtilities/DataGenerator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/DataGenerator.cs
@@ -15,8 +15,8 @@ public static class DataGenerator
 
     static DataGenerator()
     {
-        Values[typeof(bool)] = new object[] { false, true };
-        Values[typeof(bool?)] = new object[] { null, false, true };
+        Values[typeof(bool)] = [false, true];
+        Values[typeof(bool?)] = [null, false, true];
     }
 
     public static object[][] GetCombinations(object[] set, int length)

--- a/test/EFCore.Tests/DbContextFactoryTest.cs
+++ b/test/EFCore.Tests/DbContextFactoryTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Microsoft.EntityFrameworkCore;
 
@@ -617,60 +618,10 @@ public class DbContextFactoryTest
     }
 
     [ConditionalTheory]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Transient)]
+    [MemberData(
+        nameof(DataGenerator.GetCombinations),
+        [new[] { typeof(bool), typeof(ServiceLifetime), typeof(ServiceLifetime), typeof(ServiceLifetime) }],
+        MemberType = typeof(DataGenerator))]
     public void Add_factory_and_then_context_using_scope(
         bool validateScopes,
         ServiceLifetime factoryLifetime,
@@ -679,10 +630,12 @@ public class DbContextFactoryTest
     {
         var serviceCollection = new ServiceCollection()
             .AddDbContextFactory<WoolacombeContext>(
-                b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                b => b.UseInMemoryDatabase(nameof(WoolacombeContext))
+                    .ReplaceService<IModelCustomizer, FactoryModelCustomizer>(),
                 factoryLifetime)
             .AddDbContext<WoolacombeContext>(
-                b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                b => b.UseInMemoryDatabase(nameof(WoolacombeContext))
+                    .ReplaceService<IModelCustomizer, CustomModelCustomizer>(),
                 contextLifetime,
                 optionsLifetime);
 
@@ -703,74 +656,41 @@ public class DbContextFactoryTest
         using var scope = serviceProvider.CreateScope();
 
         if (validateScopes
-            && factoryLifetime == ServiceLifetime.Scoped
-            && contextLifetime == ServiceLifetime.Singleton)
+            && ((factoryLifetime == ServiceLifetime.Scoped
+                && contextLifetime == ServiceLifetime.Singleton)
+                || (factoryLifetime == ServiceLifetime.Singleton
+                    && contextLifetime != ServiceLifetime.Singleton
+                    && optionsLifetime == ServiceLifetime.Scoped)))
         {
-            Assert.Throws<InvalidOperationException>(() => scope.ServiceProvider.GetRequiredService<WoolacombeContext>());
+            Assert.Throws<InvalidOperationException>(scope.ServiceProvider.GetRequiredService<WoolacombeContext>);
         }
         else
         {
-            scope.ServiceProvider.GetRequiredService<WoolacombeContext>();
+            var context = scope.ServiceProvider.GetRequiredService<WoolacombeContext>();
+
+            Assert.IsType<CustomModelCustomizer>(context.GetService<IEnumerable<IModelCustomizer>>().Single());
         }
 
-        using var factoryContext = scope.ServiceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>().CreateDbContext();
+        if (validateScopes
+            && factoryLifetime == ServiceLifetime.Singleton
+            && contextLifetime != ServiceLifetime.Singleton
+            && optionsLifetime == ServiceLifetime.Scoped)
+        {
+            Assert.Throws<InvalidOperationException>(scope.ServiceProvider.GetRequiredService<WoolacombeContext>);
+        }
+        else
+        {
+            using var factoryContext = scope.ServiceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>().CreateDbContext();
+
+            Assert.IsType<CustomModelCustomizer>(factoryContext.GetService<IEnumerable<IModelCustomizer>>().Single());
+        }
     }
 
     [ConditionalTheory]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Transient)]
+    [MemberData(
+        nameof(DataGenerator.GetCombinations),
+        [new[] { typeof(bool), typeof(ServiceLifetime), typeof(ServiceLifetime), typeof(ServiceLifetime) }],
+        MemberType = typeof(DataGenerator))]
     public void Add_factory_and_then_context_using_root_provider(
         bool validateScopes,
         ServiceLifetime factoryLifetime,
@@ -779,10 +699,12 @@ public class DbContextFactoryTest
     {
         var serviceCollection = new ServiceCollection()
             .AddDbContextFactory<WoolacombeContext>(
-                b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                b => b.UseInMemoryDatabase(nameof(WoolacombeContext))
+                    .ReplaceService<IModelCustomizer, FactoryModelCustomizer>(),
                 factoryLifetime)
             .AddDbContext<WoolacombeContext>(
-                b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                b => b.UseInMemoryDatabase(nameof(WoolacombeContext))
+                    .ReplaceService<IModelCustomizer, CustomModelCustomizer>(),
                 contextLifetime,
                 optionsLifetime);
 
@@ -803,18 +725,25 @@ public class DbContextFactoryTest
 
         if (validateScopes
             && (factoryLifetime == ServiceLifetime.Scoped
-                || contextLifetime == ServiceLifetime.Scoped))
+                || contextLifetime == ServiceLifetime.Scoped
+                || (contextLifetime != ServiceLifetime.Singleton
+                    && optionsLifetime == ServiceLifetime.Scoped)))
         {
-            Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService<WoolacombeContext>());
+            Assert.Throws<InvalidOperationException>(serviceProvider.GetRequiredService<WoolacombeContext>);
         }
         else
         {
-            serviceProvider.GetRequiredService<WoolacombeContext>();
+            using var context = serviceProvider.GetRequiredService<WoolacombeContext>();
+
+            Assert.IsType<CustomModelCustomizer>(context.GetService<IEnumerable<IModelCustomizer>>().Single());
         }
 
-        if (validateScopes && factoryLifetime == ServiceLifetime.Scoped)
+        if (validateScopes
+            && (factoryLifetime == ServiceLifetime.Scoped
+                || (contextLifetime != ServiceLifetime.Singleton
+                    && optionsLifetime == ServiceLifetime.Scoped)))
         {
-            Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>());
+            Assert.Throws<InvalidOperationException>(serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>);
         }
         else
         {
@@ -823,60 +752,10 @@ public class DbContextFactoryTest
     }
 
     [ConditionalTheory]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Transient)]
+    [MemberData(
+        nameof(DataGenerator.GetCombinations),
+        [new[] { typeof(bool), typeof(ServiceLifetime), typeof(ServiceLifetime), typeof(ServiceLifetime) }],
+        MemberType = typeof(DataGenerator))]
     public void Add_context_and_then_factory_using_scope(
         bool validateScopes,
         ServiceLifetime factoryLifetime,
@@ -885,11 +764,13 @@ public class DbContextFactoryTest
     {
         var serviceCollection = new ServiceCollection()
             .AddDbContext<WoolacombeContext>(
-                b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                b => b.UseInMemoryDatabase(nameof(WoolacombeContext))
+                    .ReplaceService<IModelCustomizer, CustomModelCustomizer>(),
                 contextLifetime,
                 optionsLifetime)
             .AddDbContextFactory<WoolacombeContext>(
-                b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                b => b.UseInMemoryDatabase(nameof(WoolacombeContext))
+                    .ReplaceService<IModelCustomizer, FactoryModelCustomizer>(),
                 factoryLifetime);
 
         Assert.Equal(
@@ -912,76 +793,41 @@ public class DbContextFactoryTest
         var serviceProvider = serviceCollection.BuildServiceProvider(validateScopes);
         using var scope = serviceProvider.CreateScope();
 
-        scope.ServiceProvider.GetRequiredService<WoolacombeContext>();
+        if (validateScopes
+            && factoryLifetime == ServiceLifetime.Scoped
+            && effectiveOptionsLifetime == ServiceLifetime.Singleton)
+        {
+            Assert.Throws<InvalidOperationException>(scope.ServiceProvider.GetRequiredService<WoolacombeContext>);
+        }
+        else
+        {
+            var context = scope.ServiceProvider.GetRequiredService<WoolacombeContext>();
+
+            Assert.IsType<FactoryModelCustomizer>(context.GetService<IEnumerable<IModelCustomizer>>().Single());
+        }
 
         if (validateScopes
-            && factoryLifetime == ServiceLifetime.Singleton
-            && effectiveOptionsLifetime == ServiceLifetime.Scoped)
+            && ((factoryLifetime == ServiceLifetime.Singleton
+                && effectiveOptionsLifetime == ServiceLifetime.Scoped)
+            || (factoryLifetime == ServiceLifetime.Scoped
+                && effectiveOptionsLifetime == ServiceLifetime.Singleton)))
         {
-            Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>());
+            Assert.Throws<InvalidOperationException>(scope.ServiceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>);
         }
         else
         {
             using var factoryContext
                 = scope.ServiceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>().CreateDbContext();
+
+            Assert.IsType<FactoryModelCustomizer>(factoryContext.GetService<IEnumerable<IModelCustomizer>>().Single());
         }
     }
 
     [ConditionalTheory]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(false, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Singleton, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Scoped, ServiceLifetime.Transient, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Singleton, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Scoped, ServiceLifetime.Transient)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Singleton)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Scoped)]
-    [InlineData(true, ServiceLifetime.Transient, ServiceLifetime.Transient, ServiceLifetime.Transient)]
+    [MemberData(
+        nameof(DataGenerator.GetCombinations),
+        [new[] { typeof(bool), typeof(ServiceLifetime), typeof(ServiceLifetime), typeof(ServiceLifetime) }],
+        MemberType = typeof(DataGenerator))]
     public void Add_context_and_then_factory_using_root_provider(
         bool validateScopes,
         ServiceLifetime factoryLifetime,
@@ -990,11 +836,13 @@ public class DbContextFactoryTest
     {
         var serviceCollection = new ServiceCollection()
             .AddDbContext<WoolacombeContext>(
-                b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                b => b.UseInMemoryDatabase(nameof(WoolacombeContext))
+                    .ReplaceService<IModelCustomizer, CustomModelCustomizer>(),
                 contextLifetime,
                 optionsLifetime)
             .AddDbContextFactory<WoolacombeContext>(
-                b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                b => b.UseInMemoryDatabase(nameof(WoolacombeContext))
+                    .ReplaceService<IModelCustomizer, FactoryModelCustomizer>(),
                 factoryLifetime);
 
         Assert.Equal(
@@ -1018,24 +866,45 @@ public class DbContextFactoryTest
 
         if (validateScopes
             && (contextLifetime == ServiceLifetime.Scoped
+                || factoryLifetime == ServiceLifetime.Scoped
                 || effectiveOptionsLifetime == ServiceLifetime.Scoped))
         {
-            Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService<WoolacombeContext>());
+            Assert.Throws<InvalidOperationException>(serviceProvider.GetRequiredService<WoolacombeContext>);
         }
         else
         {
-            serviceProvider.GetRequiredService<WoolacombeContext>();
+            var context = serviceProvider.GetRequiredService<WoolacombeContext>();
+
+            Assert.IsType<FactoryModelCustomizer>(context.GetService<IEnumerable<IModelCustomizer>>().Single());
         }
 
         if (validateScopes
             && (factoryLifetime == ServiceLifetime.Scoped
                 || effectiveOptionsLifetime == ServiceLifetime.Scoped))
         {
-            Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>());
+            Assert.Throws<InvalidOperationException>(serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>);
         }
         else
         {
             using var factoryContext = serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>().CreateDbContext();
+
+            Assert.IsType<FactoryModelCustomizer>(factoryContext.GetService<IEnumerable<IModelCustomizer>>().Single());
+        }
+    }
+
+    private class CustomModelCustomizer : ModelCustomizer
+    {
+        public CustomModelCustomizer(ModelCustomizerDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+    }
+
+    private class FactoryModelCustomizer : ModelCustomizer
+    {
+        public FactoryModelCustomizer(ModelCustomizerDependencies dependencies)
+            : base(dependencies)
+        {
         }
     }
 

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1909,7 +1909,7 @@ public class InternalEntityTypeBuilderTest
     [ConditionalTheory]
     [MemberData(
         nameof(DataGenerator.GetCombinations),
-        new object[] { new[] { typeof(ConfigurationSource), typeof(ConfigurationSource) } },
+        [new[] { typeof(ConfigurationSource), typeof(ConfigurationSource) }],
         MemberType = typeof(DataGenerator))]
     public void Can_ignore_property_in_hierarchy(ConfigurationSource ignoreSource, ConfigurationSource addSource)
     {
@@ -2396,7 +2396,7 @@ public class InternalEntityTypeBuilderTest
     [ConditionalTheory]
     [MemberData(
         nameof(DataGenerator.GetCombinations),
-        new object[] { new[] { typeof(ConfigurationSource), typeof(ConfigurationSource) } },
+        [new[] { typeof(ConfigurationSource), typeof(ConfigurationSource) }],
         MemberType = typeof(DataGenerator))]
     public void Can_ignore_navigation_in_hierarchy(ConfigurationSource ignoreSource, ConfigurationSource addSource)
     {
@@ -2482,7 +2482,7 @@ public class InternalEntityTypeBuilderTest
     [ConditionalTheory]
     [MemberData(
         nameof(DataGenerator.GetCombinations),
-        new object[] { new[] { typeof(ConfigurationSource), typeof(ConfigurationSource) } },
+        [new[] { typeof(ConfigurationSource), typeof(ConfigurationSource) }],
         MemberType = typeof(DataGenerator))]
     public void Can_ignore_skip_navigation_in_hierarchy(ConfigurationSource ignoreSource, ConfigurationSource addSource)
     {
@@ -2525,10 +2525,9 @@ public class InternalEntityTypeBuilderTest
     [ConditionalTheory]
     [MemberData(
         nameof(DataGenerator.GetCombinations),
-        new object[]
-        {
+        [
             new[] { typeof(ConfigurationSource), typeof(ConfigurationSource), typeof(MemberType), typeof(MemberType), typeof(bool) }
-        },
+        ],
         MemberType = typeof(DataGenerator))]
     public void Can_override_members_in_hierarchy(
         ConfigurationSource firstSource,


### PR DESCRIPTION
Now the configuration specified in `AddDbContext`, `AddDbContextPool`, `AddDbContextFactory` and `AddPooledDbContextFactory` will be applied in the order specified if two or more of these methods are called with the same context type.

This is a breaking change if the configuration was conflicting, since previously the first one won and now the last one will win.

Additionally, `ConfigureDbContext` can be called before or after the aforementioned methods to perform additional configuration without affecting the `DbContext` registration.