### PR TITLE
[release/8.0] Revert behavior to throw when attempting to modify an unconstrained alternate key property

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -1414,39 +1414,28 @@ public class NavigationFixer : INavigationFixer
 
         if (foreignKey.IsRequired
             && hasOnlyKeyProperties
-            && dependentEntry.EntityState != EntityState.Detached
-            && dependentEntry.EntityState != EntityState.Deleted)
+            && dependentEntry.EntityState != EntityState.Detached)
         {
-            if (foreignKey.DeleteBehavior == DeleteBehavior.Cascade
-                || foreignKey.DeleteBehavior == DeleteBehavior.ClientCascade
-                || foreignKey.IsOwnership)
+            try
             {
-                try
+                _inFixup = true;
+                switch (dependentEntry.EntityState)
                 {
-                    _inFixup = true;
-                    switch (dependentEntry.EntityState)
-                    {
-                        case EntityState.Added:
-                            dependentEntry.SetEntityState(EntityState.Detached);
-                            DeleteFixup(dependentEntry);
-                            break;
-                        case EntityState.Unchanged:
-                        case EntityState.Modified:
-                            dependentEntry.SetEntityState(
-                                dependentEntry.SharedIdentityEntry != null ? EntityState.Detached : EntityState.Deleted);
-                            DeleteFixup(dependentEntry);
-                            break;
-                    }
-                }
-                finally
-                {
-                    _inFixup = false;
+                    case EntityState.Added:
+                        dependentEntry.SetEntityState(EntityState.Detached);
+                        DeleteFixup(dependentEntry);
+                        break;
+                    case EntityState.Unchanged:
+                    case EntityState.Modified:
+                        dependentEntry.SetEntityState(
+                            dependentEntry.SharedIdentityEntry != null ? EntityState.Detached : EntityState.Deleted);
+                        DeleteFixup(dependentEntry);
+                        break;
                 }
             }
-            else
+            finally
             {
-                throw new InvalidOperationException(
-                    CoreStrings.KeyReadOnly(dependentProperties.First().Name, dependentEntry.EntityType.DisplayName()));
+                _inFixup = false;
             }
         }
     }

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -14,6 +14,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 /// </summary>
 public class NavigationFixer : INavigationFixer
 {
+    private static readonly bool UseOldBehavior32383 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32383", out var enabled32383) && enabled32383;
+
     private IList<(
         InternalEntityEntry Entry,
         InternalEntityEntry OtherEntry,
@@ -1412,31 +1415,75 @@ public class NavigationFixer : INavigationFixer
             }
         }
 
-        if (foreignKey.IsRequired
-            && hasOnlyKeyProperties
-            && dependentEntry.EntityState != EntityState.Detached)
+        if (UseOldBehavior32383)
         {
-            try
+            if (foreignKey.IsRequired
+                && hasOnlyKeyProperties
+                && dependentEntry.EntityState != EntityState.Detached
+                && dependentEntry.EntityState != EntityState.Deleted)
             {
-                _inFixup = true;
-                switch (dependentEntry.EntityState)
+                if (foreignKey.DeleteBehavior == DeleteBehavior.Cascade
+                    || foreignKey.DeleteBehavior == DeleteBehavior.ClientCascade
+                    || foreignKey.IsOwnership)
                 {
-                    case EntityState.Added:
-                        dependentEntry.SetEntityState(EntityState.Detached);
-                        DeleteFixup(dependentEntry);
-                        break;
-                    case EntityState.Unchanged:
-                    case EntityState.Modified:
-                        dependentEntry.SetEntityState(
-                            dependentEntry.SharedIdentityEntry != null ? EntityState.Detached : EntityState.Deleted);
-                        DeleteFixup(dependentEntry);
-                        break;
+                    try
+                    {
+                        _inFixup = true;
+                        switch (dependentEntry.EntityState)
+                        {
+                            case EntityState.Added:
+                                dependentEntry.SetEntityState(EntityState.Detached);
+                                DeleteFixup(dependentEntry);
+                                break;
+                            case EntityState.Unchanged:
+                            case EntityState.Modified:
+                                dependentEntry.SetEntityState(
+                                    dependentEntry.SharedIdentityEntry != null ? EntityState.Detached : EntityState.Deleted);
+                                DeleteFixup(dependentEntry);
+                                break;
+                        }
+                    }
+                    finally
+                    {
+                        _inFixup = false;
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.KeyReadOnly(dependentProperties.First().Name, dependentEntry.EntityType.DisplayName()));
                 }
             }
-            finally
+        }
+        else
+        {
+            if (foreignKey.IsRequired
+                && hasOnlyKeyProperties
+                && dependentEntry.EntityState != EntityState.Detached)
             {
-                _inFixup = false;
+                try
+                {
+                    _inFixup = true;
+                    switch (dependentEntry.EntityState)
+                    {
+                        case EntityState.Added:
+                            dependentEntry.SetEntityState(EntityState.Detached);
+                            DeleteFixup(dependentEntry);
+                            break;
+                        case EntityState.Unchanged:
+                        case EntityState.Modified:
+                            dependentEntry.SetEntityState(
+                                dependentEntry.SharedIdentityEntry != null ? EntityState.Detached : EntityState.Deleted);
+                            DeleteFixup(dependentEntry);
+                            break;
+                    }
+                }
+                finally
+                {
+                    _inFixup = false;
+                }
             }
+
         }
     }
 

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseMiscellaneous.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseMiscellaneous.cs
@@ -1962,7 +1962,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         return secondLevel;
     }
 
-    [ConditionalTheory] // Issue #28961
+    [ConditionalTheory] // Issue #28961 and Issue #32385
     [InlineData(false)]
     [InlineData(true)]
     public virtual Task Alternate_key_over_foreign_key_doesnt_bypass_delete_behavior(bool async)
@@ -1976,16 +1976,14 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     ? await context.SaveChangesAsync()
                     : context.SaveChanges();
 
-                Assert.Equal(
-                    CoreStrings.KeyReadOnly(nameof(SneakyChild.ParentId), nameof(SneakyChild)),
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        async () =>
-                        {
-                            parent.Children.Remove(parent.Children.First());
-                            _ = async
-                                ? await context.SaveChangesAsync()
-                                : context.SaveChanges();
-                        })).Message);
+                Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                parent.Children.Remove(parent.Children.First());
+                _ = async
+                    ? await context.SaveChangesAsync()
+                    : context.SaveChanges();
+
+                Assert.Equal(1, context.ChangeTracker.Entries().Count());
             });
 
     [ConditionalTheory] // Issue #30764

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
@@ -856,9 +856,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if (Fixture.ForceClientNoAction)
                 {
-                    Assert.Equal(
-                        CoreStrings.KeyReadOnly(nameof(RequiredSingle1.Id), nameof(RequiredSingle1)),
-                        Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+                    Assert.Throws<DbUpdateException>(() => context.SaveChanges());
                 }
                 else
                 {
@@ -1202,11 +1200,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     throw new ArgumentOutOfRangeException(nameof(changeMechanism));
                 }
 
+                Assert.False(context.Entry(root).Reference(e => e.RequiredSingle).IsLoaded);
+                Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
+                Assert.True(context.ChangeTracker.HasChanges());
+
                 if (Fixture.ForceClientNoAction)
                 {
-                    Assert.Equal(
-                        CoreStrings.KeyReadOnly(nameof(RequiredSingle1.Id), nameof(RequiredSingle1)),
-                        Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+                    Assert.Throws<DbUpdateException>(() => context.SaveChanges());
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #32383
Port of #32492

### Description

In https://github.com/dotnet/efcore/issues/https://github.com/dotnet/efcore/issues/28961, an unconstrained alternate key was added to the model purely to make a non-identifying relationship artificially identifying. https://github.com/dotnet/efcore/pull/30213 attempted to fix this by throwing indicating that the key was being modified. However, this scenario is basically identical to the case for a many-to-many join type, where the composite primary key is also not the end of any relationship, but forces the two many-to-one relationships to be identifying. The only difference is that in one case the principal key is primary and in the other the principal key alternate.

I prepared a PR that would only throw if the key involved is alternate, but on reflection that doesn't seem like an appropriate distinction to make--a many-to-many join table could have an alternate key. At this point, I think the appropriate thing to do is revert the change made in 8 and just accept that the behavior is the way it is for historical reasons, even though we might do something different if we were working on this.

### Customer impact

Exception thrown when manipulating many-to-one relationships that are being used to model many-to-many with a join table in cases where it worked before.

### How found

Multiple customers reports on 8.0

### Regression

Yes

### Testing

Testing existed but was changed when we made the behavior change in 8.0. We just didn't recognize the full consquences of the change, which was intended to be a bug fix.

### Risk

Low and quirked. It is very unlikely people are relying on the new behavior, which is to throw.