### PR TITLE
[release/8.0] Fix Contains within SQL Server aggregate functions

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1376,7 +1376,14 @@ public class RelationalSqlTranslatingExpressionVisitor : ExpressionVisitor
         }
     }
 
-    private bool TryTranslateAggregateMethodCall(
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    [EntityFrameworkInternal]
+    protected virtual bool TryTranslateAggregateMethodCall(
         MethodCallExpression methodCallExpression,
         [NotNullWhen(true)] out SqlExpression? translation)
     {

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
@@ -39,4 +39,16 @@ public class SqlServerQueryCompilationContext : RelationalQueryCompilationContex
         => base.IsBuffering
             || (QuerySplittingBehavior == EntityFrameworkCore.QuerySplittingBehavior.SplitQuery
                 && !_multipleActiveResultSetsEnabled);
+
+    /// <summary>
+    ///     Tracks whether translation is currently within the argument of an aggregate method (e.g. MAX, COUNT); SQL Server does not
+    ///     allow subqueries and aggregates in that context.
+    /// </summary>
+    /// <remarks>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </remarks>
+    public virtual bool InAggregateFunction { get; set; }
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -49,5 +49,5 @@ public class SqlServerQueryableMethodTranslatingExpressionVisitorFactory : IQuer
     /// </summary>
     public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
         => new SqlServerQueryableMethodTranslatingExpressionVisitor(
-            Dependencies, RelationalDependencies, queryCompilationContext, _sqlServerSingletonOptions);
+            Dependencies, RelationalDependencies, (SqlServerQueryCompilationContext)queryCompilationContext, _sqlServerSingletonOptions);
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 /// </summary>
 public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExpressionVisitor
 {
-    private readonly QueryCompilationContext _queryCompilationContext;
+    private readonly SqlServerQueryCompilationContext _queryCompilationContext;
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
     private static readonly HashSet<string> DateTimeDataTypes
@@ -72,7 +72,7 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
     /// </summary>
     public SqlServerSqlTranslatingExpressionVisitor(
         RelationalSqlTranslatingExpressionVisitorDependencies dependencies,
-        QueryCompilationContext queryCompilationContext,
+        SqlServerQueryCompilationContext queryCompilationContext,
         QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
         : base(dependencies, queryCompilationContext, queryableMethodTranslatingExpressionVisitor)
     {
@@ -428,6 +428,28 @@ public class SqlServerSqlTranslatingExpressionVisitor : RelationalSqlTranslating
         }
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    protected override bool TryTranslateAggregateMethodCall(
+        MethodCallExpression methodCallExpression,
+        [NotNullWhen(true)] out SqlExpression? translation)
+    {
+        var previousInAggregateFunction = _queryCompilationContext.InAggregateFunction;
+        _queryCompilationContext.InAggregateFunction = true;
+
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var result = base.TryTranslateAggregateMethodCall(methodCallExpression, out translation);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        _queryCompilationContext.InAggregateFunction = previousInAggregateFunction;
+
+        return result;
     }
 
     private Expression TranslateByteArrayElementAccess(Expression array, Expression index, Type resultType)

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitorFactory.cs
@@ -39,6 +39,6 @@ public class SqlServerSqlTranslatingExpressionVisitorFactory : IRelationalSqlTra
         QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
         => new SqlServerSqlTranslatingExpressionVisitor(
             Dependencies,
-            queryCompilationContext,
+            (SqlServerQueryCompilationContext)queryCompilationContext,
             queryableMethodTranslatingExpressionVisitor);
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -2249,6 +2249,86 @@ WHERE (c["Discriminator"] = "Customer")
         AssertSql();
     }
 
+    public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
+    {
+        // GroupBy. Issue #17313.
+        await AssertTranslationFailed(() => base.Contains_inside_aggregate_function_with_GroupBy(async));
+
+        AssertSql();
+    }
+
+    public override async Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Average_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT AVG((c["City"] IN ("London", "Berlin") ? 1.0 : 0.0)) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
+    public override async Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Sum_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT SUM((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
+    public override async Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Count_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT(1) AS c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["City"] IN ("London", "Berlin"))
+""");
+    }
+
+    public override async Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_LongCount_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT(1) AS c
+FROM root c
+WHERE ((c["Discriminator"] = "Customer") AND c["City"] IN ("London", "Berlin"))
+""");
+    }
+
+    public override async Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Max_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT MAX((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
+    public override async Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Min_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT MIN((c["City"] IN ("London", "Berlin") ? 1 : 0)) AS c
+FROM root c
+WHERE (c["Discriminator"] = "Customer")
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -1923,4 +1923,89 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture> : Query
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => !c.Orders.Any(o => false)).Select(c => c.CustomerID));
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_aggregate_function_with_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>()
+                .GroupBy(c => c.Country)
+                .Select(g => g.Count(c => cities.Contains(c.City))));
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertAverage(
+            async,
+            ss => ss.Set<Customer>(),
+            selector: c => cities.Contains(c.City) ? 1.0 : 0.0);
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertSum(
+            async,
+            ss => ss.Set<Customer>(),
+            selector: c => cities.Contains(c.City) ? 1 : 0);
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertCount(
+            async,
+            ss => ss.Set<Customer>(),
+            predicate: c => cities.Contains(c.City));
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertLongCount(
+            async,
+            ss => ss.Set<Customer>(),
+            predicate: c => cities.Contains(c.City));
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertMax(
+            async,
+            ss => ss.Set<Customer>(),
+            selector: c => cities.Contains(c.City) ? 1 : 0);
+    }
+
+    [ConditionalTheory] // #32374
+    [MemberData(nameof(IsAsyncData))]
+    public virtual Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        var cities = new[] { "London", "Berlin" };
+
+        return AssertMin(
+            async,
+            ss => ss.Set<Customer>(),
+            selector: c => cities.Contains(c.City) ? 1 : 0);
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -2902,6 +2902,100 @@ FROM [Customers] AS [c]
 """);
     }
 
+    public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
+    {
+        await base.Contains_inside_aggregate_function_with_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1
+END)
+FROM [Customers] AS [c]
+GROUP BY [c].[Country]
+""");
+    }
+
+    public override async Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Average_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT AVG(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1.0E0
+    ELSE 0.0E0
+END)
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Sum_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COALESCE(SUM(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1
+    ELSE 0
+END), 0)
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Count_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT(*)
+FROM [Customers] AS [c]
+WHERE [c].[City] IN (N'London', N'Berlin')
+""");
+    }
+
+    public override async Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_LongCount_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT COUNT_BIG(*)
+FROM [Customers] AS [c]
+WHERE [c].[City] IN (N'London', N'Berlin')
+""");
+    }
+
+    public override async Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Max_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT MAX(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1
+    ELSE 0
+END)
+FROM [Customers] AS [c]
+""");
+    }
+
+    public override async Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Min_without_GroupBy(async);
+
+        AssertSql(
+            """
+SELECT MIN(CASE
+    WHEN [c].[City] IN (N'London', N'Berlin') THEN 1
+    ELSE 0
+END)
+FROM [Customers] AS [c]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -71,4 +71,139 @@ public class NorthwindAggregateOperatorsQuerySqliteTest : NorthwindAggregateOper
 
     public override async Task Contains_with_local_tuple_array_closure(bool async)
         => await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
+
+    public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
+    {
+        await base.Contains_inside_aggregate_function_with_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT COUNT(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+END)
+FROM "Customers" AS "c"
+GROUP BY "c"."Country"
+""");
+    }
+
+    public override async Task Contains_inside_Average_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Average_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT AVG(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1.0
+    ELSE 0.0
+END)
+FROM "Customers" AS "c"
+""");
+    }
+
+    public override async Task Contains_inside_Sum_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Sum_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT COALESCE(SUM(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ELSE 0
+END), 0)
+FROM "Customers" AS "c"
+""");
+    }
+
+    public override async Task Contains_inside_Count_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Count_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT COUNT(*)
+FROM "Customers" AS "c"
+WHERE EXISTS (
+    SELECT 1
+    FROM json_each(@__cities_0) AS "c0"
+    WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL))
+""");
+    }
+
+    public override async Task Contains_inside_LongCount_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_LongCount_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT COUNT(*)
+FROM "Customers" AS "c"
+WHERE EXISTS (
+    SELECT 1
+    FROM json_each(@__cities_0) AS "c0"
+    WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL))
+""");
+    }
+
+    public override async Task Contains_inside_Max_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Max_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT MAX(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ELSE 0
+END)
+FROM "Customers" AS "c"
+""");
+    }
+
+    public override async Task Contains_inside_Min_without_GroupBy(bool async)
+    {
+        await base.Contains_inside_Min_without_GroupBy(async);
+
+        AssertSql(
+            """
+@__cities_0='["London","Berlin"]' (Size = 19)
+
+SELECT MIN(CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM json_each(@__cities_0) AS "c0"
+        WHERE "c0"."value" = "c"."City" OR ("c0"."value" IS NULL AND "c"."City" IS NULL)) THEN 1
+    ELSE 0
+END)
+FROM "Customers" AS "c"
+""");
+    }
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    protected override void ClearLog()
+        => Fixture.TestSqlLoggerFactory.Clear();
 }


### PR DESCRIPTION
Fixes #32374, backports #32478

### Description

The new EF 8.0 primitive collections support translates the parameterized Contains LINQ query to an OPENJSON-based subquery (`WHERE x IN (SELECT ... FROM OPENJSON(@p))`), instead of the older IN+constants construct (`WHERE x IN (1, 2, 3)`). Unfortunately, SQL Server doesn't support any subqueries in arguments to aggregate functions (e.g. `SELECT COUNT(<something containing a subquery>)`. This limitation doesn't exist in any other database.

### Customer impact

Any query requiring a parameterized Contains within an aggregate function now fail on SQL Server; such queries worked before.

### How found

Customers reported on 8.0

### Regression

Yes

### Testing

Added

### Risk

Low risk, very targeted change for SQL Server Contains only. Also added quirk.
