### PR TITLE
[release/8.0] Fix splitting migrations SQL by GO

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -268,6 +268,7 @@ The .NET Foundation licenses this file to you under the MIT license.&#xD;
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileEF4F00E20178B341995BD2EFE53739B5/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileEF4F00E20178B341995BD2EFE53739B5/RelativePriority/@EntryValue">2</s:Double>
 	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=VsBulb/@EntryIndexedValue">DO_NOTHING</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -29,6 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations;
 /// </remarks>
 public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 {
+    private static readonly bool UseOldBehavior32457 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32457", out var enabled32457) && enabled32457;
+
     private IReadOnlyList<MigrationOperation> _operations = null!;
     private int _variableCounter;
 
@@ -1419,7 +1422,8 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
 
             var trimmed = line.TrimStart();
             if (trimmed.StartsWith("GO", StringComparison.OrdinalIgnoreCase)
-                && (trimmed.Length == 2
+                && (UseOldBehavior32457
+                    || trimmed.Length == 2
                     || char.IsWhiteSpace(trimmed[2])))
             {
                 var batch = batchBuilder.ToString();

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1418,7 +1418,9 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             }
 
             var trimmed = line.TrimStart();
-            if (trimmed.StartsWith("GO", StringComparison.OrdinalIgnoreCase))
+            if (trimmed.StartsWith("GO", StringComparison.OrdinalIgnoreCase)
+                && (trimmed.Length == 2
+                    || char.IsWhiteSpace(trimmed[2])))
             {
                 var batch = batchBuilder.ToString();
                 batchBuilder.Clear();

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -123,6 +123,38 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+    CREATE PROCEDURE [dbo].[GotoReproduction]
+    AS
+    BEGIN
+        DECLARE @Counter int;
+        SET @Counter = 1;
+        WHILE @Counter < 10
+        BEGIN
+            SELECT @Counter
+            SET @Counter = @Counter + 1
+            IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
+            IF @Counter = 5 GOTO Branch_Two --This will never execute.
+        END
+        Branch_One:
+            SELECT 'Jumping To Branch One.'
+            GOTO Branch_Three; --This will prevent Branch_Two from executing.
+        Branch_Two:
+            SELECT 'Jumping To Branch Two.'
+        Branch_Three:
+            SELECT 'Jumping To Branch Three.'
+    END;
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000004_Migration4', N'7.0.0-test');
+GO
+
+COMMIT;
+GO
+
 
 """,
                 Sql,
@@ -171,6 +203,32 @@ GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
 VALUES (N'00000000000003_Migration3', N'7.0.0-test');
+GO
+
+    CREATE PROCEDURE [dbo].[GotoReproduction]
+    AS
+    BEGIN
+        DECLARE @Counter int;
+        SET @Counter = 1;
+        WHILE @Counter < 10
+        BEGIN
+            SELECT @Counter
+            SET @Counter = @Counter + 1
+            IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
+            IF @Counter = 5 GOTO Branch_Two --This will never execute.
+        END
+        Branch_One:
+            SELECT 'Jumping To Branch One.'
+            GOTO Branch_Three; --This will prevent Branch_Two from executing.
+        Branch_Two:
+            SELECT 'Jumping To Branch Two.'
+        Branch_Three:
+            SELECT 'Jumping To Branch Three.'
+    END;
+GO
+
+INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+VALUES (N'00000000000004_Migration4', N'7.0.0-test');
 GO
 
 
@@ -333,6 +391,50 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000004_Migration4'
+)
+BEGIN
+        CREATE PROCEDURE [dbo].[GotoReproduction]
+        AS
+        BEGIN
+            DECLARE @Counter int;
+            SET @Counter = 1;
+            WHILE @Counter < 10
+            BEGIN
+                SELECT @Counter
+                SET @Counter = @Counter + 1
+                IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
+                IF @Counter = 5 GOTO Branch_Two --This will never execute.
+            END
+            Branch_One:
+                SELECT 'Jumping To Branch One.'
+                GOTO Branch_Three; --This will prevent Branch_Two from executing.
+            Branch_Two:
+                SELECT 'Jumping To Branch Two.'
+            Branch_Three:
+                SELECT 'Jumping To Branch Three.'
+        END;
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000004_Migration4'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000004_Migration4', N'7.0.0-test');
+END;
+GO
+
+COMMIT;
+GO
+
 
 """,
                 Sql,
@@ -422,6 +524,44 @@ IF NOT EXISTS (
 BEGIN
     INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
     VALUES (N'00000000000003_Migration3', N'7.0.0-test');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000004_Migration4'
+)
+BEGIN
+        CREATE PROCEDURE [dbo].[GotoReproduction]
+        AS
+        BEGIN
+            DECLARE @Counter int;
+            SET @Counter = 1;
+            WHILE @Counter < 10
+            BEGIN
+                SELECT @Counter
+                SET @Counter = @Counter + 1
+                IF @Counter = 4 GOTO Branch_One --Jumps to the first branch.
+                IF @Counter = 5 GOTO Branch_Two --This will never execute.
+            END
+            Branch_One:
+                SELECT 'Jumping To Branch One.'
+                GOTO Branch_Three; --This will prevent Branch_Two from executing.
+            Branch_Two:
+                SELECT 'Jumping To Branch Two.'
+            Branch_Three:
+                SELECT 'Jumping To Branch Three.'
+        END;
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000004_Migration4'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000004_Migration4', N'7.0.0-test');
 END;
 GO
 

--- a/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Migrations/MigrationsInfrastructureSqliteTest.cs
@@ -88,6 +88,13 @@ VALUES ('00000000000003_Migration3', '7.0.0-test');
 
 COMMIT;
 
+BEGIN TRANSACTION;
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000004_Migration4', '7.0.0-test');
+
+COMMIT;
+
 
 """,
                 Sql,
@@ -120,6 +127,9 @@ VALUES ('00000000000002_Migration2', '7.0.0-test');
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('00000000000003_Migration3', '7.0.0-test');
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('00000000000004_Migration4', '7.0.0-test');
 
 
 """,


### PR DESCRIPTION
Fixes #32457
Port of #32548

### Description

The code for parsing migrations SQL (never comes from user input) was updated to remove a regex, but this resulted in a parsing error.

### Customer impact

Truncated SQL when executing raw SQL commands in migrations.

### How found

Customer reports on 8.0.

### Regression

Yes.

### Testing

Added test case.

### Risk

Low and quirked.