### PR TITLE
[release/8.0] Make proxies thread-safe accessing a navigation once loaded

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -268,6 +268,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileEF4F00E20178B341995BD2EFE53739B5/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileEF4F00E20178B341995BD2EFE53739B5/RelativePriority/@EntryValue">2</s:Double>
 	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=VsBulb/@EntryIndexedValue">DO_NOTHING</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore/Infrastructure/Internal/LazyLoader.cs
+++ b/src/EFCore/Infrastructure/Internal/LazyLoader.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -19,8 +20,7 @@ public class LazyLoader : ILazyLoader, IInjectableService
     private bool _disposed;
     private bool _detached;
     private IDictionary<string, bool>? _loadedStates;
-    private List<(object Entity, string NavigationName)>? _isLoading;
-    private IEntityType? _entityType;
+    private readonly ConcurrentDictionary<(object Entity, string NavigationName), bool> _isLoading = new(NavEntryEqualityComparer.Instance);
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -104,11 +104,10 @@ public class LazyLoader : ILazyLoader, IInjectableService
         Check.NotEmpty(navigationName, nameof(navigationName));
 
         var navEntry = (entity, navigationName);
-        if (!IsLoading(navEntry))
+        if (_isLoading.TryAdd(navEntry, true))
         {
             try
             {
-                _isLoading!.Add(navEntry);
                 // ShouldLoad is called after _isLoading.Add because it could attempt to load the property. See #13138.
                 if (ShouldLoad(entity, navigationName, out var entry))
                 {
@@ -128,7 +127,7 @@ public class LazyLoader : ILazyLoader, IInjectableService
             }
             finally
             {
-                DoneLoading(navEntry);
+                _isLoading.TryRemove(navEntry, out _);
             }
         }
     }
@@ -148,11 +147,10 @@ public class LazyLoader : ILazyLoader, IInjectableService
         Check.NotEmpty(navigationName, nameof(navigationName));
 
         var navEntry = (entity, navigationName);
-        if (!IsLoading(navEntry))
+        if (_isLoading.TryAdd(navEntry, true))
         {
             try
             {
-                _isLoading!.Add(navEntry);
                 // ShouldLoad is called after _isLoading.Add because it could attempt to load the property. See #13138.
                 if (ShouldLoad(entity, navigationName, out var entry))
                 {
@@ -173,32 +171,16 @@ public class LazyLoader : ILazyLoader, IInjectableService
             }
             finally
             {
-                DoneLoading(navEntry);
+                _isLoading.TryRemove(navEntry, out _);
             }
         }
     }
 
-    private bool IsLoading((object Entity, string NavigationName) navEntry)
-        => (_isLoading ??= new List<(object Entity, string NavigationName)>())
-            .Contains(navEntry, EntityNavigationEqualityComparer.Instance);
-
-    private void DoneLoading((object Entity, string NavigationName) navEntry)
+    private sealed class NavEntryEqualityComparer : IEqualityComparer<(object Entity, string NavigationName)>
     {
-        for (var i = 0; i < _isLoading!.Count; i++)
-        {
-            if (EntityNavigationEqualityComparer.Instance.Equals(navEntry, _isLoading[i]))
-            {
-                _isLoading.RemoveAt(i);
-                break;
-            }
-        }
-    }
+        public static readonly NavEntryEqualityComparer Instance = new();
 
-    private sealed class EntityNavigationEqualityComparer : IEqualityComparer<(object Entity, string NavigationName)>
-    {
-        public static readonly EntityNavigationEqualityComparer Instance = new();
-
-        private EntityNavigationEqualityComparer()
+        private NavEntryEqualityComparer()
         {
         }
 
@@ -207,7 +189,7 @@ public class LazyLoader : ILazyLoader, IInjectableService
                 && string.Equals(x.NavigationName, y.NavigationName, StringComparison.Ordinal);
 
         public int GetHashCode((object Entity, string NavigationName) obj)
-            => HashCode.Combine(obj.Entity.GetHashCode(), obj.GetHashCode());
+            => HashCode.Combine(RuntimeHelpers.GetHashCode(obj.Entity), obj.NavigationName.GetHashCode());
     }
 
     private bool ShouldLoad(object entity, string navigationName, [NotNullWhen(true)] out NavigationEntry? navigationEntry)

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -57,17 +57,17 @@ public abstract class LazyLoadProxyTestBase<TFixture> : IClassFixture<TFixture>
         {
             tests[i] = () =>
             {
-                Assert.Equal(children, parent.Children);
+                Assert.Equal(children, parent.Children!);
                 Assert.Equal(singlePkToPk, parent.SinglePkToPk);
                 Assert.Equal(single, parent.Single);
-                Assert.Equal(childrenAk, parent.ChildrenAk);
+                Assert.Equal(childrenAk, parent.ChildrenAk!);
                 Assert.Equal(singleAk, parent.SingleAk);
-                Assert.Equal(childrenShadowFk, parent.ChildrenShadowFk);
+                Assert.Equal(childrenShadowFk, parent.ChildrenShadowFk!);
                 Assert.Equal(singleShadowFk, parent.SingleShadowFk);
-                Assert.Equal(childrenCompositeKey, parent.ChildrenCompositeKey);
+                Assert.Equal(childrenCompositeKey, parent.ChildrenCompositeKey!);
                 Assert.Equal(singleCompositeKey, parent.SingleCompositeKey);
                 Assert.Equal(withRecursiveProperty, parent.WithRecursiveProperty);
-                Assert.Equal(manyChildren, parent.ManyChildren);
+                Assert.Equal(manyChildren, parent.ManyChildren!);
             };
         }
 

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -24,6 +24,56 @@ public abstract class LazyLoadProxyTestBase<TFixture> : IClassFixture<TFixture>
 
     protected TFixture Fixture { get; }
 
+    [ConditionalTheory] // Issue #32390
+    [InlineData(false)]
+    [InlineData(true)]
+    public virtual void Can_use_proxies_from_multiple_threads_when_navigations_already_loaded(bool noTracking)
+    {
+        using var context = CreateContext(lazyLoadingEnabled: true);
+
+        IQueryable<Parent> query = context.Set<Parent>();
+
+        if (noTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        var parent = query.Single();
+
+        var children = parent.Children!.ToList();
+        var singlePkToPk = parent.SinglePkToPk;
+        var single = parent.Single;
+        var childrenAk = parent.ChildrenAk!.ToList();
+        var singleAk = parent.SingleAk;
+        var childrenShadowFk = parent.ChildrenShadowFk!.ToList();
+        var singleShadowFk = parent.SingleShadowFk;
+        var childrenCompositeKey = parent.ChildrenCompositeKey!.ToList();
+        var singleCompositeKey = parent.SingleCompositeKey;
+        var withRecursiveProperty = parent.WithRecursiveProperty;
+        var manyChildren = parent.ManyChildren!.ToList();
+
+        var tests = new Action[20];
+        for (var i = 0; i < 20; i++)
+        {
+            tests[i] = () =>
+            {
+                Assert.Equal(children, parent.Children);
+                Assert.Equal(singlePkToPk, parent.SinglePkToPk);
+                Assert.Equal(single, parent.Single);
+                Assert.Equal(childrenAk, parent.ChildrenAk);
+                Assert.Equal(singleAk, parent.SingleAk);
+                Assert.Equal(childrenShadowFk, parent.ChildrenShadowFk);
+                Assert.Equal(singleShadowFk, parent.SingleShadowFk);
+                Assert.Equal(childrenCompositeKey, parent.ChildrenCompositeKey);
+                Assert.Equal(singleCompositeKey, parent.SingleCompositeKey);
+                Assert.Equal(withRecursiveProperty, parent.WithRecursiveProperty);
+                Assert.Equal(manyChildren, parent.ManyChildren);
+            };
+        }
+
+        Task.WaitAll(tests.Select(Task.Run).ToArray());
+    }
+
     [ConditionalFact]
     public virtual void Detected_principal_reference_navigation_changes_are_detected_and_marked_loaded()
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/32390
Pack port of: #32522

### Description

Since the DbContext is not thread-safe, lazy-loading proxies cannot be used from multiple threads _when loading is happening_. However, it is a common pattern to pass proxies to other parts of the application after the navigations have been loaded. At this time, accesses should be thread-safe. We broke this in 8.

### Customer impact

Exceptions thrown when accessing fully loaded entity instances from multiple threads.

### How found

Customers reports on 8.0

### Regression

Yes

### Testing

Testing added.

### Risk

Low and quirked.